### PR TITLE
Improve json

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -508,38 +508,15 @@ func (ctx *Ctx) Is(extension string) bool {
 // JSON converts any interface or string to JSON.
 // This method also sets the content header to application/json.
 func (ctx *Ctx) JSON(data interface{}) error {
-	// Reset response body
-	ctx.Fasthttp.Response.ResetBody()
-
-	encoder := json.NewEncoder(ctx.Fasthttp.Response.BodyWriter())
-	encoder.SetEscapeHTML(true)
-	// Write data to response body writer directly
-	if err := encoder.Encode(data); err != nil {
-		return err
-	}
-	// Set http headers
-	ctx.Fasthttp.Response.Header.SetContentType(MIMEApplicationJSON)
-
-	b := ctx.Fasthttp.Response.Body()
-	if end := len(b) - 1; end >= 0 && b[end] == '\n' {
-		// remove extra '\n' added by encoder.Encode
-		ctx.Fasthttp.Response.SetBodyRaw(b[:end])
-	}
-	// Success!
-	return nil
-}
-
-// JSON converts any interface or string to JSON using Jsoniter.
-// This method also sets the content header to application/json.
-func (ctx *Ctx) JSONOld(data interface{}) error {
-	raw, err := json.Marshal(&data)
+	raw, err := json.Marshal(data)
 	// Check for errors
 	if err != nil {
 		return err
 	}
 	// Set http headers
 	ctx.Fasthttp.Response.Header.SetContentType(MIMEApplicationJSON)
-	ctx.SendString(getString(raw))
+	// For TFB !!!
+	ctx.Fasthttp.Response.SetBodyRaw(raw)
 	// Success!
 	return nil
 }
@@ -548,7 +525,7 @@ func (ctx *Ctx) JSONOld(data interface{}) error {
 // This method is identical to JSON, except that it opts-in to JSONP callback support.
 // By default, the callback name is simply callback.
 func (ctx *Ctx) JSONP(data interface{}, callback ...string) error {
-	raw, err := json.Marshal(&data)
+	raw, err := json.Marshal(data)
 
 	if err != nil {
 		return err

--- a/ctx.go
+++ b/ctx.go
@@ -519,6 +519,12 @@ func (ctx *Ctx) JSON(data interface{}) error {
 	}
 	// Set http headers
 	ctx.Fasthttp.Response.Header.SetContentType(MIMEApplicationJSON)
+
+	b := ctx.Fasthttp.Response.Body()
+	if end := len(b) - 1; end >= 0 && b[end] == '\n' {
+		// remove extra '\n' added by encoder.Encode
+		ctx.Fasthttp.Response.SetBodyRaw(b[:end])
+	}
 	// Success!
 	return nil
 }

--- a/ctx.go
+++ b/ctx.go
@@ -505,9 +505,27 @@ func (ctx *Ctx) Is(extension string) bool {
 	return utils.Trim(header, ' ') == extensionHeader
 }
 
-// JSON converts any interface or string to JSON using Jsoniter.
+// JSON converts any interface or string to JSON.
 // This method also sets the content header to application/json.
 func (ctx *Ctx) JSON(data interface{}) error {
+	// Reset response body
+	ctx.Fasthttp.Response.ResetBody()
+
+	encoder := json.NewEncoder(ctx.Fasthttp.Response.BodyWriter())
+	encoder.SetEscapeHTML(true)
+	// Write data to response body writer directly
+	if err := encoder.Encode(data); err != nil {
+		return err
+	}
+	// Set http headers
+	ctx.Fasthttp.Response.Header.SetContentType(MIMEApplicationJSON)
+	// Success!
+	return nil
+}
+
+// JSON converts any interface or string to JSON using Jsoniter.
+// This method also sets the content header to application/json.
+func (ctx *Ctx) JSONOld(data interface{}) error {
 	raw, err := json.Marshal(&data)
 	// Check for errors
 	if err != nil {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -346,7 +346,7 @@ func Test_Ctx_Format(t *testing.T) {
 
 	ctx.Fasthttp.Request.Header.Set(HeaderAccept, "application/json")
 	ctx.Format("Hello, World!")
-	utils.AssertEqual(t, `"Hello, World!"`, string(ctx.Fasthttp.Response.Body()))
+	utils.AssertEqual(t, "\"Hello, World!\"\n", string(ctx.Fasthttp.Response.Body()))
 
 	ctx.Fasthttp.Request.Header.Set(HeaderAccept, "application/xml")
 	ctx.Format("Hello, World!")
@@ -991,7 +991,7 @@ func Test_Ctx_JSON(t *testing.T) {
 		"Name": "Grame",
 		"Age":  20,
 	})
-	utils.AssertEqual(t, `{"Age":20,"Name":"Grame"}`, string(ctx.Fasthttp.Response.Body()))
+	utils.AssertEqual(t, "{\"Age\":20,\"Name\":\"Grame\"}\n", string(ctx.Fasthttp.Response.Body()))
 	utils.AssertEqual(t, "application/json", string(ctx.Fasthttp.Response.Header.Peek("content-type")))
 }
 
@@ -1013,6 +1013,29 @@ func Benchmark_Ctx_JSON(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		err = c.JSON(data)
+	}
+	utils.AssertEqual(b, nil, err)
+	utils.AssertEqual(b, "{\"Name\":\"Grame\",\"Age\":20}\n", string(c.Fasthttp.Response.Body()))
+}
+
+// go test -v  -run=^$ -bench=Benchmark_Ctx_JSONOld -benchmem -count=4
+func Benchmark_Ctx_JSONOld(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	type SomeStruct struct {
+		Name string
+		Age  uint8
+	}
+	data := SomeStruct{
+		Name: "Grame",
+		Age:  20,
+	}
+	var err error
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err = c.JSONOld(data)
 	}
 	utils.AssertEqual(b, nil, err)
 	utils.AssertEqual(b, `{"Name":"Grame","Age":20}`, string(c.Fasthttp.Response.Body()))

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -994,14 +994,16 @@ func Test_Ctx_JSON(t *testing.T) {
 	utils.AssertEqual(t, `{"Age":20,"Name":"Grame"}`, string(ctx.Fasthttp.Response.Body()))
 	utils.AssertEqual(t, "application/json", string(ctx.Fasthttp.Response.Header.Peek("content-type")))
 
-	ctx.JSON(nil)
-	utils.AssertEqual(t, "null", string(ctx.Fasthttp.Response.Body()))
+	testEmpty := func(v interface{}, r string) {
+		err := ctx.JSON(v)
+		utils.AssertEqual(t, nil, err)
+		utils.AssertEqual(t, r, string(ctx.Fasthttp.Response.Body()))
+	}
 
-	ctx.JSON("")
-	utils.AssertEqual(t, `""`, string(ctx.Fasthttp.Response.Body()))
-
-	ctx.JSON(0)
-	utils.AssertEqual(t, "0", string(ctx.Fasthttp.Response.Body()))
+	testEmpty(nil, "null")
+	testEmpty("", `""`)
+	testEmpty(0, "0")
+	testEmpty([]int{}, "[]")
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Ctx_JSON -benchmem -count=4

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1023,30 +1023,7 @@ func Benchmark_Ctx_JSON(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		err = c.JSON(data)
-	}
-	utils.AssertEqual(b, nil, err)
-	utils.AssertEqual(b, `{"Name":"Grame","Age":20}`, string(c.Fasthttp.Response.Body()))
-}
-
-// go test -v  -run=^$ -bench=Benchmark_Ctx_JSONOld -benchmem -count=4
-func Benchmark_Ctx_JSONOld(b *testing.B) {
-	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{})
-	defer app.ReleaseCtx(c)
-	type SomeStruct struct {
-		Name string
-		Age  uint8
-	}
-	data := SomeStruct{
-		Name: "Grame",
-		Age:  20,
-	}
-	var err error
-	b.ReportAllocs()
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		err = c.JSONOld(data)
+		err = c.JSON(&data)
 	}
 	utils.AssertEqual(b, nil, err)
 	utils.AssertEqual(b, `{"Name":"Grame","Age":20}`, string(c.Fasthttp.Response.Body()))
@@ -1084,7 +1061,7 @@ func Benchmark_Ctx_JSONP(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		err = c.JSONP(data, callback)
+		err = c.JSONP(&data, callback)
 	}
 	utils.AssertEqual(b, nil, err)
 	utils.AssertEqual(b, `emit({"Name":"Grame","Age":20});`, string(c.Fasthttp.Response.Body()))

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -346,7 +346,7 @@ func Test_Ctx_Format(t *testing.T) {
 
 	ctx.Fasthttp.Request.Header.Set(HeaderAccept, "application/json")
 	ctx.Format("Hello, World!")
-	utils.AssertEqual(t, "\"Hello, World!\"\n", string(ctx.Fasthttp.Response.Body()))
+	utils.AssertEqual(t, `"Hello, World!"`, string(ctx.Fasthttp.Response.Body()))
 
 	ctx.Fasthttp.Request.Header.Set(HeaderAccept, "application/xml")
 	ctx.Format("Hello, World!")
@@ -991,8 +991,17 @@ func Test_Ctx_JSON(t *testing.T) {
 		"Name": "Grame",
 		"Age":  20,
 	})
-	utils.AssertEqual(t, "{\"Age\":20,\"Name\":\"Grame\"}\n", string(ctx.Fasthttp.Response.Body()))
+	utils.AssertEqual(t, `{"Age":20,"Name":"Grame"}`, string(ctx.Fasthttp.Response.Body()))
 	utils.AssertEqual(t, "application/json", string(ctx.Fasthttp.Response.Header.Peek("content-type")))
+
+	ctx.JSON(nil)
+	utils.AssertEqual(t, "null", string(ctx.Fasthttp.Response.Body()))
+
+	ctx.JSON("")
+	utils.AssertEqual(t, `""`, string(ctx.Fasthttp.Response.Body()))
+
+	ctx.JSON(0)
+	utils.AssertEqual(t, "0", string(ctx.Fasthttp.Response.Body()))
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Ctx_JSON -benchmem -count=4
@@ -1015,7 +1024,7 @@ func Benchmark_Ctx_JSON(b *testing.B) {
 		err = c.JSON(data)
 	}
 	utils.AssertEqual(b, nil, err)
-	utils.AssertEqual(b, "{\"Name\":\"Grame\",\"Age\":20}\n", string(c.Fasthttp.Response.Body()))
+	utils.AssertEqual(b, `{"Name":"Grame","Age":20}`, string(c.Fasthttp.Response.Body()))
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Ctx_JSONOld -benchmem -count=4

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1023,7 +1023,7 @@ func Benchmark_Ctx_JSON(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		err = c.JSON(&data)
+		err = c.JSON(data)
 	}
 	utils.AssertEqual(b, nil, err)
 	utils.AssertEqual(b, `{"Name":"Grame","Age":20}`, string(c.Fasthttp.Response.Body()))
@@ -1061,7 +1061,7 @@ func Benchmark_Ctx_JSONP(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		err = c.JSONP(&data, callback)
+		err = c.JSONP(data, callback)
 	}
 	utils.AssertEqual(b, nil, err)
 	utils.AssertEqual(b, `emit({"Name":"Grame","Age":20});`, string(c.Fasthttp.Response.Body()))


### PR DESCRIPTION
I made adjustments to `ctx.JSON`, which can improve performance by about ~~30%~~ 20%. 

And the impacts are:
- Regardless of whether json serialization is successful or not, `response body` will be reset
- ~~The json serialization result will append an extra `\n`(see [reason in stdlib](https://github.com/golang/go/blob/release-branch.go1.14/src/encoding/json/stream.go#L211-L217)) , which I personally think will not have a destructive effect~~

This PR retains the old `ctx.JSONOld` for benchmark comparison. You can execute `go test -v -run=^$ -bench="Benchmark_Ctx_JSON(O|$)" -benchmem -count=4
`View results:
```bash
# on my machine
go test -v -run=^$ -bench="Benchmark_Ctx_JSON(O|$)" -benchmem -count=4
goos: darwin
goarch: amd64
pkg: github.com/gofiber/fiber
Benchmark_Ctx_JSON
Benchmark_Ctx_JSON-8 2703946 442 ns/op 32 B/op 1 allocs/op
Benchmark_Ctx_JSON-8 2773329 434 ns/op 32 B/op 1 allocs/op
Benchmark_Ctx_JSON-8 2753611 436 ns/op 32 B/op 1 allocs/op
Benchmark_Ctx_JSON-8 2756508 434 ns/op 32 B/op 1 allocs/op
Benchmark_Ctx_JSONOld
Benchmark_Ctx_JSONOld-8 2088817 570 ns/op 80 B/op 3 allocs/op
Benchmark_Ctx_JSONOld-8 2095932 570 ns/op 80 B/op 3 allocs/op
Benchmark_Ctx_JSONOld-8 2111797 577 ns/op 80 B/op 3 allocs/op
Benchmark_Ctx_JSONOld-8 2090282 563 ns/op 80 B/op 3 allocs/op
PASS
ok github.com/gofiber/fiber 14.568s
```

remove extra '\n' part is co-authored with @ReneWerner87 
```go
	b := ctx.Fasthttp.Response.Body()
	if end := len(b) - 1; end >= 0 && b[end] == '\n' {
		// remove extra '\n' added by encoder.Encode
		ctx.Fasthttp.Response.SetBodyRaw(b[:end])
	}
```

**If this RP is ~~approved~~ ready to be merged, I will delete the comparison code.** @Fenny 