### PR TITLE
Add fiber-cache middleware to README(s)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -498,16 +498,17 @@ The Fiber middleware modules listed here are maintained by the [Fiber team](http
 ## 🌱 Third Party Middlewares
 
 This is a list of middlewares that are created by the Fiber community, please create a PR if you want to see yours!
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 Media
 

--- a/.github/README_ar_SA.md
+++ b/.github/README_ar_SA.md
@@ -564,16 +564,17 @@ The Fiber middleware modules listed here are maintained by the [Fiber team](http
 ## 🌱 Third Party Middlewares
 
 هذه قائمة middlewares التي تم إنشاؤها من قبل المجتمع Fiber , الرجاء إنشاءPR إذا كنت تريد أن ترى ذلك!
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 وسائل الإعلام
 

--- a/.github/README_de.md
+++ b/.github/README_de.md
@@ -499,16 +499,17 @@ The Fiber middleware modules listed here are maintained by the [Fiber team](http
 ## 🌱 Third Party Middlewares
 
 This is a list of middlewares that are created by the Fiber community, please create a PR if you want to see yours!
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 Medien
 

--- a/.github/README_es.md
+++ b/.github/README_es.md
@@ -499,16 +499,17 @@ The Fiber middleware modules listed here are maintained by the [Fiber team](http
 ## 🌱 Third Party Middlewares
 
 This is a list of middlewares that are created by the Fiber community, please create a PR if you want to see yours!
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 Medios
 

--- a/.github/README_fr.md
+++ b/.github/README_fr.md
@@ -499,16 +499,17 @@ The Fiber middleware modules listed here are maintained by the [Fiber team](http
 ## 🌱 Third Party Middlewares
 
 This is a list of middlewares that are created by the Fiber community, please create a PR if you want to see yours!
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 Media
 

--- a/.github/README_he.md
+++ b/.github/README_he.md
@@ -606,16 +606,17 @@ This is a list of middlewares that are created by the Fiber community, please cr
 
 <div dir="rtl">
 
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 </div>
 
 <div dir="rtl">

--- a/.github/README_id.md
+++ b/.github/README_id.md
@@ -501,16 +501,17 @@ The Fiber middleware modules listed here are maintained by the [Fiber team](http
 ## 🌱 Third Party Middlewares
 
 This is a list of middlewares that are created by the Fiber community, please create a PR if you want to see yours!
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 Media
 

--- a/.github/README_ja.md
+++ b/.github/README_ja.md
@@ -502,16 +502,17 @@ The Fiber middleware modules listed here are maintained by the [Fiber team](http
 ## 🌱 Third Party Middlewares
 
 This is a list of middlewares that are created by the Fiber community, please create a PR if you want to see yours!
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 メディア
 

--- a/.github/README_ko.md
+++ b/.github/README_ko.md
@@ -504,16 +504,17 @@ The Fiber middleware modules listed here are maintained by the [Fiber team](http
 ## 🌱 Third Party Middlewares
 
 This is a list of middlewares that are created by the Fiber community, please create a PR if you want to see yours!
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 미디어
 

--- a/.github/README_nl.md
+++ b/.github/README_nl.md
@@ -503,16 +503,17 @@ The Fiber middleware modules listed here are maintained by the [Fiber team](http
 ## 🌱 Third Party Middlewares
 
 This is a list of middlewares that are created by the Fiber community, please create a PR if you want to see yours!
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 Media
 

--- a/.github/README_pt.md
+++ b/.github/README_pt.md
@@ -497,16 +497,17 @@ Os middlewares Fiber listados aqui são mantidos pelo [Time Fiber](https://githu
 ## 🌱 Middlewares Third Party
 
 Esta é uma lista de middlewares criados pela comunidade do Fiber, se quiser ter o seu middleware aqui, é só abrir um PR!
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 Mídia
 

--- a/.github/README_ru.md
+++ b/.github/README_ru.md
@@ -502,16 +502,17 @@ The Fiber middleware modules listed here are maintained by the [Fiber team](http
 
 Это список middlewares, созданных сообществом Fiber. Пожалуйста, [создайте PR](https://github.com/gofiber/fiber/pulls), если хотите добавить в этот список свой или известный вам middleware для веб фреймворка Fiber!
 
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 Медиа
 

--- a/.github/README_tr.md
+++ b/.github/README_tr.md
@@ -497,16 +497,17 @@ The Fiber middleware modules listed here are maintained by the [Fiber team](http
 ## 🌱 Third Party Middlewares
 
 This is a list of middlewares that are created by the Fiber community, please create a PR if you want to see yours!
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 Medya
 

--- a/.github/README_zh-CN.md
+++ b/.github/README_zh-CN.md
@@ -501,16 +501,17 @@ func main() {
 ## 🌱 第三方中间件
 
 这是由`Fiber`社区创建的中间件列表，如果您想看到自己的中间件，请创建`PR`。
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 媒体
 

--- a/.github/README_zh-TW.md
+++ b/.github/README_zh-TW.md
@@ -499,16 +499,17 @@ func main() {
 
 由社群建立的中介器列表，要新增請發PR!
 
-- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/fiber-casbin](https://github.com/arsmn/fiber-casbin)
 - [arsmn/fiber-introspect](https://github.com/arsmn/fiber-introspect)
-- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
-- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
-- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
+- [arsmn/fiber-swagger](https://github.com/arsmn/fiber-swagger)
 - [arsmn/gqlgen](https://github.com/arsmn/gqlgen)
-- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
-- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)
 - [itsursujit/fiber-boilerplate](https://github.com/itsursujit/fiber-boilerplate)
+- [juandiii/go-jwk-security](https://github.com/juandiii/go-jwk-security)
+- [kiyonlin/fiber_limiter](https://github.com/kiyonlin/fiber_limiter)
+- [shareed2k/fiber_limiter](https://github.com/shareed2k/fiber_limiter)
+- [shareed2k/fiber_tracing](https://github.com/shareed2k/fiber_tracing)
+- [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 
 ## 💬 新聞
 


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Added my fiber-cache middleware to the 3rd party middlewares section of the readmes ([codemicro/fiber-cache](https://github.com/codemicro/fiber-cache)). I also sorted the list alphabetically.

~~**Commit formatting** 
Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/~~ I sort of attempted to do this and then failed massively.