### PR TITLE
🍪 add max-age to cookie

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -63,6 +63,7 @@ type Cookie struct {
 	Value    string    `json:"value"`
 	Path     string    `json:"path"`
 	Domain   string    `json:"domain"`
+	MaxAge   int       `json:"max_age"`
 	Expires  time.Time `json:"expires"`
 	Secure   bool      `json:"secure"`
 	HTTPOnly bool      `json:"http_only"`
@@ -286,6 +287,7 @@ func (c *Ctx) Cookie(cookie *Cookie) {
 	fcookie.SetValue(cookie.Value)
 	fcookie.SetPath(cookie.Path)
 	fcookie.SetDomain(cookie.Domain)
+	fcookie.SetMaxAge(cookie.MaxAge)
 	fcookie.SetExpire(cookie.Expires)
 	fcookie.SetSecure(cookie.Secure)
 	fcookie.SetHTTPOnly(cookie.HTTPOnly)

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -78,7 +78,7 @@ func New(config ...Config) fiber.Handler {
 				cfg.Cookie.Name = "_csrf"
 			}
 			if cfg.Cookie.SameSite == "" {
-				cfg.Cookie.Name = "Strict"
+				cfg.Cookie.SameSite = "Strict"
 			}
 		}
 		if cfg.CookieExpires == 0 {

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -77,6 +77,9 @@ func New(config ...Config) fiber.Handler {
 			if cfg.Cookie.Name == "" {
 				cfg.Cookie.Name = "_csrf"
 			}
+			if cfg.Cookie.SameSite == "" {
+				cfg.Cookie.Name = "Strict"
+			}
 		}
 		if cfg.CookieExpires == 0 {
 			cfg.CookieExpires = ConfigDefault.CookieExpires


### PR DESCRIPTION
`Max-Age` is the new standard since 2009, some browsers do not support this yet so. You can test it here https://mrcoles.com/media/test/cookies-max-age-vs-expires.html

Or read more here: https://mrcoles.com/blog/cookies-max-age-vs-expires/

https://github.com/gofiber/fiber/issues/858

Also fix csrf https://github.com/gofiber/fiber/issues/861 to default to`Strict` if no `SameSite` is provided in config.