### PR TITLE
🦟 Fix star routes

### DIFF
--- a/router.go
+++ b/router.go
@@ -59,7 +59,9 @@ func (r *Route) match(path, original string) (match bool, values []string) {
 		// '*' wildcard matches any path
 	} else if r.star {
 		values := getAllocFreeParams(1)
-		values[0] = original[1:]
+		if len(original) > 1 {
+			values[0] = original[1:]
+		}
 		return true, values
 	}
 	// Does this route have parameters

--- a/router_test.go
+++ b/router_test.go
@@ -77,6 +77,16 @@ func Test_Route_Match_Star(t *testing.T) {
 	body, err = ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, "test", getString(body))
+
+	// without parameter
+	route := Route{
+		star:        true,
+		path:        "/*",
+		routeParser: routeParser{},
+	}
+	match, params := route.match("", "")
+	utils.AssertEqual(t, true, match)
+	utils.AssertEqual(t, []string{""}, params)
 }
 
 func Test_Route_Match_Root(t *testing.T) {


### PR DESCRIPTION
Fix for star route bug

```go
panic: runtime error: slice bounds out of range [1:0]

goroutine 19 [running]:
github.com/gofiber/fiber.(*Route).match(0xc000090fd0, 0xa225b0, 0x0, 0x0, 0x0, 0x1, 0xd6, 0xe0, 0x0)
    /root/go/src/github.com/gofiber/fiber/router.go:62 +0x305
github.com/gofiber/fiber.(*App).next(0xc0000f3560, 0xc00007ae60, 0xc00007ae60)
    /root/go/src/github.com/gofiber/fiber/router.go:101 +0x134
github.com/gofiber/fiber.(*App).handler(0xc0000f3560, 0xc0006ec000)
    /root/go/src/github.com/gofiber/fiber/router.go:145 +0x170
github.com/valyala/fasthttp.(*Server).serveConn(0xc000086480, 0x7d1de0, 0xc0005ed2e8, 0x0, 0x0)
    /root/go/src/github.com/valyala/fasthttp/server.go:2168 +0x11ac
github.com/valyala/fasthttp.(*workerPool).workerFunc(0xc00007abe0, 0xc000645480)
    /root/go/src/github.com/valyala/fasthttp/workerpool.go:223 +0xc2
github.com/valyala/fasthttp.(*workerPool).getCh.func1(0xc00007abe0, 0xc000645480, 0x6ffb00, 0xc000645480)
    /root/go/src/github.com/valyala/fasthttp/workerpool.go:195 +0x35
created by github.com/valyala/fasthttp.(*workerPool).getCh
    /root/go/src/github.com/valyala/fasthttp/workerpool.go:194 +0x115
exit status 2
```