### PR TITLE
Use root Group instead of the App instance

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -15,7 +15,7 @@ import (
 	fasthttp "github.com/valyala/fasthttp"
 )
 
-func testStatus200(t *testing.T, app *App, url string, method string) {
+func testStatus200(t *testing.T, app *Group, url string, method string) {
 	req := httptest.NewRequest(method, url, nil)
 
 	resp, err := app.Test(req)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.11
 require (
 	github.com/gofiber/utils v0.0.3
 	github.com/gorilla/schema v1.1.0
+	github.com/stretchr/testify v1.5.1
 	github.com/valyala/bytebufferpool v1.0.0
 	github.com/valyala/fasthttp v1.13.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,18 @@
 github.com/andybalholm/brotli v1.0.0 h1:7UCwP93aiSfvWpapti8g88vVVGp2qqtGyePsSuDafo4=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gofiber/utils v0.0.3 h1:nNQKfZbZAGmOHqTOYplJwwOvX1Mg/NsTjfFO4/wTGrU=
 github.com/gofiber/utils v0.0.3/go.mod h1:pacRFtghAE3UoknMOUiXh2Io/nLWSUHtQCi/3QASsOc=
 github.com/gorilla/schema v1.1.0 h1:CamqUDOFUBqzrvxuz2vEwo8+SUdwsluFh7IlzJh30LY=
 github.com/gorilla/schema v1.1.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/klauspost/compress v1.10.4 h1:jFzIFaf586tquEB5EhzQG0HwGNSlgAJpG53G6Ss11wc=
 github.com/klauspost/compress v1.10.4/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.13.1 h1:Z7kVhKP9NZz+tCSY7AVhCMPPAk7b+e5fq0l/BfdTlFc=
@@ -18,3 +25,7 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/req_test.go
+++ b/req_test.go
@@ -1,0 +1,76 @@
+// ⚡️ Fiber is an Express inspired web framework written in Go with ☕️
+// 🤖 Github Repository: https://gitee.com/azhai/fiber-u8l
+// 📌 API Documentation: https://docs.gofiber.io
+
+package fiber
+
+import (
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var expectBodies = []string{
+	`{"code":200,"data":{"param":"john"}}`,
+	`{"code":200,"data":{"page":1,"size":20}}`,
+}
+
+func CreateTestGroup() *Group {
+	grp := New().Group("/test")
+	grp.Get("/:param", func(c *Ctx) {
+		param := c.Params("param")
+		data := Map{"param": param}
+		c.JSON(Map{"code": 200, "data": data})
+	})
+	grp.Get("/page/:page/:size", func(c *Ctx) {
+		page, size := 1, 20
+		if pageStr := c.FormValue("page"); pageStr != "" {
+			page, _ = strconv.Atoi(pageStr)
+		}
+		if sizeStr := c.FormValue("size"); sizeStr != "" {
+			size, _ = strconv.Atoi(sizeStr)
+		}
+		data := Map{"page": page, "size": size}
+		c.JSON(Map{"code": 200, "data": data})
+	})
+	return grp
+}
+
+//func CreateSeniorGroup() *Group {
+//	grp := New().Group("/test")
+//	grp.Get("/:param", func(c *Ctx) {
+//		param := c.ParamStr("param")
+//		c.Reply(Map{"param": param})
+//	})
+//	grp.Get("/page/:page/:size", func(c *Ctx) {
+//		page, size := c.FetchInt("page", 1), c.FetchInt("size", 20)
+//		c.Reply(Map{"page": page, "size": size})
+//	})
+//	return grp
+//}
+
+func Test_Request01_ParamStr(t *testing.T) {
+	grp := CreateTestGroup()
+	req := httptest.NewRequest("GET", "/test/john", nil)
+	resp, err := grp.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.StatusCode, 200)
+	body := make([]byte, 1024)
+	n, _ := resp.Body.Read(body)
+	assert.Greater(t, n, 0)
+	assert.Equal(t, string(body[:n]), expectBodies[0])
+}
+
+func Test_Request02_FetchInt(t *testing.T) {
+	grp := CreateTestGroup()
+	req := httptest.NewRequest("GET", "/test/page/3/7", nil)
+	resp, err := grp.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.StatusCode, 200)
+	body := make([]byte, 1024)
+	n, _ := resp.Body.Read(body)
+	assert.Greater(t, n, 0)
+	assert.Equal(t, string(body[:n]), expectBodies[1])
+}

--- a/router_test.go
+++ b/router_test.go
@@ -169,7 +169,7 @@ func Test_Route_Match_Middleware_Root(t *testing.T) {
 ///////////////// BENCHMARKS /////////////////
 //////////////////////////////////////////////
 
-func registerDummyRoutes(app *App) {
+func registerDummyRoutes(app *Group) {
 	h := func(c *Ctx) {}
 	for _, r := range githubAPI {
 		switch r.method {


### PR DESCRIPTION
* Use root Group instead of the App instance
* Remove some methods of App when Group extends App