### PR TITLE
🩹 expire CSRF cookie on Post, Delete, Patch or Put

### DIFF
--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -84,21 +84,20 @@ func New(config ...Config) fiber.Handler {
 			if err != nil {
 				return cfg.ErrorHandler(c, err)
 			}
+			
+			// Expire cookie
+			c.Cookie(&fiber.Cookie{
+				Name:     cfg.CookieName,
+				Domain:   cfg.CookieDomain,
+				Path:     cfg.CookiePath,
+				Expires:  time.Now().Add(-1 * time.Minute),
+				Secure:   cfg.CookieSecure,
+				HTTPOnly: cfg.CookieHTTPOnly,
+				SameSite: cfg.CookieSameSite,
+			})
 
 			// if token does not exist in Storage
 			if manager.getRaw(token) == nil {
-
-				// Expire cookie
-				c.Cookie(&fiber.Cookie{
-					Name:     cfg.CookieName,
-					Domain:   cfg.CookieDomain,
-					Path:     cfg.CookiePath,
-					Expires:  time.Now().Add(-1 * time.Minute),
-					Secure:   cfg.CookieSecure,
-					HTTPOnly: cfg.CookieHTTPOnly,
-					SameSite: cfg.CookieSameSite,
-				})
-
 				return cfg.ErrorHandler(c, err)
 			}
 


### PR DESCRIPTION
Cookie should always expire on Post, Delete, Patch or Put as it is either valid and will be removed from storage, or is not in storage and invalid anyway.