### PR TITLE
🧹 Pre-initialize all compress handlers

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -27,6 +27,13 @@ var CompressConfigDefault = CompressConfig{
 	Level: CompressLevelDefault,
 }
 
+var compressHandlers = map[int]fasthttp.RequestHandler{
+	CompressLevelDisabled:        fasthttp.CompressHandlerBrotliLevel(func(c *fasthttp.RequestCtx) {}, fasthttp.CompressBrotliNoCompression, fasthttp.CompressNoCompression),
+	CompressLevelDefault:         fasthttp.CompressHandlerBrotliLevel(func(c *fasthttp.RequestCtx) {}, fasthttp.CompressBrotliDefaultCompression, fasthttp.CompressDefaultCompression),
+	CompressLevelBestSpeed:       fasthttp.CompressHandlerBrotliLevel(func(c *fasthttp.RequestCtx) {}, fasthttp.CompressBrotliBestSpeed, fasthttp.CompressBestSpeed),
+	CompressLevelBestCompression: fasthttp.CompressHandlerBrotliLevel(func(c *fasthttp.RequestCtx) {}, fasthttp.CompressBrotliBestCompression, fasthttp.CompressBestCompression),
+}
+
 /*
 Compress allows the following config arguments in any order:
 	- Compress()
@@ -58,17 +65,12 @@ func Compress(options ...interface{}) fiber.Handler {
 
 func compress(config CompressConfig) fiber.Handler {
 	// Init middleware settings
-	var compressHandler fasthttp.RequestHandler
-	switch config.Level {
-	case -1: // Disabled
-		compressHandler = fasthttp.CompressHandlerBrotliLevel(func(c *fasthttp.RequestCtx) {}, fasthttp.CompressBrotliNoCompression, fasthttp.CompressNoCompression)
-	case 1: // Best speed
-		compressHandler = fasthttp.CompressHandlerBrotliLevel(func(c *fasthttp.RequestCtx) {}, fasthttp.CompressBrotliBestSpeed, fasthttp.CompressBestSpeed)
-	case 2: // Best compression
-		compressHandler = fasthttp.CompressHandlerBrotliLevel(func(c *fasthttp.RequestCtx) {}, fasthttp.CompressBrotliBestCompression, fasthttp.CompressBestCompression)
-	default: // Default
-		compressHandler = fasthttp.CompressHandlerBrotliLevel(func(c *fasthttp.RequestCtx) {}, fasthttp.CompressBrotliDefaultCompression, fasthttp.CompressDefaultCompression)
+	compressHandler, ok := compressHandlers[config.Level]
+	if !ok {
+		// Use default level if provided level is invalid
+		compressHandler = compressHandlers[CompressLevelDefault]
 	}
+
 	// Return handler
 	return func(c *fiber.Ctx) {
 		// Don't execute the middleware if Next returns false

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -144,7 +144,7 @@ func Test_Middleware_Compress_Panic(t *testing.T) {
 	Compress("invalid")
 }
 
-// go test -v -run=^$ -bench=Benchmark_Middleware_Compress -benchmem -count=4
+// go test -v ./... -run=^$ -bench=Benchmark_Middleware_Compress -benchmem -count=4
 func Benchmark_Middleware_Compress(b *testing.B) {
 	app := fiber.New()
 	app.Use(Compress())


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
Initialize all compress handlers beforehand, instead of creating one each time the middleware is used.

The current [Benchmark_Middleware_Compress](https://github.com/gofiber/fiber/blob/066b93460c675219a2e826e990676ddfa301a093/middleware/compress_test.go#L148) doesn't show any difference because the `Compress` middleware is outside of the `b.N` loop.

I moved:
```
app.Use(Compress())
app.Get("/", func(c *fiber.Ctx) {
    c.SendFile(compressFilePath(CompressLevelDefault), true)
})
```

into the benchmark loop on my machine, and here is the diff:
```
BEFORE
$ go test -v ./... -run=^$ -bench=Benchmark_Middleware_Compress -benchmem -count=4
PASS
ok      github.com/gofiber/fiber        0.118s
goos: darwin
goarch: amd64
pkg: github.com/gofiber/fiber/middleware
Benchmark_Middleware_Compress
Benchmark_Middleware_Compress-12           10000            456673 ns/op            2676 B/op         23 allocs/op
Benchmark_Middleware_Compress-12           10000            501863 ns/op            2676 B/op         23 allocs/op
Benchmark_Middleware_Compress-12           10000            452332 ns/op            2676 B/op         23 allocs/op
Benchmark_Middleware_Compress-12           10000            487512 ns/op            2676 B/op         23 allocs/op
PASS
ok      github.com/gofiber/fiber/middleware     19.178s

AFTER
$ go test -v ./... -run=^$ -bench=Benchmark_Middleware_Compress -benchmem -count=4
PASS
ok      github.com/gofiber/fiber        0.116s
goos: darwin
goarch: amd64
pkg: github.com/gofiber/fiber/middleware
Benchmark_Middleware_Compress
Benchmark_Middleware_Compress-12           10000            418760 ns/op            2644 B/op         22 allocs/op
Benchmark_Middleware_Compress-12           10000            437049 ns/op            2644 B/op         22 allocs/op
Benchmark_Middleware_Compress-12           10000            524560 ns/op            2644 B/op         22 allocs/op
Benchmark_Middleware_Compress-12           10000            442473 ns/op            2644 B/op         22 allocs/op
PASS
ok      github.com/gofiber/fiber/middleware     18.397s
```

Doesn't improve too much, but seems nice to avoid initializing same handlers multiple times.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/