### PR TITLE
👷 Fix hardcode tls to startupMessage in app.Listener

### DIFF
--- a/app.go
+++ b/app.go
@@ -568,7 +568,7 @@ func (app *App) Listener(ln net.Listener) error {
 	app.startupProcess()
 	// Print startup message
 	if !app.config.DisableStartupMessage {
-		app.startupMessage(ln.Addr().String(), false, "")
+		app.startupMessage(ln.Addr().String(), getTlsConfig(ln) != nil, "")
 	}
 	// Start listening
 	return app.server.Serve(ln)

--- a/app_test.go
+++ b/app_test.go
@@ -382,29 +382,6 @@ func Test_App_Add_Method_Test(t *testing.T) {
 	app.Add("JOHN", "/doe", testEmptyHandler)
 }
 
-func Test_App_Listener_TLS(t *testing.T) {
-	app := New()
-
-	// Create tls certificate
-	cer, err := tls.LoadX509KeyPair("./.github/testdata/ssl.pem", "./.github/testdata/ssl.key")
-	if err != nil {
-		utils.AssertEqual(t, nil, err)
-	}
-	config := &tls.Config{Certificates: []tls.Certificate{cer}}
-
-	ln, err := net.Listen(NetworkTCP4, ":3078")
-	utils.AssertEqual(t, nil, err)
-
-	ln = tls.NewListener(ln, config)
-
-	go func() {
-		time.Sleep(1000 * time.Millisecond)
-		utils.AssertEqual(t, nil, app.Shutdown())
-	}()
-
-	utils.AssertEqual(t, nil, app.Listener(ln))
-}
-
 // go test -run Test_App_GETOnly
 func Test_App_GETOnly(t *testing.T) {
 	app := New(Config{
@@ -1008,6 +985,27 @@ func Test_App_Listener_Prefork(t *testing.T) {
 	app := New(Config{DisableStartupMessage: true, Prefork: true})
 
 	ln := fasthttputil.NewInmemoryListener()
+	utils.AssertEqual(t, nil, app.Listener(ln))
+}
+
+func Test_App_Listener_TLS(t *testing.T) {
+	// Create tls certificate
+	cer, err := tls.LoadX509KeyPair("./.github/testdata/ssl.pem", "./.github/testdata/ssl.key")
+	if err != nil {
+		utils.AssertEqual(t, nil, err)
+	}
+	config := &tls.Config{Certificates: []tls.Certificate{cer}}
+
+	ln, err := tls.Listen(NetworkTCP4, ":0", config)
+	utils.AssertEqual(t, nil, err)
+
+	app := New()
+
+	go func() {
+		time.Sleep(time.Millisecond * 500)
+		utils.AssertEqual(t, nil, app.Shutdown())
+	}()
+
 	utils.AssertEqual(t, nil, app.Listener(ln))
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -49,6 +49,14 @@ func lnMetadata(network string, ln net.Listener) (addr string, cfg *tls.Config) 
 		panic("listener: " + addr + ": Only one usage of each socket address (protocol/network address/port) is normally permitted.")
 	}
 
+	cfg = getTlsConfig(ln)
+
+	return
+}
+
+/* #nosec */
+// getTlsConfig returns a net listener's tls config
+func getTlsConfig(ln net.Listener) *tls.Config {
 	// Get listener type
 	pointer := reflect.ValueOf(ln)
 
@@ -63,13 +71,14 @@ func lnMetadata(network string, ln net.Listener) (addr string, cfg *tls.Config) 
 					// Get element from pointer
 					if elem := newval.Elem(); elem.Type() != nil {
 						// Cast value to *tls.Config
-						cfg = elem.Interface().(*tls.Config)
+						return elem.Interface().(*tls.Config)
 					}
 				}
 			}
 		}
 	}
-	return
+
+	return nil
 }
 
 // readContent opens a named file and read content from it


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->
Now we use hardcode `false` to `app.startupMessage` in `app.Listener`, so when even param `ln` is a tls listener,  `app.startupMessage` also displays `http://xxx`.

This PR fixes the bug via detecting `ln` type.

**Explain the *details* for making this change. What existing problem does the pull request solve?**

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/