### PR TITLE
✨ Etag middleware support to custom etags

### DIFF
--- a/middleware/etag/etag.go
+++ b/middleware/etag/etag.go
@@ -39,6 +39,10 @@ func New(config ...Config) fiber.Handler {
 		if len(body) <= 0 {
 			return
 		}
+		// Skip ETag if header is already present
+		if c.Response().Header.PeekBytes(normalizedHeaderETag) != nil {
+			return
+		}
 
 		// Generate ETag for response
 		bb := bytebufferpool.Get()


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Skip the middleware if an Etag response header already exists.
This change should be compatible with ```ctx.Fresh()```, you can set the custom header and call it to do the verification.

Also added a test to make sure that the If-Match and 412 responses for Put requests aren't messed up by the middleware to avoid problems with future changes.

Some things to consider:

We could export the ETag generation as a function so users could call it inside their handlers and compare it to return the 412 on their own, currently, there's no way to achieve that easily without using custom tags. However IMO returning the updatedAt as a custom Etag and using that is way more practical so we could keep it like this.

Currently, we're missing some behavior to conform with the specs:
- If-Match header doesn't do anything, it should have the reverse behavior of the If-None-Match header, however honestly I have no idea why someone would use this apart from the PUT use case that I've added in the tests.
- Both If-Match and If-None-Match headers can also accept a * (just ignore the header, ctx.Fresh() does this but the middleware doesn't) and a list of etags with the format "etag", "etag2", "etag3", again never seen this in practice but good to keep in mind

Specs links: 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match


**Explain the *details* for making this change. What existing problem does the pull request solve?**

Solves #1284

