### PR TITLE
Feature: Adds template caching

### DIFF
--- a/app.go
+++ b/app.go
@@ -143,13 +143,12 @@ func loadHTMLTemplates(folder, extension string, f loadHTMLTemplateFunc) error {
 				return werr
 			}
 
-			path = filepath.Clean(path)
-			content, werr := ioutil.ReadFile(path) // #nosec G304
+			content, werr := ioutil.ReadFile(filepath.Clean(path))
 			if werr != nil {
 				return werr
 			}
 
-			if werr := f(path, content); werr != nil {
+			if werr := f(strings.TrimSuffix(path[len(cleanRootPath)+1:], extension), content); werr != nil {
 				return werr
 			}
 		}

--- a/ctx.go
+++ b/ctx.go
@@ -663,20 +663,20 @@ func (ctx *Ctx) Render(file string, bind interface{}) error {
 	var html string
 	var tmpl *template.Template
 
-	if ctx.app.Settings.TemplateFolder != "" {
-		file = filepath.Join(ctx.app.Settings.TemplateFolder, file)
-	}
-	if ctx.app.Settings.TemplateExtension != "" {
-		file = file + ctx.app.Settings.TemplateExtension
-	}
-	file = filepath.Clean(file)
 	if ctx.app.templates != nil {
 		tmpl = ctx.app.templates.Lookup(file)
 	}
 
 	if tmpl == nil {
-		// #nosec G304
-		if raw, err = ioutil.ReadFile(file); err != nil {
+		filePath := file
+
+		if ctx.app.Settings.TemplateFolder != "" {
+			filePath = filepath.Join(ctx.app.Settings.TemplateFolder, filePath)
+		}
+		if ctx.app.Settings.TemplateExtension != "" {
+			filePath = filePath + ctx.app.Settings.TemplateExtension
+		}
+		if raw, err = ioutil.ReadFile(filepath.Clean(filePath)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Currently templates files are read and parsed for each call to Render, and are not cached.

This adds a `func (app *App) LoadHTMLTemplates() error` method that would load all templates specified by `TemplateFolder` and `TemplateExtension` into the template engine cache.

This currently only supports the default HTML cache, as currently template engines only receive the template file data. https://github.com/gofiber/fiber/issues/277 is needed before this could support other engines, but would probably break the lib API.

The Render call will then query the cache first if it's not empty (for the default engine), execute the template if it exists, or read it from the filesystem otherwise.

For example if we have (with `TemplateFolder = "views"` and `TemplateExtension = ".tmpl"`):
```
.
└── views
    ├── header.html.tmpl
    ├── index.html.tmpl
    └── shared
        └── index.hmtl.tmpl
```

It will have the following templates in cache: `header.html`, `index.html` and `shared/index.html`, names that can be used for nested templates.

Note: no unit tests for now, waiting for feedback first. Render doesn't have tests at the moment