### PR TITLE
🔥 Add `PathPrefix` parameter to `filesystem` middleware

### DIFF
--- a/middleware/filesystem/README.md
+++ b/middleware/filesystem/README.md
@@ -92,11 +92,11 @@ func main() {
 	}))
 
 	// Access file "image.png" under `static/` directory via URL: `http://<server>/static/image.png`.
-	// With `http.FS(embedDirStatic)`, you have to access it via URL:
+	// Without `PathPrefix`, you have to access it via URL:
 	// `http://<server>/static/static/image.png`.
-	subFS, _ := fs.Sub(embedDirStatic, "static")
 	app.Use("/static", filesystem.New(filesystem.Config{
-		Root: http.FS(subFS),
+		Root: http.FS(embedDirStatic),
+		PathPrefix: "static"
 		Browse: true,
 	}))
 
@@ -251,6 +251,14 @@ type Config struct {
 	// Required. Default: nil
 	Root http.FileSystem `json:"-"`
 
+	// PathPrefix defines a prefix to be added to a filepath when
+	// reading a file from the FileSystem.
+	//
+	// Use when using Go 1.16 embed.FS
+	//
+	// Optional. Default ""
+	PathPrefix string `json:"path_prefix"`
+
 	// Enable directory browsing.
 	//
 	// Optional. Default: false
@@ -278,10 +286,11 @@ type Config struct {
 
 ```go
 var ConfigDefault = Config{
-	Next:   nil,
-	Root:   nil,
-	Browse: false,
-	Index:  "/index.html",
-	MaxAge: 0,
+	Next:       nil,
+	Root:       nil,
+	PathPrefix: "",
+	Browse:     false,
+	Index:      "/index.html",
+	MaxAge:     0,
 }
 ```

--- a/middleware/filesystem/filesystem_test.go
+++ b/middleware/filesystem/filesystem_test.go
@@ -32,6 +32,11 @@ func Test_FileSystem(t *testing.T) {
 		NotFoundFile: "index.html",
 	}))
 
+	app.Use("/prefix", New(Config{
+		Root: http.Dir("../../.github/testdata/fs"),
+		PathPrefix: "img",
+	}))
+
 	tests := []struct {
 		name         string
 		url          string
@@ -95,6 +100,12 @@ func Test_FileSystem(t *testing.T) {
 			url:         "/spatest/doesnotexist",
 			statusCode:  200,
 			contentType: "text/html",
+		},
+		{
+			name: "PathPrefix should be applied",
+			url: "/prefix/fiber.png",
+			statusCode: 200,
+			contentType: "image/png",
 		},
 	}
 


### PR DESCRIPTION
Resolves #1308

This adds a parameter called `PathPrefix` to `filesystem.Config` that is prepended to any filepath being read from `filesystem.Root`. This is intended to be used with Go 1.16's `embed.FS`.

A new test has been added to cater for this parameter, and the README has been updated to use this parameter in the section about `embed`.

:)