### PR TITLE
🧹 Refactor etag stale checking

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -449,15 +449,7 @@ func (ctx *Ctx) Fresh() bool {
 		if etag == "" {
 			return false
 		}
-		var etagStale = true
-		var matches = parseTokenList(getBytes(noneMatch))
-		for _, match := range matches {
-			if match == etag || match == "W/"+etag || "W/"+match == etag {
-				etagStale = false
-				break
-			}
-		}
-		if etagStale {
+		if isEtagStale(etag, getBytes(noneMatch)) {
 			return false
 		}
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -632,6 +632,23 @@ func Test_Ctx_FormValue(t *testing.T) {
 	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
 }
 
+// go test -v -run=^$ -bench=Benchmark_Ctx_Fresh_StaleEtag -benchmem -count=4
+func Benchmark_Ctx_Fresh_StaleEtag(b *testing.B) {
+	app := New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+
+	for n := 0; n < b.N; n++ {
+		ctx.Fasthttp.Request.Header.Set(HeaderIfNoneMatch, "a, b, c, d")
+		ctx.Fasthttp.Request.Header.Set(HeaderCacheControl, "c")
+		ctx.Fresh()
+
+		ctx.Fasthttp.Request.Header.Set(HeaderIfNoneMatch, "a, b, c, d")
+		ctx.Fasthttp.Request.Header.Set(HeaderCacheControl, "e")
+		ctx.Fresh()
+	}
+}
+
 // go test -run Test_Ctx_Fresh
 func Test_Ctx_Fresh(t *testing.T) {
 	t.Parallel()

--- a/utils.go
+++ b/utils.go
@@ -194,11 +194,7 @@ func isEtagStale(etag string, noneMatchBytes []byte) bool {
 		}
 	}
 
-	if matchEtag(getString(noneMatchBytes[start:end]), etag) {
-		return false
-	}
-
-	return true
+	return !matchEtag(getString(noneMatchBytes[start:end]), etag)
 }
 
 func isIPv6(address string) bool {


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
Move logics of checking if the etag is stale to `utils` and replace the existing `parseTokenList` function. And also, we don't need to allocate a string slice to store all etags. Instead, we could just check in place to see if it matches the etag.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/