### PR TITLE
📚 Doc: typo line 32 `AllowHeader` to `AllowHeaders`

### DIFF
--- a/middleware/cors/README.md
+++ b/middleware/cors/README.md
@@ -29,7 +29,7 @@ app.Use(cors.New())
 // Or extend your config for customization
 app.Use(cors.New(cors.Config{
 	AllowOrigins: "https://gofiber.io, https://gofiber.net",
-	AllowHeader:  "Origin, Content-Type, Accept",
+	AllowHeaders:  "Origin, Content-Type, Accept",
 }))
 ```
 


### PR DESCRIPTION
fix: Updated line 32 `AllowHeader` to `AllowHeaders` as it appears to be a typo.