### PR TITLE
🔥 Feature Add ParamList Method to context

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -650,6 +650,15 @@ func (ctx *Ctx) Params(key string, defaultValue ...string) string {
 	return defaultString("", defaultValue)
 }
 
+// ParamList returns a list of all the parameter names for the current context
+func (ctx *Ctx) ParamList() []string {
+	paramList := make([]string, len(ctx.route.routeParams))
+
+	copy(paramList, ctx.route.routeParams)
+
+	return paramList
+}
+
 // Path returns the path part of the request URL.
 // Optionally, you could override the path.
 func (ctx *Ctx) Path(override ...string) string {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -689,6 +689,54 @@ func Benchmark_Ctx_Params(b *testing.B) {
 	utils.AssertEqual(b, "awesome", res)
 }
 
+// go test -race run Test_Ctx_ParamList
+func Test_Ctx_ParamList(t *testing.T) {
+	t.Parallel()
+	app := New()
+	app.Get("/test/:user", func(c *Ctx) {
+		utils.AssertEqual(t, []string{"user"}, c.ParamList())
+	})
+	app.Get("/test2/*", func(c *Ctx) {
+		utils.AssertEqual(t, []string{"*"}, c.ParamList())
+	})
+	app.Get("/test3/:optional?", func(c *Ctx) {
+		utils.AssertEqual(t, []string{"optional"}, c.ParamList())
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/test/john", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test2/im/a/cookie", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test3", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
+}
+
+// go test -v -run=^$ -bench=Benchmark_Ctx_ParamList -benchmem -count=4
+func Benchmark_Ctx_ParamList(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	routeParams := []string{
+		"param1", "param2", "param3", "param4",
+	}
+	c.route = &Route{
+		routeParams: routeParams,
+	}
+	c.values = []string{
+		"john", "doe", "is", "awesome",
+	}
+	var res []string
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		res = c.ParamList()
+	}
+	utils.AssertEqual(b, routeParams, res)
+}
+
 // go test -run Test_Ctx_Path
 func Test_Ctx_Path(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
[Here](https://github.com/zerbitx/gnockgnock/blob/master/gnocker/gnocker.go#L199) is my rather specific use case.  This test helper app will be dynamically configured to mock 3rd party apis, so it would be convenient to see what params are available at run time.  