### PR TITLE
🔥 Feature: add cache header to show cache status

### DIFF
--- a/middleware/cache/README.md
+++ b/middleware/cache/README.md
@@ -65,6 +65,13 @@ type Config struct {
 	// Optional. Default: 1 * time.Minute
 	Expiration time.Duration
 
+	// CacheHeader header on response header, indicate cache status, with the following possible return value
+	//
+	// hit, miss, unreachable
+	//
+	// Optional. Default: S-Cache
+	CacheHeader string
+
 	// CacheControl enables client side caching if set to true
 	//
 	// Optional. Default: false
@@ -91,6 +98,7 @@ type Config struct {
 var ConfigDefault = Config{
 	Next:         nil,
 	Expiration:   1 * time.Minute,
+	CacheHeader:  "S-Cache",
 	CacheControl: false,
 	KeyGenerator: func(c *fiber.Ctx) string {
 		return c.Path()

--- a/middleware/cache/README.md
+++ b/middleware/cache/README.md
@@ -69,7 +69,7 @@ type Config struct {
 	//
 	// hit, miss, unreachable
 	//
-	// Optional. Default: S-Cache
+	// Optional. Default: X-Cache
 	CacheHeader string
 
 	// CacheControl enables client side caching if set to true
@@ -98,7 +98,7 @@ type Config struct {
 var ConfigDefault = Config{
 	Next:         nil,
 	Expiration:   1 * time.Minute,
-	CacheHeader:  "S-Cache",
+	CacheHeader:  "X-Cache",
 	CacheControl: false,
 	KeyGenerator: func(c *fiber.Ctx) string {
 		return c.Path()

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -299,6 +299,61 @@ func Test_CustomKey(t *testing.T) {
 
 }
 
+func Test_CacheHeader(t *testing.T) {
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Expiration: 10 * time.Second,
+		Next: func(c *fiber.Ctx) bool {
+			return !(c.Response().StatusCode() == fiber.StatusOK)
+		},
+	}))
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("Hello, World!")
+	})
+
+	app.Post("/", func(c *fiber.Ctx) error {
+		return c.SendString(c.Query("cache"))
+	})
+
+	app.Get("/error", func(c *fiber.Ctx) error {
+		return c.Status(fiber.StatusInternalServerError).SendString(time.Now().String())
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "miss", resp.Header.Get("X-Cache"))
+
+	resp, err = app.Test(httptest.NewRequest("GET", "/", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "hit", resp.Header.Get("X-Cache"))
+
+	resp, err = app.Test(httptest.NewRequest("POST", "/?cache=12345", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "unreachable", resp.Header.Get("X-Cache"))
+
+	errRespCached, err := app.Test(httptest.NewRequest("GET", "/error", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "unreachable", errRespCached.Header.Get("X-Cache"))
+}
+
+func Test_CustomCacheHeader(t *testing.T) {
+	app := fiber.New()
+
+	app.Use(New(Config{
+		CacheHeader: "Cache-Status",
+	}))
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("Hello, World!")
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "miss", resp.Header.Get("Cache-Status"))
+}
+
 // go test -v -run=^$ -bench=Benchmark_Cache -benchmem -count=4
 func Benchmark_Cache(b *testing.B) {
 	app := fiber.New()

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -323,19 +323,19 @@ func Test_CacheHeader(t *testing.T) {
 
 	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
 	utils.AssertEqual(t, nil, err)
-	utils.AssertEqual(t, "miss", resp.Header.Get("X-Cache"))
+	utils.AssertEqual(t, cacheMiss, resp.Header.Get("X-Cache"))
 
 	resp, err = app.Test(httptest.NewRequest("GET", "/", nil))
 	utils.AssertEqual(t, nil, err)
-	utils.AssertEqual(t, "hit", resp.Header.Get("X-Cache"))
+	utils.AssertEqual(t, cacheHit, resp.Header.Get("X-Cache"))
 
 	resp, err = app.Test(httptest.NewRequest("POST", "/?cache=12345", nil))
 	utils.AssertEqual(t, nil, err)
-	utils.AssertEqual(t, "unreachable", resp.Header.Get("X-Cache"))
+	utils.AssertEqual(t, cacheUnreachable, resp.Header.Get("X-Cache"))
 
 	errRespCached, err := app.Test(httptest.NewRequest("GET", "/error", nil))
 	utils.AssertEqual(t, nil, err)
-	utils.AssertEqual(t, "unreachable", errRespCached.Header.Get("X-Cache"))
+	utils.AssertEqual(t, cacheUnreachable, errRespCached.Header.Get("X-Cache"))
 }
 
 func Test_CustomCacheHeader(t *testing.T) {
@@ -351,7 +351,7 @@ func Test_CustomCacheHeader(t *testing.T) {
 
 	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
 	utils.AssertEqual(t, nil, err)
-	utils.AssertEqual(t, "miss", resp.Header.Get("Cache-Status"))
+	utils.AssertEqual(t, cacheMiss, resp.Header.Get("Cache-Status"))
 }
 
 // go test -v -run=^$ -bench=Benchmark_Cache -benchmem -count=4

--- a/middleware/cache/config.go
+++ b/middleware/cache/config.go
@@ -19,6 +19,13 @@ type Config struct {
 	// Optional. Default: 1 * time.Minute
 	Expiration time.Duration
 
+	// CacheHeader header on response header, indicate cache status, with the following possible return value
+	//
+	// hit, miss, unreachable
+	//
+	// Optional. Default: S-Cache
+	CacheHeader string
+
 	// CacheControl enables client side caching if set to true
 	//
 	// Optional. Default: false
@@ -47,6 +54,7 @@ type Config struct {
 var ConfigDefault = Config{
 	Next:         nil,
 	Expiration:   1 * time.Minute,
+	CacheHeader:  "S-Cache",
 	CacheControl: false,
 	KeyGenerator: func(c *fiber.Ctx) string {
 		return c.Path()

--- a/middleware/cache/config.go
+++ b/middleware/cache/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	//
 	// hit, miss, unreachable
 	//
-	// Optional. Default: S-Cache
+	// Optional. Default: X-Cache
 	CacheHeader string
 
 	// CacheControl enables client side caching if set to true
@@ -54,7 +54,7 @@ type Config struct {
 var ConfigDefault = Config{
 	Next:         nil,
 	Expiration:   1 * time.Minute,
-	CacheHeader:  "S-Cache",
+	CacheHeader:  "X-Cache",
 	CacheControl: false,
 	KeyGenerator: func(c *fiber.Ctx) string {
 		return c.Path()
@@ -86,6 +86,9 @@ func configDefault(config ...Config) Config {
 	}
 	if int(cfg.Expiration.Seconds()) == 0 {
 		cfg.Expiration = ConfigDefault.Expiration
+	}
+	if cfg.CacheHeader == "" {
+		cfg.CacheHeader = ConfigDefault.CacheHeader
 	}
 	if cfg.KeyGenerator == nil {
 		cfg.KeyGenerator = ConfigDefault.KeyGenerator


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
Cache middleware to returns `S-Cache` header to show cache status, `hit`, `miss` or `unreachable`

Not using `X-Cache` because I think some CDN uses this value?