### PR TITLE
🔥 Add logger middleware time zone support

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -148,6 +148,7 @@ Logger allows the following config arguments in any order:
 	- Logger(next func(*fiber.Ctx) bool)
 	- Logger(output io.Writer)
 	- Logger(format string)
+	- Logger(timeZone string)
 	- Logger(timeFormat string)
 	- Logger(config LoggerConfig)
 */
@@ -163,6 +164,8 @@ func Logger(options ...interface{}) fiber.Handler {
 			case string:
 				if strings.Contains(opt, "${") {
 					config.Format = opt
+				} else if isTimeZone(opt) {
+					config.TimeZone = opt
 				} else {
 					config.TimeFormat = opt
 				}
@@ -361,6 +364,12 @@ func logger(config LoggerConfig) fiber.Handler {
 		}
 		bytebufferpool.Put(buf)
 	}
+}
+
+// Use Golang's time package to determine whether the TimeZone is available
+func isTimeZone(name string) bool {
+	_, err := time.LoadLocation(name)
+	return err == nil
 }
 
 // MIT License fasttemplate

--- a/middleware/logger.md
+++ b/middleware/logger.md
@@ -18,6 +18,9 @@ func main() {
   // Pass a custom output
   app.Use(middleware.Logger(os.Stdout))
 
+  // Pass a custom time zone
+  app.Use(middleware.Logger("UTC"))
+
   // Pass a custom timeformat
   app.Use(middleware.Logger("15:04:05"))
 

--- a/middleware/logger.md
+++ b/middleware/logger.md
@@ -34,6 +34,7 @@ func main() {
   app.Use(middleware.Logger(middleware.LoggerConfig{
       Format:     "${time} ${method} ${path}",
       TimeFormat: "15:04:05",
+      TimeZone:   "Asia/Chongqing",
       Output:     os.Stdout,
   }))
 
@@ -86,6 +87,11 @@ type LoggerConfig struct {
   //
   // Optional. Default: 15:04:05
   TimeFormat string
+
+  // TimeZone can be specified, such as "UTC" and "America/New_York" and "Asia/Chongqing", etc
+  //
+  // Optional. Default: Local
+  TimeZone string
 
   // Output is a writter where logs are written
   //

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -130,7 +130,7 @@ func Test_Middleware_Logger_Options_And_WithConfig(t *testing.T) {
 		} else if i == 3 {
 			utils.AssertEqual(t, 48, len(res), fmt.Sprintf("Has length: %v, expected: %v, raw: %s", len(res), 48, res))
 		} else if i == 4 {
-			utils.AssertEqual(t, 48, len(res), fmt.Sprintf("Has length: %v, expected: %v, raw: %s", len(res), 51, res))
+			utils.AssertEqual(t, 48, len(res), fmt.Sprintf("Has length: %v, expected: %v, raw: %s", len(res), 48, res))
 		}
 	}
 }

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -104,6 +104,7 @@ func Test_Middleware_Logger_Options_And_WithConfig(t *testing.T) {
 		Logger("15:04:05"),
 		Logger("${time} ${method} ${path} - ${ip} - ${status} - ${latency}\n"),
 		Logger(LoggerConfig{Output: buf}),
+		Logger("UTC"),
 	}
 
 	for i, logger := range loggers {
@@ -128,7 +129,58 @@ func Test_Middleware_Logger_Options_And_WithConfig(t *testing.T) {
 			utils.AssertEqual(t, 51, len(res), fmt.Sprintf("Has length: %v, expected: %v, raw: %s", len(res), 51, res))
 		} else if i == 3 {
 			utils.AssertEqual(t, 48, len(res), fmt.Sprintf("Has length: %v, expected: %v, raw: %s", len(res), 48, res))
+		} else if i == 4 {
+			utils.AssertEqual(t, 48, len(res), fmt.Sprintf("Has length: %v, expected: %v, raw: %s", len(res), 51, res))
 		}
+	}
+}
+
+func Test_isTimeZone(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			"Empty",
+			args{""},
+			true,
+		},
+		{
+			"Local",
+			args{name: "Local"},
+			true,
+		},
+		{
+			"UTC",
+			args{name: "UTC"},
+			true,
+		},
+		{
+			"America/New_York",
+			args{name: "America/New_York"},
+			true,
+		},
+		{
+			"Asia/Chongqing",
+			args{"Asia/Chongqing"},
+			true,
+		},
+		{
+			"Time format",
+			args{name: "2006-01-02 15:04:05"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTimeZone(tt.args.name); got != tt.want {
+				t.Errorf("isTimeZone() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The default value of TimeZone is "Local", using the system time zone.
You can also specify "UTC" and "America / New_York" and "Asia / Chongqing", etc.

**Example:**

```go
app := fiber.New()
app.Use(middleware.Logger(middleware.LoggerConfig{
	TimeFormat: "2006-01-02 15:04:05",
	TimeZone:   "UTC",
}))
app.Get("/", func(ctx *fiber.Ctx) {
	ctx.Write("hello world")
})
if err := app.Listen(3000); err != nil {
	log.Fatalln(err)
}
```

**Output:**

```text
#29499 - 2020-07-21 05:15:29 200 - 0s         GET /
```