### PR TITLE
Add Content-Length to app.Test()

### DIFF
--- a/app.go
+++ b/app.go
@@ -445,6 +445,10 @@ func (app *App) Test(request *http.Request, msTimeout ...int) (*http.Response, e
 	if len(msTimeout) > 0 {
 		timeout = msTimeout[0]
 	}
+	// Add Content-Length if not provided
+	if request.Header.Get("Content-Length") == "" {
+		request.Header.Add("Content-Length", strconv.FormatInt(request.ContentLength, 10))
+	}
 	// Dump raw http request
 	dump, err := httputil.DumpRequest(request, true)
 	if err != nil {

--- a/app.go
+++ b/app.go
@@ -445,8 +445,8 @@ func (app *App) Test(request *http.Request, msTimeout ...int) (*http.Response, e
 	if len(msTimeout) > 0 {
 		timeout = msTimeout[0]
 	}
-	// Add Content-Length if not provided
-	if request.Header.Get("Content-Length") == "" {
+	// Add Content-Length if not provided with body
+	if request.Body != http.NoBody && request.Header.Get("Content-Length") == "" {
 		request.Header.Add("Content-Length", strconv.FormatInt(request.ContentLength, 10))
 	}
 	// Dump raw http request


### PR DESCRIPTION
When not providing a `Content-Length` when passing a `Body` it will throw an `EOF` error in `app.Test()`