### PR TITLE
Fix incorrect comment lines.

### DIFF
--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -49,7 +49,7 @@ type Config struct {
 	// Optional. Default value false.
 	CookieHTTPOnly bool
 
-	// Indicates if CSRF cookie is HTTP only.
+	// Value of SameSite cookie.
 	// Optional. Default value "Strict".
 	CookieSameSite string
 

--- a/middleware/session/config.go
+++ b/middleware/session/config.go
@@ -37,8 +37,8 @@ type Config struct {
 	// Optional. Default value false.
 	CookieHTTPOnly bool
 
-	// Indicates if CSRF cookie is HTTP only.
-	// Optional. Default value false.
+	// Value of SameSite cookie.
+	// Optional. Default value "Lax".
 	CookieSameSite string
 
 	// KeyGenerator generates the session key.

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -160,6 +160,7 @@ func (s *Session) setCookie() {
 	fcookie.SetSecure(s.config.CookieSecure)
 	fcookie.SetHTTPOnly(s.config.CookieHTTPOnly)
 
+	// TODO Default value should be set to `strict` in fiber v3.
 	switch utils.ToLower(s.config.CookieSameSite) {
 	case "strict":
 		fcookie.SetSameSite(fasthttp.CookieSameSiteStrictMode)


### PR DESCRIPTION
Fix incorrect comment lines in 2 files:

- middleware/csrf/config.go
- middleware/session/config.go

One question left: in csrf middleware, default value is `Strict`, but in session, its `Lax` (see [line 163-170](https://github.com/iredmail/fiber/blob/master/middleware/session/session.go#L163)). Should we set it to `Strict` too in session by default?