### PR TITLE
🩹Fix: Startup message doesn't show correct amount of Handlers after mounting

### DIFF
--- a/app.go
+++ b/app.go
@@ -423,6 +423,11 @@ func (app *App) Mount(prefix string, fiber *App) Router {
 			app.addRoute(route.Method, app.addPrefixToRoute(prefix, route))
 		}
 	}
+
+	app.mutex.Lock()
+	app.handlerCount += fiber.handlerCount
+	app.mutex.Unlock()
+
 	return app
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -845,6 +845,7 @@ func Test_App_Group_Mount(t *testing.T) {
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/v1/john/doe", nil))
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
+	utils.AssertEqual(t, 2, app.handlerCount)
 }
 
 func Test_App_Group(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -270,6 +270,7 @@ func Test_App_Mount(t *testing.T) {
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/john/doe", nil))
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
+	utils.AssertEqual(t, 2, app.handlerCount)
 }
 
 func Test_App_Use_Params(t *testing.T) {

--- a/group.go
+++ b/group.go
@@ -26,6 +26,11 @@ func (grp *Group) Mount(prefix string, fiber *App) Router {
 			grp.app.addRoute(route.Method, grp.app.addPrefixToRoute(getGroupPath(grp.prefix, prefix), route))
 		}
 	}
+
+	grp.app.mutex.Lock()
+	grp.app.handlerCount += fiber.handlerCount
+	grp.app.mutex.Unlock()
+
 	return grp
 }
 


### PR DESCRIPTION
After mounting an `App` instance or `Group` to an existing instance (root), the handlerCount of the root is not being updated. I came across this issue when I noticed that the startup message showed `Handlers=0` even though my app had mounted a router with multiple handlers.

For example...
```go
router := New()
router.Get("/doe", func(c *Ctx) error {
    return c.SendStatus(StatusOK)
})

app := New()
app.Mount("/john", router)
```
... currently results in the following startup message.

![image](https://user-images.githubusercontent.com/24925821/116477015-51664500-a87c-11eb-93c2-5a4485f5035d.png)

You get the same result when mounting the `router` to a Group.

I fixed this by simply adding the handlerCount of the mounted instance to the root App's own handlerCount in the corresponding Mount-function of the App and Group struct.

**Side note**
When writing the tests I noticed that when registering a Get-Route, not *1* but **2** Handlers are being registered. This is not the case for all the other HTTP-Methods. After investigating I noticed that App.Get() not only adds the Get-Method but also the Head-Method which results in the second handler. I'm wondering whether that is this the desired behaviour or not?

Best regard, Dario ⚡ 

