### PR TITLE
v1.9.2

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -24,6 +24,9 @@
   <a href="https://github.com/gofiber/fiber/blob/master/.github/README_de.md">
     <img height="20px" src="https://github.com/gofiber/docs/blob/master/static/flags/de.svg">
   </a>
+  <a href="https://github.com/gofiber/fiber/blob/master/.github/README_nl.md">
+    <img height="20px" src="https://github.com/gofiber/docs/blob/master/static/flags/nl.svg">
+  </a>
   <a href="https://github.com/gofiber/fiber/blob/master/.github/README_ko.md">
     <img height="20px" src="https://github.com/gofiber/docs/blob/master/static/flags/ko.svg">
   </a>

--- a/ctx.go
+++ b/ctx.go
@@ -248,6 +248,7 @@ func (ctx *Ctx) Body(key ...string) string {
 	}
 	// Return post value by key
 	if len(key) > 0 {
+		fmt.Println("DEPRECATED: c.Body(\"" + key[0] + "\") is deprecated, please use c.FormValue(\"" + key[0] + "\") instead.")
 		return getString(ctx.Fasthttp.Request.PostArgs().Peek(key[0]))
 	}
 	return ""
@@ -283,7 +284,7 @@ func (ctx *Ctx) BodyParser(out interface{}) error {
 		}
 		return schemaDecoderForm.Decode(out, data.Value)
 	}
-	// query Params
+	// query params
 	if ctx.Fasthttp.QueryArgs().Len() > 0 {
 		data := make(map[string][]string)
 		ctx.Fasthttp.QueryArgs().VisitAll(func(key []byte, val []byte) {
@@ -342,7 +343,7 @@ func (ctx *Ctx) Cookie(cookie *Cookie) {
 // Cookies is used for getting a cookie value by key
 func (ctx *Ctx) Cookies(key ...string) (value string) {
 	if len(key) == 0 {
-		fmt.Println("Deprecation Warning: c.Cookies() without an key is deprecated since v1.9.2, please use c.Get(\"Cookies\") instead to get the raw cookie header.")
+		fmt.Println("DEPRECATED: c.Cookies() without a key is deprecated, please use c.Get(\"Cookies\") to get the cookie header instead.")
 		return ctx.Get(HeaderCookie)
 	}
 	return getString(ctx.Fasthttp.Request.Header.Cookie(key[0]))

--- a/ctx.go
+++ b/ctx.go
@@ -342,6 +342,7 @@ func (ctx *Ctx) Cookie(cookie *Cookie) {
 // Cookies is used for getting a cookie value by key
 func (ctx *Ctx) Cookies(key ...string) (value string) {
 	if len(key) == 0 {
+		fmt.Println("Deprecation Warning: c.Cookies() without an key is deprecated since v1.9.2, please use c.Get(\"Cookies\") instead to get the raw cookie header.")
 		return ctx.Get(HeaderCookie)
 	}
 	return getString(ctx.Fasthttp.Request.Header.Cookie(key[0]))


### PR DESCRIPTION
**[DEPRECATED]** `c.Cookies() is deprecated since v1.9.2, please use c.Get("cookies")` 

```go
👍 ctx.Cookies("name")

❌ ctx.Cookies()
👍 ctx.Get("Cookies")
```