### PR TITLE
Improve ctx links

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -821,7 +821,7 @@ func (ctx *Ctx) Render(name string, bind interface{}, layouts ...string) (err er
 			return err
 		}
 		// Parse template
-		if tmpl, err = template.New("").Parse(buf.String()); err != nil {
+		if tmpl, err = template.New("").Parse(getString(buf.Bytes())); err != nil {
 			return err
 		}
 		buf.Reset()

--- a/ctx.go
+++ b/ctx.go
@@ -585,7 +585,7 @@ func (ctx *Ctx) Links(link ...string) {
 			_, _ = bb.WriteString(`; rel="` + link[i] + `",`)
 		}
 	}
-	ctx.Set(HeaderLink, utils.TrimRight(bb.String(), ','))
+	ctx.Set(HeaderLink, utils.TrimRight(getString(bb.Bytes()), ','))
 	bytebufferpool.Put(bb)
 }
 


### PR DESCRIPTION
OLD:
Benchmark_Ctx_Links-12     6566176       178 ns/op     112 B/op       1 allocs/op
Benchmark_Ctx_Links-12     6679212       179 ns/op     112 B/op       1 allocs/op
Benchmark_Ctx_Links-12     6713257       177 ns/op     112 B/op       1 allocs/op

NEW:
Benchmark_Ctx_Links-12     9117040       132 ns/op       0 B/op       0 allocs/op
Benchmark_Ctx_Links-12     9142824       132 ns/op       0 B/op       0 allocs/op
Benchmark_Ctx_Links-12     9226419       149 ns/op       0 B/op       0 allocs/op


-----
only a small optimization, the big process takes place before
OLD:
Benchmark_Ctx_Render_Go_Template-12       52020     23381 ns/op    1621 B/op      23 allocs/op
Benchmark_Ctx_Render_Go_Template-12       52112     23215 ns/op    1618 B/op      23 allocs/op
Benchmark_Ctx_Render_Go_Template-12       51794     24065 ns/op    1618 B/op      23 allocs/op

NEW:
Benchmark_Ctx_Render_Go_Template-12       52491     22543 ns/op    1612 B/op      22 allocs/op
Benchmark_Ctx_Render_Go_Template-12       50238     22650 ns/op    1611 B/op      22 allocs/op
Benchmark_Ctx_Render_Go_Template-12       51260     23285 ns/op    1611 B/op      22 allocs/op
