### PR TITLE
🏗️ chore: enable decoder's ZeroEmpty by default

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -243,6 +243,7 @@ func (c *Ctx) Body() []byte {
 // decoderPool helps to improve BodyParser's and QueryParser's performance
 var decoderPool = &sync.Pool{New: func() interface{} {
 	var decoder = schema.NewDecoder()
+	decoder.ZeroEmpty(true)
 	decoder.IgnoreUnknownKeys(true)
 	return decoder
 }}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2003,20 +2003,28 @@ func Test_Ctx_QueryParser(t *testing.T) {
 	utils.AssertEqual(t, 0, len(empty.Hobby))
 
 	type Query2 struct {
+		Bool            bool
 		ID              int
 		Name            string
 		Hobby           string
 		FavouriteDrinks []string
 		Empty           []string
+		Alloc           []string
 		No              []int64
 	}
 
-	c.Request().URI().SetQueryString("id=1&name=tom&hobby=basketball,football&favouriteDrinks=milo,coke,pepsi&empty=&no=1")
+	c.Request().URI().SetQueryString("id=1&name=tom&hobby=basketball,football&favouriteDrinks=milo,coke,pepsi&alloc=&no=1")
 	q2 := new(Query2)
+	q2.Bool = true
+	q2.Name = "hello world"
 	utils.AssertEqual(t, nil, c.QueryParser(q2))
 	utils.AssertEqual(t, "basketball,football", q2.Hobby)
+	utils.AssertEqual(t, true, q2.Bool)
+	utils.AssertEqual(t, "tom", q2.Name) // check value get overwritten
 	utils.AssertEqual(t, []string{"milo", "coke", "pepsi"}, q2.FavouriteDrinks)
-	utils.AssertEqual(t, []string{}, q2.Empty)
+	var nilSlice []string
+	utils.AssertEqual(t, nilSlice, q2.Empty)
+	utils.AssertEqual(t, []string{""}, q2.Alloc)
 	utils.AssertEqual(t, []int64{1}, q2.No)
 
 	type RequiredQuery struct {


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

we should enable `ZeroEmpty` by default
