### PR TITLE
✨ Add feature to filesystem middleware that returns specified file if path is not found

### DIFF
--- a/.github/testdata/index.html
+++ b/.github/testdata/index.html
@@ -1,0 +1,1 @@
+<p>Hello, Fiber!</p>

--- a/middleware/filesystem/filesystem.go
+++ b/middleware/filesystem/filesystem.go
@@ -32,6 +32,11 @@ type Config struct {
 	//
 	// Optional. Default: false
 	Browse bool
+
+	// File to return if path is not found. Useful for SPA's.
+	//
+	// Optional. Default: ""
+	NotFoundFile string
 }
 
 // ConfigDefault is the default config
@@ -90,6 +95,10 @@ func New(config Config) fiber.Handler {
 		}
 
 		file, err := cfg.Root.Open(path)
+		if err != nil && os.IsNotExist(err) && cfg.NotFoundFile != "" {
+			file, err = cfg.Root.Open(cfg.NotFoundFile)
+		}
+
 		if err != nil {
 			if os.IsNotExist(err) {
 				return c.Status(fiber.StatusNotFound).Next()

--- a/middleware/filesystem/filesystem_test.go
+++ b/middleware/filesystem/filesystem_test.go
@@ -25,6 +25,11 @@ func Test_FileSystem(t *testing.T) {
 		return c.SendString("Hello, World!")
 	})
 
+	app.Use("/spatest", New(Config{
+		Root:         http.Dir("../../.github/testdata/fs"),
+		NotFoundFile: "index.html",
+	}))
+
 	tests := []struct {
 		name         string
 		url          string
@@ -82,6 +87,12 @@ func Test_FileSystem(t *testing.T) {
 			url:         "/dir/img/fiber.png",
 			statusCode:  200,
 			contentType: "image/png",
+		},
+		{
+			name:        "Should be return status 200",
+			url:         "/spatest/doesnotexist",
+			statusCode:  200,
+			contentType: "text/html",
 		},
 	}
 


### PR DESCRIPTION
Fixes #708 

Note: this is based on my previous PR #751, so this will only work in v15 

* Adds an option to filesystem middleware that returns the index page if path is not found
* Adds a test case 