### PR TITLE
:goal_net: use panic instead of log.Fatal

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"fmt"
-	"log"
 
 	fiber "github.com/gofiber/fiber"
 	fasthttp "github.com/valyala/fasthttp"
@@ -51,7 +50,7 @@ func Compress(options ...interface{}) fiber.Handler {
 			case CompressConfig:
 				config = opt
 			default:
-				log.Fatal("Compress: the following option types are allowed: int, func(*fiber.Ctx) bool, CompressConfig")
+				panic("Compress: the following option types are allowed: int, func(*fiber.Ctx) bool, CompressConfig")
 			}
 		}
 	}

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -133,6 +133,17 @@ func Test_Middleware_Compress_Skip(t *testing.T) {
 	utils.AssertEqual(t, fiber.MIMETextPlainCharsetUTF8, resp.Header.Get(fiber.HeaderContentType))
 }
 
+// go test -run Test_Middleware_Compress_Panic
+func Test_Middleware_Compress_Panic(t *testing.T) {
+	defer func() {
+		utils.AssertEqual(t,
+			"Compress: the following option types are allowed: int, func(*fiber.Ctx) bool, CompressConfig",
+			fmt.Sprintf("%s", recover()))
+	}()
+
+	Compress("invalid")
+}
+
 // go test -v -run=^$ -bench=Benchmark_Middleware_Compress -benchmem -count=4
 func Benchmark_Middleware_Compress(b *testing.B) {
 	app := fiber.New()

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -178,7 +177,7 @@ func Logger(options ...interface{}) fiber.Handler {
 			case LoggerConfig:
 				config = opt
 			default:
-				log.Fatal("Logger: the following option types are allowed: string, io.Writer, LoggerConfig")
+				panic("Logger: the following option types are allowed: string, io.Writer, LoggerConfig")
 			}
 		}
 	}

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -135,6 +135,17 @@ func Test_Middleware_Logger_Options_And_WithConfig(t *testing.T) {
 	}
 }
 
+// go test -run Test_Middleware_Logger_Panic
+func Test_Middleware_Logger_Panic(t *testing.T) {
+	defer func() {
+		utils.AssertEqual(t,
+			"Logger: the following option types are allowed: string, io.Writer, LoggerConfig",
+			fmt.Sprintf("%s", recover()))
+	}()
+
+	Logger(0)
+}
+
 func Test_isTimeZone(t *testing.T) {
 	type args struct {
 		name string

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"fmt"
-	"log"
 
 	fiber "github.com/gofiber/fiber"
 	utils "github.com/gofiber/utils"
@@ -61,7 +60,7 @@ func RequestID(options ...interface{}) fiber.Handler {
 			case RequestIDConfig:
 				config = opt
 			default:
-				log.Fatal("RequestID: the following option types are allowed: `string`, `func() string`, `func(*fiber.Ctx) bool`, `RequestIDConfig`")
+				panic("RequestID: the following option types are allowed: string, func() string, func(*fiber.Ctx) bool, RequestIDConfig")
 			}
 		}
 	}

--- a/middleware/request_id_test.go
+++ b/middleware/request_id_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -150,6 +151,17 @@ func Test_Middleware_RequestID_Skip(t *testing.T) {
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode, "Status code")
 	utils.AssertEqual(t, "", resp.Header.Get(RequestIDConfigDefault.Header), RequestIDConfigDefault.Header)
+}
+
+// go test -run Test_Middleware_RequestID_Panic
+func Test_Middleware_RequestID_Panic(t *testing.T) {
+	defer func() {
+		utils.AssertEqual(t,
+			"RequestID: the following option types are allowed: string, func() string, func(*fiber.Ctx) bool, RequestIDConfig",
+			fmt.Sprintf("%s", recover()))
+	}()
+
+	RequestID(0)
 }
 
 // go test -v -run=^$ -bench=Benchmark_Middleware_RequestID -benchmem -count=4


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
When option is invalid to the middleware factory, raise panic instead of fatal.
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**
Panic can be tested but fatal can't.
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/