### PR TITLE
🚀 feat: filesystem middleware work routes with params

### DIFF
--- a/middleware/filesystem/filesystem.go
+++ b/middleware/filesystem/filesystem.go
@@ -43,9 +43,6 @@ type Config struct {
 	//
 	// Optional. Default: ""
 	NotFoundFile string `json:"not_found_file"`
-
-	// share context with SendFile method
-	ctx *fiber.Ctx
 }
 
 // ConfigDefault is the default config
@@ -95,7 +92,6 @@ func New(config ...Config) fiber.Handler {
 			return c.Next()
 		}
 
-		cfg.ctx = c
 		method := c.Method()
 
 		// We only serve static assets on GET or HEAD methods
@@ -114,17 +110,16 @@ func New(config ...Config) fiber.Handler {
 			path = "/" + path
 		}
 
-		return SendFile(path)
+		return SendFile(c, path)
 	}
 }
 
 // SendFile ...
-func SendFile(param string) (err error) {
+func SendFile(c *fiber.Ctx, param string) (err error) {
 	var (
 		file http.File
 		stat os.FileInfo
 	)
-	c := cfg.ctx
 	method := c.Method()
 
 	// We only serve static assets on GET or HEAD methods

--- a/middleware/filesystem/filesystem_test.go
+++ b/middleware/filesystem/filesystem_test.go
@@ -161,3 +161,29 @@ func Test_FileSystem_NoRoot(t *testing.T) {
 	app.Use(New())
 	_, _ = app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
 }
+
+func Test_FileSystem_UsingParam(t *testing.T) {
+	app := fiber.New()
+
+	app.Use("/:path", func(c *fiber.Ctx) error {
+		return SendFile(c, http.Dir("../../.github/testdata/fs"), c.Params("path")+".html")
+	})
+
+	req, _ := http.NewRequest(fiber.MethodHead, "/index", nil)
+	resp, err := app.Test(req)
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+}
+
+func Test_FileSystem_UsingParam_NonFile(t *testing.T) {
+	app := fiber.New()
+
+	app.Use("/:path", func(c *fiber.Ctx) error {
+		return SendFile(c, http.Dir("../../.github/testdata/fs"), c.Params("path")+".html")
+	})
+
+	req, _ := http.NewRequest(fiber.MethodHead, "/template", nil)
+	resp, err := app.Test(req)
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 404, resp.StatusCode)
+}


### PR DESCRIPTION
Based on a user's request on issue #834 then was implemented now we have a new method called SendFile on filesystem middleware.

```go
package main

import (
	"net/http"

	"github.com/gofiber/fiber/v2"
	"github.com/gofiber/fiber/v2/middleware/filesystem"
	"github.com/gofiber/fiber/v2/middleware/logger"
)

func main() {
	app := fiber.New()

	app.Use(logger.New())

	app.Use("/:path", func(c *fiber.Ctx) error {
		return filesystem.SendFile(c, http.Dir("./assets"), c.Params("path")+".html")
	})

	app.Listen(":3000")
}
```