### PR TITLE
Improve ctx.Send and ctx.SendBytes performance

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -835,9 +835,8 @@ func (ctx *Ctx) Send(bodies ...interface{}) {
 }
 
 // SendBytes sets the HTTP response body for []byte types
-// This means no type assertion, recommended for faster performance
 func (ctx *Ctx) SendBytes(body []byte) {
-	ctx.SendString(getString(body))
+	ctx.Fasthttp.Response.SetBodyRaw(body)
 }
 
 var sendFileFS *fasthttp.FS

--- a/ctx.go
+++ b/ctx.go
@@ -829,7 +829,7 @@ func (ctx *Ctx) Secure() bool {
 // Send sets the HTTP response body. The input can be of any type, io.Reader is also supported.
 func (ctx *Ctx) Send(bodies ...interface{}) {
 	// Reset response body
-	ctx.SendString("")
+	ctx.Fasthttp.Response.ResetBody()
 	// Write response body
 	ctx.Write(bodies...)
 }

--- a/ctx.go
+++ b/ctx.go
@@ -834,7 +834,8 @@ func (ctx *Ctx) Send(bodies ...interface{}) {
 	ctx.Write(bodies...)
 }
 
-// SendBytes sets the HTTP response body for []byte types
+// SendBytes sets the HTTP response body for []byte types without copying it.
+// From this point onward the body argument must not be changed.
 func (ctx *Ctx) SendBytes(body []byte) {
 	ctx.Fasthttp.Response.SetBodyRaw(body)
 }

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1418,3 +1418,29 @@ func Test_Ctx_XHR(t *testing.T) {
 	ctx.Fasthttp.Request.Header.Set(HeaderXRequestedWith, "XMLHttpRequest")
 	utils.AssertEqual(t, true, ctx.XHR())
 }
+
+// go test -v  -run=^$ -bench=Benchmark_Ctx_SendString_For_Reset -benchmem -count=4
+func Benchmark_Ctx_SendString_For_Reset(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c.SendString("")
+	}
+	utils.AssertEqual(b, "", string(c.Fasthttp.Response.Body()))
+}
+
+// go test -v  -run=^$ -bench=Benchmark_Ctx_Reset_Body -benchmem -count=4
+func Benchmark_Ctx_Reset_Body(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c.Fasthttp.Response.ResetBody()
+	}
+	utils.AssertEqual(b, "", string(c.Fasthttp.Response.Body()))
+}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1444,3 +1444,31 @@ func Benchmark_Ctx_Reset_Body(b *testing.B) {
 	}
 	utils.AssertEqual(b, "", string(c.Fasthttp.Response.Body()))
 }
+
+// go test -v  -run=^$ -bench=Benchmark_Ctx_SendBytes_With_SendString -benchmem -count=4
+func Benchmark_Ctx_SendBytes_With_SendString(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	body := []byte("Hello, world!")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c.SendString(getString(body))
+	}
+	utils.AssertEqual(b, body, c.Fasthttp.Response.Body())
+}
+
+// go test -v  -run=^$ -bench=Benchmark_Ctx_SendBytes_With_SetBodyRaw -benchmem -count=4
+func Benchmark_Ctx_SendBytes_With_SetBodyRaw(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	body := []byte("Hello, world!")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c.Fasthttp.Response.SetBodyRaw(body)
+	}
+	utils.AssertEqual(b, body, c.Fasthttp.Response.Body())
+}


### PR DESCRIPTION
NEW
```go
Benchmark_Ctx_SendString_For_Reset
Benchmark_Ctx_SendString_For_Reset-8    100000000               11.8 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_SendString_For_Reset-8    100000000               11.6 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_SendString_For_Reset-8    100000000               12.0 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_SendString_For_Reset-8    100000000               11.9 ns/op             0 B/op          0 allocs/op

Benchmark_Ctx_Reset_Body
Benchmark_Ctx_Reset_Body-8      169810179                7.03 ns/op            0 B/op          0 allocs/op
Benchmark_Ctx_Reset_Body-8      170163852                7.05 ns/op            0 B/op          0 allocs/op
Benchmark_Ctx_Reset_Body-8      168444130                7.11 ns/op            0 B/op          0 allocs/op
Benchmark_Ctx_Reset_Body-8      168826455                7.25 ns/op            0 B/op          0 allocs/op
```

OLD
```go
Benchmark_Ctx_SendBytes_With_SendString
Benchmark_Ctx_SendBytes_With_SendString-8       84163512                14.7 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_SendBytes_With_SendString-8       86428518                14.7 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_SendBytes_With_SendString-8       84299564                14.6 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_SendBytes_With_SendString-8       83541979                14.6 ns/op             0 B/op          0 allocs/op

Benchmark_Ctx_SendBytes_With_SetBodyRaw
Benchmark_Ctx_SendBytes_With_SetBodyRaw-8       127097104                7.89 ns/op            0 B/op          0 allocs/op
Benchmark_Ctx_SendBytes_With_SetBodyRaw-8       126810813                8.05 ns/op            0 B/op          0 allocs/op
Benchmark_Ctx_SendBytes_With_SetBodyRaw-8       127799650                7.98 ns/op            0 B/op          0 allocs/op
Benchmark_Ctx_SendBytes_With_SetBodyRaw-8       126872679                7.89 ns/op            0 B/op          0 allocs/op

```