### PR TITLE
🩹 add memory storage for csrf

### DIFF
--- a/middleware/csrf/README.md
+++ b/middleware/csrf/README.md
@@ -34,7 +34,7 @@ app.Use(csrf.New(csrf.Config{
 	Cookie: &fiber.Cookie{
 		Name: "_csrf",
 	},
-	CookieExpires: 24 * time.Hour,
+	Expiration: 24 * time.Hour,
 }))
 ```
 
@@ -63,10 +63,10 @@ type Config struct {
 	// Optional.
 	Cookie *fiber.Cookie
 
-	// CookieExpires is the duration before the cookie will expire
+	// Expiration is the duration before csrf token will expire
 	//
 	// Optional. Default: 24 * time.Hour
-	CookieExpires time.Duration
+	Expiration time.Duration
 
 	// Context key to store generated CSRF token into context.
 	//
@@ -83,11 +83,8 @@ var ConfigDefault = Config{
 	ContextKey:  "csrf",
 	Cookie: &fiber.Cookie{
 		Name:     "_csrf",
-		Domain:   "",
-		Path:     "",
-		Secure:   false,
-		HTTPOnly: false,
+		SameSite: "Strict",
 	},
-	CookieExpires: 24 * time.Hour,
+	Expiration: 24 * time.Hour,
 }
 ```

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -84,7 +84,7 @@ func New(config ...Config) fiber.Handler {
 			cfg.ContextKey = ConfigDefault.ContextKey
 		}
 		if cfg.CookieExpires != 0 {
-			fmt.Println("CookieExpires is deprecated, please use Expiration")
+			fmt.Println("[CSRF] CookieExpires is deprecated, please use Expiration")
 			cfg.CookieExpires = ConfigDefault.Expiration
 		}
 		if cfg.Expiration == 0 {
@@ -183,7 +183,6 @@ func New(config ...Config) fiber.Handler {
 			db.RLock()
 			t, ok := db.tokens[csrf]
 			db.RUnlock()
-
 			// Check if token exist or expired
 			if !ok || time.Now().Unix() >= t {
 				return fiber.ErrForbidden
@@ -204,7 +203,6 @@ func New(config ...Config) fiber.Handler {
 
 		// Set cookie to response
 		c.Cookie(cookie)
-
 		// Store token in context
 		c.Locals(cfg.ContextKey, token)
 

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -35,9 +35,7 @@ type Config struct {
 	// Optional.
 	Cookie *fiber.Cookie
 
-	// CookieExpires is the duration before the cookie will expire
-	//
-	// Optional. Default: 24 * time.Hour
+	// Deprecated, please use Expiration
 	CookieExpires time.Duration
 
 	// Expiration is the duration before csrf token will expire


### PR DESCRIPTION
Will fix https://github.com/gofiber/fiber/issues/953 and adds support for `cookie:<key>` extraction.