### PR TITLE
Removing some useless spaces in the READMEs

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -126,7 +126,7 @@ func main() {
   app.Static("/prefix", "./public")
   // => http://localhost:3000/prefix/js/script.js
   // => http://localhost:3000/prefix/css/style.css
-  
+
   app.Static("*", "./public/index.html")
   // => http://localhost:3000/anything/returns/the/index/file
 
@@ -206,7 +206,7 @@ func main() {
   app.Static("./public")
 
   // Last middleware
-  app.Use(func (c *fiber.Ctx) {
+  app.Use(func(c *fiber.Ctx) {
     c.SendStatus(404) // => 404 "Not Found"
   })
 
@@ -226,7 +226,7 @@ func main() {
   }
 
   // Serialize JSON
-  app.Get("/json", func (c *fiber.Ctx) {
+  app.Get("/json", func(c *fiber.Ctx) {
     c.JSON(&User{"John", 20})
   })
 
@@ -239,15 +239,15 @@ func main() {
 ```go
 func main() {
   app := fiber.New()
-  
-  app.Get("/json", func (c *fiber.Ctx) {
+
+  app.Get("/json", func(c *fiber.Ctx) {
     panic("Something went wrong!")
   })
-  
+
   app.Recover(func(c *fiber.Ctx) {
     c.Status(500).Send(c.Error())
   })
-  
+
   app.Listen(3000)
 }
 ```

--- a/.github/README_de.md
+++ b/.github/README_de.md
@@ -203,7 +203,7 @@ func main() {
   app.Static("./public")
 
   // Last middleware
-  app.Use(func (c *fiber.Ctx) {
+  app.Use(func(c *fiber.Ctx) {
     c.SendStatus(404) // => 404 "Not Found"
   })
 
@@ -223,7 +223,7 @@ func main() {
   }
 
   // Serialize JSON
-  app.Get("/json", func (c *fiber.Ctx) {
+  app.Get("/json", func(c *fiber.Ctx) {
     c.JSON(&User{"John", 20})
   })
 

--- a/.github/README_es.md
+++ b/.github/README_es.md
@@ -202,7 +202,7 @@ func main() {
   app.Static("./public")
 
   // Last middleware
-  app.Use(func (c *fiber.Ctx) {
+  app.Use(func(c *fiber.Ctx) {
     c.SendStatus(404) // => 404 "Not Found"
   })
 
@@ -222,7 +222,7 @@ func main() {
   }
 
   // Serialize JSON
-  app.Get("/json", func (c *fiber.Ctx) {
+  app.Get("/json", func(c *fiber.Ctx) {
     c.JSON(&User{"John", 20})
   })
 

--- a/.github/README_ja.md
+++ b/.github/README_ja.md
@@ -202,7 +202,7 @@ func main() {
   app.Static("./public")
 
   // Last middleware
-  app.Use(func (c *fiber.Ctx) {
+  app.Use(func(c *fiber.Ctx) {
     c.SendStatus(404) // => 404 "Not Found"
   })
 
@@ -222,7 +222,7 @@ func main() {
   }
 
   // Serialize JSON
-  app.Get("/json", func (c *fiber.Ctx) {
+  app.Get("/json", func(c *fiber.Ctx) {
     c.JSON(&User{"John", 20})
   })
 

--- a/.github/README_ko.md
+++ b/.github/README_ko.md
@@ -203,7 +203,7 @@ func main() {
   app.Static("./public")
 
   // Last middleware
-  app.Use(func (c *fiber.Ctx) {
+  app.Use(func(c *fiber.Ctx) {
     c.SendStatus(404) // => 404 "Not Found"
   })
 
@@ -223,7 +223,7 @@ func main() {
   }
 
   // Serialize JSON
-  app.Get("/json", func (c *fiber.Ctx) {
+  app.Get("/json", func(c *fiber.Ctx) {
     c.JSON(&User{"John", 20})
   })
 

--- a/.github/README_pt.md
+++ b/.github/README_pt.md
@@ -203,7 +203,7 @@ func main() {
   app.Static("./public")
 
   // Last middleware
-  app.Use(func (c *fiber.Ctx) {
+  app.Use(func(c *fiber.Ctx) {
     c.SendStatus(404) // => 404 "Not Found"
   })
 
@@ -223,7 +223,7 @@ func main() {
   }
 
   // Serializa o JSON
-  app.Get("/json", func (c *fiber.Ctx) {
+  app.Get("/json", func(c *fiber.Ctx) {
     c.JSON(&User{"John", 20})
   })
 

--- a/.github/README_ru.md
+++ b/.github/README_ru.md
@@ -204,7 +204,7 @@ func main() {
   app.Static("./public")
 
   // Последний middleware
-  app.Use(func (c *fiber.Ctx) {
+  app.Use(func(c *fiber.Ctx) {
     c.SendStatus(404) // => 404 "Not Found"
   })
 
@@ -224,7 +224,7 @@ func main() {
   }
 
   // Сериализация JSON
-  app.Get("/json", func (c *fiber.Ctx) {
+  app.Get("/json", func(c *fiber.Ctx) {
     c.JSON(&User{"John", 20})
   })
 

--- a/.github/README_zh-CN.md
+++ b/.github/README_zh-CN.md
@@ -199,7 +199,7 @@ func main() {
   app.Static("./public")
 
   // Last middleware
-  app.Use(func (c *fiber.Ctx) {
+  app.Use(func(c *fiber.Ctx) {
     c.SendStatus(404) // => 404 "Not Found"
   })
 
@@ -219,7 +219,7 @@ func main() {
   }
 
   // Serialize JSON
-  app.Get("/json", func (c *fiber.Ctx) {
+  app.Get("/json", func(c *fiber.Ctx) {
     c.JSON(&User{"John", 20})
   })
 


### PR DESCRIPTION
There were some useless spaces in the different READMEs.
Some of these were on empty lines and others were between a `func` and the opening parenthesis.

For example, some anonymous functions were declared like this:
```golang
func () { ... } // note the extra space after `func`
```
And it's now:
```golang
func() { ... } // no more extra space after `func`
```
I think the fact that in the examples, a function is *sometime* declared with a space after the `func` could be confusing for beginners in Go (we never know). So I have removed them.