### PR TITLE
🔥 Add network option

### DIFF
--- a/app.go
+++ b/app.go
@@ -284,7 +284,7 @@ type Config struct {
 	// Known networks are "tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only)
 	// WARNING: When prefork is set to true, only "tcp4" and "tcp6" can be chose.
 	//
-	// Default: "tcp4"
+	// Default: NetworkTCP4
 	Network string
 }
 
@@ -403,7 +403,7 @@ func New(config ...Config) *App {
 		app.config.JSONEncoder = json.Marshal
 	}
 	if app.config.Network == "" {
-		app.config.Network = "tcp4"
+		app.config.Network = NetworkTCP4
 	}
 
 	// Init app

--- a/app.go
+++ b/app.go
@@ -280,6 +280,12 @@ type Config struct {
 	// Allowing for flexibility in using another json library for encoding
 	// Default: json.Marshal
 	JSONEncoder utils.JSONMarshal `json:"-"`
+
+	// Known networks are "tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only)
+	// WARNING: When prefork is set to true, only "tcp4" and "tcp6" can be chose.
+	//
+	// Default: "tcp4"
+	Network string
 }
 
 // Static defines configuration options when defining static assets.
@@ -395,6 +401,9 @@ func New(config ...Config) *App {
 	}
 	if app.config.JSONEncoder == nil {
 		app.config.JSONEncoder = json.Marshal
+	}
+	if app.config.Network == "" {
+		app.config.Network = "tcp4"
 	}
 
 	// Init app
