### PR TITLE
🐛fix: lookup cookie in response header

### DIFF
--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -274,6 +274,30 @@ func Test_Session_Cookie(t *testing.T) {
 	utils.AssertEqual(t, 84, len(ctx.Response().Header.PeekCookie(store.CookieName)))
 }
 
+// go test -run Test_Session_Cookie_In_Response
+func Test_Session_Cookie_In_Response(t *testing.T) {
+	t.Parallel()
+	store := New()
+	app := fiber.New()
+
+	// fiber context
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+
+	// get session
+	sess, _ := store.Get(ctx)
+	sess.Set("id", "1")
+	utils.AssertEqual(t, true, sess.Fresh())
+	sess.Save()
+
+	sess, _ = store.Get(ctx)
+	sess.Set("name", "john")
+	utils.AssertEqual(t, true, sess.Fresh())
+
+	utils.AssertEqual(t, "1", sess.Get("id"))
+	utils.AssertEqual(t, "john", sess.Get("name"))
+}
+
 // go test -v -run=^$ -bench=Benchmark_Session -benchmem -count=4
 func Benchmark_Session(b *testing.B) {
 	app, store := fiber.New(), New()


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

This pr try to fix this issue: https://github.com/gofiber/fiber/issues/1184

**Explain the *details* for making this change. What existing problem does the pull request solve?**

``ctx.Cookies`` will look up coookie in response header if cookie is not found in request header

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/