### PR TITLE
🚀 Don't use regexp for no-cache value check

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -644,6 +644,18 @@ func Test_Ctx_Fresh(t *testing.T) {
 	ctx.Fasthttp.Request.Header.Set(HeaderCacheControl, "no-cache")
 	utils.AssertEqual(t, false, ctx.Fresh())
 
+	ctx.Fasthttp.Request.Header.Set(HeaderIfNoneMatch, "*")
+	ctx.Fasthttp.Request.Header.Set(HeaderCacheControl, ",no-cache,")
+	utils.AssertEqual(t, false, ctx.Fresh())
+
+	ctx.Fasthttp.Request.Header.Set(HeaderIfNoneMatch, "*")
+	ctx.Fasthttp.Request.Header.Set(HeaderCacheControl, "aa,no-cache,")
+	utils.AssertEqual(t, false, ctx.Fresh())
+
+	ctx.Fasthttp.Request.Header.Set(HeaderIfNoneMatch, "*")
+	ctx.Fasthttp.Request.Header.Set(HeaderCacheControl, ",no-cache,bb")
+	utils.AssertEqual(t, false, ctx.Fresh())
+
 	ctx.Fasthttp.Request.Header.Set(HeaderIfNoneMatch, "675af34563dc-tr34")
 	ctx.Fasthttp.Request.Header.Set(HeaderCacheControl, "public")
 	utils.AssertEqual(t, false, ctx.Fresh())

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -678,6 +678,19 @@ func Test_Ctx_Fresh(t *testing.T) {
 	utils.AssertEqual(t, false, ctx.Fresh())
 }
 
+// go test -v -run=^$ -bench=Benchmark_Ctx_Fresh_WithNoCache -benchmem -count=4
+func Benchmark_Ctx_Fresh_WithNoCache(b *testing.B) {
+	app := New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+
+	ctx.Fasthttp.Request.Header.Set(HeaderIfNoneMatch, "*")
+	ctx.Fasthttp.Request.Header.Set(HeaderCacheControl, "no-cache")
+	for n := 0; n < b.N; n++ {
+		ctx.Fresh()
+	}
+}
+
 // go test -run Test_Ctx_Get
 func Test_Ctx_Get(t *testing.T) {
 	t.Parallel()

--- a/utils.go
+++ b/utils.go
@@ -454,6 +454,7 @@ const (
 	HeaderWWWAuthenticate                 = "WWW-Authenticate"
 	HeaderAge                             = "Age"
 	HeaderCacheControl                    = "Cache-Control"
+	HeaderCacheControlNoCacheValue        = "no-cache"
 	HeaderClearSiteData                   = "Clear-Site-Data"
 	HeaderExpires                         = "Expires"
 	HeaderPragma                          = "Pragma"


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

While we are on the `regexp` topic, I found another place that's using it for `no-cache` value check. The regular expression is pretty straightforward, so I implemented a function to do the same thing -- if the string has `no-cache`, and its previous non-space char is either nothing or comma, and same with the char after.

I also added a benchmark to make sure this improves the performance:
AFTER:
```
$ go test -v -run=^$ -bench=Benchmark_Ctx_Fresh_WithNoCache -benchmem -count=4
goos: darwin
goarch: amd64
pkg: github.com/gofiber/fiber
Benchmark_Ctx_Fresh_WithNoCache
Benchmark_Ctx_Fresh_WithNoCache-12      10466191               117 ns/op               0 B/op          0 allocs/op
Benchmark_Ctx_Fresh_WithNoCache-12      10317930               118 ns/op               0 B/op          0 allocs/op
Benchmark_Ctx_Fresh_WithNoCache-12       9983041               115 ns/op               0 B/op          0 allocs/op
Benchmark_Ctx_Fresh_WithNoCache-12      10603621               113 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/gofiber/fiber        5.397s
```

BEFORE:
```
➜  ~/code/gopath/src/github.com/larrylv/fiber ruby:(2.7.0) go:(1.14.5) git:(master) ✗
$ go test -v -run=^$ -bench=Benchmark_Ctx_Fresh_WithNoCache -benchmem -count=4
goos: darwin
goarch: amd64
pkg: github.com/gofiber/fiber
Benchmark_Ctx_Fresh_WithNoCache
Benchmark_Ctx_Fresh_WithNoCache-12       4557762               260 ns/op               0 B/op          0 allocs/op
Benchmark_Ctx_Fresh_WithNoCache-12       4668902               260 ns/op               0 B/op          0 allocs/op
Benchmark_Ctx_Fresh_WithNoCache-12       4625556               264 ns/op               0 B/op          0 allocs/op
Benchmark_Ctx_Fresh_WithNoCache-12       4619721               259 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/gofiber/fiber        6.133s
```

So it cuts the the per op time by more than 50%.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/