### PR TITLE
🐛 Fix filesystem tests, make compatible with v15

### DIFF
--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -138,14 +138,14 @@ func New(config Config) fiber.Handler {
 		}
 
 		if method == fiber.MethodGet {
-			c.Fasthttp().SetBodyStream(file, contentLength)
+			c.Request().SetBodyStream(file, contentLength)
 			return nil
 		}
 		if method == fiber.MethodHead {
-			c.Fasthttp().ResetBody()
+			c.Request().ResetBody()
 			// Fasthttp should skipbody by default if HEAD?
-			c.Fasthttp().Response.SkipBody = true
-			c.Fasthttp().Response.Header.SetContentLength(contentLength)
+			c.Request().Response.SkipBody = true
+			c.Request().Response.Header.SetContentLength(contentLength)
 			if err := file.Close(); err != nil {
 				return err
 			}

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -89,12 +89,12 @@ func Test_FileSystem(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", tt.url, nil)
 			resp, err := app.Test(req)
-			utils.AssertEqual(t, err, nil)
-			utils.AssertEqual(t, resp.StatusCode, tt.statusCode)
+			utils.AssertEqual(t, nil, err)
+			utils.AssertEqual(t, tt.statusCode, resp.StatusCode)
 
 			if tt.contentType != "" {
 				ct := resp.Header.Get("Content-Type")
-				utils.AssertEqual(t, ct, tt.contentType)
+				utils.AssertEqual(t, tt.contentType, ct)
 			}
 		})
 	}


### PR DESCRIPTION
* Updated filesystem middleware to be compatible with v15 by using `c.Request()` instead of `c.FastHTTP()`
* Fixed filesystem middleware tests. It seems the previous syntax was using `utils.AssertEqual(test, actual, expected)` when it should be `utils.AssertEqual(test, expected, actual)`