### PR TITLE
🩹 when X-Forwarded-For is empty, ctx.Ips() should be empty

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -502,6 +502,9 @@ func (ctx *Ctx) IP() string {
 // IPs returns an string slice of IP addresses specified in the X-Forwarded-For request header.
 func (ctx *Ctx) IPs() (ips []string) {
 	header := ctx.Fasthttp.Request.Header.Peek(HeaderXForwardedFor)
+	if len(header) == 0 {
+		return
+	}
 	ips = make([]string, bytes.Count(header, []byte(","))+1)
 	var commaPos, i int
 	for {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -706,6 +706,9 @@ func Test_Ctx_IPs(t *testing.T) {
 	defer app.ReleaseCtx(ctx)
 	ctx.Fasthttp.Request.Header.Set(HeaderXForwardedFor, "127.0.0.1, 127.0.0.1, 127.0.0.1")
 	utils.AssertEqual(t, []string{"127.0.0.1", "127.0.0.1", "127.0.0.1"}, ctx.IPs())
+
+	ctx.Fasthttp.Request.Header.Set(HeaderXForwardedFor, "")
+	utils.AssertEqual(t, 0, len(ctx.IPs()))
 }
 
 // go test -v -run=^$ -bench=Benchmark_Ctx_IPs -benchmem -count=4


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
fix #670
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**
if value of X-Forwarded-For header is empty, ctx.Ips() should be empty too
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/