### PR TITLE
Feature: Add Settings StartupBanner & HideStartupBanner

### DIFF
--- a/app.go
+++ b/app.go
@@ -28,9 +28,7 @@ import (
 // Version of current package
 const Version = "1.10.1"
 
-var fiberASCIIBanner = fmt.Sprintf("        _______ __\n  ____ / ____(_) /_  ___  _____\n_____ / /_  / / __ \\/ _ \\/ ___/\n  __ / __/ / / /_/ /  __/ /\n    /_/   /_/_.___/\\___/_/ v%s\n", Version)
-
-// Map is a shortcut for map[string]interface{}, usefull for JSON returns
+// Map is a shortcut for map[string]interface{}, useful for JSON returns
 type Map map[string]interface{}
 
 // Handler ...
@@ -93,13 +91,7 @@ type Settings struct {
 	// By default all header names are normalized: conteNT-tYPE -> Content-Type
 	DisableHeaderNormalizing bool // default: false
 
-	// Startup banner
-	StartupBanner string // default: fiberASCIIBanner
-
-	// When set to true, it will hide the startup banner
-	HideStartupBanner bool // default: false
-
-	// When set to true, it will not print out the StartupBanner and "listening" on message
+	// When set to true, it will not print out the «Fiber» ASCII art
 	DisableStartupMessage bool // default: false
 
 	// Templates is the interface that wraps the Render function.
@@ -174,10 +166,9 @@ func New(settings ...*Settings) *App {
 		},
 		// Set default settings
 		Settings: &Settings{
-			Prefork:       utils.GetArgument("-prefork"),
-			BodyLimit:     4 * 1024 * 1024,
-			Concurrency:   256 * 1024,
-			StartupBanner: fiberASCIIBanner,
+			Prefork:     utils.GetArgument("-prefork"),
+			BodyLimit:   4 * 1024 * 1024,
+			Concurrency: 256 * 1024,
 		},
 	}
 	// Overwrite settings if provided
@@ -196,9 +187,6 @@ func New(settings ...*Settings) *App {
 		if app.Settings.Immutable {
 			getBytes = getBytesImmutable
 			getString = getStringImmutable
-		}
-		if app.Settings.StartupBanner == "" {
-			app.Settings.StartupBanner = fiberASCIIBanner
 		}
 	}
 	// Initialize app
@@ -314,11 +302,9 @@ func (app *App) Serve(ln net.Listener, tlsconfig ...*tls.Config) error {
 	}
 	// Print startup message
 	if !app.Settings.DisableStartupMessage {
-		if !app.Settings.HideStartupBanner {
-			fmt.Print(app.Settings.StartupBanner)
-		}
-		fmt.Printf("Started listening on %s\n", ln.Addr().String())
+		fmt.Printf("        _______ __\n  ____ / ____(_) /_  ___  _____\n_____ / /_  / / __ \\/ _ \\/ ___/\n  __ / __/ / / /_/ /  __/ /\n    /_/   /_/_.___/\\___/_/ v%s\n", Version)
 	}
+	fmt.Printf("Started listening on %s\n", ln.Addr().String())
 	return app.server.Serve(ln)
 }
 
@@ -357,13 +343,10 @@ func (app *App) Listen(address interface{}, tlsconfig ...*tls.Config) error {
 	}
 	// Print startup message
 	if !app.Settings.DisableStartupMessage && !utils.GetArgument("-child") {
-		if !app.Settings.HideStartupBanner {
-			if !app.Settings.HideStartupBanner {
-				fmt.Print(app.Settings.StartupBanner)
-			}
-		}
-		fmt.Printf("Started listening on %s\n", ln.Addr().String())
+		fmt.Printf("        _______ __\n  ____ / ____(_) /_  ___  _____\n_____ / /_  / / __ \\/ _ \\/ ___/\n  __ / __/ / / /_/ /  __/ /\n    /_/   /_/_.___/\\___/_/ v%s\n", Version)
 	}
+	fmt.Printf("Started listening on %s\n", ln.Addr().String())
+
 	return app.server.Serve(ln)
 }
 


### PR DESCRIPTION
Current `Settings` when creating a new **App** allow to enable or disable the «startup message», which is shown when the server is started.

This message, like in most frameworks, displays a «banner» of the library (in this case «FIBER» in ASCII art), and a message with info about the address the server is currently listening.

The thing is the listening info is pretty informative and usually we want to show it (at least we know that way when the server is ready), but the «banner» before, most of the times is just decorative.
Or we want to replace it with another banner or info (as example, if we're developing an app that uses «Fiber» but we want to add instead a «banner» of the project using it, its version, some initial comments, etcetera).

So I added a pair of extra settings just for that. One to allow the `StartupBanner` customization (it defaults to the current Fiber ASCII Art if is not passed) and another for being able to `HideStartupBanner` if we want (and only show the «listening» message).

I read the [CONTRIBUTING](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md) and it says that unit tests are mandatory for new features... but I reviewed the unit tests and there are no testing about **App** `Settings`...At least I didn't find where the startup message content is being tested, if the test is there, so IDK. If tests about that should be written, I will try to do it :3. This is my first PR to a `golang` repository, so be easy on me :þ.

If this PR passes the cut, I could also update the docs about it (I saw that is in another repository).

**Note**: in fact, I tought it would be preferable something like a callback in `app.Listen` (just like Express does, if I'm not wrong), so when it's successful, you control exactly what you want to display (instead of several config settings or not configurable enough settings), but I just don't know if that is feasible with golang/Fiber or how (I'm pretty new with golang), so because of I went this way. It seems like Golang doesn't have optional arguments, just and array of extra arguments of the same type and `Listen` & `Serve` already has that occupied with a `tlsconfig` so >_<.