### PR TITLE
update: ctx.BodyParser

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -287,7 +287,6 @@ func (ctx *Ctx) BodyParser(out interface{}) error {
 	if ctx.Fasthttp.QueryArgs().Len() > 0 {
 		data := make(map[string][]string)
 		ctx.Fasthttp.QueryArgs().VisitAll(func(key []byte, val []byte) {
-			//data[getString(key)] = []string{getString(val)}
 			data[getString(key)] = append(data[getString(key)], getString(val))
 		})
 		return schemaDecoderQuery.Decode(out, data)

--- a/ctx.go
+++ b/ctx.go
@@ -287,7 +287,8 @@ func (ctx *Ctx) BodyParser(out interface{}) error {
 	if ctx.Fasthttp.QueryArgs().Len() > 0 {
 		data := make(map[string][]string)
 		ctx.Fasthttp.QueryArgs().VisitAll(func(key []byte, val []byte) {
-			data[getString(key)] = []string{getString(val)}
+			//data[getString(key)] = []string{getString(val)}
+			data[getString(key)] = append(data[getString(key)], getString(val))
 		})
 		return schemaDecoderQuery.Decode(out, data)
 	}


### PR DESCRIPTION
If the query string is `id=1&name=tom&hobby=basketball&hobby=football`, then can be parsed and get all `hobby` param。
```
type User struct {
   Id  int
   Name string
  Hobby []string
}
```