### PR TITLE
Improve errors handling

### DIFF
--- a/internal/msgp/errors.go
+++ b/internal/msgp/errors.go
@@ -3,6 +3,7 @@ package msgp
 import (
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 const resumableDefault = false
@@ -110,7 +111,7 @@ type errWrapped struct {
 
 func (e errWrapped) Error() string {
 	if e.ctx != "" {
-		return fmt.Sprintf("%s at %s", e.cause, e.ctx)
+		return strings.Join([]string{e.cause.Error(), "at", e.ctx}, " ")
 	} else {
 		return e.cause.Error()
 	}

--- a/internal/uuid/dce.go
+++ b/internal/uuid/dce.go
@@ -6,8 +6,9 @@ package uuid
 
 import (
 	"encoding/binary"
-	"fmt"
 	"os"
+	"strconv"
+	"strings"
 )
 
 // A Domain represents a Version 2 domain
@@ -76,5 +77,5 @@ func (d Domain) String() string {
 	case Org:
 		return "Org"
 	}
-	return fmt.Sprintf("Domain%d", int(d))
+	return strings.Join([]string{"Domain", strconv.Itoa(int(d))}, "")
 }

--- a/internal/uuid/marshal.go
+++ b/internal/uuid/marshal.go
@@ -4,7 +4,10 @@
 
 package uuid
 
-import "fmt"
+import (
+	"errors"
+	"strconv"
+)
 
 // MarshalText implements encoding.TextMarshaler.
 func (uuid UUID) MarshalText() ([]byte, error) {
@@ -31,7 +34,7 @@ func (uuid UUID) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
 func (uuid *UUID) UnmarshalBinary(data []byte) error {
 	if len(data) != 16 {
-		return fmt.Errorf("invalid UUID (got %d bytes)", len(data))
+		return errors.New("invalid UUID (got " + strconv.Itoa(len(data)) + " bytes)")
 	}
 	copy(uuid[:], data)
 	return nil

--- a/internal/uuid/sql.go
+++ b/internal/uuid/sql.go
@@ -6,6 +6,7 @@ package uuid
 
 import (
 	"database/sql/driver"
+	"errors"
 	"fmt"
 )
 
@@ -26,7 +27,7 @@ func (uuid *UUID) Scan(src interface{}) error {
 		// see Parse for required string format
 		u, err := Parse(src)
 		if err != nil {
-			return fmt.Errorf("Scan: %v", err)
+			return errors.New("Scan: " + err.Error())
 		}
 
 		*uuid = u
@@ -45,6 +46,7 @@ func (uuid *UUID) Scan(src interface{}) error {
 		copy((*uuid)[:], src)
 
 	default:
+		// here we use %T for type
 		return fmt.Errorf("Scan: unable to scan type %T into UUID", src)
 	}
 

--- a/internal/uuid/uuid.go
+++ b/internal/uuid/uuid.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 )
 
@@ -49,7 +50,7 @@ func Parse(s string) (UUID, error) {
 	// urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 	case 36 + 9:
 		if strings.ToLower(s[:9]) != "urn:uuid:" {
-			return uuid, fmt.Errorf("invalid urn prefix: %q", s[:9])
+			return uuid, errors.New(`invalid urn prefix: "` + s[:9] + `"`)
 		}
 		s = s[9:]
 
@@ -68,7 +69,7 @@ func Parse(s string) (UUID, error) {
 		}
 		return uuid, nil
 	default:
-		return uuid, fmt.Errorf("invalid UUID length: %d", len(s))
+		return uuid, errors.New("invalid UUID length: " + strconv.Itoa(len(s)))
 	}
 	// s is now at least 36 bytes long
 	// it must be of the form  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -97,7 +98,7 @@ func ParseBytes(b []byte) (UUID, error) {
 	case 36: // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 	case 36 + 9: // urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 		if !bytes.Equal(bytes.ToLower(b[:9]), []byte("urn:uuid:")) {
-			return uuid, fmt.Errorf("invalid urn prefix: %q", b[:9])
+			return uuid, errors.New(`invalid urn prefix: "` + string(b[:9]) + `"`)
 		}
 		b = b[9:]
 	case 36 + 2: // {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}
@@ -112,7 +113,7 @@ func ParseBytes(b []byte) (UUID, error) {
 		}
 		return uuid, nil
 	default:
-		return uuid, fmt.Errorf("invalid UUID length: %d", len(b))
+		return uuid, errors.New("invalid UUID length: " + strconv.Itoa(len(b)))
 	}
 	// s is now at least 36 bytes long
 	// it must be of the form  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx


### PR DESCRIPTION
**Hi!**

I changed all places, where we using `fmt.Errorf` to `errors.New`, because it work much faster without any allocations.
Method `Errorf` needed, when we, for example, pull out the type of variable, or use `Unwrap` method 

<img width="472" alt="Снимок экрана 2021-06-12 в 01 49 13" src="https://user-images.githubusercontent.com/56119080/121773192-e69a7000-cb82-11eb-8404-e7e99b18c2c8.png">

<img width="795" alt="Снимок экрана 2021-06-12 в 01 49 31" src="https://user-images.githubusercontent.com/56119080/121773193-e9956080-cb82-11eb-916f-8ec56d46ec63.png">

So the same situation with `fmt.Sprintf` and `strings.Join`. The last one is better to use: 

<img width="602" alt="Снимок экрана 2021-06-12 в 13 28 19" src="https://user-images.githubusercontent.com/56119080/121773322-dfc02d00-cb83-11eb-8708-5f79c2907fe9.png">

Here `d` is a global int variable 

<img width="826" alt="Снимок экрана 2021-06-12 в 13 29 09" src="https://user-images.githubusercontent.com/56119080/121773327-ebabef00-cb83-11eb-88c8-148baea6e105.png">

We have 1 allocation with method `Join` because of using int to string conversation 

There are actually many places where we can do this, but it will impair the readability of the code like this:
```Go
   - return uuid, fmt.Errorf("invalid urn prefix: %q", s[:9])		
   
   + return uuid, errors.New(`invalid urn prefix: "` + s[:9] + `"`)
```

 Perhaps error handling is not worth the quickest solution.
 
