### PR TITLE
Modify

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -716,7 +716,7 @@ func (ctx *Ctx) Send(bodies ...interface{}) {
 	if len(bodies) > 0 {
 		ctx.Fasthttp.Response.SetBodyString("")
 	}
-	ctx.Write(bodies)
+	ctx.Write(bodies...)
 }
 
 // SendBytes sets the HTTP response body for []byte types

--- a/ctx.go
+++ b/ctx.go
@@ -6,7 +6,6 @@ package fiber
 
 import (
 	"bytes"
-
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -36,7 +35,7 @@ type Ctx struct {
 	path     string               // HTTP path
 	values   []string             // Route parameter values
 	Fasthttp *fasthttp.RequestCtx // Reference to *fasthttp.RequestCtx
-	err      error                // Contains error if catched
+	err      error                // Contains error if caught
 }
 
 // Range struct

--- a/ctx.go
+++ b/ctx.go
@@ -716,16 +716,7 @@ func (ctx *Ctx) Send(bodies ...interface{}) {
 	if len(bodies) > 0 {
 		ctx.Fasthttp.Response.SetBodyString("")
 	}
-	for i := range bodies {
-		switch body := bodies[i].(type) {
-		case string:
-			ctx.Fasthttp.Response.AppendBodyString(body)
-		case []byte:
-			ctx.Fasthttp.Response.AppendBodyString(getString(body))
-		default:
-			ctx.Fasthttp.Response.AppendBodyString(fmt.Sprintf("%v", body))
-		}
-	}
+	ctx.Write(bodies)
 }
 
 // SendBytes sets the HTTP response body for []byte types


### PR DESCRIPTION
```
for i := range bodies {
		switch body := bodies[i].(type) {
		case string:
			ctx.Fasthttp.Response.AppendBodyString(body)
		case []byte:
			ctx.Fasthttp.Response.AppendBodyString(getString(body))
		default:
			ctx.Fasthttp.Response.AppendBodyString(fmt.Sprintf("%v", body))
		}
	}
```
This code block is implemented in the `ctx.Write` method, so there is no need to implement again. 

