### PR TITLE
🐛 Cache Middleware - Race condition in the cache expiration logic

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -61,7 +61,7 @@ func New(config ...Config) fiber.Handler {
 		// Get timestamp
 		ts := atomic.LoadUint64(&timestamp)
 
-		if e.exp != 0 && ts >= e.exp  {
+		if e.exp != 0 && ts >= e.exp {
 			// Check if entry is expired
 			manager.delete(key)
 			// External storage saves body data with different key

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -39,7 +39,8 @@ func Test_Cache_CacheControl(t *testing.T) {
 func Test_Cache_Expired(t *testing.T) {
 	app := fiber.New()
 
-	expiration := 1 * time.Second
+	// To avoid test failure we should set expiration time > 1s since the timer error in the cache middleware is 1s
+	expiration := 1*time.Second + 500*time.Millisecond
 
 	app.Use(New(Config{
 		Expiration: expiration,


### PR DESCRIPTION
This PR is for investigating and fixing the problem with a race condition that is shown by flaky test:

```
=== RUN   Test_Cache_Expired
Error:     cache_test.go:76: Cache should not have expired: 1615964974123514694, 1615964974123857398
--- FAIL: Test_Cache_Expired (2.00s)
```

**Upd**: details in comments