### PR TITLE
Check index to avoid slice bounds out of range panic

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -923,7 +923,12 @@ func (ctx *Ctx) Subdomains(offset ...int) []string {
 		o = offset[0]
 	}
 	subdomains := strings.Split(ctx.Hostname(), ".")
-	subdomains = subdomains[:len(subdomains)-o]
+	l := len(subdomains) - o
+	// Check index to avoid slice bounds out of range panic
+	if l < 0 {
+		l = len(subdomains)
+	}
+	subdomains = subdomains[:l]
 	return subdomains
 }
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -845,6 +845,9 @@ func Test_Ctx_Subdomains(t *testing.T) {
 	defer app.ReleaseCtx(ctx)
 	ctx.Fasthttp.Request.URI().SetHost("john.doe.is.awesome.google.com")
 	utils.AssertEqual(t, []string{"john", "doe"}, ctx.Subdomains(4))
+
+	ctx.Fasthttp.Request.URI().SetHost("localhost:3000")
+	utils.AssertEqual(t, []string{"localhost:3000"}, ctx.Subdomains())
 }
 
 // go test -v -run=^$ -bench=Benchmark_Ctx_Subdomains -benchmem -count=4


### PR DESCRIPTION
It may raise panic when the hostname does not even contain one dot.