### PR TITLE
🐛 Print logger's error to stderr if given io.writer failed

### DIFF
--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -298,7 +298,7 @@ func New(config ...Config) fiber.Handler {
 			// Write error to output
 			if _, err := cfg.Output.Write([]byte(err.Error())); err != nil {
 				// There is something wrong with the given io.Writer
-				// TODO: What should we do here?
+				fmt.Fprintf(os.Stderr, "Failed to write to log, %v\n", err)
 			}
 		}
 		mu.Unlock()


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Currently, loggger middleware doesn't do anything if it fails to write to the given io.writer. It might be a good idea to at least log something to inform the user there is a problem.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**



<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

I think it might be a good idea to print the error to stderr to inform the user there is  a problem with logger (rather than doing nothing) also some logging package like logrus do the same thing(you can see the code here   [link to logrus code](https://github.com/sirupsen/logrus/blob/b50299cfaaa1bca85be76c8984070e846c7abfd2/entry.go#L295) )
