### PR TITLE
🩹 Improve flag handling

### DIFF
--- a/app.go
+++ b/app.go
@@ -256,10 +256,6 @@ func New(settings ...*Settings) *App {
 	if app.Settings.ErrorHandler == nil {
 		app.Settings.ErrorHandler = defaultErrorHandler
 	}
-
-	if !app.Settings.Prefork { // Default to -prefork flag if false
-		app.Settings.Prefork = utils.GetArgument(flagPrefork)
-	}
 	// Replace unsafe conversion functions
 	if app.Settings.Immutable {
 		getBytes, getString = getBytesImmutable, getStringImmutable

--- a/prefork.go
+++ b/prefork.go
@@ -141,7 +141,7 @@ func usage() {
 			// for both 4- and 8-space tab stops.
 			s += "\n    \t"
 		}
-		s += strings.ReplaceAll(usage, "\n", "\n    \t")
+		s += strings.Replace(usage, "\n", "\n    \t", -1)
 
 		if !isZeroValue(f, f.DefValue) {
 			if _, ok := f.Value.(*stringValue); ok {


### PR DESCRIPTION
1. Don't define the prefork flag
2. Don't expose the prefork-child flag in the flag usage message

Closes #522