### PR TITLE
Improve coverage

### DIFF
--- a/prefork.go
+++ b/prefork.go
@@ -81,7 +81,10 @@ func (app *App) prefork(addr string, tlsconfig ...*tls.Config) (err error) {
 		/* #nosec G204 */
 		cmd := exec.Command(os.Args[0], os.Args[1:]...)
 		if testPreforkMaster {
-			cmd = exec.Command("cd")
+			// When test prefork master,
+			// just start the child process
+			// a cmd on all os is best
+			cmd = exec.Command("date")
 		}
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/prefork.go
+++ b/prefork.go
@@ -17,6 +17,8 @@ const (
 	envPreforkChildVal = "1"
 )
 
+var testPreforkMaster = false
+
 // IsChild determines if the current process is a result of Prefork
 func (app *App) IsChild() bool {
 	return os.Getenv(envPreforkChildKey) == envPreforkChildVal
@@ -43,11 +45,12 @@ func (app *App) prefork(addr string, tlsconfig ...*tls.Config) (err error) {
 
 		// kill child proc when master exits
 		go func() {
-			ppid, err := os.FindProcess(os.Getppid())
+			p, err := os.FindProcess(os.Getppid())
 			if err == nil {
-				_, _ = ppid.Wait()
+				_, _ = p.Wait()
+			} else {
+				os.Exit(1)
 			}
-			os.Exit(1)
 		}()
 		// listen for incoming connections
 		return app.server.Serve(ln)
@@ -71,12 +74,15 @@ func (app *App) prefork(addr string, tlsconfig ...*tls.Config) (err error) {
 	}()
 
 	// collect child pids
-	pids := []string{}
+	var pids []string
 
 	// launch child procs
 	for i := 0; i < max; i++ {
 		/* #nosec G204 */
 		cmd := exec.Command(os.Args[0], os.Args[1:]...)
+		if testPreforkMaster {
+			cmd = exec.Command("cd")
+		}
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 
@@ -89,12 +95,13 @@ func (app *App) prefork(addr string, tlsconfig ...*tls.Config) (err error) {
 		}
 
 		// store child process
-		childs[cmd.Process.Pid] = cmd
-		pids = append(pids, strconv.Itoa(cmd.Process.Pid))
+		pid := cmd.Process.Pid
+		childs[pid] = cmd
+		pids = append(pids, strconv.Itoa(pid))
 
 		// notify master if child crashes
 		go func() {
-			channel <- child{cmd.Process.Pid, cmd.Wait()}
+			channel <- child{pid, cmd.Wait()}
 		}()
 	}
 

--- a/prefork_test.go
+++ b/prefork_test.go
@@ -1,0 +1,42 @@
+package fiber
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	utils "github.com/gofiber/utils"
+)
+
+func Test_App_Prefork_Child_Process(t *testing.T) {
+	utils.AssertEqual(t, nil, os.Setenv(envPreforkChildKey, envPreforkChildVal))
+	defer os.Setenv(envPreforkChildKey, "")
+
+	app := New(&Settings{
+		DisableStartupMessage: true,
+	})
+	app.init()
+
+	go func() {
+		time.Sleep(1000 * time.Millisecond)
+		utils.AssertEqual(t, nil, app.Shutdown())
+	}()
+
+	utils.AssertEqual(t, nil, app.prefork("127.0.0.1:"))
+}
+
+func Test_App_Prefork_Main_Process(t *testing.T) {
+	testPreforkMaster = true
+
+	app := New(&Settings{
+		DisableStartupMessage: true,
+	})
+	app.init()
+
+	go func() {
+		time.Sleep(1000 * time.Millisecond)
+		utils.AssertEqual(t, nil, app.Shutdown())
+	}()
+
+	utils.AssertEqual(t, nil, app.prefork("127.0.0.1:"))
+}

--- a/router_test.go
+++ b/router_test.go
@@ -214,6 +214,21 @@ func Test_Ensure_Router_Interface_Implementation(t *testing.T) {
 	utils.AssertEqual(t, true, ok)
 }
 
+func Test_Router_Handler_SetETag(t *testing.T) {
+	app := New()
+	app.Settings.ETag = true
+
+	app.Get("/", func(c *Ctx) {
+		c.Send("Hello, World!")
+	})
+
+	c := &fasthttp.RequestCtx{}
+
+	app.handler(c)
+
+	utils.AssertEqual(t, `"13-1831710635"`, string(c.Response.Header.Peek(HeaderETag)))
+}
+
 //////////////////////////////////////////////
 ///////////////// BENCHMARKS /////////////////
 //////////////////////////////////////////////


### PR DESCRIPTION
```bash
go test -count=1 -cover
PASS
coverage: 93.9% of statements
```

I did some trick on `prefork.go` test
```go
cmd := exec.Command(os.Args[0], os.Args[1:]...)
if testPreforkMaster {
	// When test prefork master,
	// just start the child process
	// a cmd on all os is best
	cmd = exec.Command("date")
}
```

I'm wondering if this will be fine.