### PR TITLE
feat(middlewares): session keys

### DIFF
--- a/middleware/session/README.md
+++ b/middleware/session/README.md
@@ -6,10 +6,14 @@ _NOTE: This middleware uses our [Storage](https://github.com/gofiber/storage) pa
 
 ## Table of Contents
 
-- [Signatures](#signatures)
-- [Examples](#examples)
-- [Config](#config)
-- [Default Config](#default-config)
+- [Session](#session)
+	- [Table of Contents](#table-of-contents)
+	- [Signatures](#signatures)
+		- [Examples](#examples)
+		- [Default Configuration](#default-configuration)
+		- [Custom Storage/Database](#custom-storagedatabase)
+	- [Config](#config)
+	- [Default Config](#default-config)
 
 ## Signatures
 
@@ -27,6 +31,7 @@ func (s *Session) Regenerate() error
 func (s *Session) Save() error
 func (s *Session) Fresh() bool
 func (s *Session) ID() string
+func (s *Session) Keys() []string
 ```
 
 **⚠ _Storing `interface{}` values are limited to built-ins Go types_**
@@ -51,7 +56,7 @@ store := session.New()
 
 // This panic will be catch by the middleware
 app.Get("/", func(c *fiber.Ctx) error {
-	// get session from storage
+	// Get session from storage
 	sess, err := store.Get(c)
 	if err != nil {
 		panic(err)
@@ -63,15 +68,18 @@ app.Get("/", func(c *fiber.Ctx) error {
 	// Set key/value
 	sess.Set("name", "john")
 
+	// Get all Keys
+	keys := sess.Keys()
+
 	// Delete key
 	sess.Delete("name")
 
-	// Destry session
+	// Destroy session
 	if err := sess.Destroy(); err != nil {
 		panic(err)
 	}
 
-	// save session
+	// Save session
 	if err := sess.Save(); err != nil {
 		panic(err)
 	}

--- a/middleware/session/data.go
+++ b/middleware/session/data.go
@@ -57,6 +57,16 @@ func (d *data) Delete(key string) {
 	d.Unlock()
 }
 
+func (d *data) Keys() []string {
+	d.Lock()
+	keys := make([]string, 0, len(d.Data))
+	for k := range d.Data {
+		keys = append(keys, k)
+	}
+	d.Unlock()
+	return keys
+}
+
 func (d *data) Len() int {
 	return len(d.Data)
 }

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -161,6 +161,14 @@ func (s *Session) Save() error {
 	return nil
 }
 
+// Keys will retrive all keys in current session
+func (s *Session) Keys() []string {
+	if s.data == nil {
+		return []string{}
+	}
+	return s.data.Keys()
+}
+
 func (s *Session) setCookie() {
 	fcookie := fasthttp.AcquireCookie()
 	fcookie.SetKey(s.config.CookieName)

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -32,6 +32,10 @@ func Test_Session(t *testing.T) {
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, true, sess.Fresh())
 
+	// get keys
+	keys := sess.Keys()
+	utils.AssertEqual(t, []string{}, keys)
+
 	// get value
 	name := sess.Get("name")
 	utils.AssertEqual(t, nil, name)
@@ -43,12 +47,19 @@ func Test_Session(t *testing.T) {
 	name = sess.Get("name")
 	utils.AssertEqual(t, "john", name)
 
+	keys = sess.Keys()
+	utils.AssertEqual(t, []string{"name"}, keys)
+
 	// delete key
 	sess.Delete("name")
 
 	// get value
 	name = sess.Get("name")
 	utils.AssertEqual(t, nil, name)
+
+	// get keys
+	keys = sess.Keys()
+	utils.AssertEqual(t, []string{}, keys)
 
 	// get id
 	id := sess.ID()


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Added a sess.Keys() method who retrive all keys from current session

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

Related to [retrieve all keys](https://github.com/gofiber/fiber/issues/1333), for short, `sess.Keys()` is a simple way to get all keys from session and iterate over it or debug. 
