### PR TITLE
⚙ init on Handler call

### DIFF
--- a/app.go
+++ b/app.go
@@ -49,6 +49,8 @@ type Error struct {
 // App denotes the Fiber application.
 type App struct {
 	mutex sync.Mutex
+	// Defines if the application is initialized
+	initialized bool
 	// Route stack divided by HTTP methods
 	stack [][]*Route
 	// Route stack divided by HTTP methods and route prefixes
@@ -439,8 +441,10 @@ func (app *App) Serve(ln net.Listener, tlsconfig ...*tls.Config) error {
 // This method does not support the Prefork feature
 // To use Prefork, please use app.Listen()
 func (app *App) Listener(ln net.Listener, tlsconfig ...*tls.Config) error {
-	// Update fiber server settings
-	app.init()
+	// Update server settings
+	if !app.initialized {
+		app.init()
+	}
 	// TLS config
 	if len(tlsconfig) > 0 {
 		ln = tls.NewListener(ln, tlsconfig[0])
@@ -472,8 +476,10 @@ func (app *App) Listen(address interface{}, tlsconfig ...*tls.Config) error {
 	if !strings.Contains(addr, ":") {
 		addr = ":" + addr
 	}
-	// Update fiber server settings
-	app.init()
+	// Update server settings
+	if !app.initialized {
+		app.init()
+	}
 	// Start prefork
 	if app.Settings.Prefork {
 		return app.prefork(addr, tlsconfig...)
@@ -543,7 +549,9 @@ func (app *App) Test(request *http.Request, msTimeout ...int) (*http.Response, e
 		return nil, err
 	}
 	// Update server settings
-	app.init()
+	if !app.initialized {
+		app.init()
+	}
 	// Create test connection
 	conn := new(testConn)
 	// Write raw http request
@@ -590,6 +598,8 @@ func (dl *disableLogger) Printf(format string, args ...interface{}) {
 
 func (app *App) init() *App {
 	app.mutex.Lock()
+	// Only init once
+	app.initialized = true
 	// Load view engine if provided
 	if app.Settings != nil {
 		// Only load templates if an view engine is specified

--- a/app.go
+++ b/app.go
@@ -508,6 +508,9 @@ func (app *App) Listen(address interface{}, tlsconfig ...*tls.Config) error {
 
 // Handler returns the server handler.
 func (app *App) Handler() fasthttp.RequestHandler {
+	if !app.initialized {
+		app.init()
+	}
 	return app.handler
 }
 

--- a/app.go
+++ b/app.go
@@ -49,8 +49,6 @@ type Error struct {
 // App denotes the Fiber application.
 type App struct {
 	mutex sync.Mutex
-	// Defines if the application is initialized
-	initialized bool
 	// Route stack divided by HTTP methods
 	stack [][]*Route
 	// Route stack divided by HTTP methods and route prefixes
@@ -592,11 +590,10 @@ func (dl *disableLogger) Printf(format string, args ...interface{}) {
 }
 
 func (app *App) init() *App {
-	// Initialize only once
-	if app.initialized {
-		return app
-	}
+	// Lock application
 	app.mutex.Lock()
+	defer app.mutex.Unlock()
+
 	// Load view engine if provided
 	if app.Settings != nil {
 		// Only load templates if an view engine is specified
@@ -643,9 +640,6 @@ func (app *App) init() *App {
 	app.server.ReadBufferSize = app.Settings.ReadBufferSize
 	app.server.WriteBufferSize = app.Settings.WriteBufferSize
 	app.buildTree()
-	// App is initialized
-	app.initialized = true
-	app.mutex.Unlock()
 	return app
 }
 

--- a/app.go
+++ b/app.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Version of current package
-const Version = "1.13.4"
+const Version = "1.13.3"
 
 // Map is a shortcut for map[string]interface{}, useful for JSON returns
 type Map map[string]interface{}

--- a/app.go
+++ b/app.go
@@ -442,9 +442,7 @@ func (app *App) Serve(ln net.Listener, tlsconfig ...*tls.Config) error {
 // To use Prefork, please use app.Listen()
 func (app *App) Listener(ln net.Listener, tlsconfig ...*tls.Config) error {
 	// Update server settings
-	if !app.initialized {
-		app.init()
-	}
+	app.init()
 	// TLS config
 	if len(tlsconfig) > 0 {
 		ln = tls.NewListener(ln, tlsconfig[0])
@@ -477,9 +475,7 @@ func (app *App) Listen(address interface{}, tlsconfig ...*tls.Config) error {
 		addr = ":" + addr
 	}
 	// Update server settings
-	if !app.initialized {
-		app.init()
-	}
+	app.init()
 	// Start prefork
 	if app.Settings.Prefork {
 		return app.prefork(addr, tlsconfig...)
@@ -508,9 +504,7 @@ func (app *App) Listen(address interface{}, tlsconfig ...*tls.Config) error {
 
 // Handler returns the server handler.
 func (app *App) Handler() fasthttp.RequestHandler {
-	if !app.initialized {
-		app.init()
-	}
+	app.init()
 	return app.handler
 }
 
@@ -552,9 +546,7 @@ func (app *App) Test(request *http.Request, msTimeout ...int) (*http.Response, e
 		return nil, err
 	}
 	// Update server settings
-	if !app.initialized {
-		app.init()
-	}
+	app.init()
 	// Create test connection
 	conn := new(testConn)
 	// Write raw http request
@@ -600,9 +592,11 @@ func (dl *disableLogger) Printf(format string, args ...interface{}) {
 }
 
 func (app *App) init() *App {
+	// Initialize only once
+	if app.initialized {
+		return app
+	}
 	app.mutex.Lock()
-	// Only init once
-	app.initialized = true
 	// Load view engine if provided
 	if app.Settings != nil {
 		// Only load templates if an view engine is specified
@@ -649,6 +643,8 @@ func (app *App) init() *App {
 	app.server.ReadBufferSize = app.Settings.ReadBufferSize
 	app.server.WriteBufferSize = app.Settings.WriteBufferSize
 	app.buildTree()
+	// App is initialized
+	app.initialized = true
 	app.mutex.Unlock()
 	return app
 }

--- a/app.go
+++ b/app.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Version of current package
-const Version = "1.13.3"
+const Version = "1.13.4"
 
 // Map is a shortcut for map[string]interface{}, useful for JSON returns
 type Map map[string]interface{}


### PR DESCRIPTION
In a test environment, you might not call `Listen`, `Listener`, or `Tests` and directly test on the main `handler`. But with the new hybrid tree implementation by @ReneWerner87 we do not update the server values. This PR will fix that.