### PR TITLE
queryparser: query args count based condition removed

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -715,9 +715,6 @@ func (c *Ctx) Query(key string, defaultValue ...string) string {
 
 // QueryParser binds the query string to a struct.
 func (c *Ctx) QueryParser(out interface{}) error {
-	if c.fasthttp.QueryArgs().Len() < 1 {
-		return nil
-	}
 	// Get decoder from pool
 	var decoder = decoderPool.Get().(*schema.Decoder)
 	defer decoderPool.Put(decoder)

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1978,6 +1978,13 @@ func Test_Ctx_QueryParser(t *testing.T) {
 	utils.AssertEqual(t, nil, c.QueryParser(q2))
 	utils.AssertEqual(t, "basketball,football", q2.Hobby)
 
+	type RequiredQuery struct {
+		Name string `query:"name,required"`
+	}
+	rq := new(RequiredQuery)
+	c.Request().URI().SetQueryString("")
+	fmt.Println(c.QueryParser(rq))
+	utils.AssertEqual(t, "name is empty", c.QueryParser(rq).Error())
 }
 
 func Test_Ctx_EqualFieldType(t *testing.T) {


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
**Explain the *details* for making this change. What existing problem does the pull request solve?**

`QueryParser()` which parses query arguments into the struct which user provided along with `query` tag.

And there's a tag option - `required`.

Query arguments with no field that is required by the struct tag, `QueryParser()` returns an error.
However if there's no query argument, `QueryParser()` returns `nil` which can make user confused.

So I think the simplest way to catch this is that removing the argument length based condition.
As far as I know, it is for the performance that no query arguments mean nothing to parse so pass it with empty query string.
But `required` fields are expected to be set, otherwise it needs to be aware.  


refs:
- https://github.com/gofiber/fiber/issues/967