### PR TITLE
:bug: queryparser: query args count based condition removed

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -268,9 +268,6 @@ func (ctx *Ctx) BodyParser(out interface{}) error {
 
 // QueryParser binds the query string to a struct.
 func (ctx *Ctx) QueryParser(out interface{}) error {
-	if ctx.Fasthttp.QueryArgs().Len() < 1 {
-		return nil
-	}
 	// Get decoder from pool
 	var decoder = decoderPool.Get().(*schema.Decoder)
 	defer decoderPool.Put(decoder)

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1900,6 +1900,13 @@ func Test_Ctx_QueryParser(t *testing.T) {
 	ctx.Fasthttp.Request.URI().SetQueryString("")
 	utils.AssertEqual(t, nil, ctx.QueryParser(empty))
 	utils.AssertEqual(t, 0, len(empty.Hobby))
+
+	type RequiredQuery struct {
+		Name string `query:"name,required"`
+	}
+	rq := new(RequiredQuery)
+	ctx.Fasthttp.Request.URI().SetQueryString("")
+	utils.AssertEqual(t, "name is empty", ctx.QueryParser(rq).Error())
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Ctx_QueryParser -benchmem -count=4


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
**Explain the *details* for making this change. What existing problem does the pull request solve?**

`QueryParser()` which parses query arguments into the struct which user provided along with `query` tag.

And there's a tag option - `required`.

Query arguments with no field that is required by the struct tag, `QueryParser()` returns an error.
However if there's no query argument, `QueryParser()` returns `nil` which can make user confused.

So I think the simplest way to catch this is that removing the argument length based condition.
As far as I know, it is for the performance that no query arguments mean nothing to parse so pass it with empty query string.
But `required` fields are expected to be set, otherwise it needs to be aware.  


refs:
- https://github.com/gofiber/fiber/issues/967
- https://github.com/gofiber/fiber/pull/968

It's for v1.