### PR TITLE
Add custom types to compress middleware

### DIFF
--- a/middleware/compress/compress.go
+++ b/middleware/compress/compress.go
@@ -12,29 +12,30 @@ type Config struct {
 	// Optional. Default: nil
 	Next func(c *fiber.Ctx) bool
 
-	// CompressLevel determines the compression algoritm
+	// Level determines the compression algorithm
 	//
 	// Optional. Default: LevelDefault
 	// LevelDisabled:         -1
 	// LevelDefault:          0
 	// LevelBestSpeed:        1
 	// LevelBestCompression:  2
-	Level int
+	Level Level
 }
+
+type Level int
+
+const (
+	LevelDisabled        Level = -1
+	LevelDefault         Level = 0
+	LevelBestSpeed       Level = 1
+	LevelBestCompression Level = 2
+)
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
 	Next:  nil,
 	Level: LevelDefault,
 }
-
-// Compression levels
-const (
-	LevelDisabled        = -1
-	LevelDefault         = 0
-	LevelBestSpeed       = 1
-	LevelBestCompression = 2
-)
 
 // New creates a new middleware handler
 func New(config ...Config) fiber.Handler {
@@ -61,13 +62,22 @@ func New(config ...Config) fiber.Handler {
 	switch cfg.Level {
 	case LevelDefault:
 		// LevelDefault
-		compressor = fasthttp.CompressHandlerBrotliLevel(fctx, fasthttp.CompressBrotliDefaultCompression, fasthttp.CompressDefaultCompression)
+		compressor = fasthttp.CompressHandlerBrotliLevel(fctx,
+			fasthttp.CompressBrotliDefaultCompression,
+			fasthttp.CompressDefaultCompression,
+		)
 	case LevelBestSpeed:
 		// LevelBestSpeed
-		compressor = fasthttp.CompressHandlerBrotliLevel(fctx, fasthttp.CompressBrotliBestSpeed, fasthttp.CompressBestSpeed)
+		compressor = fasthttp.CompressHandlerBrotliLevel(fctx,
+			fasthttp.CompressBrotliBestSpeed,
+			fasthttp.CompressBestSpeed,
+		)
 	case LevelBestCompression:
 		// LevelBestCompression
-		compressor = fasthttp.CompressHandlerBrotliLevel(fctx, fasthttp.CompressBrotliBestCompression, fasthttp.CompressBestCompression)
+		compressor = fasthttp.CompressHandlerBrotliLevel(fctx,
+			fasthttp.CompressBrotliBestCompression,
+			fasthttp.CompressBestCompression,
+		)
 	default:
 		// LevelDisabled
 		return func(c *fiber.Ctx) error {

--- a/middleware/compress/compress_test.go
+++ b/middleware/compress/compress_test.go
@@ -40,7 +40,7 @@ func Test_Compress_Gzip(t *testing.T) {
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
 	utils.AssertEqual(t, "gzip", resp.Header.Get(fiber.HeaderContentEncoding))
 
-	// Validate the file size is shrinked
+	// Validate the file size is shrunk
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, true, len(body) < len(filedata))
@@ -48,7 +48,7 @@ func Test_Compress_Gzip(t *testing.T) {
 
 // go test -run Test_Compress_Different_Level
 func Test_Compress_Different_Level(t *testing.T) {
-	levels := []int{LevelBestSpeed, LevelBestCompression, 10}
+	levels := []Level{LevelBestSpeed, LevelBestCompression}
 	for _, level := range levels {
 		t.Run(fmt.Sprintf("level %d", level), func(t *testing.T) {
 			app := fiber.New()
@@ -86,7 +86,7 @@ func Test_Compress_Deflate(t *testing.T) {
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
 	utils.AssertEqual(t, "deflate", resp.Header.Get(fiber.HeaderContentEncoding))
 
-	// Validate the file size is shrinked
+	// Validate the file size is shrunk
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, true, len(body) < len(filedata))
@@ -109,7 +109,7 @@ func Test_Compress_Brotli(t *testing.T) {
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
 	utils.AssertEqual(t, "br", resp.Header.Get(fiber.HeaderContentEncoding))
 
-	// Validate the file size is shrinked
+	// Validate the file size is shrunk
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, true, len(body) < len(filedata))
@@ -132,7 +132,7 @@ func Test_Compress_Disabled(t *testing.T) {
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
 	utils.AssertEqual(t, "", resp.Header.Get(fiber.HeaderContentEncoding))
 
-	// Validate the file size is not shrinked
+	// Validate the file size is not shrunk
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, true, len(body) == len(filedata))

--- a/middleware/compress/compress_test.go
+++ b/middleware/compress/compress_test.go
@@ -40,7 +40,7 @@ func Test_Compress_Gzip(t *testing.T) {
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
 	utils.AssertEqual(t, "gzip", resp.Header.Get(fiber.HeaderContentEncoding))
 
-	// Validate the file size is shrunk
+	// Validate that the file size has shrunk
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, true, len(body) < len(filedata))
@@ -86,7 +86,7 @@ func Test_Compress_Deflate(t *testing.T) {
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
 	utils.AssertEqual(t, "deflate", resp.Header.Get(fiber.HeaderContentEncoding))
 
-	// Validate the file size is shrunk
+	// Validate that the file size has shrunk
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, true, len(body) < len(filedata))
@@ -109,7 +109,7 @@ func Test_Compress_Brotli(t *testing.T) {
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
 	utils.AssertEqual(t, "br", resp.Header.Get(fiber.HeaderContentEncoding))
 
-	// Validate the file size is shrunk
+	// Validate that the file size has shrunk
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, true, len(body) < len(filedata))


### PR DESCRIPTION
@Fenny this is more of an idea than a PR.

I believe it would help a lot if we used custom types for specific configurations:
- It enforces people to use a value that matches the type.
- We can limit only to the proper or "right" values.
- It works nicely with auto completion tools.
- It helps maintain a stricter interface and gives us more control.

If you agree I can make similar changes to the rest of the middleware and then take it from there.