### PR TITLE
🔥add the option to set a custom Cache-Control value for a favicon response

### DIFF
--- a/middleware/favicon/favicon.go
+++ b/middleware/favicon/favicon.go
@@ -18,18 +18,23 @@ type Config struct {
 	//
 	// Optional. Default: ""
 	File string
+
+	// CacheControl defines how the Cache-Control header in the response should be set
+	//
+	// Optional. Default: "public, max-age=31536000"
+	CacheControl string
 }
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
-	Next: nil,
-	File: "",
+	Next:         nil,
+	File:         "",
+	CacheControl: "public, max-age=31536000",
 }
 
 const (
 	hType  = "image/x-icon"
 	hAllow = "GET, HEAD, OPTIONS"
-	hCache = "public, max-age=31536000"
 	hZero  = "0"
 )
 
@@ -48,6 +53,9 @@ func New(config ...Config) fiber.Handler {
 		}
 		if cfg.File == "" {
 			cfg.File = ConfigDefault.File
+		}
+		if cfg.CacheControl == "" {
+			cfg.CacheControl = ConfigDefault.CacheControl
 		}
 	}
 
@@ -92,7 +100,7 @@ func New(config ...Config) fiber.Handler {
 		if len(icon) > 0 {
 			c.Set(fiber.HeaderContentLength, iconLen)
 			c.Set(fiber.HeaderContentType, hType)
-			c.Set(fiber.HeaderCacheControl, hCache)
+			c.Set(fiber.HeaderCacheControl, cfg.CacheControl)
 			return c.Status(fiber.StatusOK).Send(icon)
 		}
 

--- a/middleware/favicon/favicon_test.go
+++ b/middleware/favicon/favicon_test.go
@@ -68,6 +68,22 @@ func Test_Middleware_Favicon_Found(t *testing.T) {
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode, "Status code")
 	utils.AssertEqual(t, "image/x-icon", resp.Header.Get(fiber.HeaderContentType))
+	utils.AssertEqual(t, "public, max-age=31536000", resp.Header.Get(fiber.HeaderCacheControl), "CacheControl Control")
+}
+
+// go test -run Test_Middleware_Favicon_CacheControl
+func Test_Middleware_Favicon_CacheControl(t *testing.T) {
+	app := fiber.New()
+
+	app.Use(New(Config{
+		CacheControl: "public, max-age=100",
+		File:         "../../.github/testdata/favicon.ico",
+	}))
+	resp, err := app.Test(httptest.NewRequest("GET", "/favicon.ico", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode, "Status code")
+	utils.AssertEqual(t, "image/x-icon", resp.Header.Get(fiber.HeaderContentType))
+	utils.AssertEqual(t, "public, max-age=100", resp.Header.Get(fiber.HeaderCacheControl), "CacheControl Control")
 }
 
 // go test -v -run=^$ -bench=Benchmark_Middleware_Favicon -benchmem -count=4


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

Right now, each favicon response sets the `Cache-Control` header to `public, max-age=31536000` (1 year). In some cases this could be a little bit high if you are changing it etc. and the header is not replaced by a reverse proxy.

With this change, the favicon middleware allows the configuration of the `Cache-Control` header. The default behavior is  to keep the setting of `max-age=31536000 `, but you could fine-tune it.


<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 

✅ done 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/