### PR TITLE
ajust config.Next position

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -43,11 +43,6 @@ func New(config ...Config) fiber.Handler {
 
 	// Return new handler
 	return func(c *fiber.Ctx) error {
-		// Don't execute middleware if Next returns true
-		if cfg.Next != nil && cfg.Next(c) {
-			return c.Next()
-		}
-
 		// Only cache GET methods
 		if c.Method() != fiber.MethodGet {
 			return c.Next()
@@ -103,6 +98,11 @@ func New(config ...Config) fiber.Handler {
 		// Continue stack, return err to Fiber if exist
 		if err := c.Next(); err != nil {
 			return err
+		}
+
+		// Don't cache response if Next returns true
+		if cfg.Next != nil && cfg.Next(c) {
+			return nil
 		}
 
 		// Cache response


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
The intention of this PR is to address the issue raised here: [1116](https://github.com/gofiber/fiber/issues/1116)

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**
Move ``config.Next`` after ``ctx.Next``, so we can determine whether to cache or not after handling biz logic.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/