### PR TITLE
Fix app test parallel

### DIFF
--- a/app.go
+++ b/app.go
@@ -105,6 +105,10 @@ type App struct {
 	server *fasthttp.Server
 	// App config
 	config Config
+	// Converts string to a byte slice
+	getBytes func(s string) (b []byte)
+	// Converts byte slice to a string
+	getString func(b []byte) string
 }
 
 // Config is a struct holding the server settings.
@@ -364,7 +368,9 @@ func New(config ...Config) *App {
 			},
 		},
 		// Create config
-		config: Config{},
+		config:    Config{},
+		getBytes:  utils.GetBytes,
+		getString: utils.GetString,
 	}
 	// Override config if provided
 	if len(config) > 0 {
@@ -394,7 +400,7 @@ func New(config ...Config) *App {
 		app.config.CompressedFileSuffix = DefaultCompressedFileSuffix
 	}
 	if app.config.Immutable {
-		getBytes, getString = getBytesImmutable, getStringImmutable
+		app.getBytes, app.getString = getBytesImmutable, getStringImmutable
 	}
 	if app.config.ErrorHandler == nil {
 		app.config.ErrorHandler = DefaultErrorHandler

--- a/app_test.go
+++ b/app_test.go
@@ -335,7 +335,7 @@ func Test_App_Use_UnescapedPath(t *testing.T) {
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	// check the param result
-	utils.AssertEqual(t, "اختبار", getString(body))
+	utils.AssertEqual(t, "اختبار", app.getString(body))
 
 	// with lowercase letters
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/cr%C3%A9er/%D8%A7%D8%AE%D8%AA%D8%A8%D8%A7%D8%B1", nil))
@@ -370,7 +370,7 @@ func Test_App_Use_CaseSensitive(t *testing.T) {
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	// check the detected path result
-	utils.AssertEqual(t, "/AbC", getString(body))
+	utils.AssertEqual(t, "/AbC", app.getString(body))
 }
 
 func Test_App_Add_Method_Test(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -1249,3 +1249,17 @@ func Test_App_Error_In_Fasthttp_Server(t *testing.T) {
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, 500, resp.StatusCode)
 }
+
+// go test -race -run Test_App_New_Test_Parallel
+func Test_App_New_Test_Parallel(t *testing.T) {
+	t.Run("Test_App_New_Test_Parallel_1", func(t *testing.T) {
+		t.Parallel()
+		app := New(Config{Immutable: true})
+		app.Test(httptest.NewRequest("GET", "/", nil))
+	})
+	t.Run("Test_App_New_Test_Parallel_2", func(t *testing.T) {
+		t.Parallel()
+		app := New(Config{Immutable: true})
+		app.Test(httptest.NewRequest("GET", "/", nil))
+	})
+}

--- a/client.go
+++ b/client.go
@@ -596,7 +596,7 @@ func (a *Agent) MultipartForm(args *Args) *Agent {
 
 	if args != nil {
 		args.VisitAll(func(key, value []byte) {
-			if err := a.mw.WriteField(getString(key), getString(value)); err != nil {
+			if err := a.mw.WriteField(utils.UnsafeString(key), utils.UnsafeString(value)); err != nil {
 				a.errs = append(a.errs, err)
 			}
 		})
@@ -785,7 +785,7 @@ func (a *Agent) Bytes() (code int, body []byte, errs []error) {
 
 func printDebugInfo(req *Request, resp *Response, w io.Writer) {
 	msg := fmt.Sprintf("Connected to %s(%s)\r\n\r\n", req.URI().Host(), resp.RemoteAddr())
-	_, _ = w.Write(getBytes(msg))
+	_, _ = w.Write(utils.UnsafeBytes(msg))
 	_, _ = req.WriteTo(w)
 	_, _ = resp.WriteTo(w)
 }
@@ -794,7 +794,7 @@ func printDebugInfo(req *Request, resp *Response, w io.Writer) {
 func (a *Agent) String() (int, string, []error) {
 	code, body, errs := a.Bytes()
 
-	return code, getString(body), errs
+	return code, utils.UnsafeString(body), errs
 }
 
 // Struct returns the status code, bytes body and errors of url.

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -229,7 +229,7 @@ func Benchmark_Ctx_Append(b *testing.B) {
 		c.Append("X-Custom-Header", "World")
 		c.Append("X-Custom-Header", "Hello")
 	}
-	utils.AssertEqual(b, "Hello, World", getString(c.Response().Header.Peek("X-Custom-Header")))
+	utils.AssertEqual(b, "Hello, World", app.getString(c.Response().Header.Peek("X-Custom-Header")))
 }
 
 // go test -run Test_Ctx_Attachment
@@ -481,7 +481,7 @@ func Benchmark_Ctx_Cookie(b *testing.B) {
 			Value: "Doe",
 		})
 	}
-	utils.AssertEqual(b, "John=Doe; path=/; SameSite=Lax", getString(c.Response().Header.Peek("Set-Cookie")))
+	utils.AssertEqual(b, "John=Doe; path=/; SameSite=Lax", app.getString(c.Response().Header.Peek("Set-Cookie")))
 }
 
 // go test -run Test_Ctx_Cookies

--- a/helpers.go
+++ b/helpers.go
@@ -95,10 +95,10 @@ func readContent(rf io.ReaderFrom, name string) (n int64, err error) {
 }
 
 // quoteString escape special characters in a given string
-func quoteString(raw string) string {
+func (app *App) quoteString(raw string) string {
 	bb := bytebufferpool.Get()
 	// quoted := string(fasthttp.AppendQuotedArg(bb.B, getBytes(raw)))
-	quoted := getString(fasthttp.AppendQuotedArg(bb.B, getBytes(raw)))
+	quoted := app.getString(fasthttp.AppendQuotedArg(bb.B, app.getBytes(raw)))
 	bytebufferpool.Put(bb)
 	return quoted
 }
@@ -272,7 +272,7 @@ func matchEtag(s string, etag string) bool {
 	return false
 }
 
-func isEtagStale(etag string, noneMatchBytes []byte) bool {
+func (app *App) isEtagStale(etag string, noneMatchBytes []byte) bool {
 	var start, end int
 
 	// Adapted from:
@@ -285,7 +285,7 @@ func isEtagStale(etag string, noneMatchBytes []byte) bool {
 				end = i + 1
 			}
 		case 0x2c:
-			if matchEtag(getString(noneMatchBytes[start:end]), etag) {
+			if matchEtag(app.getString(noneMatchBytes[start:end]), etag) {
 				return false
 			}
 			start = i + 1
@@ -295,7 +295,7 @@ func isEtagStale(etag string, noneMatchBytes []byte) bool {
 		}
 	}
 
-	return !matchEtag(getString(noneMatchBytes[start:end]), etag)
+	return !matchEtag(app.getString(noneMatchBytes[start:end]), etag)
 }
 
 func parseAddr(raw string) (host, port string) {
@@ -359,14 +359,10 @@ func (c *testConn) SetDeadline(_ time.Time) error      { return nil }
 func (c *testConn) SetReadDeadline(_ time.Time) error  { return nil }
 func (c *testConn) SetWriteDeadline(_ time.Time) error { return nil }
 
-// getString converts byte slice to a string without memory allocation.
-var getString = utils.UnsafeString
 var getStringImmutable = func(b []byte) string {
 	return string(b)
 }
 
-// getBytes converts string to a byte slice without memory allocation.
-var getBytes = utils.UnsafeBytes
 var getBytesImmutable = func(s string) (b []byte) {
 	return []byte(s)
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -182,9 +182,9 @@ func Benchmark_Utils_Unescape(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		source := "/cr%C3%A9er"
-		pathBytes := getBytes(source)
+		pathBytes := utils.UnsafeBytes(source)
 		pathBytes = fasthttp.AppendUnquotedArg(dst[:0], pathBytes)
-		unescaped = getString(pathBytes)
+		unescaped = utils.UnsafeString(pathBytes)
 	}
 
 	utils.AssertEqual(b, "/créer", unescaped)

--- a/router.go
+++ b/router.go
@@ -325,7 +325,7 @@ func (app *App) registerStatic(prefix, root string, config ...Static) Router {
 		PathRewrite: func(fctx *fasthttp.RequestCtx) []byte {
 			path := fctx.Path()
 			if len(path) >= prefixLen {
-				if isStar && getString(path[0:prefixLen]) == prefix {
+				if isStar && app.getString(path[0:prefixLen]) == prefix {
 					path = append(path[0:0], '/')
 				} else if len(path) > 0 && path[len(path)-1] != '/' {
 					path = append(path[prefixLen:], '/')

--- a/router_test.go
+++ b/router_test.go
@@ -43,7 +43,7 @@ func Test_Route_Match_SameLength(t *testing.T) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
-	utils.AssertEqual(t, ":param", getString(body))
+	utils.AssertEqual(t, ":param", app.getString(body))
 
 	// with param
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test", nil))
@@ -52,7 +52,7 @@ func Test_Route_Match_SameLength(t *testing.T) {
 
 	body, err = ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
-	utils.AssertEqual(t, "test", getString(body))
+	utils.AssertEqual(t, "test", app.getString(body))
 }
 
 func Test_Route_Match_Star(t *testing.T) {
@@ -68,7 +68,7 @@ func Test_Route_Match_Star(t *testing.T) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
-	utils.AssertEqual(t, "*", getString(body))
+	utils.AssertEqual(t, "*", app.getString(body))
 
 	// with param
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test", nil))
@@ -77,7 +77,7 @@ func Test_Route_Match_Star(t *testing.T) {
 
 	body, err = ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
-	utils.AssertEqual(t, "test", getString(body))
+	utils.AssertEqual(t, "test", app.getString(body))
 
 	// without parameter
 	route := Route{
@@ -114,7 +114,7 @@ func Test_Route_Match_Root(t *testing.T) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
-	utils.AssertEqual(t, "root", getString(body))
+	utils.AssertEqual(t, "root", app.getString(body))
 }
 
 func Test_Route_Match_Parser(t *testing.T) {
@@ -132,7 +132,7 @@ func Test_Route_Match_Parser(t *testing.T) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
-	utils.AssertEqual(t, "bar", getString(body))
+	utils.AssertEqual(t, "bar", app.getString(body))
 
 	// with star
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/Foobar/test", nil))
@@ -141,7 +141,7 @@ func Test_Route_Match_Parser(t *testing.T) {
 
 	body, err = ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
-	utils.AssertEqual(t, "test", getString(body))
+	utils.AssertEqual(t, "test", app.getString(body))
 }
 
 func Test_Route_Match_Middleware(t *testing.T) {
@@ -157,7 +157,7 @@ func Test_Route_Match_Middleware(t *testing.T) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
-	utils.AssertEqual(t, "*", getString(body))
+	utils.AssertEqual(t, "*", app.getString(body))
 
 	// with param
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/foo/bar/fasel", nil))
@@ -166,7 +166,7 @@ func Test_Route_Match_Middleware(t *testing.T) {
 
 	body, err = ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
-	utils.AssertEqual(t, "bar/fasel", getString(body))
+	utils.AssertEqual(t, "bar/fasel", app.getString(body))
 }
 
 func Test_Route_Match_UnescapedPath(t *testing.T) {
@@ -182,7 +182,7 @@ func Test_Route_Match_UnescapedPath(t *testing.T) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
-	utils.AssertEqual(t, "test", getString(body))
+	utils.AssertEqual(t, "test", app.getString(body))
 	// without special chars
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/créer", nil))
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
@@ -208,7 +208,7 @@ func Test_Route_Match_Middleware_HasPrefix(t *testing.T) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
-	utils.AssertEqual(t, "middleware", getString(body))
+	utils.AssertEqual(t, "middleware", app.getString(body))
 }
 
 func Test_Route_Match_Middleware_Root(t *testing.T) {
@@ -224,7 +224,7 @@ func Test_Route_Match_Middleware_Root(t *testing.T) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
-	utils.AssertEqual(t, "middleware", getString(body))
+	utils.AssertEqual(t, "middleware", app.getString(body))
 }
 
 func Test_Router_Register_Missing_Handler(t *testing.T) {


### PR DESCRIPTION
## The problem

`fiber.New()` changes the package variables `getBytes` and `getString`, and these are used a lot across the app. This may cause data race problems, as mentioned in the issue #1313, as well as other problems like: when using 2 apps, a second of fiber may override these functions, causing the first app to use incorrect configurations.

## The solution
In order to avoid sharing app configuration between two created apps, I have moved the `getBytes` and `getString` from the package to the app struct, and fixed the usages of these functions.

## Detailed changes

- Create the test to show the problem
- Deletes `getBytes` and `getString` function: they should not be package variables.
- Adds `getBytes` and `getString` to the `App` struct
- Default `getBytes` and `getString` uses the same defaults as before: `utils.GetBytes` and `utils.GetString`
- When config Immutable is true, it use `getBytesImmutable` and `getStringImmutable`
- Changed a lot of usages of `getBytes` and `getString` to `app.getBytes` and `app.getString` in files `ctx.go`, `router.go`, `ctx_test.go`, `router_test.go` and`app_test.go` .
- `client.go` was changed to always use the `utils.UnsafeBytes`. I think this change is safe, because the function the client uses should not be change by a call to `app.New()`.
- Add the App as a receiver for `quoteString` and `isEtagStale`: `func (app *App) ...`, so they can use the functions defined in the App configuration
- `Benchmark_Utils_Unescape` now uses the default functions: `utils.UnsafeBytes` and `utils.UnsafeString`

## Commits

I made two commits: one adding a test to show the bug happening, and one to fix it.

- 24f55ef - The test: You can run it using `go test -race -run Test_App_New_Test_Parallel` to see the error happening.
- 0dc67e8 - The fix.