### PR TITLE
📝update handler example in timeout

### DIFF
--- a/middleware/timeout/README.md
+++ b/middleware/timeout/README.md
@@ -22,8 +22,12 @@ import (
 
 After you initiate your Fiber app, you can use the following possibilities:
 ```go
-handler := func(ctx *fiber.Ctx) {
-	ctx.Send("Hello, World 👋!")
+handler := func(ctx *fiber.Ctx) error {
+	err := ctx.SendString("Hello, World 👋!")
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 app.Get("/foo", timeout.New(handler, 5 * time.Second))


### PR DESCRIPTION
**Explain the *details* for making this change. What existing problem does the pull request solve?**

`ctx.Send` sends byte data instead of the text so we need to use `ctx.SendString`, also if an error isn't returned from the function it gives the error `Cannot use 'handler' (type func(ctx *fiber.Ctx)) as the type fiber.Handler`