### PR TITLE
🛠 update utils

### DIFF
--- a/app.go
+++ b/app.go
@@ -81,37 +81,46 @@ type App struct {
 // Config is a struct holding the server settings.
 type Config struct {
 	// When set to true, this will spawn multiple Go processes listening on the same port.
+	//
 	// Default: false
 	Prefork bool `json:"prefork"`
 
 	// Enables the "Server: value" HTTP header.
+	//
 	// Default: ""
 	ServerHeader string `json:"server_header"`
 
 	// When set to true, the router treats "/foo" and "/foo/" as different.
 	// By default this is disabled and both "/foo" and "/foo/" will execute the same handler.
+	//
+	// Default: false
 	StrictRouting bool `json:"strict_routing"`
 
 	// When set to true, enables case sensitive routing.
 	// E.g. "/FoO" and "/foo" are treated as different routes.
 	// By default this is disabled and both "/FoO" and "/foo" will execute the same handler.
+	//
+	// Default: false
 	CaseSensitive bool `json:"case_sensitive"`
 
 	// When set to true, this relinquishes the 0-allocation promise in certain
 	// cases in order to access the handler values (e.g. request bodies) in an
 	// immutable fashion so that these values are available even if you return
 	// from handler.
+	//
 	// Default: false
 	Immutable bool `json:"immutable"`
 
 	// When set to true, converts all encoded characters in the route back
 	// before setting the path for the context, so that the routing can also
 	// work with urlencoded special characters.
+	//
 	// Default: false
 	UnescapePath bool `json:"unescape_path"`
 
 	// Enable or disable ETag header generation, since both weak and strong etags are generated
 	// using the same hashing method (CRC-32). Weak ETags are the default when enabled.
+	//
 	// Default: false
 	ETag bool `json:"etag"`
 
@@ -120,26 +129,31 @@ type Config struct {
 	BodyLimit int `json:"body_limit"`
 
 	// Maximum number of concurrent connections.
+	//
 	// Default: 256 * 1024
 	Concurrency int `json:"concurrency"`
 
 	// Views is the interface that wraps the Render function.
+	//
 	// Default: nil
 	Views Views `json:"-"`
 
 	// The amount of time allowed to read the full request including body.
 	// It is reset after the request handler has returned.
 	// The connection's read deadline is reset when the connection opens.
+	//
 	// Default: unlimited
 	ReadTimeout time.Duration `json:"read_timeout"`
 
 	// The maximum duration before timing out writes of the response.
 	// It is reset after the request handler has returned.
+	//
 	// Default: unlimited
 	WriteTimeout time.Duration `json:"write_timeout"`
 
 	// The maximum amount of time to wait for the next request when keep-alive is enabled.
 	// If IdleTimeout is zero, the value of ReadTimeout is used.
+	//
 	// Default: unlimited
 	IdleTimeout time.Duration `json:"idle_timeout"`
 
@@ -147,15 +161,18 @@ type Config struct {
 	// This also limits the maximum header size.
 	// Increase this buffer if your clients send multi-KB RequestURIs
 	// and/or multi-KB headers (for example, BIG cookies).
+	//
 	// Default: 4096
 	ReadBufferSize int `json:"read_buffer_size"`
 
 	// Per-connection buffer size for responses' writing.
+	//
 	// Default: 4096
 	WriteBufferSize int `json:"write_buffer_size"`
 
 	// CompressedFileSuffix adds suffix to the original file name and
 	// tries saving the resulting compressed file under the new file name.
+	//
 	// Default: ".fiber.gz"
 	CompressedFileSuffix string `json:"compressed_file_suffix"`
 
@@ -163,6 +180,7 @@ type Config struct {
 	// By default c.IP() will return the Remote IP from the TCP connection
 	// This property can be useful if you are behind a load balancer: X-Forwarded-*
 	// NOTE: headers are easily spoofed and the detected IP addresses are unreliable.
+	//
 	// Default: ""
 	ProxyHeader string `json:"proxy_header"`
 
@@ -170,31 +188,39 @@ type Config struct {
 	// This option is useful as anti-DoS protection for servers
 	// accepting only GET requests. The request size is limited
 	// by ReadBufferSize if GETOnly is set.
-	// Server accepts all the requests by default.
+	//
+	// Default: false
 	GETOnly bool `json:"get_only"`
 
 	// ErrorHandler is executed when an error is returned from fiber.Handler.
+	//
+	// Default: DefaultErrorHandler
 	ErrorHandler ErrorHandler `json:"-"`
 
 	// When set to true, disables keep-alive connections.
 	// The server will close incoming connections after sending the first response to client.
+	//
 	// Default: false
 	DisableKeepalive bool `json:"disable_keepalive"`
 
 	// When set to true, causes the default date header to be excluded from the response.
+	//
 	// Default: false
 	DisableDefaultDate bool `json:"disable_default_date"`
 
 	// When set to true, causes the default Content-Type header to be excluded from the response.
+	//
 	// Default: false
 	DisableDefaultContentType bool `json:"disable_default_content_type"`
 
 	// When set to true, disables header normalization.
 	// By default all header names are normalized: conteNT-tYPE -> Content-Type.
+	//
 	// Default: false
 	DisableHeaderNormalizing bool `json:"disable_header_normalizing"`
 
 	// When set to true, it will not print out the «Fiber» ASCII art and listening address.
+	//
 	// Default: false
 	DisableStartupMessage bool `json:"disable_startup_message"`
 
@@ -202,6 +228,8 @@ type Config struct {
 	// The router executes the same handler by default if StrictRouting or CaseSensitive is disabled.
 	// Enabling RedirectFixedPath will change this behaviour into a client redirect to the original route path.
 	// Using the status code 301 for GET requests and 308 for all other request methods.
+	//
+	// Default: false
 	// RedirectFixedPath bool
 }
 

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,87 @@
+A collection of common functions but with better performance, less allocations and no dependencies created for [Fiber](https://github.com/gofiber/fiber).
+
+```go
+// go test -benchmem -run=^$ -bench=Benchmark_ -count=2
+
+Benchmark_ToLowerBytes/fiber-16                 42847654                25.7 ns/op             0 B/op          0 allocs/op
+Benchmark_ToLowerBytes/fiber-16                 46143196                25.7 ns/op             0 B/op          0 allocs/op
+Benchmark_ToLowerBytes/default-16               17387322                67.4 ns/op            48 B/op          1 allocs/op
+Benchmark_ToLowerBytes/default-16               17906491                67.4 ns/op            48 B/op          1 allocs/op
+
+Benchmark_ToUpperBytes/fiber-16                 46143729                25.7 ns/op             0 B/op          0 allocs/op
+Benchmark_ToUpperBytes/fiber-16                 47989250                25.6 ns/op             0 B/op          0 allocs/op
+Benchmark_ToUpperBytes/default-16               15580854                76.7 ns/op            48 B/op          1 allocs/op
+Benchmark_ToUpperBytes/default-16               15381202                76.9 ns/op            48 B/op          1 allocs/op
+
+Benchmark_TrimRightBytes/fiber-16               70572459                16.3 ns/op             8 B/op          1 allocs/op
+Benchmark_TrimRightBytes/fiber-16               74983597                16.3 ns/op             8 B/op          1 allocs/op
+Benchmark_TrimRightBytes/default-16             16212578                74.1 ns/op            40 B/op          2 allocs/op
+Benchmark_TrimRightBytes/default-16             16434686                74.1 ns/op            40 B/op          2 allocs/op
+
+Benchmark_TrimLeftBytes/fiber-16                74983128                16.3 ns/op             8 B/op          1 allocs/op
+Benchmark_TrimLeftBytes/fiber-16                74985002                16.3 ns/op             8 B/op          1 allocs/op
+Benchmark_TrimLeftBytes/default-16              21047868                56.5 ns/op            40 B/op          2 allocs/op
+Benchmark_TrimLeftBytes/default-16              21048015                56.5 ns/op            40 B/op          2 allocs/op
+
+Benchmark_TrimBytes/fiber-16                    54533307                21.9 ns/op            16 B/op          1 allocs/op
+Benchmark_TrimBytes/fiber-16                    54532812                21.9 ns/op            16 B/op          1 allocs/op
+Benchmark_TrimBytes/default-16                  14282517                84.6 ns/op            48 B/op          2 allocs/op
+Benchmark_TrimBytes/default-16                  14114508                84.7 ns/op            48 B/op          2 allocs/op
+
+Benchmark_EqualFolds/fiber-16                   36355153                32.6 ns/op             0 B/op          0 allocs/op
+Benchmark_EqualFolds/fiber-16                   36355593                32.6 ns/op             0 B/op          0 allocs/op
+Benchmark_EqualFolds/default-16                 15186220                78.1 ns/op             0 B/op          0 allocs/op
+Benchmark_EqualFolds/default-16                 15186412                78.3 ns/op             0 B/op          0 allocs/op
+
+Benchmark_UUID/fiber-16                         23994625                49.8 ns/op            48 B/op          1 allocs/op
+Benchmark_UUID/fiber-16                         23994768                50.1 ns/op            48 B/op          1 allocs/op
+Benchmark_UUID/default-16                        3233772                 371 ns/op           208 B/op          6 allocs/op
+Benchmark_UUID/default-16                        3251295                 370 ns/op           208 B/op          6 allocs/op
+
+Benchmark_GetString/unsafe-16                 1000000000               0.709 ns/op             0 B/op          0 allocs/op
+Benchmark_GetString/unsafe-16                 1000000000               0.713 ns/op             0 B/op          0 allocs/op
+Benchmark_GetString/default-16                  59986202                19.0 ns/op            16 B/op          1 allocs/op
+Benchmark_GetString/default-16                  63142939                19.0 ns/op            16 B/op          1 allocs/op
+
+Benchmark_GetBytes/unsafe-16                   508360195                2.36 ns/op             0 B/op          0 allocs/op
+Benchmark_GetBytes/unsafe-16                   508359979                2.35 ns/op             0 B/op          0 allocs/op
+Benchmark_GetBytes/default-16                   46143019                25.7 ns/op            16 B/op          1 allocs/op
+Benchmark_GetBytes/default-16                   44434734                25.6 ns/op            16 B/op          1 allocs/op
+
+Benchmark_GetMIME/fiber-16                      21423750                56.3 ns/op             0 B/op          0 allocs/op
+Benchmark_GetMIME/fiber-16                      21423559                55.4 ns/op             0 B/op          0 allocs/op
+Benchmark_GetMIME/default-16                     6735282                 173 ns/op             0 B/op          0 allocs/op
+Benchmark_GetMIME/default-16                     6895002                 172 ns/op             0 B/op          0 allocs/op
+
+Benchmark_StatusMessage/fiber-16              1000000000               0.766 ns/op             0 B/op          0 allocs/op
+Benchmark_StatusMessage/fiber-16              1000000000               0.767 ns/op             0 B/op          0 allocs/op
+Benchmark_StatusMessage/default-16             159538528                7.50 ns/op             0 B/op          0 allocs/op
+Benchmark_StatusMessage/default-16             159750830                7.51 ns/op             0 B/op          0 allocs/op
+
+Benchmark_ToUpper/fiber-16                      22217408                53.3 ns/op            48 B/op          1 allocs/op
+Benchmark_ToUpper/fiber-16                      22636554                53.2 ns/op            48 B/op          1 allocs/op
+Benchmark_ToUpper/default-16                    11108600                 108 ns/op            48 B/op          1 allocs/op
+Benchmark_ToUpper/default-16                    11108580                 108 ns/op            48 B/op          1 allocs/op
+
+Benchmark_ToLower/fiber-16                      23994720                49.8 ns/op            48 B/op          1 allocs/op
+Benchmark_ToLower/fiber-16                      23994768                50.1 ns/op            48 B/op          1 allocs/op
+Benchmark_ToLower/default-16                    10808376                 110 ns/op            48 B/op          1 allocs/op
+Benchmark_ToLower/default-16                    10617034                 110 ns/op            48 B/op          1 allocs/op
+
+Benchmark_TrimRight/fiber-16                   413699521                2.94 ns/op             0 B/op          0 allocs/op
+Benchmark_TrimRight/fiber-16                   415131687                2.91 ns/op             0 B/op          0 allocs/op
+Benchmark_TrimRight/default-16                  23994577                49.1 ns/op            32 B/op          1 allocs/op
+Benchmark_TrimRight/default-16                  24484249                49.4 ns/op            32 B/op          1 allocs/op
+
+Benchmark_TrimLeft/fiber-16                    379661170                3.13 ns/op             0 B/op          0 allocs/op
+Benchmark_TrimLeft/fiber-16                    382079941                3.16 ns/op             0 B/op          0 allocs/op
+Benchmark_TrimLeft/default-16                   27900877                41.9 ns/op            32 B/op          1 allocs/op
+Benchmark_TrimLeft/default-16                   28564898                42.0 ns/op            32 B/op          1 allocs/op
+
+Benchmark_Trim/fiber-16                        236632856                 4.96 ns/op            0 B/op          0 allocs/op
+Benchmark_Trim/fiber-16                        237570085                 4.93 ns/op            0 B/op          0 allocs/op
+Benchmark_Trim/default-16                       18457221                 66.0 ns/op           32 B/op          1 allocs/op
+Benchmark_Trim/default-16                       18177328                 65.9 ns/op           32 B/op          1 allocs/op
+Benchmark_Trim/default.trimspace-16            188933770                 6.33 ns/op            0 B/op          0 allocs/op
+Benchmark_Trim/default.trimspace-16            184007649                 6.42 ns/op            0 B/op          0 allocs/op
+```

--- a/utils/bytes_test.go
+++ b/utils/bytes_test.go
@@ -31,13 +31,45 @@ func Benchmark_ToLowerBytes(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			res = ToLowerBytes(path)
 		}
-		AssertEqual(b, bytes.EqualFold(GetBytes("/repos/gofiber/fiber/issues/187643/comments"), res), true)
+		AssertEqual(b, bytes.Equal(GetBytes("/repos/gofiber/fiber/issues/187643/comments"), res), true)
 	})
 	b.Run("default", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			res = bytes.ToLower(path)
 		}
-		AssertEqual(b, bytes.EqualFold(GetBytes("/repos/gofiber/fiber/issues/187643/comments"), res), true)
+		AssertEqual(b, bytes.Equal(GetBytes("/repos/gofiber/fiber/issues/187643/comments"), res), true)
+	})
+}
+
+func Test_Utils_ToUpperBytes(t *testing.T) {
+	t.Parallel()
+	res := ToUpperBytes([]byte("/my/name/is/:param/*"))
+	AssertEqual(t, true, bytes.Equal([]byte("/MY/NAME/IS/:PARAM/*"), res))
+	res = ToUpperBytes([]byte("/my1/name/is/:param/*"))
+	AssertEqual(t, true, bytes.Equal([]byte("/MY1/NAME/IS/:PARAM/*"), res))
+	res = ToUpperBytes([]byte("/my2/name/is/:param/*"))
+	AssertEqual(t, true, bytes.Equal([]byte("/MY2/NAME/IS/:PARAM/*"), res))
+	res = ToUpperBytes([]byte("/my3/name/is/:param/*"))
+	AssertEqual(t, true, bytes.Equal([]byte("/MY3/NAME/IS/:PARAM/*"), res))
+	res = ToUpperBytes([]byte("/my4/name/is/:param/*"))
+	AssertEqual(t, true, bytes.Equal([]byte("/MY4/NAME/IS/:PARAM/*"), res))
+}
+
+func Benchmark_ToUpperBytes(b *testing.B) {
+	var path = []byte("/RePos/GoFiBer/FibEr/iSsues/187643/CoMmEnts")
+	var res []byte
+
+	b.Run("fiber", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = ToUpperBytes(path)
+		}
+		AssertEqual(b, bytes.Equal(GetBytes("/REPOS/GOFIBER/FIBER/ISSUES/187643/COMMENTS"), res), true)
+	})
+	b.Run("default", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = bytes.ToUpper(path)
+		}
+		AssertEqual(b, bytes.Equal(GetBytes("/REPOS/GOFIBER/FIBER/ISSUES/187643/COMMENTS"), res), true)
 	})
 }
 

