### PR TITLE
fix logger [WARNING: DATA RACE]

### DIFF
--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -107,10 +107,9 @@ func New(config ...Config) fiber.Handler {
 
 	// Set variables
 	var (
-		start, stop time.Time
-		once        sync.Once
-		mu          sync.Mutex
-		errHandler  fiber.ErrorHandler
+		once       sync.Once
+		mu         sync.Mutex
+		errHandler fiber.ErrorHandler
 	)
 
 	// If colors are enabled, check terminal compatibility
@@ -144,6 +143,8 @@ func New(config ...Config) fiber.Handler {
 			// override error handler
 			errHandler = c.App().Config().ErrorHandler
 		})
+
+		var start, stop time.Time
 
 		// Set latency start time
 		if cfg.enableLatency {


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
```shell
23:37:45 | 200 |    20ms |       127.0.0.1 | GET     | /js/chunk-vendors.29fe8993.js.map 
==================
WARNING: DATA RACE
Write at 0x00c0004c2ac8 by goroutine 28:
  github.com/gofiber/fiber/v2/middleware/logger.New.func2()
      github.com/gofiber/fiber/v2@v2.6.0/middleware/logger/logger.go:165 +0x1138
  github.com/gofiber/fiber/v2.(*App).next()
      github.com/gofiber/fiber/v2@v2.6.0/router.go:126 +0x441
  github.com/gofiber/fiber/v2.(*App).handler()
      github.com/gofiber/fiber/v2@v2.6.0/router.go:154 +0x1d2
  github.com/gofiber/fiber/v2.(*App).handler-fm()
      github.com/gofiber/fiber/v2@v2.6.0/router.go:142 +0x54
  github.com/valyala/fasthttp.(*Server).serveConn()
      github.com/valyala/fasthttp@v1.19.0/server.go:2166 +0x1a03
  github.com/valyala/fasthttp.(*Server).serveConn-fm()
      github.com/valyala/fasthttp@v1.19.0/server.go:1957 +0x6a
  github.com/valyala/fasthttp.(*workerPool).workerFunc()
      github.com/valyala/fasthttp@v1.19.0/workerpool.go:223 +0x109
  github.com/valyala/fasthttp.(*workerPool).getCh.func1()
      github.com/valyala/fasthttp@v1.19.0/workerpool.go:195 +0x44

Previous write at 0x00c0004c2ac8 by goroutine 27:
  github.com/gofiber/fiber/v2/middleware/logger.New.func2()
      github.com/gofiber/fiber/v2@v2.6.0/middleware/logger/logger.go:165 +0x1138
  github.com/gofiber/fiber/v2.(*App).next()
      github.com/gofiber/fiber/v2@v2.6.0/router.go:126 +0x441
  github.com/gofiber/fiber/v2.(*App).handler()
      github.com/gofiber/fiber/v2@v2.6.0/router.go:154 +0x1d2
  github.com/gofiber/fiber/v2.(*App).handler-fm()
      github.com/gofiber/fiber/v2@v2.6.0/router.go:142 +0x54
  github.com/valyala/fasthttp.(*Server).serveConn()
      github.com/valyala/fasthttp@v1.19.0/server.go:2166 +0x1a03
  github.com/valyala/fasthttp.(*Server).serveConn-fm()
      github.com/valyala/fasthttp@v1.19.0/server.go:1957 +0x6a
  github.com/valyala/fasthttp.(*workerPool).workerFunc()
      github.com/valyala/fasthttp@v1.19.0/workerpool.go:223 +0x109
  github.com/valyala/fasthttp.(*workerPool).getCh.func1()
      github.com/valyala/fasthttp@v1.19.0/workerpool.go:195 +0x44

Goroutine 28 (running) created at:
  github.com/valyala/fasthttp.(*workerPool).getCh()
      github.com/valyala/fasthttp@v1.19.0/workerpool.go:194 +0x1c4
  github.com/valyala/fasthttp.(*workerPool).Serve()
      github.com/valyala/fasthttp@v1.19.0/workerpool.go:147 +0x6a6
  github.com/valyala/fasthttp.(*Server).Serve()
      github.com/valyala/fasthttp@v1.19.0/server.go:1710 +0x6b5
  github.com/gofiber/fiber/v2.(*App).Listener()
      github.com/gofiber/fiber/v2@v2.6.0/app.go:574 +0xd3
  gola/internal/server/fiber.SignalListenAndServe.func2()
      gola/internal/server/fiber/server.go:74 +0x794

Goroutine 27 (running) created at:
  github.com/valyala/fasthttp.(*workerPool).getCh()
      github.com/valyala/fasthttp@v1.19.0/workerpool.go:194 +0x1c4
  github.com/valyala/fasthttp.(*workerPool).Serve()
      github.com/valyala/fasthttp@v1.19.0/workerpool.go:147 +0x6a6
  github.com/valyala/fasthttp.(*Server).Serve()
      github.com/valyala/fasthttp@v1.19.0/server.go:1710 +0x6b5
  github.com/gofiber/fiber/v2.(*App).Listener()
      github.com/gofiber/fiber/v2@v2.6.0/app.go:574 +0xd3
  gola/internal/server/fiber.SignalListenAndServe.func2()
      gola/internal/server/fiber/server.go:74 +0x794
==================
```
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**
> Move  variables `start, stop time.Time` into closure function. Avoid sharing variables.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 
> :construction:  fix middleware logger [WARNING: DATA RACE]

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/