@@ -553,8 +562,8 @@ func NewError(code int, message ...string) *Error {
 func (app *App) Listener(ln net.Listener) error {
 	// Prefork is supported for custom listeners
 	if app.config.Prefork {
-		addr, tls := lnMetadata(ln)
-		return app.prefork(addr, tls)
+		addr, tlsConfig := lnMetadata(app.config.Network, ln)
+		return app.prefork(app.config.Network, addr, tlsConfig)
 	}
 	// prepare the server for the start
 	app.startupProcess()
@@ -573,10 +582,10 @@ func (app *App) Listener(ln net.Listener) error {
 func (app *App) Listen(addr string) error {
 	// Start prefork
 	if app.config.Prefork {
-		return app.prefork(addr, nil)
+		return app.prefork(app.config.Network, addr, nil)
 	}
 	// Setup listener
-	ln, err := net.Listen("tcp4", addr)
+	ln, err := net.Listen(app.config.Network, addr)
 	if err != nil {
 		return err
 	}
@@ -613,10 +622,10 @@ func (app *App) ListenTLS(addr, certFile, keyFile string) error {
 				cert,
 			},
 		}
-		return app.prefork(addr, config)
+		return app.prefork(app.config.Network, addr, config)
 	}
 	// Setup listener
-	ln, err := net.Listen("tcp4", addr)
+	ln, err := net.Listen(app.config.Network, addr)
 	if err != nil {
 		return err
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -392,7 +392,7 @@ func Test_App_Listener_TLS(t *testing.T) {
 	}
 	config := &tls.Config{Certificates: []tls.Certificate{cer}}
 
-	ln, err := net.Listen("tcp4", ":3078")
+	ln, err := net.Listen(NetworkTCP4, ":3078")
 	utils.AssertEqual(t, nil, err)
 
 	ln = tls.NewListener(ln, config)
@@ -1151,7 +1151,7 @@ func Test_App_ReadTimeout(t *testing.T) {
 	go func() {
 		time.Sleep(500 * time.Millisecond)
 
-		conn, err := net.Dial("tcp4", "127.0.0.1:4004")
+		conn, err := net.Dial(NetworkTCP4, "127.0.0.1:4004")
 		utils.AssertEqual(t, nil, err)
 		defer conn.Close()
 
@@ -1183,7 +1183,7 @@ func Test_App_BadRequest(t *testing.T) {
 
 	go func() {
 		time.Sleep(500 * time.Millisecond)
-		conn, err := net.Dial("tcp4", "127.0.0.1:4005")
+		conn, err := net.Dial(NetworkTCP4, "127.0.0.1:4005")
 		utils.AssertEqual(t, nil, err)
 		defer conn.Close()
 

--- a/helpers.go
+++ b/helpers.go
@@ -670,3 +670,10 @@ const (
 	HeaderXRobotsTag                      = "X-Robots-Tag"
 	HeaderXUACompatible                   = "X-UA-Compatible"
 )
+
+// Network types that are commonly used
+const (
+	NetworkTCP  = "tcp"
+	NetworkTCP4 = "tcp4"
+	NetworkTCP6 = "tcp6"
+)

--- a/helpers.go
+++ b/helpers.go
@@ -25,7 +25,7 @@ import (
 
 /* #nosec */
 // lnMetadata will close the listener and return the addr and tls config
-func lnMetadata(ln net.Listener) (addr string, cfg *tls.Config) {
+func lnMetadata(network string, ln net.Listener) (addr string, cfg *tls.Config) {
 	// Get addr
 	addr = ln.Addr().String()
 
@@ -37,7 +37,7 @@ func lnMetadata(ln net.Listener) (addr string, cfg *tls.Config) {
 	// Wait for the listener to be closed
 	var closed bool
 	for i := 0; i < 10; i++ {
-		conn, err := net.DialTimeout("tcp4", addr, 3*time.Second)
+		conn, err := net.DialTimeout(network, addr, 3*time.Second)
 		if err != nil || conn == nil {
 			closed = true
 			break

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -262,23 +262,23 @@ func Benchmark_Utils_IsNoCache(b *testing.B) {
 
 func Test_Utils_lnMetadata(t *testing.T) {
 	t.Run("closed listen", func(t *testing.T) {
-		ln, err := net.Listen("tcp", ":0")
+		ln, err := net.Listen(NetworkTCP, ":0")
 		utils.AssertEqual(t, nil, err)
 
 		utils.AssertEqual(t, nil, ln.Close())
 
-		addr, config := lnMetadata("tcp", ln)
+		addr, config := lnMetadata(NetworkTCP, ln)
 
 		utils.AssertEqual(t, ln.Addr().String(), addr)
 		utils.AssertEqual(t, true, config == nil)
 	})
 
 	t.Run("non tls", func(t *testing.T) {
-		ln, err := net.Listen("tcp", ":0")
+		ln, err := net.Listen(NetworkTCP, ":0")
 
 		utils.AssertEqual(t, nil, err)
 
-		addr, config := lnMetadata("tcp4", ln)
+		addr, config := lnMetadata(NetworkTCP4, ln)
 
 		utils.AssertEqual(t, ln.Addr().String(), addr)
 		utils.AssertEqual(t, true, config == nil)
@@ -290,12 +290,12 @@ func Test_Utils_lnMetadata(t *testing.T) {
 
 		config := &tls.Config{Certificates: []tls.Certificate{cer}}
 
-		ln, err := net.Listen("tcp4", ":0")
+		ln, err := net.Listen(NetworkTCP4, ":0")
 		utils.AssertEqual(t, nil, err)
 
 		ln = tls.NewListener(ln, config)
 
-		addr, config := lnMetadata("tcp4", ln)
+		addr, config := lnMetadata(NetworkTCP4, ln)
 
 		utils.AssertEqual(t, ln.Addr().String(), addr)
 		utils.AssertEqual(t, true, config != nil)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -267,7 +267,7 @@ func Test_Utils_lnMetadata(t *testing.T) {
 
 		utils.AssertEqual(t, nil, ln.Close())
 
-		addr, config := lnMetadata(ln)
+		addr, config := lnMetadata("tcp", ln)
 
 		utils.AssertEqual(t, ln.Addr().String(), addr)
 		utils.AssertEqual(t, true, config == nil)
@@ -278,7 +278,7 @@ func Test_Utils_lnMetadata(t *testing.T) {
 
 		utils.AssertEqual(t, nil, err)
 
-		addr, config := lnMetadata(ln)
+		addr, config := lnMetadata("tcp4", ln)
 
 		utils.AssertEqual(t, ln.Addr().String(), addr)
 		utils.AssertEqual(t, true, config == nil)
@@ -295,7 +295,7 @@ func Test_Utils_lnMetadata(t *testing.T) {
 
 		ln = tls.NewListener(ln, config)
 
-		addr, config := lnMetadata(ln)
+		addr, config := lnMetadata("tcp4", ln)
 
 		utils.AssertEqual(t, ln.Addr().String(), addr)
 		utils.AssertEqual(t, true, config != nil)

--- a/prefork.go
+++ b/prefork.go
@@ -29,7 +29,7 @@ func IsChild() bool {
 }
 
 // prefork manages child processes to make use of the OS REUSEPORT or REUSEADDR feature
-func (app *App) prefork(addr string, tlsConfig *tls.Config) (err error) {
+func (app *App) prefork(network, addr string, tlsConfig *tls.Config) (err error) {
 	// 👶 child process 👶
 	if IsChild() {
 		// use 1 cpu core per child process
@@ -37,7 +37,7 @@ func (app *App) prefork(addr string, tlsConfig *tls.Config) (err error) {
 		var ln net.Listener
 		// Linux will use SO_REUSEPORT and Windows falls back to SO_REUSEADDR
 		// Only tcp4 or tcp6 is supported when preforking, both are not supported
-		if ln, err = reuseport.Listen("tcp4", addr); err != nil {
+		if ln, err = reuseport.Listen(network, addr); err != nil {
 			if !app.config.DisableStartupMessage {
 				time.Sleep(100 * time.Millisecond) // avoid colliding with startup message
 			}

--- a/prefork_test.go
+++ b/prefork_test.go
@@ -23,7 +23,7 @@ func Test_App_Prefork_Child_Process(t *testing.T) {
 
 	app := New()
 
-	err := app.prefork("tcp4", "invalid", nil)
+	err := app.prefork(NetworkTCP4, "invalid", nil)
 	utils.AssertEqual(t, false, err == nil)
 
 	go func() {
@@ -31,7 +31,7 @@ func Test_App_Prefork_Child_Process(t *testing.T) {
 		utils.AssertEqual(t, nil, app.Shutdown())
 	}()
 
-	utils.AssertEqual(t, nil, app.prefork("tcp6", "[::]:", nil))
+	utils.AssertEqual(t, nil, app.prefork(NetworkTCP6, "[::]:", nil))
 
 	// Create tls certificate
 	cer, err := tls.LoadX509KeyPair("./.github/testdata/ssl.pem", "./.github/testdata/ssl.key")
@@ -45,7 +45,7 @@ func Test_App_Prefork_Child_Process(t *testing.T) {
 		utils.AssertEqual(t, nil, app.Shutdown())
 	}()
 
-	utils.AssertEqual(t, nil, app.prefork("tcp4", "127.0.0.1:", config))
+	utils.AssertEqual(t, nil, app.prefork(NetworkTCP4, "127.0.0.1:", config))
 }
 
 func Test_App_Prefork_Master_Process(t *testing.T) {
@@ -59,11 +59,11 @@ func Test_App_Prefork_Master_Process(t *testing.T) {
 		utils.AssertEqual(t, nil, app.Shutdown())
 	}()
 
-	utils.AssertEqual(t, nil, app.prefork("tcp4", ":3000", nil))
+	utils.AssertEqual(t, nil, app.prefork(NetworkTCP4, ":3000", nil))
 
 	dummyChildCmd = "invalid"
 
-	err := app.prefork("tcp4", "127.0.0.1:", nil)
+	err := app.prefork(NetworkTCP4, "127.0.0.1:", nil)
 	utils.AssertEqual(t, false, err == nil)
 }
 

--- a/prefork_test.go
+++ b/prefork_test.go
@@ -23,7 +23,7 @@ func Test_App_Prefork_Child_Process(t *testing.T) {
 
 	app := New()
 
-	err := app.prefork("invalid", nil)
+	err := app.prefork("tcp4", "invalid", nil)
 	utils.AssertEqual(t, false, err == nil)
 
 	go func() {
@@ -31,7 +31,7 @@ func Test_App_Prefork_Child_Process(t *testing.T) {
 		utils.AssertEqual(t, nil, app.Shutdown())
 	}()
 
-	utils.AssertEqual(t, nil, app.prefork("[::]:", nil))
+	utils.AssertEqual(t, nil, app.prefork("tcp6", "[::]:", nil))
 
 	// Create tls certificate
 	cer, err := tls.LoadX509KeyPair("./.github/testdata/ssl.pem", "./.github/testdata/ssl.key")
@@ -45,7 +45,7 @@ func Test_App_Prefork_Child_Process(t *testing.T) {
 		utils.AssertEqual(t, nil, app.Shutdown())
 	}()
 
-	utils.AssertEqual(t, nil, app.prefork("127.0.0.1:", config))
+	utils.AssertEqual(t, nil, app.prefork("tcp4", "127.0.0.1:", config))
 }
 
 func Test_App_Prefork_Master_Process(t *testing.T) {
@@ -59,11 +59,11 @@ func Test_App_Prefork_Master_Process(t *testing.T) {
 		utils.AssertEqual(t, nil, app.Shutdown())
 	}()
 
-	utils.AssertEqual(t, nil, app.prefork(":3000", nil))
+	utils.AssertEqual(t, nil, app.prefork("tcp4", ":3000", nil))
 
 	dummyChildCmd = "invalid"
 
-	err := app.prefork("127.0.0.1:", nil)
+	err := app.prefork("tcp4", "127.0.0.1:", nil)
 	utils.AssertEqual(t, false, err == nil)
 }
 


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
Solve #1154 
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->
```go
package main

import (
    "log"

    "github.com/gofiber/fiber/v2"
)

func main() {
    app := fiber.New(fiber.Config{
        Prefork: true,
        Network: fiber.NetworkTCP6,
    })

    app.Get("/", func(c *fiber.Ctx) error {
        return c.SendString("Hello IPv6 👋")
    })

    log.Println(app.Listen("[::]:3000"))
}
```
**Explain the *details* for making this change. What existing problem does the pull request solve?**
By adding `Network` option, users can decide which network stack(`tcp`, `tcp4`, `tcp6`) to use.
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/