### PR TITLE
Fixed inconsistency in middleware examples in README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -448,7 +448,7 @@ func main() {
   app := fiber.New()
 
   // Optional recover config
-  config := recover.LoggerConfig{
+  config := recover.Config{
     Handler: func(c *fiber.Ctx, err error) {
 			c.SendString(err.Error())
 			c.SendStatus(500)

--- a/.github/README.md
+++ b/.github/README.md
@@ -304,7 +304,7 @@ func main() {
     app := fiber.New()
 
     // Optional logger config
-    config := logger.LoggerConfig{
+    config := logger.Config{
       Format:     "${time} - ${method} ${path}\n",
       TimeFormat: "Mon, 2 Jan 2006 15:04:05 MST",
     }

--- a/.github/README_de.md
+++ b/.github/README_de.md
@@ -300,7 +300,7 @@ func main() {
     app := fiber.New()
 
     // Optional logger config
-    config := logger.LoggerConfig{
+    config := logger.Config{
       Format:     "${time} - ${method} ${path}\n",
       TimeFormat: "Mon, 2 Jan 2006 15:04:05 MST",
     }

--- a/.github/README_de.md
+++ b/.github/README_de.md
@@ -444,7 +444,7 @@ func main() {
   app := fiber.New()
 
   // Optional recover config
-  config := recover.LoggerConfig{
+  config := recover.Config{
     Handler: func(c *fiber.Ctx, err error) {
 			c.SendString(err.Error())
 			c.SendStatus(500)

--- a/.github/README_es.md
+++ b/.github/README_es.md
@@ -300,7 +300,7 @@ func main() {
     app := fiber.New()
 
     // Optional logger config
-    config := logger.LoggerConfig{
+    config := logger.Config{
       Format:     "${time} - ${method} ${path}\n",
       TimeFormat: "Mon, 2 Jan 2006 15:04:05 MST",
     }

--- a/.github/README_es.md
+++ b/.github/README_es.md
@@ -444,7 +444,7 @@ func main() {
   app := fiber.New()
 
   // Optional recover config
-  config := recover.LoggerConfig{
+  config := recover.Config{
     Handler: func(c *fiber.Ctx, err error) {
 			c.SendString(err.Error())
 			c.SendStatus(500)

--- a/.github/README_fr.md
+++ b/.github/README_fr.md
@@ -300,7 +300,7 @@ func main() {
     app := fiber.New()
 
     // Optional logger config
-    config := logger.LoggerConfig{
+    config := logger.Config{
       Format:     "${time} - ${method} ${path}\n",
       TimeFormat: "Mon, 2 Jan 2006 15:04:05 MST",
     }

--- a/.github/README_fr.md
+++ b/.github/README_fr.md
@@ -444,7 +444,7 @@ func main() {
   app := fiber.New()
 
   // Optional recover config
-  config := recover.LoggerConfig{
+  config := recover.Config{
     Handler: func(c *fiber.Ctx, err error) {
 			c.SendString(err.Error())
 			c.SendStatus(500)

--- a/.github/README_id.md
+++ b/.github/README_id.md
@@ -302,7 +302,7 @@ func main() {
     app := fiber.New()
 
     // Optional logger config
-    config := logger.LoggerConfig{
+    config := logger.Config{
       Format:     "${time} - ${method} ${path}\n",
       TimeFormat: "Mon, 2 Jan 2006 15:04:05 MST",
     }

--- a/.github/README_id.md
+++ b/.github/README_id.md
@@ -446,7 +446,7 @@ func main() {
   app := fiber.New()
 
   // Optional recover config
-  config := recover.LoggerConfig{
+  config := recover.Config{
     Handler: func(c *fiber.Ctx, err error) {
 			c.SendString(err.Error())
 			c.SendStatus(500)

--- a/.github/README_ja.md
+++ b/.github/README_ja.md
@@ -448,7 +448,7 @@ func main() {
   app := fiber.New()
 
   // Optional recover config
-  config := recover.LoggerConfig{
+  config := recover.Config{
     Handler: func(c *fiber.Ctx, err error) {
 			c.SendString(err.Error())
 			c.SendStatus(500)

--- a/.github/README_ja.md
+++ b/.github/README_ja.md
@@ -304,7 +304,7 @@ func main() {
     app := fiber.New()
 
     // Optional logger config
-    config := logger.LoggerConfig{
+    config := logger.Config{
       Format:     "${time} - ${method} ${path}\n",
       TimeFormat: "Mon, 2 Jan 2006 15:04:05 MST",
     }

--- a/.github/README_ko.md
+++ b/.github/README_ko.md
@@ -448,7 +448,7 @@ func main() {
   app := fiber.New()
 
   // Optional recover config
-  config := recover.LoggerConfig{
+  config := recover.Config{
     Handler: func(c *fiber.Ctx, err error) {
 			c.SendString(err.Error())
 			c.SendStatus(500)

--- a/.github/README_ko.md
+++ b/.github/README_ko.md
@@ -304,7 +304,7 @@ func main() {
     app := fiber.New()
 
     // Optional logger config
-    config := logger.LoggerConfig{
+    config := logger.Config{
       Format:     "${time} - ${method} ${path}\n",
       TimeFormat: "Mon, 2 Jan 2006 15:04:05 MST",
     }

--- a/.github/README_pt.md
+++ b/.github/README_pt.md
@@ -300,7 +300,7 @@ func main() {
     app := fiber.New()
 
     // Optional logger config
-    config := logger.LoggerConfig{
+    config := logger.Config{
       Format:     "${time} - ${method} ${path}\n",
       TimeFormat: "Mon, 2 Jan 2006 15:04:05 MST",
     }

--- a/.github/README_pt.md
+++ b/.github/README_pt.md
@@ -444,7 +444,7 @@ func main() {
   app := fiber.New()
 
   // Optional recover config
-  config := recover.LoggerConfig{
+  config := recover.Config{
     Handler: func(c *fiber.Ctx, err error) {
 			c.SendString(err.Error())
 			c.SendStatus(500)

--- a/.github/README_ru.md
+++ b/.github/README_ru.md
@@ -302,7 +302,7 @@ func main() {
     app := fiber.New()
 
     // Optional logger config
-    config := logger.LoggerConfig{
+    config := logger.Config{
       Format:     "${time} - ${method} ${path}\n",
       TimeFormat: "Mon, 2 Jan 2006 15:04:05 MST",
     }

--- a/.github/README_ru.md
+++ b/.github/README_ru.md
@@ -446,7 +446,7 @@ func main() {
   app := fiber.New()
 
   // Optional recover config
-  config := recover.LoggerConfig{
+  config := recover.Config{
     Handler: func(c *fiber.Ctx, err error) {
 			c.SendString(err.Error())
 			c.SendStatus(500)

--- a/.github/README_tr.md
+++ b/.github/README_tr.md
@@ -300,7 +300,7 @@ func main() {
     app := fiber.New()
 
     // Optional logger config
-    config := logger.LoggerConfig{
+    config := logger.Config{
       Format:     "${time} - ${method} ${path}\n",
       TimeFormat: "Mon, 2 Jan 2006 15:04:05 MST",
     }

--- a/.github/README_tr.md
+++ b/.github/README_tr.md
@@ -444,7 +444,7 @@ func main() {
   app := fiber.New()
 
   // Optional recover config
-  config := recover.LoggerConfig{
+  config := recover.Config{
     Handler: func(c *fiber.Ctx, err error) {
 			c.SendString(err.Error())
 			c.SendStatus(500)

--- a/.github/README_zh-CN.md
+++ b/.github/README_zh-CN.md
@@ -300,7 +300,7 @@ func main() {
     app := fiber.New()
 
     // Optional logger config
-    config := logger.LoggerConfig{
+    config := logger.Config{
       Format:     "${time} - ${method} ${path}\n",
       TimeFormat: "Mon, 2 Jan 2006 15:04:05 MST",
     }

--- a/.github/README_zh-CN.md
+++ b/.github/README_zh-CN.md
@@ -444,7 +444,7 @@ func main() {
   app := fiber.New()
 
   // Optional recover config
-  config := recover.LoggerConfig{
+  config := recover.Config{
     Handler: func(c *fiber.Ctx, err error) {
 			c.SendString(err.Error())
 			c.SendStatus(500)


### PR DESCRIPTION
After copying this example from the logger middleware
```
        // Optional logger config
	config := logger.LoggerConfig{
		Format:     "${time} - ${method} ${path}\n",
		TimeFormat: "Mon, 2 Jan 2006 15:04:05 MST",
	}

	// Logger with config
	app.Use(logger.New(config))
```
and running it I got the error `./main.go:18:12: undefined: logger.LoggerConfig`, changing `.LoggerConfig` to `.Config` fixed the issue as I imagine there was a name change on the API recently.

Similarly, in the example for the recovery middleware there is a `recover.LoggerConfig` instead of `recover.Config`. 

I've renamed all occurances of `LoggerConfig` in the README files to `Config` to fix these issues so the examples can be copy and pasted without errors. I thought I'd fix it for you guys instead of just telling you about it, my apologies if I've got something wrong.
