### PR TITLE
👷 Auto add '/' prefix for Group

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -211,6 +211,11 @@ func getGroupPath(prefix, path string) string {
 	if path == "/" {
 		return prefix
 	}
+
+	if path[0] != '/' {
+		path = "/" + path
+	}
+
 	return utils.TrimRight(prefix, '/') + path
 }
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -155,6 +155,9 @@ func Test_Utils_getGroupPath(t *testing.T) {
 
 	res = getGroupPath("/v1/api/", "/")
 	utils.AssertEqual(t, "/v1/api/", res)
+
+	res = getGroupPath("/v1/api", "group")
+	utils.AssertEqual(t, "/v1/api/group", res)
 }
 
 // go test -v -run=^$ -bench=Benchmark_Utils_ -benchmem -count=3


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

```go
package main

import (
	"log"

	"github.com/gofiber/fiber/v2"
)

func main() {
	app := fiber.New()
	app.Get("/", func(c *fiber.Ctx) error {
		return c.JSON("Main App")
	})
	api := app.Group("api")
	api.Get("/", func(c *fiber.Ctx) error {
		return c.JSON("API")
	})
	v1 := api.Group("v1")
	v1.Get("/", func(c *fiber.Ctx) error {
		return c.JSON("V1 Api")
	})
	account := v1.Group("account")
	account.Get("/", func(c *fiber.Ctx) error {
		return c.JSON("v1 account")
	})

	for _, routes := range app.Stack() {
		for _, route := range routes {
			log.Println(route.Method, route.Path)
		}
	}
}
```

Will produce things from
```hs
2020/12/24 14:18:15 GET /
2020/12/24 14:18:15 GET /api
2020/12/24 14:18:15 GET /apiv1
2020/12/24 14:18:15 GET /apiv1account
2020/12/24 14:18:15 HEAD /
2020/12/24 14:18:15 HEAD /api
2020/12/24 14:18:15 HEAD /apiv1
2020/12/24 14:18:15 HEAD /apiv1account
```

to

```hs
2020/12/24 14:17:04 GET /
2020/12/24 14:17:04 GET /api
2020/12/24 14:17:04 GET /api/v1
2020/12/24 14:17:04 GET /api/v1/account
2020/12/24 14:17:04 HEAD /
2020/12/24 14:17:04 HEAD /api
2020/12/24 14:17:04 HEAD /api/v1
2020/12/24 14:17:04 HEAD /api/v1/account
```

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/