### PR TITLE
🐛 fix: deadlock on session

### DIFF
--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -142,12 +142,12 @@ func (s *Session) Save() error {
 
 	// Convert data to bytes
 	mux.Lock()
+	defer mux.Unlock()
 	encCache := gob.NewEncoder(s.byteBuffer)
 	err := encCache.Encode(&s.data.Data)
 	if err != nil {
 		return err
 	}
-	mux.Unlock()
 
 	// pass raw bytes with session id to provider
 	if err := s.config.Storage.Set(s.id, s.byteBuffer.Bytes(), s.config.Expiration); err != nil {

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -70,13 +70,13 @@ func (s *Store) Get(c *fiber.Ctx) (*Session, error) {
 		// Unmashal if we found data
 		if raw != nil && err == nil {
 			mux.Lock()
+			defer mux.Unlock()
 			_, _ = sess.byteBuffer.Write(raw)
 			encCache := gob.NewDecoder(sess.byteBuffer)
 			err := encCache.Decode(&sess.data.Data)
 			if err != nil {
 				return nil, err
 			}
-			mux.Unlock()
 		} else if err != nil {
 			return nil, err
 		} else {
@@ -95,6 +95,7 @@ func (s *Store) responseCookies(c *fiber.Ctx) (string, error) {
 	}
 
 	cookie := fasthttp.AcquireCookie()
+	defer fasthttp.ReleaseCookie(cookie)
 	err := cookie.ParseBytes(cookieValue)
 	if err != nil {
 		return "", err
@@ -103,7 +104,6 @@ func (s *Store) responseCookies(c *fiber.Ctx) (string, error) {
 	value := make([]byte, len(cookie.Value()))
 	copy(value, cookie.Value())
 	id := utils.UnsafeString(value)
-	fasthttp.ReleaseCookie(cookie)
 	return id, nil
 }
 


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
The mutex lock never unlock if the subsequent code return error

**Explain the *details* for making this change. What existing problem does the pull request solve?**
This PR mainly to fix deadlock and prevent memory leak issue on `acquireCookie`, allow cookie to release back to pool if `cookie.ParseBytes` return error 
