### PR TITLE
:recycle: Removed Printed Warning

### DIFF
--- a/middleware/monitor/README.md
+++ b/middleware/monitor/README.md
@@ -1,6 +1,8 @@
 # Monitor
 Monitor middleware for [Fiber](https://github.com/gofiber/fiber) that reports server metrics, inspired by [express-status-monitor](https://github.com/RafalWilinski/express-status-monitor)
 
+:warning: **Warning:** Monitor is still in beta, API might change in the future!
+
 ![](https://i.imgur.com/4NfRCDm.gif)
 
 ### Signatures

--- a/middleware/monitor/monitor.go
+++ b/middleware/monitor/monitor.go
@@ -1,7 +1,6 @@
 package monitor
 
 import (
-	"fmt"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -52,8 +51,6 @@ var (
 func New() fiber.Handler {
 	// Start routine to update statistics
 	once.Do(func() {
-		fmt.Println("[Warning] monitor is still in beta, API might change in the future!")
-
 		p, _ := process.NewProcess(int32(os.Getpid()))
 
 		updateStatistics(p)


### PR DESCRIPTION
removed print statement for a warning from the monitor.go file in middleware 
