### PR TITLE
🔥 Feature:  Add CustomTypeRegister for form

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -259,7 +259,7 @@ var decoderPool = &sync.Pool{New: func() interface{} {
 	return decoder
 }}
 
-// SetBodyParserDecoder allow globally change the option of form decoder
+// SetBodyParserDecoder allow globally change the option of form decoder, update decoderPool
 func SetBodyParserDecoder(bodyParserConfig BodyParserConfig) {
 	decoderPool = &sync.Pool{New: func() interface{} {
 		var decoder = schema.NewDecoder()

--- a/ctx.go
+++ b/ctx.go
@@ -250,7 +250,7 @@ var decoderPool = &sync.Pool{New: func() interface{} {
 // type CustomTime time.Time
 //
 // var timeConverter = func(value string) reflect.Value {
-//	 if v, err := time.Parse("2006-02-01", value); err == nil {
+//	 if v, err := time.Parse("2006-01-02", value); err == nil {
 //		 return reflect.ValueOf(v)
 //	 }
 //	 return reflect.Value{}

--- a/ctx.go
+++ b/ctx.go
@@ -274,10 +274,8 @@ func (c *Ctx) BodyParser(out interface{}, customTypeRegister ...CustomTypeRegist
 	// Get decoder from pool
 	schemaDecoder := decoderPool.Get().(*schema.Decoder)
 
-	if len(customTypeRegister) > 0 {
-		for _, v := range customTypeRegister {
-			schemaDecoder.RegisterConverter(reflect.ValueOf(v.Customtype).Interface(), v.Converter)
-		}
+	for _, v := range customTypeRegister {
+		schemaDecoder.RegisterConverter(reflect.ValueOf(v.Customtype).Interface(), v.Converter)
 	}
 
 	defer decoderPool.Put(schemaDecoder)

--- a/ctx.go
+++ b/ctx.go
@@ -279,7 +279,7 @@ func SetBodyParserDecoder(bodyParserConfig BodyParserConfig) {
 // It supports decoding the following content types based on the Content-Type header:
 // application/json, application/xml, application/x-www-form-urlencoded, multipart/form-data
 // If none of the content types above are matched, it will return a ErrUnprocessableEntity error
-func (c *Ctx) BodyParser(out interface{}, bodyParserType ...BodyParserType) error {
+func (c *Ctx) BodyParser(out interface{}) error {
 	// Get decoder from pool
 	schemaDecoder := decoderPool.Get().(*schema.Decoder)
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -339,8 +339,8 @@ func Test_Ctx_BodyParser(t *testing.T) {
 	testDecodeParserError(MIMEMultipartForm+`;boundary="b"`, "--b")
 }
 
-// go test -run Test_Ctx_BodyParser_with_CustomFormType
-func Test_Ctx_BodyParser_with_CustomFormType(t *testing.T) {
+// go test -run Test_Ctx_BodyParser_with_BodyParserType
+func Test_Ctx_BodyParser_with_BodyParserType(t *testing.T) {
 	type CustomTime time.Time
 
 	var timeConverter = func(value string) reflect.Value {
@@ -350,7 +350,7 @@ func Test_Ctx_BodyParser_with_CustomFormType(t *testing.T) {
 		return reflect.Value{}
 	}
 
-	customTime := CustomTypeRegister{
+	customTime := BodyParserType{
 		Customtype: CustomTime{},
 		Converter:  timeConverter,
 	}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -339,8 +339,8 @@ func Test_Ctx_BodyParser(t *testing.T) {
 	testDecodeParserError(MIMEMultipartForm+`;boundary="b"`, "--b")
 }
 
-// go test -run Test_Ctx_BodyParser_WithBodyParserType
-func Test_Ctx_BodyParser_WithBodyParserType(t *testing.T) {
+// go test -run Test_Ctx_BodyParser_WithSetBodyParserDecoder
+func Test_Ctx_BodyParser_WithSetBodyParserDecoder(t *testing.T) {
 	type CustomTime time.Time
 
 	var timeConverter = func(value string) reflect.Value {
@@ -355,27 +355,41 @@ func Test_Ctx_BodyParser_WithBodyParserType(t *testing.T) {
 		Converter:  timeConverter,
 	}
 
+	SetBodyParserDecoder(BodyParserConfig{
+		IgnoreUnknownKeys: true,
+		BodyParserType:    []BodyParserType{customTime},
+		ZeroEmpty:         true,
+		SetAliasTag:       "form",
+	})
+
 	t.Parallel()
 	app := New()
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 	defer app.ReleaseCtx(c)
 
 	type Demo struct {
-		Date CustomTime `form:"date"`
+		Date  CustomTime `form:"date"`
+		Title string     `form:"title"`
+		Body  string     `form:"body"`
 	}
 
 	testDecodeParser := func(contentType, body string) {
 		c.Request().Header.SetContentType(contentType)
 		c.Request().SetBody([]byte(body))
 		c.Request().Header.SetContentLength(len(body))
-		d := new(Demo)
-		utils.AssertEqual(t, nil, c.BodyParser(d, customTime))
+		d := Demo{
+			Title: "Existing title",
+			Body:  "Existing Body",
+		}
+		utils.AssertEqual(t, nil, c.BodyParser(&d))
 		date := fmt.Sprintf("%v", d.Date)
 		utils.AssertEqual(t, "{0 63743587200 <nil>}", date)
+		utils.AssertEqual(t, "", d.Title)
+		utils.AssertEqual(t, "New Body", d.Body)
 	}
 
-	testDecodeParser(MIMEApplicationForm, "date=2020-12-15")
-	testDecodeParser(MIMEMultipartForm+`; boundary="b"`, "--b\r\nContent-Disposition: form-data; name=\"date\"\r\n\r\n2020-12-15\r\n--b--")
+	testDecodeParser(MIMEApplicationForm, "date=2020-12-15&body=New Body&title=")
+	testDecodeParser(MIMEMultipartForm+`; boundary="b"`, "--b\r\nContent-Disposition: form-data; name=\"date\"\r\n\r\n2020-12-15\r\n--b\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\n\r\n--b\r\nContent-Disposition: form-data; name=\"body\"\r\n\r\nNew Body\r\n--b--")
 }
 
 // go test -v -run=^$ -bench=Benchmark_Ctx_BodyParser_JSON -benchmem -count=4

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -339,8 +339,8 @@ func Test_Ctx_BodyParser(t *testing.T) {
 	testDecodeParserError(MIMEMultipartForm+`;boundary="b"`, "--b")
 }
 
-// go test -run Test_Ctx_BodyParser_with_BodyParserType
-func Test_Ctx_BodyParser_with_BodyParserType(t *testing.T) {
+// go test -run Test_Ctx_BodyParser_WithBodyParserType
+func Test_Ctx_BodyParser_WithBodyParserType(t *testing.T) {
 	type CustomTime time.Time
 
 	var timeConverter = func(value string) reflect.Value {
@@ -361,7 +361,7 @@ func Test_Ctx_BodyParser_with_BodyParserType(t *testing.T) {
 	defer app.ReleaseCtx(c)
 
 	type Demo struct {
-		Date string `form:"date"`
+		Date CustomTime `form:"date"`
 	}
 
 	testDecodeParser := func(contentType, body string) {
@@ -371,7 +371,7 @@ func Test_Ctx_BodyParser_with_BodyParserType(t *testing.T) {
 		d := new(Demo)
 		utils.AssertEqual(t, nil, c.BodyParser(d, customTime))
 		date := fmt.Sprintf("%v", d.Date)
-		utils.AssertEqual(t, "2020-12-15", date)
+		utils.AssertEqual(t, "{0 63743587200 <nil>}", date)
 	}
 
 	testDecodeParser(MIMEApplicationForm, "date=2020-12-15")


### PR DESCRIPTION
Add "CustomTypeRegister" for form data bodyparser, allow you to input any custom type, provide flexibility for form, so you can register you own custom type in form.

**Please provide enough information so that others can review your pull request:**

I added "CustomTypeRegister" struct just above the bodyparser, and optional parameter for form bodyparser.
The comment above "CustomTypeRegister" provide example and how to use.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

You can do custom type in JSON format, Create custom type and related "UnmarshalJSON" method.
But in form you need to register converter in decoder, I added option for supporting this feature. In order to solve problem when you need custom type for form.

For example: 
It is mostly happen when people will sent you "2020-12-15" in browser form instead of RFC3339 format.
You can register this custom format, instead of force to use RFC3339. Other use case like, You can register own member ID type, etc.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/