### PR TITLE
Fix panic on serving not-exists dir

### DIFF
--- a/static.go
+++ b/static.go
@@ -9,6 +9,7 @@ package fiber
 
 import (
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -34,6 +35,11 @@ func (r *Fiber) Static(args ...string) {
 	// Check if wildcard for single files
 	if prefix == "*" || prefix == "/*" {
 		wildcard = true
+	}
+
+	// Check if root exists
+	if _, err := os.Lstat(root); err != nil {
+		log.Fatal("Static: ", err)
 	}
 
 	// Lets get all files from root


### PR DESCRIPTION
When we try to serve not-exists dir, segmentation violation occured.

```go
app.Static("./publi") // typo
```

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x7dc998]

goroutine 1 [running]:
github.com/gofiber/fiber.getFiles.func1(0x8c277e, 0x7, 0x0, 0x0, 0x957d80, 0xc000167b60, 0x8, 0x8)
        /home/koyamaso/pkg/mod/github.com/gofiber/fiber@v1.3.4/utils.go:67 +0x38
path/filepath.Walk(0x8c277e, 0x7, 0xc000067da8, 0xc0000b6140, 0x8758c0)
```
This PR makes the error message clearer. Like below.
```
2020/02/07 01:48:07 Static: lstat ./publi: no such file or directory
```

This framework is great and I want to use it proactively. Thanks!