### PR TITLE
✨c.GetAll

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -455,6 +455,14 @@ func (c *Ctx) Get(key string, defaultValue ...string) string {
 	return defaultString(getString(c.fasthttp.Request.Header.Peek(key)), defaultValue)
 }
 
+// GetAll returns a map of all HTTP request headers
+func (c *Ctx) GetAll() (out map[string]string) {
+	c.fasthttp.Request.Header.VisitAll(func(key, value []byte) {
+		out[getString(key)] = getString(value)
+	})
+	return out
+}
+
 // Hostname contains the hostname derived from the Host HTTP header.
 // Returned value is only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting instead.

--- a/ctx.go
+++ b/ctx.go
@@ -457,6 +457,7 @@ func (c *Ctx) Get(key string, defaultValue ...string) string {
 
 // GetAll returns a map of all HTTP request headers
 func (c *Ctx) GetAll() (out map[string]string) {
+	out = make(map[string]string)
 	c.fasthttp.Request.Header.VisitAll(func(key, value []byte) {
 		out[getString(key)] = getString(value)
 	})

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -727,6 +727,21 @@ func Test_Ctx_Get(t *testing.T) {
 	utils.AssertEqual(t, "default", c.Get("unknown", "default"))
 }
 
+// go test -run Test_Ctx_GetAll
+func Test_Ctx_GetAll(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	c.Request().Header.Set(HeaderAcceptCharset, "utf-8, iso-8859-1;q=0.5")
+	c.Request().Header.Set(HeaderReferer, "Monster")
+	expected := map[string]string{
+		HeaderAcceptCharset: "utf-8, iso-8859-1;q=0.5",
+		HeaderReferer:       "Monster",
+	}
+	utils.AssertEqual(t, expected, c.GetAll())
+}
+
 // go test -run Test_Ctx_Hostname
 func Test_Ctx_Hostname(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

This PR introduces `c.GetAll()` to accompany `c.Get()` by returning a `map[string]string` of all the request headers.  

**Explain the *details* for making this change. What existing problem does the pull request solve?**

Several people have asked me how to get all the headers of a request at once. Fiber doesn't have a method for this out of the box, instead relying on fasthttp.

This may or may not be relevant to everyone, but it covers an edge-case more than core functionality and promotes use of fiber instead of just going to fasthttp for that need.

In some cases, this may be more performant than running `c.Get()` for multiple headers. However, `GetAll` would not have default values like `Get` does.
