### PR TITLE
improve base uri for ctx

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -39,6 +39,7 @@ type Ctx struct {
 	indexHandler int                  // Index of the current handler
 	method       string               // HTTP method
 	methodINT    int                  // HTTP method INT equivalent
+	baseURI      string               // HTTP base uri
 	path         string               // Prettified HTTP path -> string copy from pathBuffer
 	pathBuffer   []byte               // Prettified HTTP path buffer
 	treePath     string               // Path for the search in the tree
@@ -94,6 +95,8 @@ func (app *App) AcquireCtx(fctx *fasthttp.RequestCtx) *Ctx {
 	c.methodINT = methodInt(c.method)
 	// Attach *fasthttp.RequestCtx to ctx
 	c.fasthttp = fctx
+	// reset base uri
+	c.baseURI = ""
 	// Prettify path
 	c.prettifyPath()
 	return c
@@ -206,7 +209,11 @@ func (c *Ctx) Attachment(filename ...string) {
 func (c *Ctx) BaseURL() string {
 	// TODO: Could be improved: 53.8 ns/op  32 B/op  1 allocs/op
 	// Should work like https://codeigniter.com/user_guide/helpers/url_helper.html
-	return c.Protocol() + "://" + c.Hostname()
+	if c.baseURI != "" {
+		return c.baseURI
+	}
+	c.baseURI = c.Protocol() + "://" + c.Hostname()
+	return c.baseURI
 }
 
 // Body contains the raw body submitted in a POST request.

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -259,7 +259,7 @@ func Test_Ctx_BaseURL(t *testing.T) {
 	utils.AssertEqual(t, "http://google.com", c.BaseURL())
 }
 
-// go test -v -run=^$ -bench=Benchmark_Ctx_Append -benchmem -count=4
+// go test -v -run=^$ -bench=Benchmark_Ctx_BaseURL -benchmem
 func Benchmark_Ctx_BaseURL(b *testing.B) {
 	app := New()
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})


### PR DESCRIPTION
bench compare result:
```
benchmark                    old ns/op     new ns/op     delta
Benchmark_Ctx_BaseURL-12     58.0          2.24          -96.14%

benchmark                    old allocs     new allocs     delta
Benchmark_Ctx_BaseURL-12     1              0              -100.00%

benchmark                    old bytes     new bytes     delta
Benchmark_Ctx_BaseURL-12     32            0             -100.00%
```