### PR TITLE
🩹 Fix: Allow Request timestamp to be more accurate by using Time() from fasthttp.RequestCtx

### DIFF
--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -159,15 +159,15 @@ func New(config ...Config) fiber.Handler {
 	var timestamp atomic.Value
 	timestamp.Store(time.Now().In(cfg.timeZoneLocation).Format(cfg.TimeFormat))
 
-	// Update date/time every 750 milliseconds in a separate go routine
-	if strings.Contains(cfg.Format, "${time}") {
-		go func() {
-			for {
-				time.Sleep(750 * time.Millisecond)
-				timestamp.Store(time.Now().In(cfg.timeZoneLocation).Format(cfg.TimeFormat))
-			}
-		}()
-	}
+	// // Update date/time every 750 milliseconds in a separate go routine
+	// if strings.Contains(cfg.Format, "${time}") {
+	// 	go func() {
+	// 		for {
+	// 			time.Sleep(750 * time.Millisecond)
+	// 			timestamp.Store(time.Now().In(cfg.timeZoneLocation).Format(cfg.TimeFormat))
+	// 		}
+	// 	}()
+	// }
 
 	// Set PID once
 	pid := strconv.Itoa(os.Getpid())
@@ -266,7 +266,7 @@ func New(config ...Config) fiber.Handler {
 		_, err = tmpl.ExecuteFunc(buf, func(w io.Writer, tag string) (int, error) {
 			switch tag {
 			case TagTime:
-				return buf.WriteString(timestamp.Load().(string))
+				return buf.WriteString(c.Context().Time().In(cfg.timeZoneLocation).Format(cfg.TimeFormat))
 			case TagReferer:
 				return buf.WriteString(c.Get(fiber.HeaderReferer))
 			case TagProtocol:


### PR DESCRIPTION
Also fixed formatting to use TimeFormat.


**Please provide enough information so that others can review your pull request:**

- I commended out the timestamp code, was not sure on the rules of just straight up removing it, as it may still serve a need?  I couldnt see that it did, so I shut it off and my testing didnt show any difference.

- Added code to take the output from the *fasthttp.RequestCtx context for the request, and use the Time() function to putll the time.Time object it had from starting to process the Request. 

- Used the Logger.Config options for TimeFormat and Timezone to output a string to go into the 'time' tag/variable.

**Explain the *details* for making this change. What existing problem does the pull request solve?**

When working with HTTP requests it is desirable to have at least milliseconds fidelity on the timestamp.  There can be thousands of requests per second happening and if we want to trace a particular one for security or operational reasons, it can be difficult if the timestamps are not setup correctly.

It looks like fasthttp already calculates these time stamps when it processes a Request and so instead of computing these, I think we could use the ones provided.  fasthttp put these in the *fasthttp.RequestCtx struct and I see that is inside the *fiber.Ctx struct.  This also removes the need for the timestamp creating go-routine that was sleeping for 750ms for performance reasons.  I think this might even improve performance.

⚡️🔥💩🔊