### PR TITLE
Router updates

### DIFF
--- a/app.go
+++ b/app.go
@@ -31,7 +31,7 @@ const Version = "1.10.2"
 // Map is a shortcut for map[string]interface{}, useful for JSON returns
 type Map map[string]interface{}
 
-// Handler ...
+// Handler defines a function to serve HTTP requests.
 type Handler = func(*Ctx)
 
 // App denotes the Fiber application.

--- a/app.go
+++ b/app.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Version of current package
-const Version = "1.10.1"
+const Version = "1.10.2"
 
 // Map is a shortcut for map[string]interface{}, useful for JSON returns
 type Map map[string]interface{}

--- a/app.go
+++ b/app.go
@@ -47,8 +47,6 @@ type App struct {
 	Settings *Settings
 }
 
-// Enables automatic redirection if the current route can't be matched but a handler for the path with (without) the trailing slash exists. For example if /foo/ is requested but a route only exists for /foo, the client is redirected to /foo with http status code 301 for GET requests and 308 for all other request methods.
-
 // Settings holds is a struct holding the server settings
 type Settings struct {
 	// This will spawn multiple Go processes listening on the same port

--- a/app_test.go
+++ b/app_test.go
@@ -208,10 +208,10 @@ func Test_App_Shutdown(t *testing.T) {
 func Test_App_Static_Index(t *testing.T) {
 	app := New()
 
+	app.Static("/prefix", "./.github/workflows")
 	app.Static("/", "./.github")
 
-	req := httptest.NewRequest("GET", "/", nil)
-	resp, err := app.Test(req)
+	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
 	utils.AssertEqual(t, false, resp.Header.Get("Content-Length") == "")
@@ -220,6 +220,7 @@ func Test_App_Static_Index(t *testing.T) {
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, true, strings.Contains(string(body), "Hello, World!"))
+
 }
 func Test_App_Static_Group(t *testing.T) {
 	app := New()

--- a/ctx.go
+++ b/ctx.go
@@ -781,7 +781,7 @@ func (ctx *Ctx) Secure() bool {
 	return ctx.Fasthttp.IsTLS()
 }
 
-// Send sets the HTTP response body. The Send body can be of any type.
+// Send sets the HTTP response body. The input can be of any type, io.Reader is also supported.
 func (ctx *Ctx) Send(bodies ...interface{}) {
 	if len(bodies) > 0 {
 		ctx.Fasthttp.Response.SetBodyString("")
@@ -877,7 +877,7 @@ func (ctx *Ctx) Vary(fields ...string) {
 	ctx.Append(HeaderVary, fields...)
 }
 
-// Write appends any input to the HTTP body response.
+// Write appends any input to the HTTP body response, io.Reader is also supported as input.
 func (ctx *Ctx) Write(bodies ...interface{}) {
 	for i := range bodies {
 		switch body := bodies[i].(type) {

--- a/ctx.go
+++ b/ctx.go
@@ -826,6 +826,16 @@ func (ctx *Ctx) SendString(body string) {
 	ctx.Fasthttp.Response.SetBodyString(body)
 }
 
+// SendStream sets response body stream and optional body size
+func (ctx *Ctx) SendStream(stream io.Reader, size ...int) {
+	if len(size) > 0 && size[0] >= 0 {
+		ctx.Fasthttp.Response.SetBodyStream(stream, size[0])
+	} else {
+		ctx.Fasthttp.Response.SetBodyStream(stream, -1)
+		ctx.Set(HeaderContentLength, strconv.Itoa(len(ctx.Fasthttp.Response.Body())))
+	}
+}
+
 // Set sets the response’s HTTP header field to the specified key, value.
 func (ctx *Ctx) Set(key string, val string) {
 	ctx.Fasthttp.Response.Header.Set(key, val)
@@ -879,6 +889,9 @@ func (ctx *Ctx) Write(bodies ...interface{}) {
 			ctx.Fasthttp.Response.AppendBodyString(strconv.Itoa(body))
 		case bool:
 			ctx.Fasthttp.Response.AppendBodyString(strconv.FormatBool(body))
+		case io.Reader:
+			ctx.Fasthttp.Response.SetBodyStream(body, -1)
+			ctx.Set(HeaderContentLength, strconv.Itoa(len(ctx.Fasthttp.Response.Body())))
 		default:
 			ctx.Fasthttp.Response.AppendBodyString(fmt.Sprintf("%v", body))
 		}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -8,6 +8,7 @@ package fiber
 // go test -run Test_Ctx
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -1061,6 +1062,25 @@ func Test_Ctx_SendString(t *testing.T) {
 	defer app.ReleaseCtx(ctx)
 	ctx.SendString("Don't crash please")
 	utils.AssertEqual(t, "Don't crash please", string(ctx.Fasthttp.Response.Body()))
+}
+
+// go test -run Test_Ctx_SendStream
+func Test_Ctx_SendStream(t *testing.T) {
+	t.Parallel()
+	app := New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+
+	ctx.SendStream(bytes.NewReader([]byte("Don't crash please")))
+	utils.AssertEqual(t, "Don't crash please", string(ctx.Fasthttp.Response.Body()))
+
+	ctx.SendStream(bufio.NewReader(bytes.NewReader([]byte("Hello bufio"))))
+	utils.AssertEqual(t, "Hello bufio", string(ctx.Fasthttp.Response.Body()))
+
+	file, err := os.Open("./.github/index.html")
+	utils.AssertEqual(t, nil, err)
+	ctx.SendStream(bufio.NewReader(file))
+	utils.AssertEqual(t, "227", string(ctx.Fasthttp.Response.Header.Peek("Content-Length")))
 }
 
 // go test -run Test_Ctx_Set

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1080,7 +1080,7 @@ func Test_Ctx_SendStream(t *testing.T) {
 	file, err := os.Open("./.github/index.html")
 	utils.AssertEqual(t, nil, err)
 	ctx.SendStream(bufio.NewReader(file))
-	utils.AssertEqual(t, "227", string(ctx.Fasthttp.Response.Header.Peek("Content-Length")))
+	utils.AssertEqual(t, true, (ctx.Fasthttp.Response.Header.ContentLength() > 200))
 }
 
 // go test -run Test_Ctx_Set

--- a/router.go
+++ b/router.go
@@ -87,6 +87,7 @@ func (app *App) next(ctx *Ctx) bool {
 		// Stop scanning the stack
 		return true
 	}
+	// If c.Next() does not match, return 404
 	ctx.SendStatus(404)
 	ctx.SendString("Cannot " + ctx.method + " " + ctx.pathOriginal)
 	return false
@@ -99,12 +100,8 @@ func (app *App) handler(rctx *fasthttp.RequestCtx) {
 	ctx.prettifyPath()
 	// Find match in stack
 	match := app.next(ctx)
-	// Send a 404 by default if no route matched
-	if !match {
-		ctx.SendStatus(404)
-		ctx.SendString("Cannot " + ctx.method + " " + ctx.pathOriginal)
-	} else if app.Settings.ETag {
-		// Generate ETag if enabled
+	// Generate ETag if enabled
+	if match && app.Settings.ETag {
 		setETag(ctx, false)
 	}
 	// Release Ctx

--- a/router.go
+++ b/router.go
@@ -98,7 +98,7 @@ func (app *App) handler(rctx *fasthttp.RequestCtx) {
 	// Find match in stack
 	match := app.next(ctx)
 	// Send a 404 by default if no route matched
-	if !match || len(ctx.Fasthttp.Response.Body()) == 0 {
+	if !match || ctx.route.use && len(ctx.Fasthttp.Response.Body()) == 0 {
 		ctx.SendStatus(404)
 		ctx.SendString("Cannot " + ctx.method + " " + ctx.pathOriginal)
 	} else if app.Settings.ETag {

--- a/router.go
+++ b/router.go
@@ -98,7 +98,7 @@ func (app *App) handler(rctx *fasthttp.RequestCtx) {
 	// Find match in stack
 	match := app.next(ctx)
 	// Send a 404 by default if no route matched
-	if !match || ctx.route.use && len(ctx.Fasthttp.Response.Body()) == 0 {
+	if !match {
 		ctx.SendStatus(404)
 		ctx.SendString("Cannot " + ctx.method + " " + ctx.pathOriginal)
 	} else if app.Settings.ETag {
@@ -259,6 +259,7 @@ func (app *App) registerStatic(prefix, root string, config ...Static) *Route {
 			return
 		}
 		// Reset response to default
+		c.Fasthttp.SetContentType("") // Issue #420
 		c.Fasthttp.Response.SetStatusCode(200)
 		c.Fasthttp.Response.SetBodyString("")
 		// Next middleware

--- a/router.go
+++ b/router.go
@@ -87,6 +87,8 @@ func (app *App) next(ctx *Ctx) bool {
 		// Stop scanning the stack
 		return true
 	}
+	ctx.SendStatus(404)
+	ctx.SendString("Cannot " + ctx.method + " " + ctx.pathOriginal)
 	return false
 }
 

--- a/router.go
+++ b/router.go
@@ -5,7 +5,6 @@
 package fiber
 
 import (
-	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -101,7 +100,7 @@ func (app *App) handler(rctx *fasthttp.RequestCtx) {
 	// Send a 404 by default if no route matched
 	if !match || len(ctx.Fasthttp.Response.Body()) == 0 {
 		ctx.SendStatus(404)
-		ctx.SendString(fmt.Sprintf("Cannot %s %s", ctx.method, ctx.pathOriginal))
+		ctx.SendString("Cannot " + ctx.method + " " + ctx.pathOriginal)
 	} else if app.Settings.ETag {
 		// Generate ETag if enabled
 		setETag(ctx, false)

--- a/router.go
+++ b/router.go
@@ -5,6 +5,7 @@
 package fiber
 
 import (
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -98,8 +99,9 @@ func (app *App) handler(rctx *fasthttp.RequestCtx) {
 	// Find match in stack
 	match := app.next(ctx)
 	// Send a 404 by default if no route matched
-	if !match {
+	if !match || len(ctx.Fasthttp.Response.Body()) == 0 {
 		ctx.SendStatus(404)
+		ctx.SendString(fmt.Sprintf("Cannot %s %s", ctx.method, ctx.pathOriginal))
 	} else if app.Settings.ETag {
 		// Generate ETag if enabled
 		setETag(ctx, false)

--- a/router_test.go
+++ b/router_test.go
@@ -179,10 +179,10 @@ func registerDummyRoutes(app *App) {
 // go test -v ./... -run=^$ -bench=Benchmark_Router_NotFound -benchmem -count=4
 func Benchmark_Router_NotFound(b *testing.B) {
 	app := New()
-	registerDummyRoutes(app)
 	app.Use(func(c *Ctx) {
-
+		c.Next()
 	})
+	registerDummyRoutes(app)
 	c := &fasthttp.RequestCtx{}
 
 	c.Request.Header.SetMethod("DELETE")

--- a/router_test.go
+++ b/router_test.go
@@ -172,20 +172,7 @@ func Test_Route_Match_Middleware_Root(t *testing.T) {
 func registerDummyRoutes(app *App) {
 	h := func(c *Ctx) {}
 	for _, r := range githubAPI {
-		switch r.method {
-		case "GET":
-			app.Get(r.path, h)
-		case "POST":
-			app.Post(r.path, h)
-		case "PUT":
-			app.Put(r.path, h)
-		case "PATCH":
-			app.Patch(r.path, h)
-		case "DELETE":
-			app.Delete(r.path, h)
-		default:
-			panic("Unknow HTTP method: " + r.method)
-		}
+		app.Add(r.method, r.path, h)
 	}
 }
 
@@ -193,7 +180,9 @@ func registerDummyRoutes(app *App) {
 func Benchmark_Router_NotFound(b *testing.B) {
 	app := New()
 	registerDummyRoutes(app)
+	app.Use(func(c *Ctx) {
 
+	})
 	c := &fasthttp.RequestCtx{}
 
 	c.Request.Header.SetMethod("DELETE")
@@ -202,7 +191,7 @@ func Benchmark_Router_NotFound(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		app.handler(c)
 	}
-
+	utils.AssertEqual(b, 404, c.Response.StatusCode())
 	utils.AssertEqual(b, "Cannot DELETE /this/route/does/not/exist", string(c.Response.Body()))
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -189,6 +189,23 @@ func registerDummyRoutes(app *App) {
 	}
 }
 
+// go test -v ./... -run=^$ -bench=Benchmark_Router_NotFound -benchmem -count=4
+func Benchmark_Router_NotFound(b *testing.B) {
+	app := New()
+	registerDummyRoutes(app)
+
+	c := &fasthttp.RequestCtx{}
+
+	c.Request.Header.SetMethod("DELETE")
+	c.URI().SetPath("/this/route/does/not/exist")
+
+	for n := 0; n < b.N; n++ {
+		app.handler(c)
+	}
+
+	utils.AssertEqual(b, "Cannot DELETE /this/route/does/not/exist", string(c.Response.Body()))
+}
+
 // go test -v ./... -run=^$ -bench=Benchmark_Router_Handler -benchmem -count=4
 func Benchmark_Router_Handler(b *testing.B) {
 	app := New()

--- a/utils.go
+++ b/utils.go
@@ -18,6 +18,10 @@ import (
 
 // Generate and set ETag header to response
 func setETag(ctx *Ctx, weak bool) {
+	// Don't generate ETags for invalid responses
+	if ctx.Fasthttp.Response.StatusCode() != 200 {
+		return
+	}
 	body := ctx.Fasthttp.Response.Body()
 	// Skips ETag if no response body is present
 	if len(body) <= 0 {


### PR DESCRIPTION
- Update Version: `v1.10.2`
- Add/Remove code comments
- Add response body to `404`: `Cannot %method %path`
- Add more benchmarks & tests
- Fix Static Content-Type https://github.com/gofiber/fiber/issues/420
- Update router behaviour on `c.Next()` by returning a `404` if no match https://github.com/gofiber/fiber/issues/430
- Add `ctx.SendStream` with `io.Reader` support