### PR TITLE
💡 add ctx.matched to determine if request matched a non USE route.

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -69,6 +69,31 @@ func Test_App_MethodNotAllowed(t *testing.T) {
 	utils.AssertEqual(t, "GET, HEAD, POST", resp.Header.Get(HeaderAllow))
 }
 
+func Test_App_Custom_Middleware_404_Should_Not_SetMethodNotAllowed(t *testing.T) {
+	app := New()
+
+	app.Use(func(ctx *Ctx) {
+		ctx.Status(404)
+	})
+
+	app.Post("/", func(c *Ctx) {})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 404, resp.StatusCode)
+
+	g := app.Group("/with-next", func(ctx *Ctx) {
+		ctx.Status(404)
+		ctx.Next()
+	})
+
+	g.Post("/", func(c *Ctx) {})
+
+	resp, err = app.Test(httptest.NewRequest("GET", "/with-next", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 404, resp.StatusCode)
+}
+
 func Test_App_Routes(t *testing.T) {
 	app := New()
 	h := func(c *Ctx) {}

--- a/ctx.go
+++ b/ctx.go
@@ -44,6 +44,7 @@ type Ctx struct {
 	values       []string             // Route parameter values
 	err          error                // Contains error if passed to Next
 	Fasthttp     *fasthttp.RequestCtx // Reference to *fasthttp.RequestCtx
+	matched      bool                 // Non use route matched
 }
 
 // Range data for ctx.Range

--- a/router.go
+++ b/router.go
@@ -101,6 +101,11 @@ func (app *App) next(ctx *Ctx) bool {
 		}
 		// Pass route reference and param values
 		ctx.route = route
+		// Non use handler matched
+		if !ctx.matched && !route.use {
+			ctx.matched = true
+		}
+
 		ctx.values = values
 		// Execute first handler of route
 		ctx.indexHandler = 0
@@ -111,6 +116,14 @@ func (app *App) next(ctx *Ctx) bool {
 	// If c.Next() does not match, return 404
 	ctx.SendStatus(404)
 	ctx.SendString("Cannot " + ctx.method + " " + ctx.pathOriginal)
+
+	// Scan stack for other methods
+	// Moved from app.handler
+	// It should be here,
+	// because middleware may break the route chain
+	if !ctx.matched {
+		setMethodNotAllowed(ctx)
+	}
 	return false
 }
 
@@ -124,10 +137,6 @@ func (app *App) handler(rctx *fasthttp.RequestCtx) {
 	// Generate ETag if enabled
 	if match && app.Settings.ETag {
 		setETag(ctx, false)
-	}
-	// Scan stack for other methods
-	if !match || ctx.Fasthttp.Response.StatusCode() == StatusNotFound {
-		setMethodNotAllowed(ctx)
 	}
 	// Release Ctx
 	app.ReleaseCtx(ctx)


### PR DESCRIPTION
While `ctx.matched` false after scanning route chain, function `setMethodNotAllowed` should be called.