### PR TITLE
Minor requestid middleware change

### DIFF
--- a/middleware/requestid/requestid.go
+++ b/middleware/requestid/requestid.go
@@ -19,19 +19,15 @@ type Config struct {
 
 	// Generator defines a function to generate the unique identifier.
 	//
-	// Optional. Default: func() string {
-	//   return utils.UUID()
-	// }
+	// Optional. Default: utils.UUID
 	Generator func() string
 }
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
-	Next:   nil,
-	Header: fiber.HeaderXRequestID,
-	Generator: func() string {
-		return utils.UUID()
-	},
+	Next:      nil,
+	Header:    fiber.HeaderXRequestID,
+	Generator: utils.UUID,
 }
 
 // New creates a new middleware handler

--- a/middleware/requestid/requestid_test.go
+++ b/middleware/requestid/requestid_test.go
@@ -45,5 +45,6 @@ func Test_RequestID_Next(t *testing.T) {
 
 	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
 	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, resp.Header.Get(fiber.HeaderXRequestID), "")
 	utils.AssertEqual(t, fiber.StatusNotFound, resp.StatusCode)
 }


### PR DESCRIPTION
- Adds a minor (clarity) only change to the defaults.
- Adds an assertion that is missing from a test.