### PR TITLE
🚀 Add ctx.PureJSON() to response json without escaped HTML

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -558,6 +558,26 @@ func (ctx *Ctx) JSONP(data interface{}, callback ...string) error {
 	return nil
 }
 
+// PureJSON converts any interface or string to JSON without escaped HTML.
+// This method also sets the content header to application/json.
+func (ctx *Ctx) PureJSON(data interface{}) error {
+	encoder := json.NewEncoder(ctx.Fasthttp.Response.BodyWriter())
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode(data); err != nil {
+		return err
+	}
+
+	// remove extra '\n' added by encoder.Encode
+	b := ctx.Fasthttp.Response.Body()
+	if end := len(b) - 1; end >= 0 && b[end] == '\n' {
+		ctx.Fasthttp.Response.SetBodyRaw(b[:end])
+	}
+
+	ctx.Fasthttp.Response.Header.SetContentType(MIMEApplicationJSON)
+	return nil
+}
+
 // Links joins the links followed by the property to populate the response's Link HTTP header field.
 func (ctx *Ctx) Links(link ...string) {
 	if len(link) == 0 {


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Fix issue #690 
By using `ctx.JSON()`, it would always do HTML escape because it's the default behavior of `json.Marshal()`.
```
app.Get("/json", func(c *fiber.Ctx) {
	c.Status(fiber.StatusOK).JSON(map[string]string{
		"message": "<foo> hello&",
	})
})
```
```
$ curl localhost:8080/json
{"message":"\u003cfoo\u003e hello\u0026"}
```

**Explain the *details* for making this change. What existing problem does the pull request solve?**

Add a new function, `PureJSON()`, which would use a custom json encoder by `SetEscapeHTML(false)`.

PureJSON:
```
Benchmark_Ctx_PureJSON-4         3393968               347 ns/op              32 B/op          1 allocs/op
Benchmark_Ctx_PureJSON-4         3522820               346 ns/op              32 B/op          1 allocs/op
Benchmark_Ctx_PureJSON-4         3450595               349 ns/op              32 B/op          1 allocs/op
Benchmark_Ctx_PureJSON-4         3477880               408 ns/op              32 B/op          1 allocs/op
```

JSON and JSONP:
```
Benchmark_Ctx_JSON-4             3532759               342 ns/op              64 B/op          2 allocs/op
Benchmark_Ctx_JSON-4             3403322               340 ns/op              64 B/op          2 allocs/op
Benchmark_Ctx_JSON-4             3610423               343 ns/op              64 B/op          2 allocs/op
Benchmark_Ctx_JSON-4             3452790               353 ns/op              64 B/op          2 allocs/op
Benchmark_Ctx_JSONP-4            2596646               474 ns/op              64 B/op          2 allocs/op
Benchmark_Ctx_JSONP-4            2604108               476 ns/op              64 B/op          2 allocs/op
Benchmark_Ctx_JSONP-4            2559540               469 ns/op              64 B/op          2 allocs/op
Benchmark_Ctx_JSONP-4            2637728               459 ns/op              64 B/op          2 allocs/op
```
