### PR TITLE
♻️ refactor: ineffectual assignment and unused variable

### DIFF
--- a/middleware/basicauth/basicauth_test.go
+++ b/middleware/basicauth/basicauth_test.go
@@ -80,6 +80,7 @@ func Test_Middleware_BasicAuth(t *testing.T) {
 		req := httptest.NewRequest("GET", "/testauth", nil)
 		req.Header.Add("Authorization", "Basic "+creds)
 		resp, err := app.Test(req)
+		utils.AssertEqual(t, nil, err)
 
 		body, err := ioutil.ReadAll(resp.Body)
 

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -29,10 +29,10 @@ func Test_Cache_CacheControl(t *testing.T) {
 		return c.SendString("Hello, World!")
 	})
 
-	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
+	_, err := app.Test(httptest.NewRequest("GET", "/", nil))
 	utils.AssertEqual(t, nil, err)
 
-	resp, err = app.Test(httptest.NewRequest("GET", "/", nil))
+	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, "public, max-age=10", resp.Header.Get(fiber.HeaderCacheControl))
 }


### PR DESCRIPTION
## Summary

Fix ineffectual assignment and remove unused variable.

## Ref

Here is the result of [golangci-lint](https://github.com/golangci/golangci-lint) of middleware:

```
middleware/basicauth/basicauth_test.go:82:9: ineffectual assignment to `err` (ineffassign)
		resp, err := app.Test(req)
		      ^
middleware/cache/cache_test.go:32:2: SA4006: this value of `resp` is never used (staticcheck)
	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
	^
middleware/logger/logger.go:368:4: SA9003: empty branch (staticcheck)
			if _, err := cfg.Output.Write([]byte(err.Error())); err != nil {
			^
```