### PR TITLE
Fix panic on routing with parameters

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -35,6 +35,9 @@ func getRegex(path string) (*regexp.Regexp, error) {
 	pattern := "^"
 	segments := strings.Split(path, "/")
 	for _, s := range segments {
+		if s == "" {
+			continue
+		}
 		if s[0] == ':' {
 			if strings.Contains(s, "?") {
 				pattern += "(?:/([^/]+?))?"


### PR DESCRIPTION
Based on https://github.com/gofiber/fiber/blob/master/docs/routing.md#parameters we should be able to register a route of `/api/values/:id` but we can't.

There is a bug on your `utils.getRegex`. The `strings.Split` there may return a first segment of empty string, please read the documentation of [strings.Split](https://golang.org/pkg/strings/#Split).

**Screenshot before this PR**

![](https://dev-to-uploads.s3.amazonaws.com/i/8cjq6caln2b09115laau.png)

**Screenshot after this PR**

![](https://dev-to-uploads.s3.amazonaws.com/i/a31qo84v6fjc93qmlg81.png)

Thanks,
[Gerasimos Maropoulos](https://twitter.com/makismaropoulos). Author of the [Iris](https://iris-go.com) web framework.