### PR TITLE
Refactor cache middleware to not-use the deprecated methods 

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -102,10 +102,10 @@ func New(config ...Config) fiber.Handler {
 		}
 
 		// Cache response
-		e.body = utils.SafeBytes(c.Response().Body())
+		e.body = utils.CopyBytes(c.Response().Body())
 		e.status = c.Response().StatusCode()
-		e.ctype = utils.SafeBytes(c.Response().Header.ContentType())
-		e.cencoding = utils.SafeBytes(c.Response().Header.Peek(fiber.HeaderContentEncoding))
+		e.ctype = utils.CopyBytes(c.Response().Header.ContentType())
+		e.cencoding = utils.CopyBytes(c.Response().Header.Peek(fiber.HeaderContentEncoding))
 		e.exp = ts + expiration
 
 		// For external Storage we store raw body seperated

--- a/utils/deprecated.go
+++ b/utils/deprecated.go
@@ -16,18 +16,3 @@ func GetBytes(s string) []byte {
 func ImmutableString(s string) string {
 	return CopyString(s)
 }
-
-// DEPRECATED, please use EqualFoldBytes
-func EqualsFold(b, s []byte) (equals bool) {
-	return EqualFoldBytes(b, s)
-}
-
-// DEPRECATED, Please use CopyString instead
-func SafeString(s string) string {
-	return CopyString(s)
-}
-
-// DEPRECATED, Please use CopyBytes instead
-func SafeBytes(b []byte) []byte {
-	return CopyBytes(b)
-}


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

Right now, the cache middleware uses methods from utils that are marked as deprecated. I've changed them to use the underlying and not deprecated methods.

Also: removed the _not-used-and-deprecated_ methods from utils.

**Commit formatting** 

✅ 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/