### PR TITLE
🔥 Feature: Add encrypt cookies middleware

### DIFF
--- a/middleware/encryptcookie/README.md
+++ b/middleware/encryptcookie/README.md
@@ -1,5 +1,66 @@
 # Encrypt Cookie Middleware
 
-Encrypt middleware for [Fiber](https://github.com/gofiber/fiber)
+Encrypt middleware for [Fiber](https://github.com/gofiber/fiber) which encrypts cookie values. Note: this middleware does not encrypt cookie names.
 
-TODO
+
+## Signaures
+
+```go
+func New(config ...Config) fiber.Handler
+
+func GenerateKey(length int) string
+```
+
+## Setup
+
+First import the middleware from Fiber,
+
+import (
+  "github.com/gofiber/fiber/v2"
+  "github.com/gofiber/fiber/v2/middleware/cache"
+)
+
+Then create a Fiber app with `app := fiber.New()`.
+
+## Minimum Config
+
+```go
+// `Key` must be a 32 character string. It's used to encrpyt the values, so make sure it is random and keep it secret. 
+// You can call `encryptcookie.GenerateKey()` to create a random key for you. 
+// Make sure not to set `Key` to `encryptcookie.GenerateKey()` because that will create a new key every run.
+app.Use(encryptcookie.New(encryptcookie.Config{
+    Key: "secret-thirty-2-character-string",
+}))
+```
+
+## Config
+
+```go
+type Config struct {
+	// Next defines a function to skip this middleware when returned true.
+	//
+	// Optional. Default: nil
+	Next func(c *fiber.Ctx) bool
+
+	// Array of cookie keys that should not be encrypted.
+	//
+	// Optional. Default: []
+	Except []string
+
+	// Base64 encoded unique key to encode & decode cookies.
+	//
+	// Required. Key length should be 32 characters.
+	// You may use `encryptcookie.GenerateKey(32)` to generate a new key.
+	Key string
+
+	// Custom function to encrypt cookies.
+	//
+	// Optional. Default: EncryptCookie
+	Encryptor func(decryptedString, key string) (string, error)
+
+	// Custom function to decrypt cookies.
+	//
+	// Optional. Default: DecryptCookie
+	Decryptor func(encryptedString, key string) (string, error)
+}
+```

--- a/middleware/encryptcookie/README.md
+++ b/middleware/encryptcookie/README.md
@@ -25,8 +25,8 @@ Then create a Fiber app with `app := fiber.New()`.
 ## Minimum Config
 
 ```go
-// `Key` must be a 32 character string. It's used to encrpyt the values, so make sure it is random and keep it secret. 
-// You can call `encryptcookie.GenerateKey()` to create a random key for you. 
+// `Key` must be a 32 character string. It's used to encrpyt the values, so make sure it is random and keep it secret.
+// You can call `encryptcookie.GenerateKey()` to create a random key for you.
 // Make sure not to set `Key` to `encryptcookie.GenerateKey()` because that will create a new key every run.
 app.Use(encryptcookie.New(encryptcookie.Config{
     Key: "secret-thirty-2-character-string",
@@ -50,7 +50,7 @@ type Config struct {
 	// Base64 encoded unique key to encode & decode cookies.
 	//
 	// Required. Key length should be 32 characters.
-	// You may use `encryptcookie.GenerateKey(32)` to generate a new key.
+	// You may use `encryptcookie.GenerateKey()` to generate a new key.
 	Key string
 
 	// Custom function to encrypt cookies.

--- a/middleware/encryptcookie/README.md
+++ b/middleware/encryptcookie/README.md
@@ -6,9 +6,11 @@ Encrypt middleware for [Fiber](https://github.com/gofiber/fiber) which encrypts 
 ## Signaures
 
 ```go
+// Intitializes the middleware
 func New(config ...Config) fiber.Handler
 
-func GenerateKey(length int) string
+// Returns a random 32 character long string
+func GenerateKey() string
 ```
 
 ## Setup

--- a/middleware/encryptcookie/README.md
+++ b/middleware/encryptcookie/README.md
@@ -1,0 +1,5 @@
+# Encrypt Cookie Middleware
+
+Encrypt middleware for [Fiber](https://github.com/gofiber/fiber)
+
+TODO

--- a/middleware/encryptcookie/config.go
+++ b/middleware/encryptcookie/config.go
@@ -1,0 +1,75 @@
+package encryptcookie
+
+import "github.com/gofiber/fiber/v2"
+
+// Config defines the config for middleware.
+type Config struct {
+	// Next defines a function to skip this middleware when returned true.
+	//
+	// Optional. Default: nil
+	Next func(c *fiber.Ctx) bool
+
+	// Array of cookies that should not encrypt
+	//
+	// Optional. Default: []
+	Except []string
+
+	// Base64 unique key to encode & decode cookies
+	//
+	// Optional. Default: Generating new key on every run
+	Key string
+
+	// Custom function to encrypt cookies
+	//
+	// Optional. Default: EncryptCookie
+	Encryptor func(decryptedString, key string) (string, error)
+
+	// Custom function to decrypt cookies
+	//
+	// Optional. Default: DecryptCookie
+	Decryptor func(encryptedString, key string) (string, error)
+}
+
+// ConfigDefault is the default config
+var ConfigDefault = Config{
+	Next:      nil,
+	Except:    make([]string, 0),
+	Key:       GenerateKey(32),
+	Encryptor: EncryptCookie,
+	Decryptor: DecryptCookie,
+}
+
+// Helper function to set default values
+func configDefault(config ...Config) Config {
+	// Set default config
+	cfg := ConfigDefault
+
+	// Override config if provided
+	if len(config) > 0 {
+		cfg = config[0]
+
+		// Set default values
+
+		if cfg.Next == nil {
+			cfg.Next = ConfigDefault.Next
+		}
+
+		if cfg.Except == nil {
+			cfg.Except = ConfigDefault.Except
+		}
+
+		if cfg.Key == "" {
+			cfg.Key = ConfigDefault.Key
+		}
+
+		if cfg.Encryptor == nil {
+			cfg.Encryptor = ConfigDefault.Encryptor
+		}
+
+		if cfg.Decryptor == nil {
+			cfg.Decryptor = ConfigDefault.Decryptor
+		}
+	}
+
+	return cfg
+}

--- a/middleware/encryptcookie/config.go
+++ b/middleware/encryptcookie/config.go
@@ -9,7 +9,7 @@ type Config struct {
 	// Optional. Default: nil
 	Next func(c *fiber.Ctx) bool
 
-	// Array of cookies that should not encrypt
+	// Array of cookie keys that should not be encrypted
 	//
 	// Optional. Default: []
 	Except []string
@@ -34,7 +34,7 @@ type Config struct {
 var ConfigDefault = Config{
 	Next:      nil,
 	Except:    make([]string, 0),
-	Key:       GenerateKey(32),
+	Key:       "",
 	Encryptor: EncryptCookie,
 	Decryptor: DecryptCookie,
 }
@@ -58,10 +58,6 @@ func configDefault(config ...Config) Config {
 			cfg.Except = ConfigDefault.Except
 		}
 
-		if cfg.Key == "" {
-			cfg.Key = ConfigDefault.Key
-		}
-
 		if cfg.Encryptor == nil {
 			cfg.Encryptor = ConfigDefault.Encryptor
 		}
@@ -69,6 +65,10 @@ func configDefault(config ...Config) Config {
 		if cfg.Decryptor == nil {
 			cfg.Decryptor = ConfigDefault.Decryptor
 		}
+	}
+
+	if cfg.Key == "" {
+		panic("Fiber: Encrypt cookie middleware requires key")
 	}
 
 	return cfg

--- a/middleware/encryptcookie/config.go
+++ b/middleware/encryptcookie/config.go
@@ -9,22 +9,23 @@ type Config struct {
 	// Optional. Default: nil
 	Next func(c *fiber.Ctx) bool
 
-	// Array of cookie keys that should not be encrypted
+	// Array of cookie keys that should not be encrypted.
 	//
 	// Optional. Default: []
 	Except []string
 
-	// Base64 unique key to encode & decode cookies
+	// Base64 encoded unique key to encode & decode cookies.
 	//
-	// Optional. Default: Generating new key on every run
+	// Required. Key length should be 32 characters.
+	// you may use `encryptcookie.GenerateKey(32)` to generate a new key.
 	Key string
 
-	// Custom function to encrypt cookies
+	// Custom function to encrypt cookies.
 	//
 	// Optional. Default: EncryptCookie
 	Encryptor func(decryptedString, key string) (string, error)
 
-	// Custom function to decrypt cookies
+	// Custom function to decrypt cookies.
 	//
 	// Optional. Default: DecryptCookie
 	Decryptor func(encryptedString, key string) (string, error)
@@ -68,7 +69,7 @@ func configDefault(config ...Config) Config {
 	}
 
 	if cfg.Key == "" {
-		panic("Fiber: Encrypt cookie middleware requires key")
+		panic("fiber: encrypt cookie middleware requires key")
 	}
 
 	return cfg

--- a/middleware/encryptcookie/config.go
+++ b/middleware/encryptcookie/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	// Base64 encoded unique key to encode & decode cookies.
 	//
 	// Required. Key length should be 32 characters.
-	// you may use `encryptcookie.GenerateKey(32)` to generate a new key.
+	// You may use `encryptcookie.GenerateKey(32)` to generate a new key.
 	Key string
 
 	// Custom function to encrypt cookies.

--- a/middleware/encryptcookie/config.go
+++ b/middleware/encryptcookie/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	// Base64 encoded unique key to encode & decode cookies.
 	//
 	// Required. Key length should be 32 characters.
-	// You may use `encryptcookie.GenerateKey(32)` to generate a new key.
+	// You may use `encryptcookie.GenerateKey()` to generate a new key.
 	Key string
 
 	// Custom function to encrypt cookies.

--- a/middleware/encryptcookie/encryptcookie.go
+++ b/middleware/encryptcookie/encryptcookie.go
@@ -1,0 +1,58 @@
+package encryptcookie
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/valyala/fasthttp"
+)
+
+// New creates a new middleware handler
+func New(config ...Config) fiber.Handler {
+	// Set default config
+	cfg := configDefault(config...)
+
+	// Return new handler
+	return func(c *fiber.Ctx) error {
+		// Don't execute middleware if Next returns true
+		if cfg.Next != nil && cfg.Next(c) {
+			return c.Next()
+		}
+
+		// Decrypt request cookies
+		c.Request().Header.VisitAllCookie(func(key, value []byte) {
+			keyString := string(key)
+			if !isDisabled(keyString, cfg.Except) {
+				decryptedValue, err := cfg.Decryptor(string(value), cfg.Key)
+				if err != nil {
+					c.Request().Header.SetCookie(string(key), "")
+				} else {
+					c.Request().Header.SetCookie(string(key), decryptedValue)
+				}
+			}
+		})
+
+		// Continue stack
+		if err := c.Next(); err != nil {
+			return err
+		}
+
+		// Encrypt response cookies
+		c.Response().Header.VisitAllCookie(func(key, value []byte) {
+			keyString := string(key)
+			if !isDisabled(keyString, cfg.Except) {
+				cookieValue := fasthttp.Cookie{}
+				cookieValue.SetKeyBytes(key)
+				if c.Response().Header.Cookie(&cookieValue) {
+					encryptedValue, err := cfg.Encryptor(string(cookieValue.Value()), cfg.Key)
+					if err == nil {
+						cookieValue.SetValue(encryptedValue)
+						c.Response().Header.SetCookie(&cookieValue)
+					} else {
+						panic(err)
+					}
+				}
+			}
+		})
+
+		return nil
+	}
+}

--- a/middleware/encryptcookie/encryptcookie.go
+++ b/middleware/encryptcookie/encryptcookie.go
@@ -23,7 +23,7 @@ func New(config ...Config) fiber.Handler {
 			if !isDisabled(keyString, cfg.Except) {
 				decryptedValue, err := cfg.Decryptor(string(value), cfg.Key)
 				if err != nil {
-					c.Request().Header.SetCookie(string(key), "")
+					c.Request().Header.SetCookieBytesKV(key, nil)
 				} else {
 					c.Request().Header.SetCookie(string(key), decryptedValue)
 				}

--- a/middleware/encryptcookie/encryptcookie.go
+++ b/middleware/encryptcookie/encryptcookie.go
@@ -31,9 +31,7 @@ func New(config ...Config) fiber.Handler {
 		})
 
 		// Continue stack
-		if err := c.Next(); err != nil {
-			return err
-		}
+		err := c.Next()
 
 		// Encrypt response cookies
 		c.Response().Header.VisitAllCookie(func(key, value []byte) {
@@ -53,6 +51,6 @@ func New(config ...Config) fiber.Handler {
 			}
 		})
 
-		return nil
+		return err
 	}
 }

--- a/middleware/encryptcookie/encryptcookie_test.go
+++ b/middleware/encryptcookie/encryptcookie_test.go
@@ -137,8 +137,8 @@ func Test_Encrypt_Cookie_Custom_Encryptor(t *testing.T) {
 		Encryptor: func(decryptedString, _ string) (string, error) {
 			return base64.StdEncoding.EncodeToString([]byte(decryptedString)), nil
 		},
-		Decryptor: func(decryptedString, _ string) (string, error) {
-			decodedBytes, err := base64.StdEncoding.DecodeString(decryptedString)
+		Decryptor: func(encryptedString, _ string) (string, error) {
+			decodedBytes, err := base64.StdEncoding.DecodeString(encryptedString)
 			return string(decodedBytes), err
 		},
 	}))

--- a/middleware/encryptcookie/encryptcookie_test.go
+++ b/middleware/encryptcookie/encryptcookie_test.go
@@ -1,0 +1,177 @@
+package encryptcookie
+
+import (
+	"encoding/base64"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/utils"
+	"github.com/valyala/fasthttp"
+)
+
+func Test_Middleware_Encrypt_Cookie(t *testing.T) {
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("value=" + c.Cookies("test"))
+	})
+	app.Post("/", func(c *fiber.Ctx) error {
+		c.Cookie(&fiber.Cookie{
+			Name:  "test",
+			Value: "SomeThing",
+		})
+		return nil
+	})
+
+	h := app.Handler()
+
+	// Test empty cookie
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	h(ctx)
+	utils.AssertEqual(t, 200, ctx.Response.StatusCode())
+	utils.AssertEqual(t, "value=", string(ctx.Response.Body()))
+
+	// Test invalid cookie
+	ctx = &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.Header.SetCookie("test", "Invalid")
+	h(ctx)
+	utils.AssertEqual(t, 200, ctx.Response.StatusCode())
+	utils.AssertEqual(t, "value=", string(ctx.Response.Body()))
+	ctx.Request.Header.SetCookie("test", "ixQURE2XOyZUs0WAOh2ehjWcP7oZb07JvnhWOsmeNUhPsj4+RyI=")
+	h(ctx)
+	utils.AssertEqual(t, 200, ctx.Response.StatusCode())
+	utils.AssertEqual(t, "value=", string(ctx.Response.Body()))
+
+	// Test valid cookie
+	ctx = &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("POST")
+	h(ctx)
+	utils.AssertEqual(t, 200, ctx.Response.StatusCode())
+
+	encryptedCookie := fasthttp.Cookie{}
+	encryptedCookie.SetKey("test")
+	utils.AssertEqual(t, true, ctx.Response.Header.Cookie(&encryptedCookie), "Get cookie value")
+	decryptedCookieValue, _ := DecryptCookie(string(encryptedCookie.Value()), ConfigDefault.Key)
+	utils.AssertEqual(t, "SomeThing", decryptedCookieValue)
+
+	ctx = &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.Header.SetCookie("test", string(encryptedCookie.Value()))
+	h(ctx)
+	utils.AssertEqual(t, 200, ctx.Response.StatusCode())
+	utils.AssertEqual(t, "value=SomeThing", string(ctx.Response.Body()))
+}
+
+func Test_Encrypt_Cookie_Next(t *testing.T) {
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Next: func(_ *fiber.Ctx) bool {
+			return true
+		},
+	}))
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		c.Cookie(&fiber.Cookie{
+			Name:  "test",
+			Value: "SomeThing",
+		})
+		return nil
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "SomeThing", resp.Cookies()[0].Value)
+}
+
+func Test_Encrypt_Cookie_Except(t *testing.T) {
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Except: []string{
+			"test1",
+		},
+	}))
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		c.Cookie(&fiber.Cookie{
+			Name:  "test1",
+			Value: "SomeThing",
+		})
+		c.Cookie(&fiber.Cookie{
+			Name:  "test2",
+			Value: "SomeThing",
+		})
+
+		return nil
+	})
+
+	h := app.Handler()
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	h(ctx)
+	utils.AssertEqual(t, 200, ctx.Response.StatusCode())
+
+	rawCookie := fasthttp.Cookie{}
+	rawCookie.SetKey("test1")
+	utils.AssertEqual(t, true, ctx.Response.Header.Cookie(&rawCookie), "Get cookie value")
+	utils.AssertEqual(t, "SomeThing", string(rawCookie.Value()))
+
+	encryptedCookie := fasthttp.Cookie{}
+	encryptedCookie.SetKey("test2")
+	utils.AssertEqual(t, true, ctx.Response.Header.Cookie(&encryptedCookie), "Get cookie value")
+	decryptedCookieValue, _ := DecryptCookie(string(encryptedCookie.Value()), ConfigDefault.Key)
+	utils.AssertEqual(t, "SomeThing", decryptedCookieValue)
+}
+
+func Test_Encrypt_Cookie_Custom_Encryptor(t *testing.T) {
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Encryptor: func(decryptedString, _ string) (string, error) {
+			return base64.StdEncoding.EncodeToString([]byte(decryptedString)), nil
+		},
+		Decryptor: func(decryptedString, _ string) (string, error) {
+			decodedBytes, err := base64.StdEncoding.DecodeString(decryptedString)
+			return string(decodedBytes), err
+		},
+	}))
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("value=" + c.Cookies("test"))
+	})
+	app.Post("/", func(c *fiber.Ctx) error {
+		c.Cookie(&fiber.Cookie{
+			Name:  "test",
+			Value: "SomeThing",
+		})
+
+		return nil
+	})
+
+	h := app.Handler()
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("POST")
+	h(ctx)
+	utils.AssertEqual(t, 200, ctx.Response.StatusCode())
+
+	encryptedCookie := fasthttp.Cookie{}
+	encryptedCookie.SetKey("test")
+	utils.AssertEqual(t, true, ctx.Response.Header.Cookie(&encryptedCookie), "Get cookie value")
+	decodedBytes, _ := base64.StdEncoding.DecodeString(string(encryptedCookie.Value()))
+	utils.AssertEqual(t, "SomeThing", string(decodedBytes))
+
+	ctx = &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.Header.SetCookie("test", string(encryptedCookie.Value()))
+	h(ctx)
+	utils.AssertEqual(t, 200, ctx.Response.StatusCode())
+	utils.AssertEqual(t, "value=SomeThing", string(ctx.Response.Body()))
+}

--- a/middleware/encryptcookie/encryptcookie_test.go
+++ b/middleware/encryptcookie/encryptcookie_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-var testKey = GenerateKey(32)
+var testKey = GenerateKey()
 
 func Test_Middleware_Encrypt_Cookie(t *testing.T) {
 	app := fiber.New()

--- a/middleware/encryptcookie/utils.go
+++ b/middleware/encryptcookie/utils.go
@@ -1,0 +1,89 @@
+package encryptcookie
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"io"
+	"math/big"
+)
+
+func EncryptCookie(value, key string) (string, error) {
+	keyDecoded, _ := base64.StdEncoding.DecodeString(key)
+	plaintext := []byte(value)
+
+	block, err := aes.NewCipher(keyDecoded)
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+func DecryptCookie(value, key string) (string, error) {
+	keyDecoded, _ := base64.StdEncoding.DecodeString(key)
+	enc, _ := base64.StdEncoding.DecodeString(value)
+	block, err := aes.NewCipher(keyDecoded)
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonceSize := gcm.NonceSize()
+
+	if len(enc) < nonceSize {
+		return "", errors.New("encrypted value is not valid")
+	}
+
+	nonce, ciphertext := enc[:nonceSize], enc[nonceSize:]
+
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return string(plaintext), nil
+}
+
+func GenerateKey(length int) string {
+	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+	ret := make([]byte, length)
+	for i := 0; i < length; i++ {
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		if err != nil {
+			return ""
+		}
+		ret[i] = letters[num.Int64()]
+	}
+
+	return base64.StdEncoding.EncodeToString(ret)
+}
+
+// Check given cookie key is disabled for encryption or not
+func isDisabled(key string, except []string) bool {
+	for _, k := range except {
+		if key == k {
+			return true
+		}
+	}
+
+	return false
+}

--- a/middleware/encryptcookie/utils.go
+++ b/middleware/encryptcookie/utils.go
@@ -66,8 +66,8 @@ func DecryptCookie(value, key string) (string, error) {
 }
 
 // GenerateKey Generates an encryption key
-func GenerateKey(length int) string {
-	ret := make([]byte, length)
+func GenerateKey() string {
+	ret := make([]byte, 32)
 
 	if _, err := rand.Read(ret); err != nil {
 		panic(err)

--- a/middleware/encryptcookie/utils.go
+++ b/middleware/encryptcookie/utils.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
-	"math/big"
 )
 
 func EncryptCookie(value, key string) (string, error) {
@@ -37,6 +36,7 @@ func EncryptCookie(value, key string) (string, error) {
 func DecryptCookie(value, key string) (string, error) {
 	keyDecoded, _ := base64.StdEncoding.DecodeString(key)
 	enc, _ := base64.StdEncoding.DecodeString(value)
+
 	block, err := aes.NewCipher(keyDecoded)
 	if err != nil {
 		return "", err
@@ -64,15 +64,8 @@ func DecryptCookie(value, key string) (string, error) {
 }
 
 func GenerateKey(length int) string {
-	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
 	ret := make([]byte, length)
-	for i := 0; i < length; i++ {
-		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
-		if err != nil {
-			return ""
-		}
-		ret[i] = letters[num.Int64()]
-	}
+	rand.Read(ret)
 
 	return base64.StdEncoding.EncodeToString(ret)
 }

--- a/middleware/encryptcookie/utils.go
+++ b/middleware/encryptcookie/utils.go
@@ -9,6 +9,7 @@ import (
 	"io"
 )
 
+// EncryptCookie Encrypts a cookie value with specific encryption key
 func EncryptCookie(value, key string) (string, error) {
 	keyDecoded, _ := base64.StdEncoding.DecodeString(key)
 	plaintext := []byte(value)
@@ -33,6 +34,7 @@ func EncryptCookie(value, key string) (string, error) {
 	return base64.StdEncoding.EncodeToString(ciphertext), nil
 }
 
+// DecryptCookie Decrypts a cookie value with specific encryption key
 func DecryptCookie(value, key string) (string, error) {
 	keyDecoded, _ := base64.StdEncoding.DecodeString(key)
 	enc, _ := base64.StdEncoding.DecodeString(value)
@@ -63,9 +65,13 @@ func DecryptCookie(value, key string) (string, error) {
 	return string(plaintext), nil
 }
 
+// GenerateKey Generates an encryption key
 func GenerateKey(length int) string {
 	ret := make([]byte, length)
-	rand.Read(ret)
+
+	if _, err := rand.Read(ret); err != nil {
+		panic(err)
+	}
 
 	return base64.StdEncoding.EncodeToString(ret)
 }


### PR DESCRIPTION
## Description
This PR adds a new middleware to encrypt cookie values to increase security
([Similar middleware in Laravel](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Cookie/Middleware/EncryptCookies.php))

Middleware decrypts request cookies and encrypts response cookies.
If a user manually changes the cookie value to something invalid cookie value will convert to `""`.

## Usage
```go
app := fiber.New()

app.Use(encryptcookie.New())

app.Get("/", func(c *fiber.Ctx) error {
	c.Cookie(&fiber.Cookie{
		Name:  "SomeThing",
		Value: "A Secret Value Here",
	})
	// ...
})
```

The middleware uses `AES-256-GCM` by default, and generates a new encryption key on each run but we should always use a secret encryption key like this:
```go
app.Use(encryptcookie.New(
    encryptcookie.Config{
        Key: "QjEyRTBWcU1NTGpzT0xCRXd2SUN3VFZBOUVoRzJzWUs=" // A secret base64 encoded key
    }
))
```

Also, it is possible to use a custom function to encrypt and decrypt cookies, So developers can use their own encryption algorithms:
```go
app.Use(encryptcookie.New(encryptcookie.Config{
	Encryptor: func(decryptedString, _ string) (string, error) {
		return base64.StdEncoding.EncodeToString([]byte(decryptedString)), nil // Not safe, just a sample
	},
	Decryptor: func(encryptedString, _ string) (string, error) {
		decodedBytes, err := base64.StdEncoding.DecodeString(encryptedString)  // Not safe, just a sample
		return string(decodedBytes), err
	},
}))
```

We can also exclude specific cookies from being encrypted like cookies using for Google Auth:
```go
app.Use(encryptcookie.New(encryptcookie.Config{
	Except: []string{
		"g_csrf_token", // This cookie using for Google One Tap and should not be encrypted
	},
}))
```

(Sorry for not providing documentation because I'm not fluent in English and writing documents.)