### PR TITLE
Error strings to lowercase

### DIFF
--- a/application.go
+++ b/application.go
@@ -387,7 +387,7 @@ func (app *Application) Listen(address interface{}, tls ...string) {
 // Shutdown server gracefully
 func (app *Application) Shutdown() error {
 	if app.httpServer == nil {
-		return fmt.Errorf("Server is not running")
+		return fmt.Errorf("server is not running")
 	}
 	return app.httpServer.Shutdown()
 }
@@ -422,7 +422,7 @@ func (app *Application) Test(req *http.Request) (*http.Response, error) {
 		}
 		// Throw timeout error after 200ms
 	case <-time.After(500 * time.Millisecond):
-		return nil, fmt.Errorf("Timeout")
+		return nil, fmt.Errorf("timeout")
 	}
 	// Get raw HTTP response
 	respRaw, err := ioutil.ReadAll(&conn.w)

--- a/request.go
+++ b/request.go
@@ -204,7 +204,7 @@ func (ctx *Ctx) BodyParser(v interface{}) error {
 	} else if cType == contentTypeXML {
 		return xml.Unmarshal(ctx.Fasthttp.Request.Body(), &v)
 	}
-	return fmt.Errorf("Cannot parse Content-Type: %v", cType)
+	return fmt.Errorf("cannot parse Content-Type: %v", cType)
 }
 
 // Cookies : https://fiber.wiki/context#cookies

--- a/request.go
+++ b/request.go
@@ -204,7 +204,7 @@ func (ctx *Ctx) BodyParser(v interface{}) error {
 	} else if cType == contentTypeXML {
 		return xml.Unmarshal(ctx.Fasthttp.Request.Body(), &v)
 	}
-	return fmt.Errorf("cannot parse Content-Type: %v", cType)
+	return fmt.Errorf("cannot parse content-type: %v", cType)
 }
 
 // Cookies : https://fiber.wiki/context#cookies


### PR DESCRIPTION
Error strings should be all lowercase.

Reference:
https://github.com/golang/go/wiki/CodeReviewComments#error-strings