### PR TITLE
🎨 Adjust multiple comments to comply with the linter

### DIFF
--- a/app.go
+++ b/app.go
@@ -278,7 +278,7 @@ const (
 	DefaultCompressedFileSuffix = ".fiber.gz"
 )
 
-// Default ErrorHandler that process return errors from handlers
+// DefaultErrorHandler that process return errors from handlers
 var DefaultErrorHandler = func(c *Ctx, err error) error {
 	code := StatusInternalServerError
 	if e, ok := err.(*Error); ok {

--- a/internal/encoding/ascii/valid.go
+++ b/internal/encoding/ascii/valid.go
@@ -14,12 +14,12 @@ func ValidString(s string) bool {
 	return valid(unsafe.Pointer(&s), uintptr(len(s)))
 }
 
-// ValidBytes returns true if b is an ASCII character.
+// ValidByte returns true if b is an ASCII character.
 func ValidByte(b byte) bool {
 	return b <= 0x7f
 }
 
-// ValidBytes returns true if b is an ASCII character.
+// ValidRune returns true if r is an ASCII character.
 func ValidRune(r rune) bool {
 	return r <= 0x7f
 }
@@ -59,22 +59,22 @@ func valid(s unsafe.Pointer, n uintptr) bool {
 	return (x & 0x80808080) == 0
 }
 
-// Valid returns true if b contains only printable ASCII characters.
+// ValidPrint returns true if b contains only printable ASCII characters.
 func ValidPrint(b []byte) bool {
 	return validPrint(unsafe.Pointer(&b), uintptr(len(b)))
 }
 
-// ValidString returns true if s contains only printable ASCII characters.
+// ValidPrintString returns true if s contains only printable ASCII characters.
 func ValidPrintString(s string) bool {
 	return validPrint(unsafe.Pointer(&s), uintptr(len(s)))
 }
 
-// ValidBytes returns true if b is an ASCII character.
+// ValidPrintByte returns true if b is an ASCII character.
 func ValidPrintByte(b byte) bool {
 	return 0x20 <= b && b <= 0x7e
 }
 
-// ValidBytes returns true if b is an ASCII character.
+// ValidPrintRune returns true if r is an ASCII character.
 func ValidPrintRune(r rune) bool {
 	return 0x20 <= r && r <= 0x7e
 }

--- a/middleware/compress/compress.go
+++ b/middleware/compress/compress.go
@@ -22,8 +22,10 @@ type Config struct {
 	Level Level
 }
 
+// Level is numeric representation of compression level
 type Level int
 
+// Represents compression level that will be used in the middleware
 const (
 	LevelDisabled        Level = -1
 	LevelDefault         Level = 0

--- a/utils/common.go
+++ b/utils/common.go
@@ -26,6 +26,7 @@ var uuidSeed [24]byte
 var uuidCounter uint64
 var uuidSetup sync.Once
 
+// UUID generates an universally unique identifier (UUID)
 func UUID() string {
 	// Setup seed & counter once
 	uuidSetup.Do(func() {
@@ -62,7 +63,7 @@ func UUID() string {
 	return GetString(b)
 }
 
-// Returns function name
+// FunctionName returns function name
 func FunctionName(fn interface{}) string {
 	t := reflect.ValueOf(fn).Type()
 	if t.Kind() == reflect.Func {


### PR DESCRIPTION
During reading some code and getting know with the repo I adjusted multiple comments that were marked by the linter as warnings.