### PR TITLE
🔥set a `Cache Control` header for static ressources

### DIFF
--- a/app.go
+++ b/app.go
@@ -261,6 +261,12 @@ type Static struct {
 	// The name of the index file for serving a directory.
 	// Optional. Default value "index.html".
 	Index string `json:"index"`
+
+	// The value for the Cache-Control HTTP-header
+	// that is set on the file response. MaxAge is defined in seconds.
+	//
+	// Optional. Default value 0.
+	MaxAge int `json:"max_age"`
 }
 
 // Default Config values

--- a/app_test.go
+++ b/app_test.go
@@ -562,12 +562,30 @@ func Test_App_Static_Direct(t *testing.T) {
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
 	utils.AssertEqual(t, false, resp.Header.Get(HeaderContentLength) == "")
-	utils.AssertEqual(t, "text/plain; charset=utf-8", resp.Header.Get(HeaderContentType))
+	utils.AssertEqual(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
+	utils.AssertEqual(t, "", resp.Header.Get(HeaderCacheControl), "CacheControl Control")
+
 
 	body, err = ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, true, strings.Contains(string(body), "gofiber.io/support"))
 }
+
+// go test -run Test_App_Static_MaxAge
+func Test_App_Static_MaxAge(t *testing.T) {
+	app := New()
+
+	app.Static("/", "./.github", Static{MaxAge: 100})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/index.html", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
+	utils.AssertEqual(t, false, resp.Header.Get(HeaderContentLength) == "")
+	utils.AssertEqual(t, "text/html; charset=utf-8", resp.Header.Get(HeaderContentType))
+	utils.AssertEqual(t, "public, max-age=100", resp.Header.Get(HeaderCacheControl), "CacheControl Control")
+}
+
+// go test -run Test_App_Static_Group
 func Test_App_Static_Group(t *testing.T) {
 	app := New()
 


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Right now, each static request returns the file without any `Cache-Control` header. If you are using `app.Static` to serve your assets, the browser won't cache it. This PR introduces a way to set the `cache control` header (if the file was found) on the file response to set a custom `max-age` to e.g. cache it 1 year.


**Explain the *details* for making this change. What existing problem does the pull request solve?**


A general use case for 

```go
app.Static("/public", "./public")
```

could be to serve your CSS and JS assets. Right now, there is no `Cache-Control` header present on the file-response. With this change, the `Cache-Control`-header can be configured through something like this

```go
app.Static("/public", "./ public", Static{MaxAge: 100})
```

Which improves the performance for your webpage and reduces the bandwidth.


**Commit formatting** 

✅ done

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/