### PR TITLE
✨ Add method to get an integer directly from the Ctx params (route params)

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -672,6 +672,14 @@ func (c *Ctx) Params(key string, defaultValue ...string) string {
 	return defaultString("", defaultValue)
 }
 
+// ParamsInt is used to get an integer from the route parameters
+// it defaults to zero if the parameter is not found or if the
+// parameter cannot be converted to an integer
+func (c *Ctx) ParamsInt(key string) (int, error) {
+	// Use Atoi to convert the param to an int or return zero and an error
+	return strconv.Atoi(c.Params(key))
+}
+
 // Path returns the path part of the request URL.
 // Optionally, you could override the path.
 func (c *Ctx) Path(override ...string) string {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2153,3 +2153,56 @@ func Test_Ctx_String(t *testing.T) {
 
 	utils.AssertEqual(t, "#0000000000000000 - 0.0.0.0:0 <-> 0.0.0.0:0 - GET http:///", c.String())
 }
+
+func TestCtx_ParamsInt(t *testing.T) {
+	// Create a test context and set some strings (or params)
+
+	// create a fake app to be used within this test
+	app := New()
+
+	// Create some test endpoints
+
+	// For the user id I will use the number 1111, so I should be able to get the number
+	// 1111 from the Ctx
+	app.Get("/test/:user", func(c *Ctx) error {
+		// utils.AssertEqual(t, "john", c.Params("user"))
+
+		num, err := c.ParamsInt("user")
+
+		// Check the number matches
+		if num != 1111 {
+			t.Fatalf("Expected number 1111 from the path, got %d", num)
+		}
+
+		// Check no errors are returned, because we want NO errors in this one
+		if err != nil {
+			t.Fatalf("Expected nil error for 1111 test, got " + err.Error())
+		}
+
+		return nil
+	})
+
+	// In this test case, there will be a bad request where the expected number is NOT
+	// a number in the path
+	app.Get("/testnoint/:user", func(c *Ctx) error {
+		// utils.AssertEqual(t, "john", c.Params("user"))
+
+		num, err := c.ParamsInt("user")
+
+		// Check the number matches
+		if num != 0 {
+			t.Fatalf("Expected number 0 from the path, got %d", num)
+		}
+
+		// Check an error is returned, because we want NO errors in this one
+		if err == nil {
+			t.Fatal("Expected non nil error for bad req test, got nil")
+		}
+
+		return nil
+	})
+
+	app.Test(httptest.NewRequest(MethodGet, "/test/1111", nil))
+	app.Test(httptest.NewRequest(MethodGet, "/testnoint/xd", nil))
+
+}


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

I added a method to Ctx and its tests. The method is `ParamsInt`. It helps developers get an integer directly from the request

**Explain the *details* for making this change. What existing problem does the pull request solve?**

It is very common to send integers like IDs directly in the route as parameters. I added an utility function, `ParamsInt` to directly get an integer from the Ctx that is passed on each request. It returns zero and an error if the param cannot be found OR if the param is not a valid integer

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/

:sparkles: