### PR TITLE
🐛 Fix passing partial cookie to csrf.New

### DIFF
--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -77,10 +77,10 @@ func New(config ...Config) fiber.Handler {
 		}
 		if cfg.Cookie != nil {
 			if cfg.Cookie.Name == "" {
-				cfg.Cookie.Name = "_csrf"
+				cfg.Cookie.Name = ConfigDefault.Cookie.Name
 			}
 			if cfg.Cookie.SameSite == "" {
-				cfg.Cookie.SameSite = "Strict"
+				cfg.Cookie.SameSite = ConfigDefault.Cookie.SameSite
 			}
 		} else {
 			cfg.Cookie = ConfigDefault.Cookie

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -72,17 +72,18 @@ func New(config ...Config) fiber.Handler {
 		if cfg.ContextKey == "" {
 			cfg.ContextKey = ConfigDefault.ContextKey
 		}
-		if cfg.Cookie == nil {
-			cfg.Cookie = ConfigDefault.Cookie
+		if cfg.Cookie != nil {
 			if cfg.Cookie.Name == "" {
 				cfg.Cookie.Name = "_csrf"
 			}
 			if cfg.Cookie.SameSite == "" {
 				cfg.Cookie.SameSite = "Strict"
 			}
-		}
-		if cfg.CookieExpires == 0 {
-			cfg.CookieExpires = ConfigDefault.CookieExpires
+			if cfg.CookieExpires == 0 {
+				cfg.CookieExpires = ConfigDefault.CookieExpires
+			}
+		} else {
+			cfg.Cookie = ConfigDefault.Cookie
 		}
 	}
 

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -72,15 +72,15 @@ func New(config ...Config) fiber.Handler {
 		if cfg.ContextKey == "" {
 			cfg.ContextKey = ConfigDefault.ContextKey
 		}
+		if cfg.CookieExpires == 0 {
+			cfg.CookieExpires = ConfigDefault.CookieExpires
+		}
 		if cfg.Cookie != nil {
 			if cfg.Cookie.Name == "" {
 				cfg.Cookie.Name = "_csrf"
 			}
 			if cfg.Cookie.SameSite == "" {
 				cfg.Cookie.SameSite = "Strict"
-			}
-			if cfg.CookieExpires == 0 {
-				cfg.CookieExpires = ConfigDefault.CookieExpires
 			}
 		} else {
 			cfg.Cookie = ConfigDefault.Cookie


### PR DESCRIPTION
Fixes #861

When passing a partial cookie like to csrf.New, the cookie's Name and SameSite are not set to their default values. Caused by [this](https://github.com/gofiber/fiber/blob/v2.0.5/middleware/csrf/csrf.go#L75) line:

```go
		if cfg.Cookie == nil {
			cfg.Cookie = ConfigDefault.Cookie
			if cfg.Cookie.Name == "" {
				cfg.Cookie.Name = "_csrf"
			}
			if cfg.Cookie.SameSite == "" {
				cfg.Cookie.SameSite = "Strict"
			}
		}
```

If cfg.Cookie *is* passed, it expects you to have SameSite and Name included. With my fix, you can pass `&Cookie{Name: "_csrf"}` and `SameSite` will still be set to the default.