### PR TITLE
[middleware/proxy] add buffer size configuration

### DIFF
--- a/middleware/proxy/config.go
+++ b/middleware/proxy/config.go
@@ -28,6 +28,15 @@ type Config struct {
 	//
 	// Optional. Default: nil
 	ModifyResponse fiber.Handler
+
+	// Per-connection buffer size for requests' reading.
+	// This also limits the maximum header size.
+	// Increase this buffer if your clients send multi-KB RequestURIs
+	// and/or multi-KB headers (for example, BIG cookies).
+	ReadBufferSize int
+
+	// Per-connection buffer size for responses' writing.
+	WriteBufferSize int
 }
 
 // ConfigDefault is the default config

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -40,6 +40,9 @@ func Balancer(config Config) fiber.Handler {
 			NoDefaultUserAgentHeader: true,
 			DisablePathNormalizing:   true,
 			Addr:                     u.Host,
+
+			ReadBufferSize:  config.ReadBufferSize,
+			WriteBufferSize: config.WriteBufferSize,
 		}
 
 		lbc.Clients = append(lbc.Clients, client)


### PR DESCRIPTION
Adding buffer size configuration to proxy middleware.
Probably default should be propagate from fiber server configuration, but I didn't know how to do it