### PR TITLE
add validator

### DIFF
--- a/app.go
+++ b/app.go
@@ -24,16 +24,22 @@ import (
 )
 
 // Version of current package
-const Version = "1.9.2"
+const Version = "1.9.3"
 
 // Map is a shortcut for map[string]interface{}
 type Map map[string]interface{}
 
+// Validator is the interface that wraps the Validate function.
+type Validator interface {
+	Validate(i interface{}) error
+}
+
 // App denotes the Fiber application.
 type App struct {
-	server   *fasthttp.Server // FastHTTP server
-	routes   []*Route         // Route stack
-	Settings *Settings        // Fiber settings
+	server    *fasthttp.Server // FastHTTP server
+	routes    []*Route         // Route stack
+	Settings  *Settings        // Fiber settings
+	Validator Validator        // Validator
 }
 
 // Settings holds is a struct holding the server settings

--- a/ctx.go
+++ b/ctx.go
@@ -6,7 +6,6 @@ package fiber
 
 import (
 	"bytes"
-
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -252,6 +251,14 @@ func (ctx *Ctx) Body(key ...string) string {
 		return getString(ctx.Fasthttp.Request.PostArgs().Peek(key[0]))
 	}
 	return ""
+}
+
+// Validate for structs and individual fields based on tags.
+func (ctx *Ctx) Validate(i interface{}) error {
+	if ctx.app.Validator == nil {
+		return fmt.Errorf("validator not registered")
+	}
+	return ctx.app.Validator.Validate(i)
 }
 
 // BodyParser binds the request body to a struct.


### PR DESCRIPTION
you can register a custom validator using App#Validator and leverage third-party libraries.
like in [echo](https://echo.labstack.com/guide/request) 

Example below uses https://github.com/go-playground/validator framework for validation:

```go
type (
	User struct {
		Name  string `json:"name" validate:"required"`
		Email string `json:"email" validate:"required,email"`
	}

	CustomValidator struct {
		validator *validator.Validate
	}
)

func (v *CustomValidator) Validate(i interface{}) error {
	return v.validator.Struct(i)
}

app := fiber.New()
app.Validator = &CustomValidator{validator: validator.New()}

app.Post("/test", func(ctx *Ctx) {
		user:= new(User)
		if err := ctx.BodyParser(user); err != nil {
			log.Fatal(err)
		}

		if err := ctx.Validate(user); err != nil {
			log.Fatal(err)
		}
	})
```