### PR TITLE
🚀 improve ctx.QueryParser performance

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1320,6 +1320,25 @@ func Test_Ctx_Render_Engine(t *testing.T) {
 	utils.AssertEqual(t, "<h1>Hello, World!</h1>", string(ctx.Fasthttp.Response.Body()))
 }
 
+func Benchmark_Ctx_Render_Engine(b *testing.B) {
+	engine := &testTemplateEngine{}
+	err := engine.Load()
+	utils.AssertEqual(b, nil, err)
+	app := New()
+	app.Settings.Views = engine
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err = ctx.Render("index.tmpl", Map{
+			"Title": "Hello, World!",
+		})
+	}
+	utils.AssertEqual(b, nil, err)
+	utils.AssertEqual(b, "<h1>Hello, World!</h1>", string(ctx.Fasthttp.Response.Body()))
+}
+
 // go test -run Test_Ctx_Render_Go_Template
 func Test_Ctx_Render_Go_Template(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
OLD:
```
Benchmark_Ctx_QueryParser-8       152832              7445 ns/op            1832 B/op         62 allocs/op
Benchmark_Ctx_QueryParser-8       157682              7515 ns/op            1832 B/op         62 allocs/op
Benchmark_Ctx_QueryParser-8       158262              7495 ns/op            1832 B/op         62 allocs/op
Benchmark_Ctx_QueryParser-8       159984              7468 ns/op            1832 B/op         62 allocs/op
```

NEW:
```
Benchmark_Ctx_QueryParser-8       214756              5021 ns/op             912 B/op         39 allocs/op
Benchmark_Ctx_QueryParser-8       232807              5064 ns/op             912 B/op         39 allocs/op
Benchmark_Ctx_QueryParser-8       233775              5111 ns/op             912 B/op         39 allocs/op
Benchmark_Ctx_QueryParser-8       235822              5015 ns/op             912 B/op         39 allocs/op
```