### PR TITLE
:seedling: Add fiber_vhost middleware

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -531,6 +531,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [sujit-baniya/fiber-boilerplate](https://github.com/sujit-baniya/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 Contribute
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -531,7 +531,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [sujit-baniya/fiber-boilerplate](https://github.com/sujit-baniya/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 Contribute
 

--- a/.github/README_de.md
+++ b/.github/README_de.md
@@ -532,7 +532,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
-
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 ## 👍 Mitwirken
 
 Falls du **danke** sagen möchtest und/oder aktiv die Entwicklung von `fiber` fördern möchtest:

--- a/.github/README_de.md
+++ b/.github/README_de.md
@@ -532,7 +532,8 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+- [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+
 ## 👍 Mitwirken
 
 Falls du **danke** sagen möchtest und/oder aktiv die Entwicklung von `fiber` fördern möchtest:

--- a/.github/README_es.md
+++ b/.github/README_es.md
@@ -529,7 +529,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 
 ## 👍 Contribuir

--- a/.github/README_es.md
+++ b/.github/README_es.md
@@ -529,6 +529,8 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+
 
 ## 👍 Contribuir
 

--- a/.github/README_fr.md
+++ b/.github/README_fr.md
@@ -532,7 +532,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
-
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 ## 👍 Contribuer
 
 Si vous voulez nous remercier et/ou soutenir le développement actif de `Fiber`:

--- a/.github/README_fr.md
+++ b/.github/README_fr.md
@@ -532,7 +532,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 ## 👍 Contribuer
 
 Si vous voulez nous remercier et/ou soutenir le développement actif de `Fiber`:

--- a/.github/README_he.md
+++ b/.github/README_he.md
@@ -662,7 +662,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 </div>
 

--- a/.github/README_he.md
+++ b/.github/README_he.md
@@ -662,6 +662,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 </div>
 

--- a/.github/README_id.md
+++ b/.github/README_id.md
@@ -532,6 +532,7 @@ Berikut adalah kumpulan _middlewares_ yang dibuat oleh komunitas Fiber, silahkan
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 Berkontribusi
 

--- a/.github/README_id.md
+++ b/.github/README_id.md
@@ -532,7 +532,7 @@ Berikut adalah kumpulan _middlewares_ yang dibuat oleh komunitas Fiber, silahkan
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 Berkontribusi
 

--- a/.github/README_ja.md
+++ b/.github/README_ja.md
@@ -536,7 +536,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 貢献する
 

--- a/.github/README_ja.md
+++ b/.github/README_ja.md
@@ -536,6 +536,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 貢献する
 

--- a/.github/README_ko.md
+++ b/.github/README_ko.md
@@ -536,7 +536,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 기여
 

--- a/.github/README_ko.md
+++ b/.github/README_ko.md
@@ -536,6 +536,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 기여
 

--- a/.github/README_nl.md
+++ b/.github/README_nl.md
@@ -536,7 +536,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 Bijdragen
 

--- a/.github/README_nl.md
+++ b/.github/README_nl.md
@@ -536,6 +536,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 Bijdragen
 

--- a/.github/README_pt.md
+++ b/.github/README_pt.md
@@ -530,6 +530,7 @@ Esta é uma lista de middlewares criados pela comunidade do Fiber, se quiser ter
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 Contribuindo
 

--- a/.github/README_pt.md
+++ b/.github/README_pt.md
@@ -530,7 +530,7 @@ Esta é uma lista de middlewares criados pela comunidade do Fiber, se quiser ter
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 Contribuindo
 

--- a/.github/README_ru.md
+++ b/.github/README_ru.md
@@ -532,7 +532,7 @@ func main() {
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 Помощь проекту
 

--- a/.github/README_ru.md
+++ b/.github/README_ru.md
@@ -532,6 +532,7 @@ func main() {
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 Помощь проекту
 

--- a/.github/README_sa.md
+++ b/.github/README_sa.md
@@ -596,6 +596,7 @@ List of externally hosted middleware modules and maintained by the [Fiber team](
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 مساهمة
 

--- a/.github/README_sa.md
+++ b/.github/README_sa.md
@@ -596,7 +596,7 @@ List of externally hosted middleware modules and maintained by the [Fiber team](
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 مساهمة
 

--- a/.github/README_tr.md
+++ b/.github/README_tr.md
@@ -529,6 +529,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 Destek
 

--- a/.github/README_tr.md
+++ b/.github/README_tr.md
@@ -529,7 +529,7 @@ This is a list of middlewares that are created by the Fiber community, please cr
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 Destek
 

--- a/.github/README_zh-CN.md
+++ b/.github/README_zh-CN.md
@@ -531,6 +531,7 @@ List of externally hosted middleware modules and maintained by the [Fiber team](
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 贡献
 

--- a/.github/README_zh-CN.md
+++ b/.github/README_zh-CN.md
@@ -531,7 +531,7 @@ List of externally hosted middleware modules and maintained by the [Fiber team](
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 贡献
 

--- a/.github/README_zh-TW.md
+++ b/.github/README_zh-TW.md
@@ -532,7 +532,7 @@ List of externally hosted middleware modules and maintained by the [Fiber team](
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
--		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
+-   [K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 貢獻
 

--- a/.github/README_zh-TW.md
+++ b/.github/README_zh-TW.md
@@ -532,6 +532,7 @@ List of externally hosted middleware modules and maintained by the [Fiber team](
 -   [thomasvvugt/fiber-boilerplate](https://github.com/thomasvvugt/fiber-boilerplate)
 -   [ansrivas/fiberprometheus](https://github.com/ansrivas/fiberprometheus)
 -   [LdDl/fiber-long-poll](https://github.com/LdDl/fiber-long-poll)
+-		[K0enM/fiber_vhost](https://github.com/K0enM/fiber_vhost)
 
 ## 👍 貢獻
 


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

I wrote a small middleware to enable the use of virtual hosts by comparing the Host header with the Hostname specified in the Config. I plan on extending the middleware to match Host's by regex as well.