### PR TITLE
 💯 improve path.go coverage

### DIFF
--- a/path.go
+++ b/path.go
@@ -239,7 +239,7 @@ func getAllocFreeParamsPos(allocLen int) [][2]int {
 func getAllocFreeParams(allocLen int) []string {
 	size := uint32(allocLen)
 	start := atomic.AddUint32(&startParamList, size)
-	if (start + 10) >= uint32(len(paramsPosDummy)) {
+	if (start + 10) >= uint32(len(paramsDummy)) {
 		atomic.StoreUint32(&startParamList, 0)
 		return getAllocFreeParams(allocLen)
 	}

--- a/path_test.go
+++ b/path_test.go
@@ -198,3 +198,25 @@ func Test_Path_matchParams(t *testing.T) {
 		{url: "xyz/", params: nil, match: false},
 	})
 }
+
+// go test -race -run Test_Reset_StartParamPosList
+func Test_Reset_StartParamPosList(t *testing.T) {
+	t.Parallel()
+
+	startParamPosList = uint32(len(paramsPosDummy)) - 10
+
+	getAllocFreeParamsPos(5)
+
+	utils.AssertEqual(t, uint32(5), startParamPosList)
+}
+
+// go test -race -run Test_Reset_startParamList
+func Test_Reset_startParamList(t *testing.T) {
+	t.Parallel()
+
+	startParamList = uint32(len(paramsDummy)) - 10
+
+	getAllocFreeParams(5)
+
+	utils.AssertEqual(t, uint32(5), startParamList)
+}


### PR DESCRIPTION
`getAllocFreeParams` should use corresponding `len(paramsDummy)`.