### PR TITLE
fix pprof redirect path

### DIFF
--- a/middleware/pprof/pprof.go
+++ b/middleware/pprof/pprof.go
@@ -64,7 +64,7 @@ func New() fiber.Handler {
 				path = "/debug/pprof"
 			}
 
-			return c.Redirect(path, 302)
+			return c.Redirect(path, fiber.StatusFound)
 		}
 		return nil
 	}

--- a/middleware/pprof/pprof.go
+++ b/middleware/pprof/pprof.go
@@ -34,7 +34,7 @@ func New() fiber.Handler {
 		}
 		// Switch to original path without stripped slashes
 		switch path {
-		case "/debug/pprof/":
+		case "/debug/pprof":
 			pprofIndex(c.Context())
 		case "/debug/pprof/cmdline":
 			pprofCmdline(c.Context())
@@ -58,7 +58,13 @@ func New() fiber.Handler {
 			pprofThreadcreate(c.Context())
 		default:
 			// pprof index only works with trailing slash
-			return c.Redirect("/debug/pprof/", 302)
+			if strings.HasSuffix(path, "/") {
+				path = strings.TrimSuffix(path, "/")
+			} else {
+				path = "/debug/pprof"
+			}
+
+			return c.Redirect(path, 302)
 		}
 		return nil
 	}

--- a/middleware/pprof/pprof.go
+++ b/middleware/pprof/pprof.go
@@ -59,7 +59,7 @@ func New() fiber.Handler {
 		default:
 			// pprof index only works with trailing slash
 			if strings.HasSuffix(path, "/") {
-				path = strings.TrimSuffix(path, "/")
+				path = strings.TrimRight(path, "/")
 			} else {
 				path = "/debug/pprof"
 			}

--- a/middleware/pprof/pprof_test.go
+++ b/middleware/pprof/pprof_test.go
@@ -2,11 +2,12 @@ package pprof
 
 import (
 	"bytes"
-	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/utils"
 	"io/ioutil"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/utils"
 )
 
 func Test_Non_Pprof_Path(t *testing.T) {
@@ -36,7 +37,7 @@ func Test_Pprof_Index(t *testing.T) {
 		return c.SendString("escaped")
 	})
 
-	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/debug/pprof/", nil))
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/debug/pprof", nil))
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, 200, resp.StatusCode)
 	utils.AssertEqual(t, fiber.MIMETextHTMLCharsetUTF8, resp.Header.Get(fiber.HeaderContentType))


### PR DESCRIPTION
I think the redirected path can be optimized.
For example, if the path is `/debug/pprof/block/`, it better to redirect to `/debug/pprof/block` instead of `/debug/pprof`.
