### PR TITLE
🚀  Improve routing behavior

### DIFF
--- a/app.go
+++ b/app.go
@@ -50,7 +50,8 @@ type Error struct {
 type App struct {
 	mutex sync.Mutex
 	// Route stack divided by HTTP methods
-	stack     [][]*Route
+	stack [][]*Route
+	// Route stack divided by HTTP methods and route prefixes
 	treeStack []map[string][]*Route
 	// Amount of registered routes
 	routesCount int

--- a/app.go
+++ b/app.go
@@ -634,6 +634,7 @@ func (app *App) init() *App {
 	app.server.IdleTimeout = app.Settings.IdleTimeout
 	app.server.ReadBufferSize = app.Settings.ReadBufferSize
 	app.server.WriteBufferSize = app.Settings.WriteBufferSize
+	app.buildTree()
 	app.mutex.Unlock()
 	return app
 }

--- a/ctx.go
+++ b/ctx.go
@@ -646,6 +646,9 @@ func (ctx *Ctx) OriginalURL() string {
 // Returned value is only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting to use the value outside the Handler.
 func (ctx *Ctx) Params(key string, defaultValue ...string) string {
+	if key == "*" || key == "+" {
+		key += "1"
+	}
 	for i := range ctx.route.Params {
 		if len(key) != len(ctx.route.Params[i]) {
 			continue

--- a/ctx.go
+++ b/ctx.go
@@ -38,7 +38,7 @@ type Ctx struct {
 	method       string               // HTTP method
 	methodINT    int                  // HTTP method INT equivalent
 	path         string               // Prettified HTTP path
-	treePart     string               //
+	treePath     string               // Path for the search in the tree
 	pathOriginal string               // Original HTTP path
 	values       []string             // Route parameter values
 	err          error                // Contains error if passed to Next
@@ -1038,8 +1038,8 @@ func (ctx *Ctx) prettifyPath() {
 		ctx.path = utils.TrimRight(ctx.path, '/')
 	}
 
-	ctx.treePart = ctx.treePart[0:0]
+	ctx.treePath = ctx.treePath[0:0]
 	if len(ctx.path) >= 3 {
-		ctx.treePart = ctx.path[:3]
+		ctx.treePath = ctx.path[:3]
 	}
 }

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -913,16 +913,26 @@ func Test_Ctx_Params(t *testing.T) {
 	app.Get("/test2/*", func(c *Ctx) {
 		utils.AssertEqual(t, "im/a/cookie", c.Params("*"))
 	})
-	app.Get("/test3/:optional?", func(c *Ctx) {
+	app.Get("/test3/*/blafasel/*", func(c *Ctx) {
+		utils.AssertEqual(t, "1111", c.Params("*1"))
+		utils.AssertEqual(t, "2222", c.Params("*2"))
+	})
+	app.Get("/test4/:optional?", func(c *Ctx) {
 		utils.AssertEqual(t, "", c.Params("optional"))
 	})
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/test/john", nil))
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
+
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test2/im/a/cookie", nil))
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
-	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test3", nil))
+
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test3/1111/blafasel/2222", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
+
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test4", nil))
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
 }

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -916,6 +916,7 @@ func Test_Ctx_Params(t *testing.T) {
 	app.Get("/test3/*/blafasel/*", func(c *Ctx) {
 		utils.AssertEqual(t, "1111", c.Params("*1"))
 		utils.AssertEqual(t, "2222", c.Params("*2"))
+		utils.AssertEqual(t, "1111", c.Params("*"))
 	})
 	app.Get("/test4/:optional?", func(c *Ctx) {
 		utils.AssertEqual(t, "", c.Params("optional"))

--- a/path.go
+++ b/path.go
@@ -162,7 +162,7 @@ func (routeParser *routeParser) analyseParameterPart(pattern string) (string, ro
 		parameterEndPosition = 0
 	} else if parameterEndPosition == -1 {
 		parameterEndPosition = len(pattern) - 1
-	} else if false == isInCharset(pattern[parameterEndPosition+1], parameterDelimiterChars) {
+	} else if !isInCharset(pattern[parameterEndPosition+1], parameterDelimiterChars) {
 		parameterEndPosition = parameterEndPosition + 1
 	}
 	// cut params part
@@ -230,7 +230,7 @@ func (routeParser *routeParser) getMatch(s string, partialCheck bool) ([][2]int,
 				}
 			}
 			// is optional part or the const part must match with the given string
-			if optionalPart == false && (partLen < i || (i == 0 && partLen > 0) || s[:i] != segment.Const) {
+			if !optionalPart && (partLen < i || (i == 0 && partLen > 0) || s[:i] != segment.Const) {
 				return nil, false
 			}
 		} else {

--- a/path.go
+++ b/path.go
@@ -15,91 +15,141 @@ import (
 
 // routeParser  holds the path segments and param names
 type routeParser struct {
-	segs   []paramSeg
+	segs   []routeSegment
 	params []string
 }
 
 // paramsSeg holds the segment metadata
-type paramSeg struct {
+type routeSegment struct {
 	Param      string
 	Const      string
 	IsParam    bool
+	IsWildcard bool
 	IsOptional bool
 	IsLast     bool
-	EndChar    byte
+	EndChar    byte // TODO: remove ?
 }
 
-// list of possible parameter and segment delimiter
-// slash has a special role, unlike the other parameters it must not be interpreted as a parameter
-// TODO '(' ')' delimiters for regex patterns
-var routeDelimiter = []byte{'/', '-', '.'}
+const (
+	wildcardParam    byte = '*'
+	optionalParam    byte = '?'
+	slashDelimiter   byte = '/'
+	paramStarterChar byte = ':'
+)
 
-const wildcardParam string = "*"
+var (
+	// list of possible parameter and segment delimiter
+	// slash has a special role, unlike the other parameters it must not be interpreted as a parameter
+	// TODO '(' ')' delimiters for regex patterns
+	routeDelimiter = []byte{slashDelimiter, '-', '.'}
+	// list of chars for the parameter recognising
+	parameterStartChars = []byte{wildcardParam, paramStarterChar}
+	// list of chars to find the end of a parameter
+	parameterDelimiterChars = append([]byte{paramStarterChar}, routeDelimiter...)
+	// list of chars to find the end of a parameter
+	parameterEndChars = append([]byte{optionalParam}, parameterDelimiterChars...)
+)
 
 // parseRoute analyzes the route and divides it into segments for constant areas and parameters,
 // this information is needed later when assigning the requests to the declared routes
-func parseRoute(pattern string) (p routeParser) {
-	var out []paramSeg
+func parseRoute(pattern string) routeParser {
+	var segList []routeSegment
 	var params []string
 
-	part, delimiterPos := "", 0
-	for len(pattern) > 0 && delimiterPos != -1 {
-		delimiterPos = findNextRouteSegmentEnd(pattern)
-		if delimiterPos != -1 {
-			part = pattern[:delimiterPos]
+	part := ""
+	for len(pattern) > 0 {
+		nextParamPosition := findNextParamPosition(pattern)
+		// handle the parameter part
+		if nextParamPosition == 0 {
+			processedPart, seg := analyseParameterPart(pattern)
+			params, segList, part = append(params, seg.Param), append(segList, seg), processedPart
 		} else {
-			part = pattern
+			processedPart, seg := analyseConstantPart(pattern, nextParamPosition)
+			segList, part = append(segList, seg), processedPart
 		}
 
-		partLen, lastSeg := len(part), len(out)-1
-		if partLen == 0 { // skip empty parts
-			if len(pattern) > 0 {
-				// remove first char
-				pattern = pattern[1:]
-			}
-			continue
+		// reduce the pattern by the processed parts
+		if len(part) == len(pattern) {
+			break
 		}
-		// is parameter ?
-		if part[0] == '*' || part[0] == ':' {
-			out = append(out, paramSeg{
-				Param:      utils.GetTrimmedParam(part),
-				IsParam:    true,
-				IsOptional: part == wildcardParam || part[partLen-1] == '?',
-			})
-			lastSeg = len(out) - 1
-			params = append(params, out[lastSeg].Param)
-			// combine const segments
-		} else if lastSeg >= 0 && !out[lastSeg].IsParam {
-			out[lastSeg].Const += string(out[lastSeg].EndChar) + part
-			// create new const segment
-		} else {
-			out = append(out, paramSeg{
-				Const: part,
-			})
-			lastSeg = len(out) - 1
-		}
-
-		if delimiterPos != -1 && len(pattern) >= delimiterPos+1 {
-			out[lastSeg].EndChar = pattern[delimiterPos]
-			pattern = pattern[delimiterPos+1:]
-		} else {
-			// last default char
-			out[lastSeg].EndChar = '/'
-		}
+		pattern = pattern[len(part):]
 	}
-	if len(out) > 0 {
-		out[len(out)-1].IsLast = true
+	// mark last segment
+	if len(segList) > 0 {
+		segList[len(segList)-1].IsLast = true
 	}
 
-	p = routeParser{segs: out, params: params}
-	return
+	return routeParser{segs: segList, params: params}
 }
 
-// findNextRouteSegmentEnd searches in the route for the next end position for a segment
-func findNextRouteSegmentEnd(search string) int {
+// findNextParamPosition search for the next possible parameter start position
+func findNextParamPosition(pattern string) int {
+	nextParamPosition := findNextCharsetPosition(pattern, parameterStartChars)
+	if nextParamPosition != -1 && len(pattern) > nextParamPosition && pattern[nextParamPosition] != wildcardParam {
+		// search for parameter characters for the found parameter start,
+		// if there are more, move the parameter start to the last parameter char
+		for found := findNextCharsetPosition(pattern[nextParamPosition+1:], parameterStartChars); found == 0; {
+			nextParamPosition++
+			if len(pattern) > nextParamPosition {
+				break
+			}
+		}
+	}
+
+	return nextParamPosition
+}
+
+// analyseConstantPart find the end of the constant part and create the route segment
+func analyseConstantPart(pattern string, nextParamPosition int) (string, routeSegment) {
+	// handle the constant part
+	processedPart := pattern
+	if nextParamPosition != -1 {
+		// remove the constant part until the parameter
+		processedPart = pattern[:nextParamPosition]
+	}
+	return processedPart, routeSegment{
+		Const: processedPart,
+	}
+}
+
+// analyseParameterPart find the parameter end and create the route segment
+func analyseParameterPart(pattern string) (string, routeSegment) {
+	isWildCard := pattern[0] == wildcardParam
+	parameterEndPosition := findNextCharsetPosition(pattern[1:], parameterEndChars)
+	// handle wildcard end
+	if isWildCard {
+		parameterEndPosition = 0
+	} else if parameterEndPosition == -1 {
+		parameterEndPosition = len(pattern) - 1
+	} else if false == isInCharset(pattern[parameterEndPosition+1], parameterDelimiterChars) {
+		parameterEndPosition = parameterEndPosition + 1
+	}
+	// cut params part
+	processedPart := pattern[0 : parameterEndPosition+1]
+
+	return processedPart, routeSegment{
+		Param:      utils.GetTrimmedParam(processedPart),
+		IsParam:    true,
+		IsOptional: isWildCard || pattern[parameterEndPosition] == optionalParam,
+		IsWildcard: isWildCard,
+	}
+}
+
+// isInCharset check is the given character in the charset list
+func isInCharset(searchChar byte, charset []byte) bool {
+	for _, char := range charset {
+		if char == searchChar {
+			return true
+		}
+	}
+	return false
+}
+
+// findNextCharsetPosition search the next char position from the charset
+func findNextCharsetPosition(search string, charset []byte) int {
 	nextPosition := -1
-	for _, delimiter := range routeDelimiter {
-		if pos := strings.IndexByte(search, delimiter); pos != -1 && (pos < nextPosition || nextPosition == -1) {
+	for _, char := range charset {
+		if pos := strings.IndexByte(search, char); pos != -1 && (pos < nextPosition || nextPosition == -1) {
 			nextPosition = pos
 		}
 	}
@@ -111,33 +161,18 @@ func findNextRouteSegmentEnd(search string) int {
 func (p *routeParser) getMatch(s string, partialCheck bool) ([][2]int, bool) {
 	lenKeys := len(p.params)
 	paramsPositions := getAllocFreeParamsPos(lenKeys)
-	var i, j, paramsIterator, partLen, paramStart int
-	if len(s) > 0 {
-		s = s[1:]
-		paramStart++
-	}
+	var i, paramsIterator, partLen, paramStart int
+	//if len(s) > 0 {
+	//	s = s[1:]
+	//	paramStart++
+	//}
 	for index, segment := range p.segs {
 		partLen = len(s)
 		// check parameter
 		if segment.IsParam {
 			// determine parameter length
-			if segment.Param == wildcardParam {
-				if segment.IsLast {
-					i = partLen
-				} else {
-					i = findWildcardParamLen(s, p.segs, index)
-				}
-			} else {
-				i = strings.IndexByte(s, segment.EndChar)
-			}
-			if i == -1 {
-				i = partLen
-			}
-
+			i = findParamLen(s, p.segs, index)
 			if !segment.IsOptional && i == 0 {
-				return nil, false
-				// special case for not slash end character
-			} else if i > 0 && partLen >= i && segment.EndChar != '/' && s[i-1] == '/' {
 				return nil, false
 			}
 
@@ -145,21 +180,28 @@ func (p *routeParser) getMatch(s string, partialCheck bool) ([][2]int, bool) {
 			paramsIterator++
 		} else {
 			// check const segment
+			optionalPart := false
 			i = len(segment.Const)
-			if partLen < i || (i == 0 && partLen > 0) || s[:i] != segment.Const || (partLen > i && s[i] != segment.EndChar) {
+			if i > 0 && partLen == i-1 && segment.Const[i-1] == slashDelimiter && s[:i-1] == segment.Const[:i-1] {
+				if segment.IsLast || p.segs[index+1].IsOptional {
+					i--
+					optionalPart = true
+				}
+			}
+
+			if optionalPart == false && (partLen < i || (i == 0 && partLen > 0) || s[:i] != segment.Const) {
 				return nil, false
 			}
 		}
 
 		// reduce founded part from the string
 		if partLen > 0 {
-			j = i + 1
-			if segment.IsLast || partLen < j {
-				j = i
+			if partLen < i {
+				i = partLen
 			}
-			paramStart += j
+			paramStart += i
 
-			s = s[j:]
+			s = s[i:]
 		}
 	}
 	if len(s) != 0 && !partialCheck {
@@ -184,29 +226,42 @@ func (p *routeParser) paramsForPos(path string, paramsPositions [][2]int) []stri
 	return params
 }
 
-// findWildcardParamLen for the expressjs wildcard behavior (right to left greedy)
+// findParamLen for the expressjs wildcard behavior (right to left greedy)
 // look at the other segments and take what is left for the wildcard from right to left
-func findWildcardParamLen(s string, segments []paramSeg, currIndex int) int {
+func findParamLen(s string, segments []routeSegment, currIndex int) int {
+	if segments[currIndex].IsLast {
+		if segments[currIndex].IsWildcard {
+			return len(s)
+		}
+		if i := strings.IndexByte(s, slashDelimiter); i != -1 {
+			return i
+		}
+
+		return len(s)
+	}
 	// "/api/*/:param" - "/api/joker/batman/robin/1" -> "joker/batman/robin", "1"
 	// "/api/*/:param" - "/api/joker/batman"         -> "joker", "batman"
 	// "/api/*/:param" - "/api/joker-batman-robin/1" -> "joker-batman-robin", "1"
-	endChar := segments[currIndex].EndChar
-	neededEndChars := 0
-	// count the needed chars for the other segments
-	for i := currIndex + 1; i < len(segments); i++ {
-		if segments[i].EndChar == endChar {
-			neededEndChars++
+	nextSeg := segments[currIndex+1]
+	// check next segment
+	if nextSeg.IsParam {
+		if segments[currIndex].IsWildcard || nextSeg.IsWildcard {
+			// greedy logic
+			for i := currIndex + 1; i < len(segments); i++ {
+				if false == segments[i].IsParam {
+					nextSeg = segments[i]
+					break
+				}
+			}
+		} else if len(s) > 0 {
+			// in case the next parameter or the current parameter is not a wildcard its not greedy, we only want one character
+			return 1
 		}
 	}
-	// remove the part the other segments still need
-	for {
-		pos := strings.LastIndexByte(s, endChar)
-		if pos != -1 {
-			s = s[:pos]
-		}
-		neededEndChars--
-		if neededEndChars <= 0 || pos == -1 {
-			break
+	// get the length to the next constant part
+	if false == nextSeg.IsParam {
+		if constPosition := strings.Index(s, nextSeg.Const); constPosition != -1 {
+			return constPosition
 		}
 	}
 
@@ -221,6 +276,7 @@ var paramsDummy, paramsPosDummy = make([]string, 100000), make([][2]int, 100000)
 // to assign a separate range to each request
 var startParamList, startParamPosList uint32 = 0, 0
 
+// TODO: replace it with bytebufferpool and release the parameter buffers in ctx release function
 // getAllocFreeParamsPos fetches a slice area from the predefined slice, which is currently not in use
 func getAllocFreeParamsPos(allocLen int) [][2]int {
 	size := uint32(allocLen)

--- a/path.go
+++ b/path.go
@@ -27,7 +27,6 @@ type routeSegment struct {
 	IsWildcard bool
 	IsOptional bool
 	IsLast     bool
-	EndChar    byte // TODO: remove ?
 }
 
 const (
@@ -44,7 +43,7 @@ var (
 	routeDelimiter = []byte{slashDelimiter, '-', '.'}
 	// list of chars for the parameter recognising
 	parameterStartChars = []byte{wildcardParam, paramStarterChar}
-	// list of chars to find the end of a parameter
+	// list of chars at the end of the parameter
 	parameterDelimiterChars = append([]byte{paramStarterChar}, routeDelimiter...)
 	// list of chars to find the end of a parameter
 	parameterEndChars = append([]byte{optionalParam}, parameterDelimiterChars...)
@@ -162,10 +161,6 @@ func (p *routeParser) getMatch(s string, partialCheck bool) ([][2]int, bool) {
 	lenKeys := len(p.params)
 	paramsPositions := getAllocFreeParamsPos(lenKeys)
 	var i, paramsIterator, partLen, paramStart int
-	//if len(s) > 0 {
-	//	s = s[1:]
-	//	paramStart++
-	//}
 	for index, segment := range p.segs {
 		partLen = len(s)
 		// check parameter

--- a/path.go
+++ b/path.go
@@ -256,7 +256,11 @@ func findParamLen(s string, segments []routeSegment, currIndex int) int {
 	}
 	// get the length to the next constant part
 	if false == nextSeg.IsParam {
-		if constPosition := strings.Index(s, nextSeg.Const); constPosition != -1 {
+		searchString := nextSeg.Const
+		if len(searchString) > 1 {
+			searchString = utils.TrimRight(nextSeg.Const, slashDelimiter)
+		}
+		if constPosition := strings.Index(s, searchString); constPosition != -1 {
 			return constPosition
 		}
 	}

--- a/path.go
+++ b/path.go
@@ -156,6 +156,7 @@ func findNextCharsetPosition(search string, charset []byte) int {
 	return nextPosition
 }
 
+// TODO: check performance
 // getMatch parses the passed url and tries to match it against the route segments and determine the parameter positions
 func (p *routeParser) getMatch(s string, partialCheck bool) ([][2]int, bool) {
 	lenKeys := len(p.params)

--- a/path_test.go
+++ b/path_test.go
@@ -26,9 +26,7 @@ func Test_Path_parseRoute(t *testing.T) {
 			{Const: "/size:"},
 			{IsParam: true, ParamName: "size", IsLast: true},
 		},
-		params:        []string{"filter", "color", "size"},
-		wildCardCount: 0,
-		plusCount:     0,
+		params: []string{"filter", "color", "size"},
 	}, rp)
 
 	rp = parseRoute("/api/v1/:param/abc/*")
@@ -41,7 +39,6 @@ func Test_Path_parseRoute(t *testing.T) {
 		},
 		params:        []string{"param", "*1"},
 		wildCardCount: 1,
-		plusCount:     0,
 	}, rp)
 
 	rp = parseRoute("/api/*/:param/:param2")
@@ -56,7 +53,6 @@ func Test_Path_parseRoute(t *testing.T) {
 		},
 		params:        []string{"*1", "param", "param2"},
 		wildCardCount: 1,
-		plusCount:     0,
 	}, rp)
 
 	rp = parseRoute("/test:optional?:optional2?")
@@ -66,21 +62,18 @@ func Test_Path_parseRoute(t *testing.T) {
 			{IsParam: true, ParamName: "optional", IsOptional: true},
 			{IsParam: true, ParamName: "optional2", IsOptional: true, IsLast: true},
 		},
-		params:        []string{"optional", "optional2"},
-		wildCardCount: 0,
-		plusCount:     0,
+		params: []string{"optional", "optional2"},
 	}, rp)
 
 	rp = parseRoute("/config/+.json")
 	utils.AssertEqual(t, routeParser{
 		segs: []routeSegment{
 			{Const: "/config/"},
-			{IsParam: true, ParamName: "+1", IsGreedy: true, IsOptional: false, ComparePart: ".json", PartCount: 0},
+			{IsParam: true, ParamName: "+1", IsGreedy: true, IsOptional: false, ComparePart: ".json", PartCount: 1},
 			{Const: ".json", IsLast: true},
 		},
-		params:        []string{"+1"},
-		wildCardCount: 0,
-		plusCount:     1,
+		params:    []string{"+1"},
+		plusCount: 1,
 	}, rp)
 
 	rp = parseRoute("/api/:day.:month?.:year?")
@@ -93,9 +86,20 @@ func Test_Path_parseRoute(t *testing.T) {
 			{Const: "."},
 			{IsParam: true, ParamName: "year", IsOptional: true, IsLast: true},
 		},
-		params:        []string{"day", "month", "year"},
-		wildCardCount: 0,
-		plusCount:     0,
+		params: []string{"day", "month", "year"},
+	}, rp)
+
+	rp = parseRoute("/*v1*/proxy")
+	utils.AssertEqual(t, routeParser{
+		segs: []routeSegment{
+			{Const: "/"},
+			{IsParam: true, ParamName: "*1", IsGreedy: true, IsOptional: true, ComparePart: "v1", PartCount: 1},
+			{Const: "v1"},
+			{IsParam: true, ParamName: "*2", IsGreedy: true, IsOptional: true, ComparePart: "/proxy", PartCount: 1},
+			{Const: "/proxy", IsLast: true},
+		},
+		params:        []string{"*1", "*2"},
+		wildCardCount: 2,
 	}, rp)
 }
 

--- a/path_test.go
+++ b/path_test.go
@@ -238,43 +238,36 @@ func Test_Path_matchParams(t *testing.T) {
 		{url: "/api/", params: []string{"", ""}, match: true},
 		{url: "/api/joker", params: []string{"joker", ""}, match: true},
 		{url: "/api/joker/batman", params: []string{"joker", "batman"}, match: true},
-		//{url: "/api/joker//batman", params: []string{"joker//batman", "batman"}, match: true},
-		//{url: "/api/joker/batman/robin", params: []string{"joker/batman", "robin"}, match: true},
-		//{url: "/api/joker/batman/robin/1", params: []string{"joker/batman/robin", "1"}, match: true},
-		//{url: "/api/joker/batman/robin/1/", params: []string{"joker/batman/robin/1", ""}, match: true},
-		//{url: "/api/joker-batman/robin/1", params: []string{"joker-batman/robin", "1"}, match: true},
-		//{url: "/api/joker-batman-robin/1", params: []string{"joker-batman-robin", "1"}, match: true},
-		//{url: "/api/joker-batman-robin-1", params: []string{"joker-batman-robin-1", ""}, match: true},
+		//{url: "/api/joker//batman", params: []string{"joker//batman", "batman"}, match: true},// TODO: fix it
+		//{url: "/api/joker/batman/robin", params: []string{"joker/batman", "robin"}, match: true},// TODO: fix it
+		//{url: "/api/joker/batman/robin/1", params: []string{"joker/batman/robin", "1"}, match: true},// TODO: fix it
+		//{url: "/api/joker/batman/robin/1/", params: []string{"joker/batman/robin/1", ""}, match: true},// TODO: fix it
+		//{url: "/api/joker-batman/robin/1", params: []string{"joker-batman/robin", "1"}, match: true},// TODO: fix it
+		//{url: "/api/joker-batman-robin/1", params: []string{"joker-batman-robin", "1"}, match: true},// TODO: fix it
+		//{url: "/api/joker-batman-robin-1", params: []string{"joker-batman-robin-1", ""}, match: true},// TODO: fix it
 		{url: "/api", params: []string{"", ""}, match: true},
 	})
-	//testCase("/api/*/:param", []testparams{
-	//	{url: "/api/test/abc", params: []string{"test", "abc"}, match: true},
-	//	{url: "/api/joker/batman", params: []string{"joker", "batman"}, match: true},
-	//	{url: "/api/joker/batman/robin", params: []string{"joker/batman", "robin"}, match: true},
-	//	{url: "/api/joker/batman/robin/1", params: []string{"joker/batman/robin", "1"}, match: true},
-	//	{url: "/api/joker/batman-robin/1", params: []string{"joker/batman-robin", "1"}, match: true},
-	//	{url: "/api/joker-batman-robin-1", params: nil, match: false},
-	//	{url: "/api", params: nil, match: false},
-	//})
-	//testCase("/api/*/:param/:param2", []testparams{
-	//	{url: "/api/test/abc/1", params: []string{"test", "abc", "1"}, match: true},
-	//	{url: "/api/joker/batman", params: nil, match: false},
-	//	{url: "/api/joker/batman/robin", params: []string{"joker", "batman", "robin"}, match: true},
-	//	{url: "/api/joker/batman/robin/1", params: []string{"joker/batman", "robin", "1"}, match: true},
-	//	{url: "/api/joker/batman/robin/2/1", params: []string{"joker/batman/robin", "2", "1"}, match: true},
-	//	{url: "/api/joker/batman-robin/1", params: []string{"joker", "batman-robin", "1"}, match: true},
-	//	{url: "/api/joker-batman-robin-1", params: nil, match: false},
-	//	{url: "/api", params: nil, match: false},
-	//})
-	//testCase("/api/*/:param/:param2", []testparams{
-	//	{url: "/api/test/abc", params: nil, match: false},
-	//	{url: "/api/joker/batman", params: nil, match: false},
-	//	{url: "/api/joker/batman/robin", params: []string{"joker", "batman", "robin"}, match: true},
-	//	{url: "/api/joker/batman/robin/1", params: []string{"joker/batman", "robin", "1"}, match: true},
-	//	{url: "/api/joker/batman/robin/1/2", params: []string{"joker/batman/robin", "1", "2"}, match: true},
-	//	{url: "/api", params: nil, match: false},
-	//	{url: "/api/:test", params: nil, match: false},
-	//})
+	testCase("/api/*/:param", []testparams{
+		{url: "/api/test/abc", params: []string{"test", "abc"}, match: true},
+		{url: "/api/joker/batman", params: []string{"joker", "batman"}, match: true},
+		//{url: "/api/joker/batman/robin", params: []string{"joker/batman", "robin"}, match: true},// TODO: fix it
+		//{url: "/api/joker/batman/robin/1", params: []string{"joker/batman/robin", "1"}, match: true},// TODO: fix it
+		//{url: "/api/joker/batman-robin/1", params: []string{"joker/batman-robin", "1"}, match: true},// TODO: fix it
+		{url: "/api/joker-batman-robin-1", params: nil, match: false},
+		{url: "/api", params: nil, match: false},
+	})
+	testCase("/api/*/:param/:param2", []testparams{
+		{url: "/api/test/abc/1", params: []string{"test", "abc", "1"}, match: true},
+		{url: "/api/joker/batman", params: nil, match: false},
+		{url: "/api/joker/batman-robin/1", params: []string{"joker", "batman-robin", "1"}, match: true},
+		{url: "/api/joker-batman-robin-1", params: nil, match: false},
+		{url: "/api/test/abc", params: nil, match: false},
+		{url: "/api/joker/batman/robin", params: []string{"joker", "batman", "robin"}, match: true},
+		//{url: "/api/joker/batman/robin/1", params: []string{"joker/batman", "robin", "1"}, match: true}, // TODO: fix it
+		//{url: "/api/joker/batman/robin/1/2", params: []string{"joker/batman/robin", "1", "2"}, match: true},// TODO: fix it
+		{url: "/api", params: nil, match: false},
+		{url: "/api/:test", params: nil, match: false},
+	})
 }
 
 // go test -race -run Test_Reset_StartParamPosList

--- a/path_test.go
+++ b/path_test.go
@@ -128,12 +128,11 @@ func Test_Path_matchParams(t *testing.T) {
 		{url: "/foobar", params: []string{""}, match: true},
 		{url: "/", params: []string{""}, match: false},
 	})
-	// TODO: fix it
-	//testCase("/a*cde*g/", []testparams{
-	//	{url: "/abbbcdefffg", params: []string{"bbb", "fff"}, match: true},
-	//	{url: "/acdeg", params: []string{"", ""}, match: true},
-	//	{url: "/", params: nil, match: false},
-	//})
+	testCase("/a*cde*g/", []testparams{
+		{url: "/abbbcdefffg", params: []string{"bbb", "fff"}, match: true},
+		{url: "/acdeg", params: []string{"", ""}, match: true},
+		{url: "/", params: nil, match: false},
+	})
 	testCase("/*v1*/proxy", []testparams{
 		{url: "/customer/v1/cart/proxy", params: []string{"customer/", "/cart"}, match: true},
 		{url: "/v1/proxy", params: []string{"", ""}, match: true},
@@ -162,7 +161,7 @@ func Test_Path_matchParams(t *testing.T) {
 	testCase("/api/v1/:param/abc/*", []testparams{
 		{url: "/api/v1/well/abc/wildcard", params: []string{"well", "wildcard"}, match: true},
 		{url: "/api/v1/well/abc/", params: []string{"well", ""}, match: true},
-		{url: "/api/v1/well/abc", params: nil, match: false},
+		{url: "/api/v1/well/abc", params: []string{"well", ""}, match: true},
 		{url: "/api/v1/well/ttt", params: nil, match: false},
 	})
 	testCase("/api/:day/:month?/:year?", []testparams{
@@ -235,19 +234,19 @@ func Test_Path_matchParams(t *testing.T) {
 		{url: "xyz/", params: nil, match: false},
 	})
 	// TODO: fix this
-	//testCase("/api/*/:param?", []testparams{
-	//	{url: "/api/", params: []string{"", ""}, match: true},
-	//	{url: "/api/joker", params: []string{"joker", ""}, match: true},
-	//	{url: "/api/joker/batman", params: []string{"joker", "batman"}, match: true},
-	//	{url: "/api/joker//batman", params: []string{"joker//batman", "batman"}, match: true},
-	//	{url: "/api/joker/batman/robin", params: []string{"joker/batman", "robin"}, match: true},
-	//	{url: "/api/joker/batman/robin/1", params: []string{"joker/batman/robin", "1"}, match: true},
-	//	{url: "/api/joker/batman/robin/1/", params: []string{"joker/batman/robin/1", ""}, match: true},
-	//	{url: "/api/joker-batman/robin/1", params: []string{"joker-batman/robin", "1"}, match: true},
-	//	{url: "/api/joker-batman-robin/1", params: []string{"joker-batman-robin", "1"}, match: true},
-	//	{url: "/api/joker-batman-robin-1", params: []string{"joker-batman-robin-1", ""}, match: true},
-	//	{url: "/api", params: []string{"", ""}, match: true},
-	//})
+	testCase("/api/*/:param?", []testparams{
+		{url: "/api/", params: []string{"", ""}, match: true},
+		{url: "/api/joker", params: []string{"joker", ""}, match: true},
+		{url: "/api/joker/batman", params: []string{"joker", "batman"}, match: true},
+		//{url: "/api/joker//batman", params: []string{"joker//batman", "batman"}, match: true},
+		//{url: "/api/joker/batman/robin", params: []string{"joker/batman", "robin"}, match: true},
+		//{url: "/api/joker/batman/robin/1", params: []string{"joker/batman/robin", "1"}, match: true},
+		//{url: "/api/joker/batman/robin/1/", params: []string{"joker/batman/robin/1", ""}, match: true},
+		//{url: "/api/joker-batman/robin/1", params: []string{"joker-batman/robin", "1"}, match: true},
+		//{url: "/api/joker-batman-robin/1", params: []string{"joker-batman-robin", "1"}, match: true},
+		//{url: "/api/joker-batman-robin-1", params: []string{"joker-batman-robin-1", ""}, match: true},
+		{url: "/api", params: []string{"", ""}, match: true},
+	})
 	//testCase("/api/*/:param", []testparams{
 	//	{url: "/api/test/abc", params: []string{"test", "abc"}, match: true},
 	//	{url: "/api/joker/batman", params: []string{"joker", "batman"}, match: true},

--- a/path_test.go
+++ b/path_test.go
@@ -41,6 +41,14 @@ func Test_Path_matchParams(t *testing.T) {
 		{url: "/api/v2", params: nil, match: false},
 		{url: "/api/v1/", params: nil, match: false},
 	})
+	testCase("/api/v1/:param/+", []testparams{
+		{url: "/api/v1/entity", params: nil, match: false},
+		{url: "/api/v1/entity/", params: nil, match: false},
+		{url: "/api/v1/entity/1", params: []string{"entity", "1"}, match: true},
+		{url: "/api/v", params: nil, match: false},
+		{url: "/api/v2", params: nil, match: false},
+		{url: "/api/v1/", params: nil, match: false},
+	})
 	testCase("/api/v1/:param?", []testparams{
 		{url: "/api/v1", params: []string{""}, match: true},
 		{url: "/api/v1/", params: []string{""}, match: true},
@@ -126,7 +134,12 @@ func Test_Path_matchParams(t *testing.T) {
 	testCase("/foo*bar", []testparams{
 		{url: "/foofaselbar", params: []string{"fasel"}, match: true},
 		{url: "/foobar", params: []string{""}, match: true},
-		{url: "/", params: []string{""}, match: false},
+		{url: "/", params: nil, match: false},
+	})
+	testCase("/foo+bar", []testparams{
+		{url: "/foofaselbar", params: []string{"fasel"}, match: true},
+		{url: "/foobar", params: nil, match: false},
+		{url: "/", params: nil, match: false},
 	})
 	testCase("/a*cde*g/", []testparams{
 		{url: "/abbbcdefffg", params: []string{"bbb", "fff"}, match: true},
@@ -225,6 +238,15 @@ func Test_Path_matchParams(t *testing.T) {
 	testCase("/config/*.json", []testparams{
 		{url: "/config/abc.json", params: []string{"abc"}, match: true},
 		{url: "/config/efg.json", params: []string{"efg"}, match: true},
+		{url: "/config/.json", params: []string{""}, match: true},
+		{url: "/config/efg.csv", params: nil, match: false},
+		{url: "config/abc.json", params: nil, match: false},
+		{url: "/config", params: nil, match: false},
+	})
+	testCase("/config/+.json", []testparams{
+		{url: "/config/abc.json", params: []string{"abc"}, match: true},
+		{url: "/config/.json", params: nil, match: false},
+		{url: "/config/efg.json", params: []string{"efg"}, match: true},
 		{url: "/config/efg.csv", params: nil, match: false},
 		{url: "config/abc.json", params: nil, match: false},
 		{url: "/config", params: nil, match: false},
@@ -233,27 +255,32 @@ func Test_Path_matchParams(t *testing.T) {
 		{url: "xyz", params: nil, match: false},
 		{url: "xyz/", params: nil, match: false},
 	})
-	// TODO: fix this
 	testCase("/api/*/:param?", []testparams{
 		{url: "/api/", params: []string{"", ""}, match: true},
 		{url: "/api/joker", params: []string{"joker", ""}, match: true},
 		{url: "/api/joker/batman", params: []string{"joker", "batman"}, match: true},
-		//{url: "/api/joker//batman", params: []string{"joker//batman", "batman"}, match: true},// TODO: fix it
-		//{url: "/api/joker/batman/robin", params: []string{"joker/batman", "robin"}, match: true},// TODO: fix it
-		//{url: "/api/joker/batman/robin/1", params: []string{"joker/batman/robin", "1"}, match: true},// TODO: fix it
-		//{url: "/api/joker/batman/robin/1/", params: []string{"joker/batman/robin/1", ""}, match: true},// TODO: fix it
-		//{url: "/api/joker-batman/robin/1", params: []string{"joker-batman/robin", "1"}, match: true},// TODO: fix it
-		//{url: "/api/joker-batman-robin/1", params: []string{"joker-batman-robin", "1"}, match: true},// TODO: fix it
-		//{url: "/api/joker-batman-robin-1", params: []string{"joker-batman-robin-1", ""}, match: true},// TODO: fix it
+		{url: "/api/joker//batman", params: []string{"joker/", "batman"}, match: true},
+		{url: "/api/joker/batman/robin", params: []string{"joker/batman", "robin"}, match: true},
+		{url: "/api/joker/batman/robin/1", params: []string{"joker/batman/robin", "1"}, match: true},
+		{url: "/api/joker/batman/robin/1/", params: []string{"joker/batman/robin/1", ""}, match: true},
+		{url: "/api/joker-batman/robin/1", params: []string{"joker-batman/robin", "1"}, match: true},
+		{url: "/api/joker-batman-robin/1", params: []string{"joker-batman-robin", "1"}, match: true},
+		{url: "/api/joker-batman-robin-1", params: []string{"joker-batman-robin-1", ""}, match: true},
 		{url: "/api", params: []string{"", ""}, match: true},
 	})
 	testCase("/api/*/:param", []testparams{
 		{url: "/api/test/abc", params: []string{"test", "abc"}, match: true},
 		{url: "/api/joker/batman", params: []string{"joker", "batman"}, match: true},
-		//{url: "/api/joker/batman/robin", params: []string{"joker/batman", "robin"}, match: true},// TODO: fix it
-		//{url: "/api/joker/batman/robin/1", params: []string{"joker/batman/robin", "1"}, match: true},// TODO: fix it
-		//{url: "/api/joker/batman-robin/1", params: []string{"joker/batman-robin", "1"}, match: true},// TODO: fix it
+		{url: "/api/joker/batman/robin", params: []string{"joker/batman", "robin"}, match: true},
+		{url: "/api/joker/batman/robin/1", params: []string{"joker/batman/robin", "1"}, match: true},
+		{url: "/api/joker/batman-robin/1", params: []string{"joker/batman-robin", "1"}, match: true},
 		{url: "/api/joker-batman-robin-1", params: nil, match: false},
+		{url: "/api", params: nil, match: false},
+	})
+	testCase("/api/+/:param", []testparams{
+		{url: "/api/test/abc", params: []string{"test", "abc"}, match: true},
+		{url: "/api/joker/batman/robin/1", params: []string{"joker/batman/robin", "1"}, match: true},
+		{url: "/api/joker", params: nil, match: false},
 		{url: "/api", params: nil, match: false},
 	})
 	testCase("/api/*/:param/:param2", []testparams{
@@ -263,8 +290,8 @@ func Test_Path_matchParams(t *testing.T) {
 		{url: "/api/joker-batman-robin-1", params: nil, match: false},
 		{url: "/api/test/abc", params: nil, match: false},
 		{url: "/api/joker/batman/robin", params: []string{"joker", "batman", "robin"}, match: true},
-		//{url: "/api/joker/batman/robin/1", params: []string{"joker/batman", "robin", "1"}, match: true}, // TODO: fix it
-		//{url: "/api/joker/batman/robin/1/2", params: []string{"joker/batman/robin", "1", "2"}, match: true},// TODO: fix it
+		{url: "/api/joker/batman/robin/1", params: []string{"joker/batman", "robin", "1"}, match: true},
+		{url: "/api/joker/batman/robin/1/2", params: []string{"joker/batman/robin", "1", "2"}, match: true},
 		{url: "/api", params: nil, match: false},
 		{url: "/api/:test", params: nil, match: false},
 	})

--- a/router.go
+++ b/router.go
@@ -356,7 +356,7 @@ func (app *App) addRoute(method string, route *Route) {
 	}
 }
 
-// uniqueRouteStack
+// buildTree build the prefix tree from the previously registered routes
 func (app *App) buildTree() *App {
 	// loop all the methods and stacks and create the prefix tree
 	for m := range intMethod {

--- a/router_test.go
+++ b/router_test.go
@@ -98,8 +98,8 @@ func Test_Route_Match_Root(t *testing.T) {
 func Test_Route_Match_Parser(t *testing.T) {
 	app := New()
 
-	app.Get("/foo/:Param", func(ctx *Ctx) {
-		ctx.Send(ctx.Params("Param"))
+	app.Get("/foo/:ParamName", func(ctx *Ctx) {
+		ctx.Send(ctx.Params("ParamName"))
 	})
 	app.Get("/Foobar/*", func(ctx *Ctx) {
 		ctx.Send(ctx.Params("*"))

--- a/router_test.go
+++ b/router_test.go
@@ -234,8 +234,7 @@ func Test_Router_Handler_SetETag(t *testing.T) {
 	})
 
 	c := &fasthttp.RequestCtx{}
-
-	app.handler(c)
+	app.init().handler(c)
 
 	utils.AssertEqual(t, `"13-1831710635"`, string(c.Response.Header.Peek(HeaderETag)))
 }
@@ -375,6 +374,7 @@ func Benchmark_Router_Next(b *testing.B) {
 	request.URI().SetPath("/user/keys/1337")
 	var res bool
 
+	app.init()
 	c := app.AcquireCtx(request)
 	defer app.ReleaseCtx(c)
 
@@ -518,6 +518,7 @@ func Benchmark_Router_Handler_StrictRouting(b *testing.B) {
 func Benchmark_Router_Github_API(b *testing.B) {
 	app := New()
 	registerDummyRoutes(app)
+	app.init()
 
 	c := &fasthttp.RequestCtx{}
 	var match bool

--- a/utils.go
+++ b/utils.go
@@ -51,7 +51,7 @@ func setMethodNotAllowed(ctx *Ctx) {
 		}
 		// Reset stack index
 		ctx.indexRoute = -1
-		tree, ok := ctx.app.treeStack[i][ctx.treePart]
+		tree, ok := ctx.app.treeStack[i][ctx.treePath]
 		if !ok {
 			tree = ctx.app.treeStack[i][""]
 		}
@@ -292,6 +292,22 @@ var getStringImmutable = func(b []byte) string {
 var getBytes = utils.GetBytes
 var getBytesImmutable = func(s string) (b []byte) {
 	return []byte(s)
+}
+
+// uniqueRouteStack drop all not unique routes from the slice
+func uniqueRouteStack(stack []*Route) []*Route {
+	var unique []*Route
+	m := make(map[*Route]int)
+	for _, v := range stack {
+		if _, ok := m[v]; !ok {
+			// Unique key found. Record position and collect
+			// in result.
+			m[v] = len(unique)
+			unique = append(unique, v)
+		}
+	}
+
+	return unique
 }
 
 // HTTP methods and their unique INTs

--- a/utils_test.go
+++ b/utils_test.go
@@ -211,6 +211,34 @@ func Test_Utils_TestConn_Deadline(t *testing.T) {
 	utils.AssertEqual(t, nil, conn.SetWriteDeadline(time.Time{}))
 }
 
+func Test_Utils_UniqueRouteStack(t *testing.T) {
+	route1 := &Route{}
+	route2 := &Route{}
+	route3 := &Route{}
+	utils.AssertEqual(
+		t,
+		[]*Route{
+			route1,
+			route2,
+			route3,
+		},
+		uniqueRouteStack([]*Route{
+			route1,
+			route1,
+			route1,
+			route2,
+			route2,
+			route2,
+			route3,
+			route3,
+			route3,
+			route1,
+			route2,
+			route3,
+		}),
+	)
+}
+
 func Test_Utils_IsNoCache(t *testing.T) {
 	testCases := []struct {
 		string


### PR DESCRIPTION
🌵  hybrid routing with tree and fast router:
for performance reasons, a new layer has been added to reduce the number of routes to be checked
NEW:
```go
Benchmark_Router_NotFound-12                  4345894       249 ns/op      80 B/op       2 allocs/op
Benchmark_Router_NotFound-12                  5195691       252 ns/op      80 B/op       2 allocs/op
Benchmark_Router_NotFound-12                  4069700       262 ns/op      80 B/op       2 allocs/op
Benchmark_Router_Handler-12                   6323901       200 ns/op      16 B/op       1 allocs/op
Benchmark_Router_Handler-12                   5701125       207 ns/op      16 B/op       1 allocs/op
Benchmark_Router_Handler-12                   5515296       204 ns/op      16 B/op       1 allocs/op
Benchmark_Router_Handler_Strict_Case-12       8015640       163 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_Strict_Case-12       6137475       166 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_Strict_Case-12       6816235       161 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Chain-12                     7098813       181 ns/op       1 B/op       1 allocs/op
Benchmark_Router_Chain-12                     5729186       184 ns/op       1 B/op       1 allocs/op
Benchmark_Router_Chain-12                     6193328       193 ns/op       1 B/op       1 allocs/op
Benchmark_Router_WithCompression-12           7151931       210 ns/op       1 B/op       1 allocs/op
Benchmark_Router_WithCompression-12           5523699       253 ns/op       1 B/op       1 allocs/op
Benchmark_Router_WithCompression-12           5808300       196 ns/op       1 B/op       1 allocs/op
Benchmark_Router_Next-12                      6674808       168 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Next-12                      7946442       170 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Next-12                      6494916       181 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_CaseSensitive-12     5816659       181 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_CaseSensitive-12     6736150       184 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_CaseSensitive-12     5855480       177 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_StrictRouting-12     5917713       171 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_StrictRouting-12     7801450       172 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_StrictRouting-12     6779619       185 ns/op       0 B/op       0 allocs/op
```
OLD:
```go
Benchmark_Router_NotFound-12                   180708      6370 ns/op      81 B/op       2 allocs/op
Benchmark_Router_NotFound-12                   182854      6283 ns/op      81 B/op       2 allocs/op
Benchmark_Router_NotFound-12                   186518      6678 ns/op      81 B/op       2 allocs/op
Benchmark_Router_Handler-12                   1287981       932 ns/op      16 B/op       1 allocs/op
Benchmark_Router_Handler-12                   1382036       874 ns/op      16 B/op       1 allocs/op
Benchmark_Router_Handler-12                   1323716       939 ns/op      16 B/op       1 allocs/op
Benchmark_Router_Handler_Strict_Case-12       1359414       861 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_Strict_Case-12       1343726       816 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_Strict_Case-12       1398574       833 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Chain-12                     8485028       151 ns/op       1 B/op       1 allocs/op
Benchmark_Router_Chain-12                     7041121       159 ns/op       1 B/op       1 allocs/op
Benchmark_Router_Chain-12                     8779014       145 ns/op       1 B/op       1 allocs/op
Benchmark_Router_WithCompression-12           7582238       162 ns/op       1 B/op       1 allocs/op
Benchmark_Router_WithCompression-12           7094360       151 ns/op       1 B/op       1 allocs/op
Benchmark_Router_WithCompression-12           8705498       161 ns/op       1 B/op       1 allocs/op
Benchmark_Router_Next-12                      1387620       854 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Next-12                      1495340       841 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Next-12                      1441519       897 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_CaseSensitive-12     1362174       894 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_CaseSensitive-12     1443130       830 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_CaseSensitive-12     1422104       811 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_StrictRouting-12     1421395       856 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_StrictRouting-12     1412744       939 ns/op       0 B/op       0 allocs/op
Benchmark_Router_Handler_StrictRouting-12     1360618       834 ns/op       0 B/op       0 allocs/op
```

🐞 Benchmark_Router_Handler_Unescape
-> there was a bug in benchmark, which caused the slow "methodNotAllowed" logic to be addressed
```go
NEW:
Benchmark_Router_Handler_Unescape-12          3236104       359 ns/op       8 B/op       1 allocs/op
Benchmark_Router_Handler_Unescape-12          3056844       350 ns/op       8 B/op       1 allocs/op
Benchmark_Router_Handler_Unescape-12          4107015       330 ns/op       8 B/op       1 allocs/op
OLD:
Benchmark_Router_Handler_Unescape-12           218133      6616 ns/op      17 B/op       1 allocs/op
Benchmark_Router_Handler_Unescape-12           157705      6470 ns/op      17 B/op       1 allocs/op
Benchmark_Router_Handler_Unescape-12           189160      6358 ns/op      17 B/op       1 allocs/op
```

🚀  improve routing behavior:
https://github.com/gofiber/fiber/issues/707
routing behaviour has been rewritten, simplified and made more readable, additionally the greedy logic has been improved.
-> the greedy logic is a bit slower, but more correct, should be bearable

Now something like this is possible 🔥
```go
"/shop/product/::filter/color::color/size::size"
"/api/v1/:param/+"
"/test:sign:param"
"/:param1:param2?:param3"
"/test:optional?:mandatory"
"/test:optional?:optional2?"
"/foo:param?bar"
"/foo*bar"
"/foo+bar"
"/a*cde*g/"
"/*v1*/proxy"
"/foo***bar"
"/name::name"
"/@:name"
"/-:name"
"/.:name"
"/config/+.json"
```

🗽The logic for parsing the route now better recognizes the parts which are not parameters, so the parameter can be placed anywhere, it is only important that the normal non-optional parameters are terminated by a delimiter character:
```go
"/test::param/"
```

➕ Added support for the plus parameter, this is greedy like the wildcard parameter with the difference that it is required:
```go
route: "/config/+.json"
request uris:
/config/abc.json -> match
/config/.json    -> no match

access per ctx.Params("+") or ctx.Params("+1")
```

🌟 ✨ Support for multiple wildcard and plus parameters has been added, they can now be accessed via wild or plus position in the route or normally for the first as in the current fiber version:
```go
// request uri -> /customer/v1/cart/proxy
app.Get("/*v1*/proxy", func(c *Ctx) {
	utils.AssertEqual(t, "customer/", c.Params("*1"))
	utils.AssertEqual(t, "/cart", c.Params("*2"))
        // old way is still possible
	utils.AssertEqual(t, "customer/", c.Params("*"))
})
```

🚨 And some more testcases for the route parser....

❗ attention 3 routing cases are still open, these should be negligible, because they are not used in the real world, but they are necessary to reproduce the express behaviour