### PR TITLE
📈 Add regular expression support in route path

### DIFF
--- a/path.go
+++ b/path.go
@@ -146,7 +146,7 @@ func isSegRegexp(seg string) bool {
 func buildSegRegexp(seg string) (*regexp.Regexp, error) {
 	// `\A` is added because we need the match from the beginning
 	//  `*` is replaced with `.*` because we need to turn the wildcard to a regular expression.
-	return regexp.Compile("\\A" + strings.ReplaceAll(seg, "*", ".*"))
+	return regexp.Compile("\\A" + strings.Replace(seg, "*", ".*", -1))
 }
 
 // getMatch parses the passed url and tries to match it against the route segments and determine the parameter positions

--- a/path.go
+++ b/path.go
@@ -36,7 +36,7 @@ type paramSeg struct {
 // list of possible parameter and segment delimiter
 // slash has a special role, unlike the other parameters it must not be interpreted as a parameter
 var routeDelimiter = []byte{'/', '-', '.'}
-var regexpCharacters = []byte{'?', '+', '*', '(', ')'}
+var regexpCharacters string = "?+*()"
 
 const wildcardParam string = "*"
 
@@ -136,13 +136,7 @@ func findNextRouteSegmentEnd(search string) int {
 // segment (isParam != true) uses this method. So as long as it has `*`, it will
 // always be part of the regular expression but not the wildcard.
 func isSegRegexp(seg string) bool {
-	for _, regexpChar := range regexpCharacters {
-		if pos := strings.IndexByte(seg, regexpChar); pos != -1 {
-			return true
-		}
-	}
-
-	return false
+	return strings.ContainsAny(seg, regexpCharacters)
 }
 
 /// buildSegRegexp builds the Regexp based on the segment string.

--- a/path.go
+++ b/path.go
@@ -35,7 +35,7 @@ type paramSeg struct {
 
 // list of possible parameter and segment delimiter
 // slash has a special role, unlike the other parameters it must not be interpreted as a parameter
-var routeDelimiter = []byte{'/', '-', '.'}
+var routeDelimiters string = "/-."
 var regexpCharacters string = "?+*()"
 
 const wildcardParam string = "*"
@@ -121,14 +121,7 @@ func parseRoute(pattern string) (p routeParser) {
 
 // findNextRouteSegmentEnd searches in the route for the next end position for a segment
 func findNextRouteSegmentEnd(search string) int {
-	nextPosition := -1
-	for _, delimiter := range routeDelimiter {
-		if pos := strings.IndexByte(search, delimiter); pos != -1 && (pos < nextPosition || nextPosition == -1) {
-			nextPosition = pos
-		}
-	}
-
-	return nextPosition
+	return strings.IndexAny(search, routeDelimiters)
 }
 
 // isSegRegexp checks if the segment contains regexp chars in `regexpCharacters`.

--- a/path_test.go
+++ b/path_test.go
@@ -167,6 +167,44 @@ func Test_Path_matchParams(t *testing.T) {
 		{url: "/partialCheck/foo/bar", params: nil, match: false, partialCheck: true},
 		{url: "/partiaFoo", params: nil, match: false, partialCheck: true},
 	})
+	testCase("/api/ab?cd", []testparams{
+		{url: "/api/acd", params: []string{}, match: true},
+		{url: "/api/abcd/", params: []string{}, match: true},
+		{url: "/api/acd/foo", params: nil, match: false},
+		{url: "/api/ab-cd", params: nil, match: false},
+		{url: "/api/abcd/foo", params: nil, match: false},
+	})
+	testCase("/api/ab?cd/ef?gh", []testparams{
+		{url: "/api/abcd/efgh", params: []string{}, match: true},
+		{url: "/api/abcd/efgh/", params: []string{}, match: true},
+		{url: "/api/abcd/egh", params: []string{}, match: true},
+		{url: "/api/acd/efgh", params: []string{}, match: true},
+		{url: "/api/acd/egh", params: []string{}, match: true},
+		{url: "/api/abcd/efgh/ijkl", params: nil, match: false},
+		{url: "/api/acd", params: nil, match: false},
+		{url: "/api/abcd/", params: nil, match: false},
+		{url: "/api/abcd/efg", params: nil, match: false},
+		{url: "/api/efgh", params: nil, match: false},
+	})
+	testCase("/api/ab?cd/ef?gh/:param", []testparams{
+		{url: "/api/abcd/efgh/foo", params: []string{"foo"}, match: true},
+		{url: "/api/abcd/egh/foo", params: []string{"foo"}, match: true},
+		{url: "/api/acd/efgh/foo", params: []string{"foo"}, match: true},
+		{url: "/api/abcd/efgh/", params: nil, match: false},
+		{url: "/api/abcd/efgh/foo/bar", params: nil, match: false},
+		{url: "/api/abcd/foo", params: nil, match: false},
+		{url: "/api/efgh/foo", params: nil, match: false},
+		{url: "/api/abcd", params: nil, match: false},
+		{url: "/api/efgh", params: nil, match: false},
+	})
+	testCase("/api/:param/ab?cd", []testparams{
+		{url: "/api/foo/abcd", params: []string{"foo"}, match: true},
+		{url: "/api/foo/acd", params: []string{"foo"}, match: true},
+		{url: "/api/abcd", params: nil, match: false},
+		{url: "/api/acd", params: nil, match: false},
+		{url: "/api/foo/abbcd", params: nil, match: false},
+		{url: "/api/acd", params: nil, match: false},
+	})
 	testCase("/api/ab?cd/:param", []testparams{
 		{url: "/api/acd/foo", params: []string{"foo"}, match: true},
 		{url: "/api/abcd/foo", params: []string{"foo"}, match: true},
@@ -180,6 +218,22 @@ func Test_Path_matchParams(t *testing.T) {
 		{url: "/api/acd-foo", params: []string{"foo"}, match: true},
 		{url: "/api/abccd/foo", params: nil, match: false},
 		{url: "/api/abcd", params: nil, match: false},
+	})
+	testCase("/api/ab?cd-ef+gh/:param", []testparams{
+		{url: "/api/abcd-efgh/foo", params: []string{"foo"}, match: true},
+		{url: "/api/acd-effffgh/foo", params: []string{"foo"}, match: true},
+		{url: "/api/abcd-efgh/foo/bar", params: nil, match: false},
+		{url: "/api/abcd-efgh", params: nil, match: false},
+		{url: "/api/acd-efffffgh", params: nil, match: false},
+		{url: "/api/abcd", params: nil, match: false},
+	})
+	testCase("/api/ab+cd", []testparams{
+		{url: "/api/abcd", params: []string{}, match: true},
+		{url: "/api/abbcd/", params: []string{}, match: true},
+		{url: "/api/abbbcd", params: []string{}, match: true},
+		{url: "/api/abcd/foo", params: nil, match: false},
+		{url: "/api/ab-cd", params: nil, match: false},
+		{url: "/api/abccd", params: nil, match: false},
 	})
 	testCase("/api/ab+cd/:param", []testparams{
 		{url: "/api/abcd/foo", params: []string{"foo"}, match: true},

--- a/path_test.go
+++ b/path_test.go
@@ -167,6 +167,46 @@ func Test_Path_matchParams(t *testing.T) {
 		{url: "/partialCheck/foo/bar", params: nil, match: false, partialCheck: true},
 		{url: "/partiaFoo", params: nil, match: false, partialCheck: true},
 	})
+	testCase("/api/ab?cd/:param", []testparams{
+		{url: "/api/acd/foo", params: []string{"foo"}, match: true},
+		{url: "/api/abcd/foo", params: []string{"foo"}, match: true},
+		{url: "/api/abbcd/foo", params: nil, match: false},
+		{url: "/api/ab-cd/foo", params: nil, match: false},
+		{url: "/api/abcd", params: nil, match: false},
+		{url: "/api/acd", params: nil, match: false},
+	})
+	testCase("/api/ab?cd-:param", []testparams{
+		{url: "/api/abcd-foo", params: []string{"foo"}, match: true},
+		{url: "/api/acd-foo", params: []string{"foo"}, match: true},
+		{url: "/api/abccd/foo", params: nil, match: false},
+		{url: "/api/abcd", params: nil, match: false},
+	})
+	testCase("/api/ab+cd/:param", []testparams{
+		{url: "/api/abcd/foo", params: []string{"foo"}, match: true},
+		{url: "/api/abbcd/foo", params: []string{"foo"}, match: true},
+		{url: "/api/abbbcd/foo", params: []string{"foo"}, match: true},
+		{url: "/api/abccd/foo", params: nil, match: false},
+		{url: "/api/ab-cd/foo", params: nil, match: false},
+		{url: "/api/abcd", params: nil, match: false},
+		{url: "/api/abbcd", params: nil, match: false},
+	})
+	testCase("/api/ab*cd/:param", []testparams{
+		{url: "/api/abcd/foo", params: []string{"foo"}, match: true},
+		{url: "/api/abxcd/foo", params: []string{"foo"}, match: true},
+		{url: "/api/abRANDOMcd/foo", params: []string{"foo"}, match: true},
+		{url: "/api/ab123cd/foo", params: []string{"foo"}, match: true},
+		{url: "/api/a123cd/foo", params: nil, match: false},
+		{url: "/api/abcd", params: nil, match: false},
+		{url: "/api/abbcd", params: nil, match: false},
+	})
+	testCase("/api/ab(cd)?e/:param", []testparams{
+		{url: "/api/abe/foo", params: []string{"foo"}, match: true},
+		{url: "/api/abcde/foo", params: []string{"foo"}, match: true},
+		{url: "/api/abce/foo", params: nil, match: false},
+		{url: "/api/abcd/foo", params: nil, match: false},
+		{url: "/api/abe", params: nil, match: false},
+		{url: "/api/abcde", params: nil, match: false},
+	})
 	testCase("/api/*/:param/:param2", []testparams{
 		{url: "/api/test/abc", params: nil, match: false},
 		{url: "/api/joker/batman", params: nil, match: false},


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Express supports regular expression with `?`, `+`, `*`, and `()` in their route path. So this PR adds the support for those too.
Unfortunately I have to use `regexp` since part of the route path will be a regular expression. If you have better suggestion than this, happy to make the change.

Note that even with the `regexp` introduced, it won't be used for all previous route path cases. This PR only uses it when the segment has a regular expression char (`?`, `+`, `*`, and `()`) in it, so the old code won't get the performance hit.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**
Goal of this PR is to provide the same route functionality as Express does https://expressjs.com/en/guide/routing.html
Tests in this PR are also found in their document page.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/