### PR TITLE
🩹 Fix: add missing utf-8 charset

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -541,7 +541,7 @@ func (c *Ctx) JSON(data interface{}) error {
 		return err
 	}
 	c.fasthttp.Response.SetBodyRaw(raw)
-	c.fasthttp.Response.Header.SetContentType(MIMEApplicationJSON)
+	c.fasthttp.Response.Header.SetContentType(MIMEApplicationJSONCharsetUTF8)
 	return nil
 }
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1411,7 +1411,7 @@ func Test_Ctx_JSON(t *testing.T) {
 		"Age":  20,
 	})
 	utils.AssertEqual(t, `{"Age":20,"Name":"Grame"}`, string(c.Response().Body()))
-	utils.AssertEqual(t, "application/json", string(c.Response().Header.Peek("content-type")))
+	utils.AssertEqual(t, "application/json; charset=utf-8", string(c.Response().Header.Peek("content-type")))
 
 	testEmpty := func(v interface{}, r string) {
 		err := c.JSON(v)


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

* While testing an API, I detected that the response using the JSON function was returning strange characters, so I checked the Content-type header and saw that the **charset** was missing.


**Explain the *details* for making this change. What existing problem does the pull request solve?**

Based on the standard [RFC 3629](https://tools.ietf.org/html/rfc3629). I modified the [MIME Type](https://pkg.go.dev/github.com/gofiber/fiber#pkg-constants) of the JSON function in the ctx as follows:

**Before:**
```go
c.fasthttp.Response.Header.SetContentType(MIMEApplicationJSON)
```
**After:**
```go
c.fasthttp.Response.Header.SetContentType(MIMEApplicationJSONCharsetUTF8)
```
🩹🩹🩹🩹