### PR TITLE
Add template engines: Render(file, data)

### DIFF
--- a/application.go
+++ b/application.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// Version : Fiber release
-	Version = "1.6.0"
+	Version = "1.6.1"
 	// Website : Fiber documentation
 	Website = "https://fiber.wiki"
 	banner  = "\x1b[1;32m" + ` ______   __     ______     ______     ______
@@ -284,6 +284,24 @@ func (app *Application) Use(args ...interface{}) *Application {
 func (grp *Group) Use(args ...interface{}) *Group {
 	grp.register("USE", args...)
 	return grp
+}
+
+// Static for groups
+func (grp *Group) Static(args ...string) {
+	prefix := grp.path
+	root := "./"
+
+	if len(args) == 1 {
+		root = args[0]
+	} else if len(args) == 2 {
+		root = args[1]
+		prefix = prefix + args[0]
+		prefix = strings.Replace(prefix, "//", "/", -1)
+		prefix = filepath.Clean(prefix)
+		prefix = filepath.ToSlash(prefix)
+	}
+	fmt.Println(prefix, root)
+	grp.app.Static(prefix, root)
 }
 
 // Static https://fiber.wiki/application#static

--- a/application_test.go
+++ b/application_test.go
@@ -45,7 +45,8 @@ func Test_Methods(t *testing.T) {
 
 func Test_Static(t *testing.T) {
 	app := New()
-
+	grp := app.Group("/v1")
+	grp.Static("/v2", ".travis.yml")
 	app.Static("/yesyes*", ".github/FUNDING.yml")
 	app.Static("./.github")
 	app.Static("/john", "./.github")
@@ -72,6 +73,17 @@ func Test_Static(t *testing.T) {
 		t.Fatalf(`%s: Missing Content-Length`, t.Name())
 	}
 	req, _ = http.NewRequest("GET", "/john/stale.yml", nil)
+	resp, err = app.Test(req)
+	if err != nil {
+		t.Fatalf(`%s: %s`, t.Name(), err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf(`%s: StatusCode %v`, t.Name(), resp.StatusCode)
+	}
+	if resp.Header.Get("Content-Length") == "" {
+		t.Fatalf(`%s: Missing Content-Length`, t.Name())
+	}
+	req, _ = http.NewRequest("GET", "/v1/v2", nil)
 	resp, err = app.Test(req)
 	if err != nil {
 		t.Fatalf(`%s: %s`, t.Name(), err)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,13 @@ module github.com/gofiber/fiber
 go 1.11
 
 require (
+	github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53 // indirect
+	github.com/CloudyKit/jet v2.1.2+incompatible
+	github.com/aymerick/raymond v2.0.2+incompatible
+	github.com/cbroglie/mustache v1.0.1
+	github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385
 	github.com/gorilla/schema v1.1.0
 	github.com/json-iterator/go v1.1.9
 	github.com/valyala/fasthttp v1.9.0
+	github.com/yosssi/ace v0.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,15 @@
+github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53 h1:sR+/8Yb4slttB4vD+b9btVEnWgL3Q00OBTzVT8B9C0c=
+github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
+github.com/CloudyKit/jet v2.1.2+incompatible h1:ybZoYzMBdoijK6I+Ke3vg9GZsmlKo/ZhKdNMWz0P26c=
+github.com/CloudyKit/jet v2.1.2+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
+github.com/aymerick/raymond v2.0.2+incompatible h1:VEp3GpgdAnv9B2GFyTvqgcKvY+mfKMjPOA3SbKLtnU0=
+github.com/aymerick/raymond v2.0.2+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
+github.com/cbroglie/mustache v1.0.1 h1:ivMg8MguXq/rrz2eu3tw6g3b16+PQhoTn6EZAhst2mw=
+github.com/cbroglie/mustache v1.0.1/go.mod h1:R/RUa+SobQ14qkP4jtx5Vke5sDytONDQXNLPY/PO69g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385 h1:clC1lXBpe2kTj2VHdaIu9ajZQe4kcEY9j0NsnDDBZ3o=
+github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/schema v1.1.0 h1:CamqUDOFUBqzrvxuz2vEwo8+SUdwsluFh7IlzJh30LY=
 github.com/gorilla/schema v1.1.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
@@ -22,6 +32,8 @@ github.com/valyala/fasthttp v1.9.0 h1:hNpmUdy/+ZXYpGy0OBfm7K0UQTzb73W0T0U4iJIVrM
 github.com/valyala/fasthttp v1.9.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBnvPM1Su9w=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a h1:0R4NLDRDZX6JcmhJgXi5E4b8Wg84ihbmUKp/GvSPEzc=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
+github.com/yosssi/ace v0.0.5 h1:tUkIP/BLdKqrlrPwcmH0shwEEhTRHoGnc1wFIWmaBUA=
+github.com/yosssi/ace v0.0.5/go.mod h1:ALfIzm2vT7t5ZE7uoIZqF3TQ7SAOyupFZnkrF5id+K0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/response.go
+++ b/response.go
@@ -8,15 +8,23 @@
 package fiber
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
+	"html/template"
+	"io/ioutil"
 	"log"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/CloudyKit/jet"
+	"github.com/aymerick/raymond"
+	"github.com/cbroglie/mustache"
+	"github.com/eknkc/amber"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/valyala/fasthttp"
+	"github.com/yosssi/ace"
 )
 
 // Cookie : struct
@@ -287,8 +295,73 @@ func (ctx *Ctx) Redirect(path string, status ...int) {
 }
 
 // Render : https://fiber.wiki/context#render
-func (ctx *Ctx) Render() {
-
+func (ctx *Ctx) Render(file string, v ...interface{}) error {
+	var err error
+	var raw []byte
+	var html string
+	var data interface{}
+	var tmpl *template.Template
+	if len(v) > 0 {
+		data = v[0]
+	}
+	if raw, err = ioutil.ReadFile(file); err != nil {
+		return err
+	}
+	engine := filepath.Ext(file)
+	switch engine {
+	case ".template": // https://golang.org/pkg/text/template/
+		if tmpl, err = template.New("test").Parse(getString(raw)); err != nil {
+			return err
+		}
+		var buf bytes.Buffer
+		if err = tmpl.Execute(&buf, data); err != nil {
+			return err
+		}
+		html = buf.String()
+	case ".ace": // https://github.com/yosssi/ace
+		if tmpl, err = ace.Load(strings.TrimSuffix(file, filepath.Ext(file)), "", nil); err != nil {
+			return err
+		}
+		var buf bytes.Buffer
+		if err = tmpl.Execute(&buf, data); err != nil {
+			return err
+		}
+		html = buf.String()
+	case ".amber": // https://github.com/eknkc/amber
+		if tmpl, err = amber.Compile(getString(raw), amber.DefaultOptions); err != nil {
+			return err
+		}
+		var buf bytes.Buffer
+		if err = tmpl.Execute(&buf, data); err != nil {
+			return err
+		}
+		html = buf.String()
+	case ".jet": // https://github.com/CloudyKit/jet
+		d, f := filepath.Split(file)
+		var jetview = jet.NewHTMLSet(d)
+		var t *jet.Template
+		if t, err = jetview.GetTemplate(f); err != nil {
+			return err
+		}
+		var buf bytes.Buffer
+		if err = t.Execute(&buf, make(jet.VarMap), data); err != nil {
+			return err
+		}
+		html = buf.String()
+	case ".mustache": // https://github.com/hoisie/mustache
+		if html, err = mustache.Render(getString(raw), data); err != nil {
+			return err
+		}
+	case ".raymond": // https://github.com/aymerick/raymond
+		if html, err = raymond.Render(getString(raw), data); err != nil {
+			return err
+		}
+	default:
+		err = fmt.Errorf("render: does not support the %s extension", engine)
+	}
+	ctx.Set("Content-Type", "text/html")
+	ctx.SendString(html)
+	return err
 }
 
 // Send : https://fiber.wiki/context#send


### PR DESCRIPTION
Add `Render` for alpha testing, 6 template engines are available:

- [.template](https://golang.org/pkg/text/template/)
- [.ace](https://github.com/yosssi/ace)
- [.amber](https://github.com/eknkc/amber)
- [.jet](https://github.com/CloudyKit/jet)
- [.mustache](github.com/cbroglie/mustache)
- [.raymond](https://github.com/aymerick/raymond)

The function uses the correct engine based on the file extension.

```go
func main() {
  app := fiber.New()
  app.Get("/", func(c *fiber.Ctx) {
    data := map[string]interface{}{
      "name": "John",
      "age":  "35",
    }
    var err error
    //err = c.Render("views/test.template", data)
    //err = c.Render("views/test.ace", data)
    //err = c.Render("views/test.amber", data)
    //err = c.Render("views/test.jet", data)
    //err = c.Render("views/test.raymond", data)
    err = c.Render("views/test.mustache", data)
    if err != nil {
      fmt.Println(err)
    }
  })

  app.Listen(3000)
}
```