### PR TITLE
🐞 fix: reduce coupling by removing auto registering Head method on App.Get() call

### DIFF
--- a/app.go
+++ b/app.go
@@ -465,7 +465,7 @@ func (app *App) Use(args ...interface{}) Router {
 // Get registers a route for GET methods that requests a representation
 // of the specified resource. Requests using GET should only retrieve data.
 func (app *App) Get(path string, handlers ...Handler) Router {
-	return app.Add(MethodHead, path, handlers...).Add(MethodGet, path, handlers...)
+	return app.Add(MethodGet, path, handlers...)
 }
 
 // Head registers a route for HEAD methods that asks for a response identical

--- a/app_test.go
+++ b/app_test.go
@@ -69,6 +69,7 @@ func Test_App_MethodNotAllowed(t *testing.T) {
 	utils.AssertEqual(t, "POST, OPTIONS", resp.Header.Get(HeaderAllow))
 
 	app.Get("/", testEmptyHandler)
+	app.Head("/", testEmptyHandler)
 
 	resp, err = app.Test(httptest.NewRequest(MethodTrace, "/", nil))
 	utils.AssertEqual(t, nil, err)
@@ -270,7 +271,7 @@ func Test_App_Mount(t *testing.T) {
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/john/doe", nil))
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
-	utils.AssertEqual(t, uint32(2), app.handlerCount)
+	utils.AssertEqual(t, uint32(1), app.handlerCount)
 }
 
 func Test_App_Use_Params(t *testing.T) {
@@ -845,7 +846,7 @@ func Test_App_Group_Mount(t *testing.T) {
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/v1/john/doe", nil))
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
-	utils.AssertEqual(t, uint32(2), app.handlerCount)
+	utils.AssertEqual(t, uint32(1), app.handlerCount)
 }
 
 func Test_App_Group(t *testing.T) {
@@ -1125,7 +1126,7 @@ func Test_App_Stack(t *testing.T) {
 	stack := app.Stack()
 	utils.AssertEqual(t, 9, len(stack))
 	utils.AssertEqual(t, 3, len(stack[methodInt(MethodGet)]))
-	utils.AssertEqual(t, 3, len(stack[methodInt(MethodHead)]))
+	utils.AssertEqual(t, 1, len(stack[methodInt(MethodHead)]))
 	utils.AssertEqual(t, 2, len(stack[methodInt(MethodPost)]))
 	utils.AssertEqual(t, 1, len(stack[methodInt(MethodPut)]))
 	utils.AssertEqual(t, 1, len(stack[methodInt(MethodPatch)]))

--- a/client_test.go
+++ b/client_test.go
@@ -91,7 +91,7 @@ func Test_Client_Head(t *testing.T) {
 
 	app := New(Config{DisableStartupMessage: true})
 
-	app.Get("/", func(c *Ctx) error {
+	app.Head("/", func(c *Ctx) error {
 		return c.SendString(c.Hostname())
 	})
 


### PR DESCRIPTION
Hey Pals 🤓 

The declaration of a Head-endpoint should be explicit to achieve a lower coupling and leaner performance for Fiber. Currently Fiber registers an additional Head handler when setting up a Get-endpoint (see code snippet).

```go
// Get registers a route for GET methods that requests a representation
// of the specified resource. Requests using GET should only retrieve data.
func (app *App) Get(path string, handlers ...Handler) Router {
	return app.Add(MethodHead, path, handlers...).Add(MethodGet, path, handlers...)
}
```

The current state can be misleading and redundant since it registers extra handlers unknowingly. The implicit handler therefore ought to be removed. When a Head-handler is needed it should be defined via the designated Head-method. See `Side note` in [PR-1302](https://github.com/gofiber/fiber/pull/1302) for further information.

I committed and tested the changes to be applied.

Best regard, Dario ⚡