### PR TITLE
v1.8.33

### DIFF
--- a/app.go
+++ b/app.go
@@ -51,7 +51,6 @@ type (
 		// Enables handler values to be immutable even if you return from handler
 		Immutable bool `default:"false"`
 		// Deprecated v1.8.2
-		// Enables GZip / Deflate compression for all responses
 		Compression bool `default:"false"`
 		// Max body size that the server accepts
 		BodyLimit int `default:"4 * 1024 * 1024"`
@@ -64,7 +63,10 @@ type (
 	}
 )
 
-// New : https://fiber.wiki/application#new
+// This method creates a new Fiber named instance.
+// You can pass optional settings when creating a new instance.
+//
+// https://fiber.wiki/application#new
 func New(settings ...*Settings) *App {
 	var prefork, child bool
 	// Loop trought args without using flag.Parse()
@@ -97,14 +99,17 @@ func New(settings ...*Settings) *App {
 			getBytes = func(s string) []byte { return []byte(s) }
 		}
 	}
-	// Deprecated
+	// This function is deprecated since v1.8.2!
+	// Please us github.com/gofiber/compression
 	if app.Settings.Compression {
 		log.Println("Warning: Settings.Compression is deprecated since v1.8.2, please use github.com/gofiber/compression instead.")
 	}
 	return app
 }
 