--- a/utils/common.go
+++ b/utils/common.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
+	"os"
 	"reflect"
 	"runtime"
 	"sync"
@@ -68,4 +69,14 @@ func FunctionName(fn interface{}) string {
 		return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
 	}
 	return t.String()
+}
+
+// GetArgument check if key is in arguments
+func GetArgument(arg string) bool {
+	for i := range os.Args[1:] {
+		if os.Args[1:][i] == arg {
+			return true
+		}
+	}
+	return false
 }

--- a/utils/convert.go
+++ b/utils/convert.go
@@ -6,6 +6,8 @@ package utils
 
 import (
 	"reflect"
+	"strconv"
+	"strings"
 	"unsafe"
 )
 
@@ -29,4 +31,48 @@ func GetBytes(s string) (bs []byte) {
 // ImmutableString copies a string to make it immutable
 func ImmutableString(s string) string {
 	return string(GetBytes(s))
+}
+
+const (
+	uByte = 1 << (10 * iota)
+	uKilobyte
+	uMegabyte
+	uGigabyte
+	uTerabyte
+	uPetabyte
+	uExabyte
+)
+
+// ByteSize returns a human-readable byte string of the form 10M, 12.5K, and so forth.
+// The unit that results in the smallest number greater than or equal to 1 is always chosen.
+func ByteSize(bytes uint64) string {
+	unit := ""
+	value := float64(bytes)
+	switch {
+	case bytes >= uExabyte:
+		unit = "E"
+		value = value / uExabyte
+	case bytes >= uPetabyte:
+		unit = "P"
+		value = value / uPetabyte
+	case bytes >= uTerabyte:
+		unit = "T"
+		value = value / uTerabyte
+	case bytes >= uGigabyte:
+		unit = "G"
+		value = value / uGigabyte
+	case bytes >= uMegabyte:
+		unit = "M"
+		value = value / uMegabyte
+	case bytes >= uKilobyte:
+		unit = "K"
+		value = value / uKilobyte
+	case bytes >= uByte:
+		unit = "B"
+	default:
+		return "0B"
+	}
+	result := strconv.FormatFloat(value, 'f', 1, 64)
+	result = strings.TrimSuffix(result, ".0")
+	return result + unit
 }

--- a/utils/convert_test.go
+++ b/utils/convert_test.go
@@ -17,7 +17,7 @@ func Test_Utils_GetString(t *testing.T) {
 func Benchmark_GetString(b *testing.B) {
 	var hello = []byte("Hello, World!")
 	var res string
-	b.Run("fiber", func(b *testing.B) {
+	b.Run("unsafe", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			res = GetString(hello)
 		}
@@ -42,7 +42,7 @@ func Test_Utils_GetBytes(t *testing.T) {
 func Benchmark_GetBytes(b *testing.B) {
 	var hello = "Hello, World!"
 	var res []byte
-	b.Run("fiber", func(b *testing.B) {
+	b.Run("unsafe", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			res = GetBytes(hello)
 		}

--- a/utils/http_test.go
+++ b/utils/http_test.go
@@ -80,11 +80,19 @@ func Test_Utils_StatusMessage(t *testing.T) {
 	AssertEqual(t, "", res)
 }
 
-// go test -v -run=^$ -bench=Benchmark_StatusMessage -benchmem -count=4
+// go test -run=^$ -bench=Benchmark_StatusMessage -benchmem -count=2
 func Benchmark_StatusMessage(b *testing.B) {
 	var res string
-	for n := 0; n < b.N; n++ {
-		res = StatusMessage(http.StatusNotExtended)
-	}
-	AssertEqual(b, "Not Extended", res)
+	b.Run("fiber", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = StatusMessage(http.StatusNotExtended)
+		}
+		AssertEqual(b, "Not Extended", res)
+	})
+	b.Run("default", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = http.StatusText(http.StatusNotExtended)
+		}
+		AssertEqual(b, "Not Extended", res)
+	})
 }


### PR DESCRIPTION
```go
// go test -benchmem -run=^$ -bench=Benchmark_ -count=2

Benchmark_ToLowerBytes/fiber-16                 42847654                25.7 ns/op             0 B/op          0 allocs/op
Benchmark_ToLowerBytes/fiber-16                 46143196                25.7 ns/op             0 B/op          0 allocs/op
Benchmark_ToLowerBytes/default-16               17387322                67.4 ns/op            48 B/op          1 allocs/op
Benchmark_ToLowerBytes/default-16               17906491                67.4 ns/op            48 B/op          1 allocs/op

Benchmark_ToUpperBytes/fiber-16                 46143729                25.7 ns/op             0 B/op          0 allocs/op
Benchmark_ToUpperBytes/fiber-16                 47989250                25.6 ns/op             0 B/op          0 allocs/op
Benchmark_ToUpperBytes/default-16               15580854                76.7 ns/op            48 B/op          1 allocs/op
Benchmark_ToUpperBytes/default-16               15381202                76.9 ns/op            48 B/op          1 allocs/op

Benchmark_TrimRightBytes/fiber-16               70572459                16.3 ns/op             8 B/op          1 allocs/op
Benchmark_TrimRightBytes/fiber-16               74983597                16.3 ns/op             8 B/op          1 allocs/op
Benchmark_TrimRightBytes/default-16             16212578                74.1 ns/op            40 B/op          2 allocs/op
Benchmark_TrimRightBytes/default-16             16434686                74.1 ns/op            40 B/op          2 allocs/op

Benchmark_TrimLeftBytes/fiber-16                74983128                16.3 ns/op             8 B/op          1 allocs/op
Benchmark_TrimLeftBytes/fiber-16                74985002                16.3 ns/op             8 B/op          1 allocs/op
Benchmark_TrimLeftBytes/default-16              21047868                56.5 ns/op            40 B/op          2 allocs/op
Benchmark_TrimLeftBytes/default-16              21048015                56.5 ns/op            40 B/op          2 allocs/op

Benchmark_TrimBytes/fiber-16                    54533307                21.9 ns/op            16 B/op          1 allocs/op
Benchmark_TrimBytes/fiber-16                    54532812                21.9 ns/op            16 B/op          1 allocs/op
Benchmark_TrimBytes/default-16                  14282517                84.6 ns/op            48 B/op          2 allocs/op
Benchmark_TrimBytes/default-16                  14114508                84.7 ns/op            48 B/op          2 allocs/op

Benchmark_EqualFolds/fiber-16                   36355153                32.6 ns/op             0 B/op          0 allocs/op
Benchmark_EqualFolds/fiber-16                   36355593                32.6 ns/op             0 B/op          0 allocs/op
Benchmark_EqualFolds/default-16                 15186220                78.1 ns/op             0 B/op          0 allocs/op
Benchmark_EqualFolds/default-16                 15186412                78.3 ns/op             0 B/op          0 allocs/op

Benchmark_UUID/fiber-16                         23994625                49.8 ns/op            48 B/op          1 allocs/op
Benchmark_UUID/fiber-16                         23994768                50.1 ns/op            48 B/op          1 allocs/op
Benchmark_UUID/default-16                        3233772                 371 ns/op           208 B/op          6 allocs/op
Benchmark_UUID/default-16                        3251295                 370 ns/op           208 B/op          6 allocs/op

Benchmark_GetString/unsafe-16                 1000000000               0.709 ns/op             0 B/op          0 allocs/op
Benchmark_GetString/unsafe-16                 1000000000               0.713 ns/op             0 B/op          0 allocs/op
Benchmark_GetString/default-16                  59986202                19.0 ns/op            16 B/op          1 allocs/op
Benchmark_GetString/default-16                  63142939                19.0 ns/op            16 B/op          1 allocs/op

Benchmark_GetBytes/unsafe-16                   508360195                2.36 ns/op             0 B/op          0 allocs/op
Benchmark_GetBytes/unsafe-16                   508359979                2.35 ns/op             0 B/op          0 allocs/op
Benchmark_GetBytes/default-16                   46143019                25.7 ns/op            16 B/op          1 allocs/op
Benchmark_GetBytes/default-16                   44434734                25.6 ns/op            16 B/op          1 allocs/op

Benchmark_GetMIME/fiber-16                      21423750                56.3 ns/op             0 B/op          0 allocs/op
Benchmark_GetMIME/fiber-16                      21423559                55.4 ns/op             0 B/op          0 allocs/op
Benchmark_GetMIME/default-16                     6735282                 173 ns/op             0 B/op          0 allocs/op
Benchmark_GetMIME/default-16                     6895002                 172 ns/op             0 B/op          0 allocs/op

Benchmark_StatusMessage/fiber-16              1000000000               0.766 ns/op             0 B/op          0 allocs/op
Benchmark_StatusMessage/fiber-16              1000000000               0.767 ns/op             0 B/op          0 allocs/op
Benchmark_StatusMessage/default-16             159538528                7.50 ns/op             0 B/op          0 allocs/op
Benchmark_StatusMessage/default-16             159750830                7.51 ns/op             0 B/op          0 allocs/op

Benchmark_ToUpper/fiber-16                      22217408                53.3 ns/op            48 B/op          1 allocs/op
Benchmark_ToUpper/fiber-16                      22636554                53.2 ns/op            48 B/op          1 allocs/op
Benchmark_ToUpper/default-16                    11108600                 108 ns/op            48 B/op          1 allocs/op
Benchmark_ToUpper/default-16                    11108580                 108 ns/op            48 B/op          1 allocs/op

Benchmark_ToLower/fiber-16                      23994720                49.8 ns/op            48 B/op          1 allocs/op
Benchmark_ToLower/fiber-16                      23994768                50.1 ns/op            48 B/op          1 allocs/op
Benchmark_ToLower/default-16                    10808376                 110 ns/op            48 B/op          1 allocs/op
Benchmark_ToLower/default-16                    10617034                 110 ns/op            48 B/op          1 allocs/op

Benchmark_TrimRight/fiber-16                   413699521                2.94 ns/op             0 B/op          0 allocs/op
Benchmark_TrimRight/fiber-16                   415131687                2.91 ns/op             0 B/op          0 allocs/op
Benchmark_TrimRight/default-16                  23994577                49.1 ns/op            32 B/op          1 allocs/op
Benchmark_TrimRight/default-16                  24484249                49.4 ns/op            32 B/op          1 allocs/op

Benchmark_TrimLeft/fiber-16                    379661170                3.13 ns/op             0 B/op          0 allocs/op
Benchmark_TrimLeft/fiber-16                    382079941                3.16 ns/op             0 B/op          0 allocs/op
Benchmark_TrimLeft/default-16                   27900877                41.9 ns/op            32 B/op          1 allocs/op
Benchmark_TrimLeft/default-16                   28564898                42.0 ns/op            32 B/op          1 allocs/op

Benchmark_Trim/fiber-16                        236632856                 4.96 ns/op            0 B/op          0 allocs/op
Benchmark_Trim/fiber-16                        237570085                 4.93 ns/op            0 B/op          0 allocs/op
Benchmark_Trim/default-16                       18457221                 66.0 ns/op           32 B/op          1 allocs/op
Benchmark_Trim/default-16                       18177328                 65.9 ns/op           32 B/op          1 allocs/op
Benchmark_Trim/default.trimspace-16            188933770                 6.33 ns/op            0 B/op          0 allocs/op
Benchmark_Trim/default.trimspace-16            184007649                 6.42 ns/op            0 B/op          0 allocs/op
```