### PR TITLE
🚀 compress same route's handler and sort routes when registering

### DIFF
--- a/app.go
+++ b/app.go
@@ -421,14 +421,14 @@ func (app *App) Routes() []*Route {
 						continue stackLoop
 					}
 				}
-				// Ignore HEAD routesCount handling GET routesCount
+				// Ignore HEAD routes handling GET routesCount
 			} else if m != methodInt(app.stack[m][r].Method) {
 				continue
 			}
 			routes = append(routes, app.stack[m][r])
 		}
 	}
-	// Sort routesCount by stack position
+	// Sort routes by stack position
 	sort.Slice(routes, func(i, k int) bool {
 		return routes[i].pos < routes[k].pos
 	})

--- a/app_test.go
+++ b/app_test.go
@@ -113,6 +113,38 @@ func Test_App_Routes(t *testing.T) {
 	utils.AssertEqual(t, 4, len(app.Routes()))
 }
 
+// go test -v -run=^$ -bench=Benchmark_App_Routes -benchmem -count=4
+func Benchmark_App_Routes(b *testing.B) {
+	app := New()
+	h := func(c *Ctx) {}
+	app.Use("/", h)
+	app.Use("/", h)
+	app.Get("/Get", h)
+	app.Head("/Head", h)
+	app.Post("/post", h)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		app.Routes()
+	}
+	utils.AssertEqual(b, 5, len(app.Routes()))
+}
+
+func Test_App_Router_Compress(t *testing.T) {
+	app := New()
+	h := func(c *Ctx) { c.Next() }
+	app.Use("/", h)
+	app.Use("/", h)
+	app.Use("/", h)
+	app.Get("/:a/:b/:c", h)
+	app.Get("/:a/:b/:c", h)
+	app.Get("/:a/:b/:c", h)
+
+	utils.AssertEqual(t, 2, len(app.stack[methodInt(MethodGet)]))
+}
+
 func Test_App_ServerErrorHandler_SmallReadBuffer(t *testing.T) {
 	expectedError := regexp.MustCompile(
 		`error when reading request headers: small read buffer\. Increase ReadBufferSize\. Buffer size=4096, contents: "GET / HTTP/1.1\\r\\nHost: example\.com\\r\\nVery-Long-Header: -+`,

--- a/app_test.go
+++ b/app_test.go
@@ -119,6 +119,7 @@ func Test_App_Routes(t *testing.T) {
 	app := New()
 	h := func(c *Ctx) {}
 	app.Use("/", h)
+	app.Use("/", h)
 	app.Get("/Get", h)
 	app.Head("/Head", h)
 	app.Post("/post", h)
@@ -141,20 +142,7 @@ func Benchmark_App_Routes(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		app.Routes()
 	}
-	utils.AssertEqual(b, 5, len(app.Routes()))
-}
-
-func Test_App_Router_Compress(t *testing.T) {
-	app := New()
-	h := func(c *Ctx) { c.Next() }
-	app.Use("/", h)
-	app.Use("/", h)
-	app.Use("/", h)
-	app.Get("/:a/:b/:c", h)
-	app.Get("/:a/:b/:c", h)
-	app.Get("/:a/:b/:c", h)
-
-	utils.AssertEqual(t, 2, len(app.stack[methodInt(MethodGet)]))
+	utils.AssertEqual(b, 4, len(app.Routes()))
 }
 
 func Test_App_ServerErrorHandler_SmallReadBuffer(t *testing.T) {
@@ -486,11 +474,13 @@ func Test_App_RegisteredRouteCount(t *testing.T) {
 	app.Delete("/:john?/:doe?", dummyHandler)
 	testStatus200(t, app, "/john/doe", MethodDelete)
 	checkRouteCount(t, app, 1)
+
 	// with use
 	app = New()
 	app.Use("/:john?/:doe?", dummyHandler)
 	testStatus200(t, app, "/john/doe", MethodPut)
 	checkRouteCount(t, app, len(intMethod))
+
 	// with group
 	app = New()
 	app.Group("/:john?/:doe?", dummyHandler).Put("/wtf", dummyHandler)

--- a/group.go
+++ b/group.go
@@ -107,7 +107,10 @@ func (grp *Group) Static(prefix, root string, config ...Static) Router {
 // All ...
 func (grp *Group) All(path string, handlers ...Handler) Router {
 	for _, method := range intMethod {
-		_ = grp.Add(method, path, handlers...)
+		// MethodHead will be added by MethodGet
+		if method != MethodHead {
+			_ = grp.Add(method, path, handlers...)
+		}
 	}
 	return grp
 }

--- a/group.go
+++ b/group.go
@@ -42,7 +42,11 @@ func (grp *Group) Use(args ...interface{}) Router {
 // Get registers a route for GET methods that requests a representation
 // of the specified resource. Requests using GET should only retrieve data.
 func (grp *Group) Get(path string, handlers ...Handler) Router {
-	return grp.Add(MethodGet, path, handlers...)
+	route := grp.app.register(MethodGet, getGroupPath(grp.prefix, path), handlers...)
+	// Add head route
+	headRoute := route
+	grp.app.addRoute(MethodHead, &headRoute)
+	return grp
 }
 
 // Head registers a route for HEAD methods that asks for a response identical
@@ -107,10 +111,7 @@ func (grp *Group) Static(prefix, root string, config ...Static) Router {
 // All ...
 func (grp *Group) All(path string, handlers ...Handler) Router {
 	for _, method := range intMethod {
-		// MethodHead will be added by MethodGet
-		if method != MethodHead {
-			_ = grp.Add(method, path, handlers...)
-		}
+		grp.Add(method, path, handlers...)
 	}
 	return grp
 }

--- a/router_test.go
+++ b/router_test.go
@@ -364,29 +364,6 @@ func Benchmark_Router_WithCompression(b *testing.B) {
 	}
 }
 
-// go test -v ./... -run=^$ -bench=Benchmark_Router_Compress -benchmem -count=4
-func Benchmark_Router_Compress(b *testing.B) {
-	app := New()
-	handler := func(c *Ctx) {
-		c.Next()
-	}
-	app.Get("/", handler)
-	app.Get("/", handler)
-	app.Get("/", handler)
-	app.Get("/", handler)
-	app.Get("/", handler)
-	app.Get("/", handler)
-
-	c := &fasthttp.RequestCtx{}
-
-	c.Request.Header.SetMethod("GET")
-	c.URI().SetPath("/")
-
-	for n := 0; n < b.N; n++ {
-		app.handler(c)
-	}
-}
-
 // go test -v ./... -run=^$ -bench=Benchmark_Router_Next -benchmem -count=4
 func Benchmark_Router_Next(b *testing.B) {
 	app := New()

--- a/router_test.go
+++ b/router_test.go
@@ -329,6 +329,24 @@ func Benchmark_Router_Chain(b *testing.B) {
 	handler := func(c *Ctx) {
 		c.Next()
 	}
+	app.Get("/", handler, handler, handler, handler, handler, handler)
+
+	c := &fasthttp.RequestCtx{}
+
+	c.Request.Header.SetMethod("GET")
+	c.URI().SetPath("/")
+
+	for n := 0; n < b.N; n++ {
+		app.handler(c)
+	}
+}
+
+// go test -v ./... -run=^$ -bench=Benchmark_Router_WithCompression -benchmem -count=4
+func Benchmark_Router_WithCompression(b *testing.B) {
+	app := New()
+	handler := func(c *Ctx) {
+		c.Next()
+	}
 	app.Get("/", handler)
 	app.Get("/", handler)
 	app.Get("/", handler)

--- a/router_test.go
+++ b/router_test.go
@@ -329,7 +329,12 @@ func Benchmark_Router_Chain(b *testing.B) {
 	handler := func(c *Ctx) {
 		c.Next()
 	}
-	app.Get("/", handler, handler, handler, handler, handler, handler)
+	app.Get("/", handler)
+	app.Get("/", handler)
+	app.Get("/", handler)
+	app.Get("/", handler)
+	app.Get("/", handler)
+	app.Get("/", handler)
 
 	c := &fasthttp.RequestCtx{}
 


### PR DESCRIPTION
- compress route handers when it is identical with pre-one
- use routes slice to store all registered routes
- Get route shares handlers with Head route which is spawned by itself 