### PR TITLE
🔥 make the fasthttp `ReduceMemoryUsage` flag public

### DIFF
--- a/app.go
+++ b/app.go
@@ -224,6 +224,16 @@ type Config struct {
 	// Default: false
 	DisableStartupMessage bool `json:"disable_startup_message"`
 
+	// Aggressively reduces memory usage at the cost of higher CPU usage
+	// if set to true.
+	//
+	// Try enabling this option only if the server consumes too much memory
+	// serving mostly idle keep-alive connections. This may reduce memory
+	// usage by more than 50%.
+	//
+	// Default: false
+	ReduceMemoryUsage bool `json:"reduce_memory_usage"`
+
 	// FEATURE: v2.2.x
 	// The router executes the same handler by default if StrictRouting or CaseSensitive is disabled.
 	// Enabling RedirectFixedPath will change this behaviour into a client redirect to the original route path.
@@ -663,6 +673,7 @@ func (app *App) init() *App {
 	app.server.ReadBufferSize = app.config.ReadBufferSize
 	app.server.WriteBufferSize = app.config.WriteBufferSize
 	app.server.GetOnly = app.config.GETOnly
+	app.server.ReduceMemoryUsage = app.config.ReduceMemoryUsage
 
 	// unlock application
 	app.mutex.Unlock()


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

This PR introduces the `ReduceMemoryUsage` flag to the app config that is pulled to the underlying `fasthttp` server. The default value is `false` to keep the old behavior.

The implementation of `ReduceMemoryUsage` is here: https://github.com/valyala/fasthttp/blob/01acd76daf36a86fabc2b73fd5fc1deb3ec10fec/server.go#L285

Refs: #866 / https://github.com/gofiber/fiber/issues/866#issuecomment-704818583


**Explain the *details* for making this change. What existing problem does the pull request solve?**

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 

✅ done

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/