### PR TITLE
🐛 Cache Middleware - Update expiration for expired entry

### DIFF
--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -65,6 +65,16 @@ func Test_Cache_Expired(t *testing.T) {
 	if bytes.Equal(body, bodyCached) {
 		t.Errorf("Cache should have expired: %s, %s", body, bodyCached)
 	}
+
+	// Next response should be also cached
+	respCachedNextRound, err := app.Test(httptest.NewRequest("GET", "/", nil))
+	utils.AssertEqual(t, nil, err)
+	bodyCachedNextRound, err := ioutil.ReadAll(respCachedNextRound.Body)
+	utils.AssertEqual(t, nil, err)
+
+	if !bytes.Equal(bodyCachedNextRound, bodyCached) {
+		t.Errorf("Cache should not have expired: %s, %s", bodyCached, bodyCachedNextRound)
+	}
 }
 
 func Test_Cache(t *testing.T) {


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
I noticed that expiration timestamp is still the same after cache entry has been expired. It leads to situation when right after the entry has been expired, all the next requests that were made right after the eviction are not cached since the expiration time is always behind the expiration deadline.

```
-> call - miss
-> call - hit
-> call - hit
-> call - hit
...
(wait for expiration)
...
(now we'll make the calls right after each other)
-> call - miss
-> call - miss
-> call - miss
....
```

This PR contains one-liner fix and updated test.