### PR TITLE
🩹 fix ctx.Render when using Go Templates

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -751,15 +750,8 @@ func (ctx *Ctx) Render(name string, bind interface{}) (err error) {
 		}
 	} else {
 		// Render raw template using 'name' as filepath if no engine is set
-		var tmpl *template.Template
-		var raw []byte
-		// Read file
-		if raw, err = ioutil.ReadFile(filepath.Clean(name)); err != nil {
-			return err
-		}
-		// Parse template
-		// tmpl, err := template.ParseGlob(name)
-		if tmpl, err = template.New("").ParseGlob(getString(raw)); err != nil {
+		tmpl, err := template.ParseFiles(filepath.Clean(name))
+		if err != nil {
 			return err
 		}
 		// Render template

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1054,6 +1054,24 @@ func Test_Ctx_Redirect(t *testing.T) {
 // 	// TODO
 // }
 
+// go test -run Test_Ctx_Render_Go_Template
+func Test_Ctx_Render_Go_Template(t *testing.T) {
+	t.Parallel()
+	file, err := ioutil.TempFile(os.TempDir(), "fiber")
+	utils.AssertEqual(t, nil, err)
+	defer os.Remove(file.Name())
+	_, err = file.Write([]byte("template"))
+	utils.AssertEqual(t, nil, err)
+	err = file.Close()
+	utils.AssertEqual(t, nil, err)
+	app := New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+	err = ctx.Render(file.Name(), nil)
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "template", string(ctx.Fasthttp.Response.Body()))
+}
+
 // go test -run Test_Ctx_Send
 func Test_Ctx_Send(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Ran into a bug with `ctx.Render`