### PR TITLE
🔥 feat: expiration per session

### DIFF
--- a/middleware/session/README.md
+++ b/middleware/session/README.md
@@ -32,6 +32,7 @@ func (s *Session) Save() error
 func (s *Session) Fresh() bool
 func (s *Session) ID() string
 func (s *Session) Keys() []string
+func (s *Session) ExpiresIn(time.Duration) 
 ```
 
 **⚠ _Storing `interface{}` values are limited to built-ins Go types_**
@@ -78,6 +79,9 @@ app.Get("/", func(c *fiber.Ctx) error {
 	if err := sess.Destroy(); err != nil {
 		panic(err)
 	}
+
+	// Set a custom expiration for this session
+	sess.ExpiresIn(time.Second * 2)
 
 	// Save session
 	if err := sess.Save(); err != nil {

--- a/middleware/session/README.md
+++ b/middleware/session/README.md
@@ -32,7 +32,7 @@ func (s *Session) Save() error
 func (s *Session) Fresh() bool
 func (s *Session) ID() string
 func (s *Session) Keys() []string
-func (s *Session) ExpiresIn(time.Duration) 
+func (s *Session) SetExpiry(time.Duration) 
 ```
 
 **⚠ _Storing `interface{}` values are limited to built-ins Go types_**
@@ -80,8 +80,8 @@ app.Get("/", func(c *fiber.Ctx) error {
 		panic(err)
 	}
 
-	// Set a custom expiration for this session
-	sess.ExpiresIn(time.Second * 2)
+	// Sets a specific expiration for this session
+	sess.SetExpiry(time.Second * 2)
 
 	// Save session
 	if err := sess.Save(); err != nil {

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -176,8 +176,8 @@ func (s *Session) Keys() []string {
 	return s.data.Keys()
 }
 
-// ExpiresIn set a specific expiration for this session
-func (s *Session) ExpiresIn(exp time.Duration) {
+// SetExpiry sets a specific expiration for this session
+func (s *Session) SetExpiry(exp time.Duration) {
 	s.exp = exp
 }
 

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -18,6 +18,7 @@ type Session struct {
 	config     *Store        // store configuration
 	data       *data         // key value data
 	byteBuffer *bytes.Buffer // byte buffer for the en- and decode
+	exp        time.Duration // expiration of this session
 }
 
 var sessionPool = sync.Pool{
@@ -40,6 +41,7 @@ func acquireSession() *Session {
 
 func releaseSession(s *Session) {
 	s.id = ""
+	s.exp = 0
 	s.ctx = nil
 	s.config = nil
 	if s.data != nil {
@@ -130,6 +132,11 @@ func (s *Session) Save() error {
 		return nil
 	}
 
+	// Check if session has your own expiration, otherwise use default value
+	if s.exp <= 0 {
+		s.exp = s.config.Expiration
+	}
+
 	// Create session with the session ID if fresh
 	if s.fresh {
 		s.setSession()
@@ -150,7 +157,7 @@ func (s *Session) Save() error {
 	}
 
 	// pass raw bytes with session id to provider
-	if err := s.config.Storage.Set(s.id, s.byteBuffer.Bytes(), s.config.Expiration); err != nil {
+	if err := s.config.Storage.Set(s.id, s.byteBuffer.Bytes(), s.exp); err != nil {
 		return err
 	}
 
@@ -169,6 +176,11 @@ func (s *Session) Keys() []string {
 	return s.data.Keys()
 }
 
+// ExpiresIn set a specific expiration for this session
+func (s *Session) ExpiresIn(exp time.Duration) {
+	s.exp = exp
+}
+
 func (s *Session) setSession() {
 	if s.config.source == SourceHeader {
 		s.ctx.Request().Header.SetBytesV(s.config.sessionName, []byte(s.id))
@@ -179,8 +191,8 @@ func (s *Session) setSession() {
 		fcookie.SetValue(s.id)
 		fcookie.SetPath(s.config.CookiePath)
 		fcookie.SetDomain(s.config.CookieDomain)
-		fcookie.SetMaxAge(int(s.config.Expiration.Seconds()))
-		fcookie.SetExpire(time.Now().Add(s.config.Expiration))
+		fcookie.SetMaxAge(int(s.exp.Seconds()))
+		fcookie.SetExpire(time.Now().Add(s.exp))
 		fcookie.SetSecure(s.config.CookieSecure)
 		fcookie.SetHTTPOnly(s.config.CookieHTTPOnly)
 

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -272,7 +272,7 @@ func Test_Session_Save_Expiration(t *testing.T) {
 		sess.Set("name", "john")
 
 		// expire this session in 5 seconds
-		sess.ExpiresIn(time.Second * 5)
+		sess.SetExpiry(time.Second * 5)
 
 		// save session
 		err := sess.Save()

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -255,6 +255,42 @@ func Test_Session_Save(t *testing.T) {
 	})
 }
 
+func Test_Session_Save_Expiration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("save to cookie", func(t *testing.T) {
+		// session store
+		store := New()
+		// fiber instance
+		app := fiber.New()
+		// fiber context
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+		// get session
+		sess, _ := store.Get(ctx)
+		// set value
+		sess.Set("name", "john")
+
+		// expire this session in 5 seconds
+		sess.ExpiresIn(time.Second * 5)
+
+		// save session
+		err := sess.Save()
+		utils.AssertEqual(t, nil, err)
+
+		// here you need to get the old session yet
+		sess, _ = store.Get(ctx)
+		utils.AssertEqual(t, "john", sess.Get("name"))
+
+		// just to make sure the session has been expired
+		time.Sleep(time.Second * 5)
+
+		// here you should get a new session
+		sess, _ = store.Get(ctx)
+		utils.AssertEqual(t, nil, sess.Get("name"))
+	})
+}
+
 // go test -run Test_Session_Reset
 func Test_Session_Reset(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Added a sess.ExpiresIn() method who set a custom expiration for a session.

Explain the details for making this change. What existing problem does the pull request solve?

Related to #1298 , for short, sess.ExpiresIn() use a custom session expiration insted of default value.