### PR TITLE
♻️ compression: avoid magic numbers in compression level check

### DIFF
--- a/middleware/compress/compress.go
+++ b/middleware/compress/compress.go
@@ -46,7 +46,7 @@ func New(config ...Config) fiber.Handler {
 		cfg = config[0]
 
 		// Set default values
-		if cfg.Level < -1 || cfg.Level > 2 {
+		if cfg.Level < LevelDisabled || cfg.Level > LevelBestCompression {
 			cfg.Level = ConfigDefault.Level
 		}
 	}


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Avoid the magic numbers to make it easier to read. Right now the integer values of the `const` are used instead of the `const` constants.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 
✅ done


Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/