### PR TITLE
support config param in Compress() and RequestID()

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -35,6 +35,7 @@ Compress allows the following config arguments in any order:
 	- Compress()
 	- Compress(next func(*fiber.Ctx) bool)
 	- Compress(level int)
+	- Compress(config CompressConfig)
 */
 func Compress(options ...interface{}) fiber.Handler {
 	// Create default config
@@ -47,8 +48,10 @@ func Compress(options ...interface{}) fiber.Handler {
 				config.Next = opt
 			case int:
 				config.Level = opt
+			case CompressConfig:
+				config = opt
 			default:
-				log.Fatal("Compress: the following option types are allowed: int")
+				log.Fatal("Compress: the following option types are allowed: int, func(*fiber.Ctx) bool, CompressConfig")
 			}
 		}
 	}

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -43,6 +43,7 @@ RequestID adds an UUID indentifier to the request, the following config argument
 	- RequestID(next func(*fiber.Ctx) bool)
 	- RequestID(header string)
 	- RequestID(generator func() string)
+	- RequestID(config RequestIDConfig)
 */
 func RequestID(options ...interface{}) fiber.Handler {
 	// Create default config
@@ -57,8 +58,10 @@ func RequestID(options ...interface{}) fiber.Handler {
 				config.Header = opt
 			case func() string:
 				config.Generator = opt
+			case RequestIDConfig:
+				config = opt
 			default:
-				log.Fatal("RequestID: the following option types are allowed: `string`, `func() string`")
+				log.Fatal("RequestID: the following option types are allowed: `string`, `func() string`, `func(*fiber.Ctx) bool`, `RequestIDConfig`")
 			}
 		}
 	}


### PR DESCRIPTION
`Compress()` did not support `CompressConfig` param while `CompressWithConfig()` is deprecated since v1.12.3.

`RequestID()` did not support `RequestIDConfig` param while `RequestIDWithConfig()` is deprecated since v1.12.3.