-// Group : https://fiber.wiki/application#group
+// You can group routes by creating a *Group struct.
+//
+// https://fiber.wiki/application#group
 func (app *App) Group(prefix string, handlers ...func(*Ctx)) *Group {
 	if len(handlers) > 0 {
 		app.registerMethod("USE", prefix, handlers...)
@@ -115,7 +120,9 @@ func (app *App) Group(prefix string, handlers ...func(*Ctx)) *Group {
 	}
 }
 
-// Static represents settings for serving static files
+// Settings struct for serving static files
+//
+// https://fiber.wiki/application#static
 type Static struct {
 	// Transparently compresses responses if set to true
 	// This works differently than the github.com/gofiber/compression middleware
@@ -134,13 +141,22 @@ type Static struct {
 	Index string
 }
 
-// Static : https://fiber.wiki/application#static
+// Serve static files such as images, CSS and JavaScript files, you can use the Static method.
+//
+// https://fiber.wiki/application#static
 func (app *App) Static(prefix, root string, config ...Static) *App {
 	app.registerStatic(prefix, root, config...)
 	return app
 }
 
-// Use : https://fiber.wiki/application#http-methods
+// Use only match requests starting with the specified prefix
+// It's optional to provide a prefix, default: "/"
+// Example: Use("/product", handler)
+// will match 	/product
+// will match 	/product/cool
+// will match 	/product/foo
+//
+// https://fiber.wiki/application#http-methods
 func (app *App) Use(args ...interface{}) *App {
 	var path = ""
 	var handlers []func(*Ctx)
@@ -212,19 +228,28 @@ func (app *App) Get(path string, handlers ...func(*Ctx)) *App {
 	return app
 }
 
-// All : https://fiber.wiki/application#http-methods
+// All matches all HTTP methods and complete paths
+// Example: All("/product", handler)
+// will match 	/product
+// won't match 	/product/cool   <-- important
+// won't match 	/product/foo    <-- important
+//
+// https://fiber.wiki/application#http-methods
 func (app *App) All(path string, handlers ...func(*Ctx)) *App {
 	app.registerMethod("ALL", path, handlers...)
 	return app
 }
 
-// WebSocket : https://fiber.wiki/application#websocket
+// This function is deprecated since v1.8.2!
+// Please us github.com/gofiber/websocket
 func (app *App) WebSocket(path string, handle func(*Ctx)) *App {
+	log.Println("Warning: app.WebSocket() is deprecated since v1.8.2, please use github.com/gofiber/websocket instead.")
 	app.registerWebSocket(http.MethodGet, path, handle)
 	return app
 }
 
-// Recover : https://fiber.wiki/application#recover
+// This function is deprecated since v1.8.2!
+// Please us github.com/gofiber/recover
 func (app *App) Recover(handler func(*Ctx)) {
 	log.Println("Warning: app.Recover() is deprecated since v1.8.2, please use github.com/gofiber/recover instead.")
 	app.recover = handler

--- a/app.go
+++ b/app.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Version of Fiber
-const Version = "1.8.32"
+const Version = "1.8.33"
 
 type (
 	// App denotes the Fiber application.

--- a/context.go
+++ b/context.go
@@ -167,6 +167,7 @@ func (ctx *Ctx) AcceptsCharsets(offers ...string) (offer string) {
 	specs := strings.Split(h, ",")
 	for _, value := range offers {
 		for _, spec := range specs {
+
 			spec = strings.TrimSpace(spec)
 			if strings.HasPrefix(spec, "*") {
 				return value

--- a/context.go
+++ b/context.go
@@ -36,8 +36,7 @@ type Ctx struct {
 	values   []string             // Route parameter values
 	compress bool                 // If the response needs to be compressed
 	Fasthttp *fasthttp.RequestCtx // Reference to *fasthttp.RequestCtx
-	Conn     *Conn
-	err      error // Contains error if catched
+	err      error                // Contains error if catched
 }
 
 // Range struct
@@ -515,8 +514,11 @@ func (ctx *Ctx) Location(path string) {
 }
 
 // Method : https://fiber.wiki/context#method
-func (ctx *Ctx) Method() string {
-	return getString(ctx.Fasthttp.Request.Header.Method())
+func (ctx *Ctx) Method(override ...string) string {
+	if len(override) > 0 {
+		ctx.method = override[0]
+	}
+	return ctx.method
 }
 
 // MultipartForm : https://fiber.wiki/context#multipartform
@@ -552,9 +554,14 @@ func (ctx *Ctx) Params(key string) (value string) {
 	return
 }
 
-// Path : https://fiber.wiki/context#path
-func (ctx *Ctx) Path() string {
-	return getString(ctx.Fasthttp.URI().Path())
+// Returns the path part of the request URL.
+// Optionally, you could override the path.
+// https://fiber.wiki/context#path
+func (ctx *Ctx) Path(override ...string) string {
+	if len(override) > 0 {
+		ctx.path = override[0]
+	}
+	return ctx.path
 }
 
 // Protocol : https://fiber.wiki/context#protocol

--- a/context.go
+++ b/context.go
@@ -556,6 +556,7 @@ func (ctx *Ctx) Params(key string) (value string) {
 
 // Returns the path part of the request URL.
 // Optionally, you could override the path.
+//
 // https://fiber.wiki/context#path
 func (ctx *Ctx) Path(override ...string) string {
 	if len(override) > 0 {
@@ -564,7 +565,9 @@ func (ctx *Ctx) Path(override ...string) string {
 	return ctx.path
 }
 
-// Protocol : https://fiber.wiki/context#protocol
+// Contains the request protocol string: http or https for TLS requests.
+//
+// https://fiber.wiki/context#protocol
 func (ctx *Ctx) Protocol() string {
 	if ctx.Fasthttp.IsTLS() {
 		return "https"
@@ -572,12 +575,16 @@ func (ctx *Ctx) Protocol() string {
 	return "http"
 }
 
-// Query : https://fiber.wiki/context#query
+// Returns the query string parameter in the url.
+//
+// https://fiber.wiki/context#query
 func (ctx *Ctx) Query(key string) (value string) {
 	return getString(ctx.Fasthttp.QueryArgs().Peek(key))
 }
 
-// Range : https://fiber.wiki/context#range
+// An struct containing the type and a slice of ranges will be returned.
+//
+// https://fiber.wiki/context#range
 func (ctx *Ctx) Range(size int) (rangeData Range, err error) {
 	rangeStr := string(ctx.Fasthttp.Request.Header.Peek("range"))
 	if rangeStr == "" || !strings.Contains(rangeStr, "=") {
@@ -619,7 +626,10 @@ func (ctx *Ctx) Range(size int) (rangeData Range, err error) {
 	return rangeData, nil
 }
 
-// Redirect : https://fiber.wiki/context#redirect
+// Redirects to the URL derived from the specified path, with specified status.
+// If status is not specified, status defaults to 302 Found
+//
+// https://fiber.wiki/context#redirect
 func (ctx *Ctx) Redirect(path string, status ...int) {
 	code := 302
 	if len(status) > 0 {
@@ -630,7 +640,10 @@ func (ctx *Ctx) Redirect(path string, status ...int) {
 	ctx.Fasthttp.Response.SetStatusCode(code)
 }
 
-// Render : https://fiber.wiki/context#render
+// Renders a template with data and sends a text/html response.
+// We support the following engines: html, amber, handlebars, mustache, pug
+//
+// https://fiber.wiki/context#render
 func (ctx *Ctx) Render(file string, bind interface{}, engine ...string) error {
 	var err error
 	var raw []byte
@@ -681,22 +694,30 @@ func (ctx *Ctx) Render(file string, bind interface{}, engine ...string) error {
 	return err
 }
 
-// Route : https://fiber.wiki/context#route
+// Returns the matched Route struct.
+//
+// https://fiber.wiki/context#route
 func (ctx *Ctx) Route() *Route {
 	return ctx.route
 }
 
-// SaveFile : https://fiber.wiki/context#secure
+// Save any multipart file to disk.
+//
+// https://fiber.wiki/context#secure
 func (ctx *Ctx) SaveFile(fileheader *multipart.FileHeader, path string) error {
 	return fasthttp.SaveMultipartFile(fileheader, path)
 }
 
-// Secure : https://fiber.wiki/context#secure
+// A boolean property, that is true, if a TLS connection is established.
+//
+// https://fiber.wiki/context#secure
 func (ctx *Ctx) Secure() bool {
 	return ctx.Fasthttp.IsTLS()
 }
 
-// Send : https://fiber.wiki/context#send
+// Sets the HTTP response body. The Send body can be of any type.
+//
+// https://fiber.wiki/context#send
 func (ctx *Ctx) Send(bodies ...interface{}) {
 	if len(bodies) > 0 {
 		ctx.Fasthttp.Response.SetBodyString("")
@@ -713,15 +734,21 @@ func (ctx *Ctx) Send(bodies ...interface{}) {
 	}
 }
 
-// SendBytes : https://fiber.wiki/context#sendbytes
+// Sets the HTTP response body for []byte types
+// This means no type assertion, recommended for faster performance
+//
+// https://fiber.wiki/context#send
 func (ctx *Ctx) SendBytes(body []byte) {
 	ctx.Fasthttp.Response.SetBodyString(getString(body))
 }
 
-// SendFile : https://fiber.wiki/context#sendfile
-func (ctx *Ctx) SendFile(file string, gzip ...bool) {
+// Transfers the file from the given path.
+// Sets the Content-Type response HTTP header field based on the filenames extension.
+//
+// https://fiber.wiki/context#sendfile
+func (ctx *Ctx) SendFile(file string, compress ...bool) {
 	// Disable gzipping
-	if len(gzip) > 0 && !gzip[0] {
+	if len(compress) > 0 && !compress[0] {
 		fasthttp.ServeFileUncompressed(ctx.Fasthttp, file)
 		return
 	}
@@ -731,7 +758,10 @@ func (ctx *Ctx) SendFile(file string, gzip ...bool) {
 	//ctx.Fasthttp.SendFile(path)
 }
 
-// SendStatus : https://fiber.wiki/context#sendstatus
+// Sets the HTTP status code and if the response body is empty,
+// it sets the correct status message in the body.
+//
+// https://fiber.wiki/context#sendstatus
 func (ctx *Ctx) SendStatus(status int) {
 	ctx.Fasthttp.Response.SetStatusCode(status)
 	// Only set status body when there is no response body
@@ -740,17 +770,25 @@ func (ctx *Ctx) SendStatus(status int) {
 	}
 }
 
-// SendString : https://fiber.wiki/context#sendstring
+// Sets the HTTP response body for string types
+// This means no type assertion, recommended for faster performance
+//
+// https://fiber.wiki/context#send
 func (ctx *Ctx) SendString(body string) {
 	ctx.Fasthttp.Response.SetBodyString(body)
 }
 
-// Set : https://fiber.wiki/context#set
+// Sets the response’s HTTP header field to the specified key, value.
+//
+// https://fiber.wiki/context#set
 func (ctx *Ctx) Set(key string, val string) {
 	ctx.Fasthttp.Response.Header.Set(key, val)
 }
 
-// Subdomains : https://fiber.wiki/context#subdomains
+// Returns a string slive of subdomains in the domain name of the request.
+// The subdomain offset, which defaults to 2, is used for determining the beginning of the subdomain segments.
+//
+// https://fiber.wiki/context#subdomains
 func (ctx *Ctx) Subdomains(offset ...int) []string {
 	o := 2
 	if len(offset) > 0 {
@@ -761,24 +799,34 @@ func (ctx *Ctx) Subdomains(offset ...int) []string {
 	return subdomains
 }
 
-// Stale : https://fiber.wiki/context#stale
+// Not implemented yet, pull requests are welcome!
+//
+// https://fiber.wiki/context#stale
 func (ctx *Ctx) Stale() bool {
 	return !ctx.Fresh()
 }
 
-// Status : https://fiber.wiki/context#status
+// Sets the HTTP status for the response.
+// This method is chainable.
+//
+// https://fiber.wiki/context#status
 func (ctx *Ctx) Status(status int) *Ctx {
 	ctx.Fasthttp.Response.SetStatusCode(status)
 	return ctx
 }
 
-// Type : https://fiber.wiki/context#type
+// Sets the Content-Type HTTP header to the MIME type specified by the file extension.
+//
+// https://fiber.wiki/context#type
 func (ctx *Ctx) Type(ext string) *Ctx {
 	ctx.Fasthttp.Response.Header.SetContentType(getType(ext))
 	return ctx
 }
 
-// Vary : https://fiber.wiki/context#vary
+// Adds the given header field to the Vary response header.
+// This will append the header, if not already listed, otherwise leaves it listed in the current location.
+//
+// https://fiber.wiki/context#vary
 func (ctx *Ctx) Vary(fields ...string) {
 	if len(fields) == 0 {
 		return

--- a/context.go
+++ b/context.go
@@ -645,6 +645,14 @@ func (ctx *Ctx) Params(key string) (value string) {
 // https://fiber.wiki/context#path
 func (ctx *Ctx) Path(override ...string) string {
 	if len(override) > 0 {
+		// Non strict routing
+		if !ctx.app.Settings.StrictRouting && len(override[0]) > 1 {
+			override[0] = strings.TrimRight(override[0], "/")
+		}
+		// Not case sensitive
+		if !ctx.app.Settings.CaseSensitive {
+			override[0] = strings.ToLower(override[0])
+		}
 		ctx.path = override[0]
 	}
 	return ctx.path

--- a/context.go
+++ b/context.go
@@ -111,7 +111,9 @@ func releaseConn(conn *Conn) {
 	poolConn.Put(conn)
 }
 
-// Accepts : https://fiber.wiki/context#accepts
+// Checks, if the specified extensions or content types are acceptable.
+//
+// https://fiber.wiki/context#accepts
 func (ctx *Ctx) Accepts(offers ...string) (offer string) {
 	if len(offers) == 0 {
 		return ""
@@ -149,7 +151,9 @@ func (ctx *Ctx) Accepts(offers ...string) (offer string) {
 	return ""
 }
 
-// AcceptsCharsets : https://fiber.wiki/context#acceptscharsets
+// Checks, if the specified charset is acceptable.
+//
+// https://fiber.wiki/context#accepts
 func (ctx *Ctx) AcceptsCharsets(offers ...string) (offer string) {
 	if len(offers) == 0 {
 		return ""
@@ -175,7 +179,9 @@ func (ctx *Ctx) AcceptsCharsets(offers ...string) (offer string) {
 	return ""
 }
 
-// AcceptsEncodings : https://fiber.wiki/context#acceptsencodings
+// Checks, if the specified encoding is acceptable.
+//
+// https://fiber.wiki/context#accepts
 func (ctx *Ctx) AcceptsEncodings(offers ...string) (offer string) {
 	if len(offers) == 0 {
 		return ""
@@ -201,7 +207,9 @@ func (ctx *Ctx) AcceptsEncodings(offers ...string) (offer string) {
 	return ""
 }
 
-// AcceptsLanguages : https://fiber.wiki/context#acceptslanguages
+// Checks, if the specified language is acceptable.
+//
+// https://fiber.wiki/context#accepts
 func (ctx *Ctx) AcceptsLanguages(offers ...string) (offer string) {
 	if len(offers) == 0 {
 		return ""
@@ -226,7 +234,10 @@ func (ctx *Ctx) AcceptsLanguages(offers ...string) (offer string) {
 	return ""
 }
 
-// Append : https://fiber.wiki/context#append
+// Appends the specified value to the HTTP response header field.
+// If the header is not already set, it creates the header with the specified value.
+//
+// https://fiber.wiki/context#append
 func (ctx *Ctx) Append(field string, values ...string) {
 	if len(values) == 0 {
 		return
@@ -242,7 +253,9 @@ func (ctx *Ctx) Append(field string, values ...string) {
 	ctx.Set(field, h)
 }
 
-// Attachment : https://fiber.wiki/context#attachment
+// Sets the HTTP response Content-Disposition header field to attachment.
+//
+// https://fiber.wiki/context#attachment
 func (ctx *Ctx) Attachment(name ...string) {
 	if len(name) > 0 {
 		filename := filepath.Base(name[0])
@@ -253,12 +266,17 @@ func (ctx *Ctx) Attachment(name ...string) {
 	ctx.Set(HeaderContentDisposition, "attachment")
 }
 
-// BaseURL : https://fiber.wiki/context#baseurl
+// Returns base URL (protocol + host) as a string.
+//
+// https://fiber.wiki/context#baseurl
 func (ctx *Ctx) BaseURL() string {
 	return ctx.Protocol() + "://" + ctx.Hostname()
 }
 
-// Body : https://fiber.wiki/context#body
+// Contains the raw body submitted in a POST request.
+// If a key is provided, it returns the form value
+//
+// https://fiber.wiki/context#body
 func (ctx *Ctx) Body(key ...string) string {
 	// Return request body
 	if len(key) == 0 {
@@ -271,7 +289,11 @@ func (ctx *Ctx) Body(key ...string) string {
 	return ""
 }
 
-// BodyParser : https://fiber.wiki/context#bodyparser
+// Binds the request body to a struct.
+// BodyParser supports decoding the following content types based on the Content-Type header:
+// application/json, application/xml, application/x-www-form-urlencoded, multipart/form-data
+//
+// https://fiber.wiki/context#bodyparser
 func (ctx *Ctx) BodyParser(out interface{}) error {
 	// TODO : Query Params
 	ctype := getString(ctx.Fasthttp.Request.Header.ContentType())
@@ -303,7 +325,9 @@ func (ctx *Ctx) BodyParser(out interface{}) error {
 	return fmt.Errorf("BodyParser: cannot parse content-type: %v", ctype)
 }
 
-// ClearCookie : https://fiber.wiki/context#clearcookie
+// Expire a client cookie (or all cookies if left empty)
+//
+// https://fiber.wiki/context#clearcookie
 func (ctx *Ctx) ClearCookie(key ...string) {
 	if len(key) > 0 {
 		for i := range key {
@@ -318,7 +342,8 @@ func (ctx *Ctx) ClearCookie(key ...string) {
 	})
 }
 
-// Compress : https://fiber.wiki/context#compress
+// This function is deprecated since v1.8.2!
+// Please us github.com/gofiber/compression
 func (ctx *Ctx) Compress(enable ...bool) {
 	log.Println("Warning: c.Compress() is deprecated since v1.8.2, please use github.com/gofiber/compression instead.")
 	ctx.compress = true
@@ -327,7 +352,9 @@ func (ctx *Ctx) Compress(enable ...bool) {
 	}
 }
 
-// Cookie : https://fiber.wiki/context#cookie
+// Set cookie by passing a cookie struct
+//
+// https://fiber.wiki/context#cookie
 func (ctx *Ctx) Cookie(cookie *Cookie) {
 	fcookie := &fasthttp.Cookie{}
 	fcookie.SetKey(cookie.Name)
@@ -340,7 +367,9 @@ func (ctx *Ctx) Cookie(cookie *Cookie) {
 	ctx.Fasthttp.Response.Header.SetCookie(fcookie)
 }
 
-// Cookies : https://fiber.wiki/context#cookies
+// Get cookie value by key
+//
+// https://fiber.wiki/context#cookies
 func (ctx *Ctx) Cookies(key ...string) (value string) {
 	if len(key) == 0 {
 		return ctx.Get(HeaderCookie)
@@ -348,6 +377,11 @@ func (ctx *Ctx) Cookies(key ...string) (value string) {
 	return getString(ctx.Fasthttp.Request.Header.Cookie(key[0]))
 }
 
+// Transfers the file from path as an attachment.
+// Typically, browsers will prompt the user for download.
+// By default, the Content-Disposition header filename= parameter is the filepath (this typically appears in the browser dialog).
+// Override this default with the filename parameter.
+//
 // Download : https://fiber.wiki/context#download
 func (ctx *Ctx) Download(file string, name ...string) {
 	filename := filepath.Base(file)
@@ -360,12 +394,17 @@ func (ctx *Ctx) Download(file string, name ...string) {
 	ctx.SendFile(file)
 }
 
-// Error returns err that is passed via Next(err)
+// This contains the error information that thrown by a panic or passed via the Next(err) method.
+//
+// https://fiber.wiki/context#error
 func (ctx *Ctx) Error() error {
 	return ctx.err
 }
 
-// Format : https://fiber.wiki/context#format
+// Performs content-negotiation on the Accept HTTP header. It uses Accepts to select a proper format.
+// If the header is not specified or there is no proper format, text/plain is used.
+//
+// https://fiber.wiki/context#format
 func (ctx *Ctx) Format(body interface{}) {
 	var b string
 	accept := ctx.Accepts("html", "json")
@@ -390,22 +429,31 @@ func (ctx *Ctx) Format(body interface{}) {
 	}
 }
 
-// FormFile : https://fiber.wiki/context#formfile
+// MultipartForm files can be retrieved by name, the first file from the given key is returned.
+//
+// https://fiber.wiki/context#formfile
 func (ctx *Ctx) FormFile(key string) (*multipart.FileHeader, error) {
 	return ctx.Fasthttp.FormFile(key)
 }
 
-// FormValue : https://fiber.wiki/context#formvalue
+// MultipartForm values can be retrieved by name, the first value from the given key is returned.
+//
+// https://fiber.wiki/context#formvalue
 func (ctx *Ctx) FormValue(key string) (value string) {
 	return getString(ctx.Fasthttp.FormValue(key))
 }
 
-// Fresh : https://fiber.wiki/context#fresh
+// Not implemented yet, pull requests are welcome!
+//
+// https://fiber.wiki/context#fresh
 func (ctx *Ctx) Fresh() bool {
 	return false
 }
 
-// Get : https://fiber.wiki/context#get
+// Returns the HTTP request header specified by field.
+// Field names are case-insensitive
+//
+// https://fiber.wiki/context#get
 func (ctx *Ctx) Get(key string) (value string) {
 	if key == "referrer" {
 		key = "referer"
@@ -413,17 +461,23 @@ func (ctx *Ctx) Get(key string) (value string) {
 	return getString(ctx.Fasthttp.Request.Header.Peek(key))
 }
 
-// Hostname : https://fiber.wiki/context#hostname
+// Contains the hostname derived from the Host HTTP header.
+//
+// https://fiber.wiki/context#hostname
 func (ctx *Ctx) Hostname() string {
 	return getString(ctx.Fasthttp.URI().Host())
 }
 
-// IP : https://fiber.wiki/context#Ip
+// Returns the remote IP address of the request.
+//
+// https://fiber.wiki/context#Ip
 func (ctx *Ctx) IP() string {
 	return ctx.Fasthttp.RemoteIP().String()
 }
 
-// IPs : https://fiber.wiki/context#ips
+// Returns an string slice of IP addresses specified in the X-Forwarded-For request header.
+//
+// https://fiber.wiki/context#ips
 func (ctx *Ctx) IPs() []string {
 	ips := strings.Split(ctx.Get(HeaderXForwardedFor), ",")
 	for i := range ips {
@@ -432,7 +486,10 @@ func (ctx *Ctx) IPs() []string {
 	return ips
 }
 
-// Is : https://fiber.wiki/context#is
+// Returns the matching content type,
+// if the incoming request’s Content-Type HTTP header field matches the MIME type specified by the type parameter.
+//
+// https://fiber.wiki/context#is
 func (ctx *Ctx) Is(extension string) (match bool) {
 	if extension[0] != '.' {
 		extension = "." + extension
@@ -449,7 +506,10 @@ func (ctx *Ctx) Is(extension string) (match bool) {
 	return
 }
 
-// JSON : https://fiber.wiki/context#json
+// Converts any interface or string to JSON using Jsoniter.
+// This method also sets the content header to application/json.
+//
+// https://fiber.wiki/context#json
 func (ctx *Ctx) JSON(json interface{}) error {
 	ctx.Fasthttp.Response.Header.SetContentType(MIMEApplicationJSON)
 	raw, err := jsoniter.Marshal(&json)
@@ -462,7 +522,11 @@ func (ctx *Ctx) JSON(json interface{}) error {
 	return nil
 }
 
-// JSONP : https://fiber.wiki/context#jsonp
+// Sends a JSON response with JSONP support.
+// This method is identical to JSON, except that it opts-in to JSONP callback support.
+// By default, the callback name is simply callback.
+//
+// https://fiber.wiki/context#jsonp
 func (ctx *Ctx) JSONP(json interface{}, callback ...string) error {
 	raw, err := jsoniter.Marshal(&json)
 	if err != nil {
@@ -482,7 +546,9 @@ func (ctx *Ctx) JSONP(json interface{}, callback ...string) error {
 	return nil
 }
 
-// Links : https://fiber.wiki/context#links
+// Joins the links followed by the property to populate the response’s Link HTTP header field.
+//
+// https://fiber.wiki/context#links
 func (ctx *Ctx) Links(link ...string) {
 	h := ""
 	for i, l := range link {
@@ -499,7 +565,10 @@ func (ctx *Ctx) Links(link ...string) {
 	}
 }
 
-// Locals : https://fiber.wiki/context#locals
+// You can pass interface{} values under string keys scoped to the request
+// and therefore available to all routes that match the request.
+//
+// https://fiber.wiki/context#locals
 func (ctx *Ctx) Locals(key string, value ...interface{}) (val interface{}) {
 	if len(value) == 0 {
 		return ctx.Fasthttp.UserValue(key)
@@ -508,12 +577,16 @@ func (ctx *Ctx) Locals(key string, value ...interface{}) (val interface{}) {
 	return value[0]
 }
 
-// Location : https://fiber.wiki/context#location
+// Sets the response Location HTTP header to the specified path parameter.
+//
+// https://fiber.wiki/context#location
 func (ctx *Ctx) Location(path string) {
 	ctx.Set(HeaderLocation, path)
 }
 
-// Method : https://fiber.wiki/context#method
+// Contains a string corresponding to the HTTP method of the request: GET, POST, PUT and so on.
+//
+// https://fiber.wiki/context#method
 func (ctx *Ctx) Method(override ...string) string {
 	if len(override) > 0 {
 		ctx.method = override[0]
@@ -521,12 +594,18 @@ func (ctx *Ctx) Method(override ...string) string {
 	return ctx.method
 }
 
-// MultipartForm : https://fiber.wiki/context#multipartform
+// Access multipart form entries, you can parse the binary with MultipartForm().
+// This returns a map[string][]string, so given a key the value will be a string slice.
+//
+// https://fiber.wiki/context#multipartform
 func (ctx *Ctx) MultipartForm() (*multipart.Form, error) {
 	return ctx.Fasthttp.MultipartForm()
 }
 
-// Next : https://fiber.wiki/context#next
+// Next executes the next method in the stack that matches the current route.
+// You can pass an optional error for custom error handling.
+//
+// https://fiber.wiki/context#next
 func (ctx *Ctx) Next(err ...error) {
 	ctx.route = nil
 	ctx.values = nil
@@ -536,12 +615,17 @@ func (ctx *Ctx) Next(err ...error) {
 	ctx.app.nextRoute(ctx)
 }
 
-// OriginalURL : https://fiber.wiki/context#originalurl
+// Contains the original request URL.
+//
+// https://fiber.wiki/context#originalurl
 func (ctx *Ctx) OriginalURL() string {
 	return getString(ctx.Fasthttp.Request.Header.RequestURI())
 }
 
-// Params : https://fiber.wiki/context#params
+// Used to get the route parameters.
+// Defaults to empty string "", if the param doesn't exist.
+//
+// https://fiber.wiki/context#params
 func (ctx *Ctx) Params(key string) (value string) {
 	if ctx.route.Params == nil {
 		return
@@ -844,7 +928,9 @@ func (ctx *Ctx) Vary(fields ...string) {
 	ctx.Set(HeaderVary, h)
 }
 
-// Write : https://fiber.wiki/context#write
+// Appends any input to the HTTP body response.
+//
+// https://fiber.wiki/context#write
 func (ctx *Ctx) Write(bodies ...interface{}) {
 	for i := range bodies {
 		switch body := bodies[i].(type) {
@@ -858,7 +944,10 @@ func (ctx *Ctx) Write(bodies ...interface{}) {
 	}
 }
 
-// XHR : https://fiber.wiki/context#xhr
+// A Boolean property, that is true, if the request’s X-Requested-With header field is XMLHttpRequest,
+// indicating that the request was issued by a client library (such as jQuery).
+//
+// https://fiber.wiki/context#xhr
 func (ctx *Ctx) XHR() bool {
 	return ctx.Get(HeaderXRequestedWith) == "XMLHttpRequest"
 }

--- a/group.go
+++ b/group.go
@@ -35,7 +35,14 @@ func (grp *Group) Static(prefix, root string, config ...Static) *Group {
 	return grp
 }
 
-// Use : https://fiber.wiki/application#http-methods
+// Use only match requests starting with the specified prefix
+// It's optional to provide a prefix, default: "/"
+// Example: Use("/product", handler)
+// will match 	/product
+// will match 	/product/cool
+// will match 	/product/foo
+//
+// https://fiber.wiki/application#http-methods
 func (grp *Group) Use(args ...interface{}) *Group {
 	var path = ""
 	var handlers []func(*Ctx)
@@ -117,22 +124,31 @@ func (grp *Group) Get(path string, handlers ...func(*Ctx)) *Group {
 	return grp
 }
 
-// All : https://fiber.wiki/application#http-methods
+// All matches all HTTP methods and complete paths
+// Example: All("/product", handler)
+// will match 	/product
+// won't match 	/product/cool   <-- important
+// won't match 	/product/foo    <-- important
+//
+// https://fiber.wiki/application#http-methods
 func (grp *Group) All(path string, handlers ...func(*Ctx)) *Group {
 	path = groupPaths(grp.prefix, path)
 	grp.app.registerMethod("ALL", path, handlers...)
 	return grp
 }
 
-// WebSocket : https://fiber.wiki/application#websocket
+// This function is deprecated since v1.8.2!
+// Please us github.com/gofiber/websocket
 func (grp *Group) WebSocket(path string, handle func(*Ctx)) *Group {
+	log.Println("Warning: app.WebSocket() is deprecated since v1.8.2, please use github.com/gofiber/websocket instead.")
 	path = groupPaths(grp.prefix, path)
 	grp.app.registerWebSocket(http.MethodGet, path, handle)
 	return grp
 }
 
-// Recover : https://fiber.wiki/application#recover
+// This function is deprecated since v1.8.2!
+// Please us github.com/gofiber/recover
 func (grp *Group) Recover(handler func(*Ctx)) {
-	log.Println("Warning: Recover(handler) is deprecated since v1.8.2, please use middleware.Recover(handler, error) instead.")
+	log.Println("Warning: Recover() is deprecated since v1.8.2, please use github.com/gofiber/recover instead.")
 	grp.app.recover = handler
 }

--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -30,7 +30,7 @@ var BasicAuthConfigDefault = BasicAuthConfig{
 
 // BasicAuth ...
 func BasicAuth(config ...BasicAuthConfig) func(*fiber.Ctx) {
-	log.Println("Warning: middleware.BasicAuth() is deprecated since v1.8.3, please use github.com/gofiber/basicauth")
+	log.Println("Warning: middleware.BasicAuth() is deprecated since v1.8.2, please use github.com/gofiber/basicauth")
 	// Init config
 	var cfg BasicAuthConfig
 	if len(config) > 0 {

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -42,7 +42,7 @@ var CorsConfigDefault = CORSConfig{
 
 // Cors ...
 func Cors(config ...CORSConfig) func(*fiber.Ctx) {
-	log.Println("Warning: middleware.Cors() is deprecated since v1.8.3, please use github.com/gofiber/cors")
+	log.Println("Warning: middleware.Cors() is deprecated since v1.8.2, please use github.com/gofiber/cors")
 	// Init config
 	var cfg CORSConfig
 	// Set config if provided

--- a/middleware/helmet.go
+++ b/middleware/helmet.go
@@ -52,7 +52,7 @@ var HelmetConfigDefault = HelmetConfig{
 
 // Helmet ...
 func Helmet(config ...HelmetConfig) func(*fiber.Ctx) {
-	log.Println("Warning: middleware.Helmet() is deprecated since v1.8.3, please use github.com/gofiber/helmet")
+	log.Println("Warning: middleware.Helmet() is deprecated since v1.8.2, please use github.com/gofiber/helmet")
 	// Init config
 	var cfg HelmetConfig
 	if len(config) > 0 {

--- a/middleware/limiter.go
+++ b/middleware/limiter.go
@@ -49,7 +49,7 @@ var LimiterConfigDefault = LimiterConfig{
 
 // Limiter ...
 func Limiter(config ...LimiterConfig) func(*fiber.Ctx) {
-	log.Println("Warning: middleware.Limiter() is deprecated since v1.8.3, please use github.com/gofiber/limiter")
+	log.Println("Warning: middleware.Limiter() is deprecated since v1.8.2, please use github.com/gofiber/limiter")
 	// Init config
 	var cfg LimiterConfig
 	// Set config if provided

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -43,7 +43,7 @@ var LoggerConfigDefault = LoggerConfig{
 
 // Logger ...
 func Logger(config ...LoggerConfig) func(*fiber.Ctx) {
-	log.Println("Warning: middleware.Logger() is deprecated since v1.8.3, please use github.com/gofiber/logger")
+	log.Println("Warning: middleware.Logger() is deprecated since v1.8.2, please use github.com/gofiber/logger")
 	// Init config
 	var cfg LoggerConfig
 	// Set config if provided

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -9,7 +9,7 @@ import (
 
 // Recover ...
 func Recover(handle ...func(*fiber.Ctx, error)) func(*fiber.Ctx) {
-	log.Println("Warning: middleware.Recover() is deprecated since v1.8.3, please use github.com/gofiber/recover")
+	log.Println("Warning: middleware.Recover() is deprecated since v1.8.2, please use github.com/gofiber/recover")
 	h := func(c *fiber.Ctx, err error) {
 		log.Println(err)
 		c.SendStatus(500)

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -30,7 +30,7 @@ var RequestIDConfigDefault = RequestIDConfig{
 
 // RequestID adds an indentifier to the request using the `X-Request-ID` header
 func RequestID(config ...RequestIDConfig) func(*fiber.Ctx) {
-	log.Println("Warning: middleware.RequestID() is deprecated since v1.8.3, please use github.com/gofiber/requestid")
+	log.Println("Warning: middleware.RequestID() is deprecated since v1.8.2, please use github.com/gofiber/requestid")
 	// Init config
 	var cfg RequestIDConfig
 	if len(config) > 0 {

--- a/router.go
+++ b/router.go
@@ -83,7 +83,7 @@ func (r *Route) matchRoute(method, path string) (match bool, values []string) {
 	// non-middleware route, http method must match!
 	// the wildcard method is for .All() & .Use() methods
 	// If route is GET, also match HEAD requests
-	if r.Method == method || r.Method[0] == '*' || (r.isGet && method == "HEAD") {
+	if r.Method == method || r.Method[0] == '*' || (r.isGet && isEqual(method, "HEAD")) {
 		// '*' means we match anything
 		if r.isStar {
 			return true, values
@@ -109,7 +109,7 @@ func (r *Route) matchRoute(method, path string) (match bool, values []string) {
 			return true, values
 		}
 		// last thing to do is to check for a simple path match
-		if r.Path == path {
+		if isEqual(r.Path, path) {
 			return true, values
 		}
 	}

--- a/router.go
+++ b/router.go
@@ -83,7 +83,7 @@ func (r *Route) matchRoute(method, path string) (match bool, values []string) {
 	// non-middleware route, http method must match!
 	// the wildcard method is for .All() & .Use() methods
 	// If route is GET, also match HEAD requests
-	if r.Method == method || r.Method[0] == '*' || (r.isGet && isEqual(method, "HEAD")) {
+	if r.Method == method || r.Method[0] == '*' || (r.isGet && len(method) == 4 && method == "HEAD") {
 		// '*' means we match anything
 		if r.isStar {
 			return true, values
@@ -109,7 +109,7 @@ func (r *Route) matchRoute(method, path string) (match bool, values []string) {
 			return true, values
 		}
 		// last thing to do is to check for a simple path match
-		if isEqual(r.Path, path) {
+		if len(r.Path) == len(path) && r.Path == path {
 			return true, values
 		}
 	}

--- a/router.go
+++ b/router.go
@@ -51,8 +51,7 @@ func (app *App) nextRoute(ctx *Ctx) {
 				if err := websocketUpgrader.Upgrade(ctx.Fasthttp, func(fconn *websocket.Conn) {
 					conn := acquireConn(fconn)
 					defer releaseConn(conn)
-					ctx.Conn = conn
-					route.HandleCtx(ctx)
+					route.HandleConn(conn)
 				}); err != nil { // Upgrading failed
 					ctx.SendStatus(400)
 				}

--- a/utils.go
+++ b/utils.go
@@ -39,6 +39,15 @@ func groupPaths(prefix, path string) string {
 	return path
 }
 
+// BenchmarkDefault    322504144    18.6 ns/op // string == string
+// BenchmarkisEqual    353663168    17.0 ns/op // isEqual(string, string)
+func isEqual(a, b string) bool {
+	if len(a) == len(b) {
+		return a == b
+	}
+	return false
+}
+
 func getParams(path string) (params []string) {
 	if len(path) < 1 {
 		return

--- a/utils.go
+++ b/utils.go
@@ -41,12 +41,12 @@ func groupPaths(prefix, path string) string {
 
 // BenchmarkDefault    322504144    18.6 ns/op // string == string
 // BenchmarkisEqual    353663168    17.0 ns/op // isEqual(string, string)
-func isEqual(a, b string) bool {
-	if len(a) == len(b) {
-		return a == b
-	}
-	return false
-}
+// func isEqual(a, b string) bool {
+// 	if len(a) == len(b) {
+// 		return a == b
+// 	}
+// 	return false
+// }
 
 func getParams(path string) (params []string) {
 	if len(path) < 1 {


### PR DESCRIPTION
Able to override the method or path for creating `rewrite` / `methodoverride` middleware.
**[UPDATE]** c.Method(`override ...string`)
**[UPDATE]** c.Path(`override ...string`)

**[FIX]** Add partial comments to all functions for faster development
![](https://i.imgur.com/o1QfitL.png)

**[FIX]** Remove unused `*Conn` from `*Ctx` struct
Please use https://github.com/gofiber/websocket