### PR TITLE
👷 Remove redundant validation of CacheDuration when checking static config

### DIFF
--- a/router.go
+++ b/router.go
@@ -349,9 +349,7 @@ func (app *App) registerStatic(prefix, root string, config ...Static) Router {
 		if maxAge > 0 {
 			cacheControlValue = "public, max-age=" + strconv.Itoa(maxAge)
 		}
-		if config[0].CacheDuration != 0 {
-			fs.CacheDuration = config[0].CacheDuration
-		}
+		fs.CacheDuration = config[0].CacheDuration
 		fs.Compress = config[0].Compress
 		fs.AcceptByteRange = config[0].ByteRange
 		fs.GenerateIndexPages = config[0].Browse


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

Fasthttp already [validates](https://github.com/valyala/fasthttp/blob/master/fs.go#L368-L371) this option.