### PR TITLE
:art: Fix gosimple and deadcode lint warnings

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -121,7 +121,7 @@ func Test_App_ServerErrorHandler_SmallReadBuffer(t *testing.T) {
 	})
 
 	request := httptest.NewRequest("GET", "/", nil)
-	logHeaderSlice := make([]string, 5000, 5000)
+	logHeaderSlice := make([]string, 5000)
 	request.Header.Set("Very-Long-Header", strings.Join(logHeaderSlice, "-"))
 	_, err := app.Test(request)
 

--- a/ctx.go
+++ b/ctx.go
@@ -708,7 +708,7 @@ func (c *Ctx) QueryParser(out interface{}) error {
 	c.fasthttp.QueryArgs().VisitAll(func(key []byte, val []byte) {
 		k := utils.UnsafeString(key)
 		v := utils.UnsafeString(val)
-		if strings.Index(v, ",") > -1 && equalFieldType(out, reflect.Slice, k) {
+		if strings.Contains(v, ",") && equalFieldType(out, reflect.Slice, k) {
 			values := strings.Split(v, ",")
 			for i := 0; i < len(values); i++ {
 				data[k] = append(data[k], values[i])

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1326,7 +1326,7 @@ func Test_Ctx_SendFile_Immutable(t *testing.T) {
 		if err := c.SendFile("./.github/" + file + ".html"); err != nil {
 			utils.AssertEqual(t, nil, err)
 		}
-		utils.AssertEqual(t, "index", fmt.Sprintf("%s", file))
+		utils.AssertEqual(t, "index", file)
 		return c.SendString(file)
 	})
 	// 1st try

--- a/helpers.go
+++ b/helpers.go
@@ -307,10 +307,6 @@ func isEtagStale(etag string, noneMatchBytes []byte) bool {
 	return !matchEtag(getString(noneMatchBytes[start:end]), etag)
 }
 
-func isIPv6(address string) bool {
-	return strings.Count(address, ":") >= 2
-}
-
 func parseAddr(raw string) (host, port string) {
 	if i := strings.LastIndex(raw, ":"); i != -1 {
 		return raw[:i], raw[i+1:]

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -209,30 +209,6 @@ func Benchmark_Utils_Unescape(b *testing.B) {
 	utils.AssertEqual(b, "/créer", unescaped)
 }
 
-func Test_Utils_IPv6(t *testing.T) {
-	testCases := []struct {
-		string
-		bool
-	}{
-		{"::FFFF:C0A8:1:3000", true},
-		{"::FFFF:C0A8:0001:3000", true},
-		{"0000:0000:0000:0000:0000:FFFF:C0A8:1:3000", true},
-		{"::FFFF:C0A8:1%1:3000", true},
-		{"::FFFF:192.168.0.1:3000", true},
-		{"[::FFFF:C0A8:1]:3000", true},
-		{"[::FFFF:C0A8:1%1]:3000", true},
-		{":3000", false},
-		{"127.0.0.1:3000", false},
-		{"127.0.0.1:", false},
-		{"0.0.0.0:3000", false},
-		{"", false},
-	}
-
-	for _, c := range testCases {
-		utils.AssertEqual(t, c.bool, isIPv6(c.string))
-	}
-}
-
 func Test_Utils_Parse_Address(t *testing.T) {
 	testCases := []struct {
 		addr, host, port string


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

This fixes warnings found by the `deadcode` and `gosimple` scanners using the latest golangci-lint

**Explain the *details* for making this change. What existing problem does the pull request solve?**

```
helpers.go:310:6: `isIPv6` is unused (deadcode)
func isIPv6(address string) bool {
     ^
ctx_test.go:1329:33: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
		utils.AssertEqual(t, "index", fmt.Sprintf("%s", file))
		                              ^
app_test.go:124:35: S1019: should use make([]string, 5000) instead (gosimple)
	logHeaderSlice := make([]string, 5000, 5000)
	                                 ^
ctx.go:711:6: S1003: should use strings.Contains(v, ",") instead (gosimple)
		if strings.Index(v, ",") > -1 && equalFieldType(out, reflect.Slice, k) {
		   ^
```

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/