### PR TITLE
👷 fixed ctx.Render bug

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -833,7 +833,7 @@ func (ctx *Ctx) Render(name string, bind interface{}, layouts ...string) (err er
 	// Set Content-Type to text/html
 	ctx.Set(HeaderContentType, MIMETextHTMLCharsetUTF8)
 	// Set rendered template to body
-	ctx.SendBytes(buf.Bytes())
+	ctx.Fasthttp.Response.SetBody(buf.Bytes())
 	// Return err if exist
 	return
 }


### PR DESCRIPTION
According to #625 , I did some investigation and found that both `ctx.Render` and `logger` middleware use `bytebufferpool`, so `ctx.Render` can't use `ctx.SendBytes()` because it sets response body without copying it.

I think this fix can close #625.