### PR TITLE
add tls config for http client in proxy middleware

### DIFF
--- a/middleware/proxy/README.md
+++ b/middleware/proxy/README.md
@@ -119,6 +119,9 @@ type Config struct {
     
 	// Per-connection buffer size for responses' writing.
 	WriteBufferSize int
+
+	// tls config for the http client
+	TlsConfig *tls.Config
 }
 ```
 
@@ -127,6 +130,9 @@ type Config struct {
 ```go
 // ConfigDefault is the default config
 var ConfigDefault = Config{
-	Next: nil,
+    Next:           nil,
+    ModifyRequest:  nil,
+    ModifyResponse: nil,
+    Timeout:        fasthttp.DefaultLBClientTimeout,
 }
 ```

--- a/middleware/proxy/README.md
+++ b/middleware/proxy/README.md
@@ -32,7 +32,7 @@ After you initiate your Fiber app, you can use the following possibilities:
 
 ```go
 // if target https site uses a self-signed certificate, you should
-// call WithTlsConfig before Balancer and Forward
+// call WithTlsConfig before Do and Forward
 proxy.WithTlsConfig(&tls.Config{
     InsecureSkipVerify: true,
 })

--- a/middleware/proxy/README.md
+++ b/middleware/proxy/README.md
@@ -31,6 +31,12 @@ import (
 After you initiate your Fiber app, you can use the following possibilities:
 
 ```go
+// if target https site uses a self-signed certificate, you should
+// call WithTlsConfig before Balancer and Forward
+proxy.WithTlsConfig(&tls.Config{
+    InsecureSkipVerify: true,
+})
+
 // Forward to url
 app.Get("/gif", proxy.Forward("https://i.imgur.com/IWaBepg.gif"))
 

--- a/middleware/proxy/config.go
+++ b/middleware/proxy/config.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"crypto/tls"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -45,6 +46,9 @@ type Config struct {
 
 	// Per-connection buffer size for responses' writing.
 	WriteBufferSize int
+
+	// tls config for the http client
+	TlsConfig *tls.Config
 }
 
 // ConfigDefault is the default config

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -47,7 +47,7 @@ func Balancer(config Config) fiber.Handler {
 			ReadBufferSize:  config.ReadBufferSize,
 			WriteBufferSize: config.WriteBufferSize,
 
-			TLSConfig: client.TLSConfig,
+			TLSConfig: clientTlsConfig,
 		}
 
 		lbc.Clients = append(lbc.Clients, client)
@@ -96,6 +96,8 @@ func Balancer(config Config) fiber.Handler {
 	}
 }
 
+var clientTlsConfig *tls.Config
+
 var client = fasthttp.Client{
 	NoDefaultUserAgentHeader: true,
 	DisablePathNormalizing:   true,
@@ -105,6 +107,7 @@ var client = fasthttp.Client{
 // also affects the TLSConfig of fasthttp.LBClient in Balancer.
 // This function should be called before Balancer and Forward.
 func WithTlsConfig(tlsConfig *tls.Config) {
+	clientTlsConfig = tlsConfig
 	client.TLSConfig = tlsConfig
 }
 

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -46,6 +46,8 @@ func Balancer(config Config) fiber.Handler {
 
 			ReadBufferSize:  config.ReadBufferSize,
 			WriteBufferSize: config.WriteBufferSize,
+
+			TLSConfig: client.TLSConfig,
 		}
 
 		lbc.Clients = append(lbc.Clients, client)
@@ -99,7 +101,9 @@ var client = fasthttp.Client{
 	DisablePathNormalizing:   true,
 }
 
-// WithTlsConfig update http client with a user specified tls.config.
+// WithTlsConfig update http client with a user specified tls.config
+// also affects the TLSConfig of fasthttp.LBClient in Balancer.
+// This function should be called before Balancer and Forward.
 func WithTlsConfig(tlsConfig *tls.Config) {
 	client.TLSConfig = tlsConfig
 }

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/url"
 	"strings"
@@ -96,6 +97,11 @@ func Balancer(config Config) fiber.Handler {
 var client = fasthttp.Client{
 	NoDefaultUserAgentHeader: true,
 	DisablePathNormalizing:   true,
+}
+
+// WithTlsConfig update http client with a user specified tls.config.
+func WithTlsConfig(tlsConfig *tls.Config) {
+	client.TLSConfig = tlsConfig
 }
 
 // Forward performs the given http request and fills the given http response.

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -101,8 +101,7 @@ var client = fasthttp.Client{
 }
 
 // WithTlsConfig update http client with a user specified tls.config
-// also affects the TLSConfig of fasthttp.LBClient in Balancer.
-// This function should be called before Balancer and Forward.
+// This function should be called before Do and Forward.
 func WithTlsConfig(tlsConfig *tls.Config) {
 	client.TLSConfig = tlsConfig
 }

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -84,6 +84,42 @@ func Test_Proxy(t *testing.T) {
 	utils.AssertEqual(t, fiber.StatusTeapot, resp.StatusCode)
 }
 
+// go test -run Test_Proxy_Balancer_WithTlsConfig
+func Test_Proxy_Balancer_WithTlsConfig(t *testing.T) {
+	t.Parallel()
+
+	serverTLSConf, clientTLSConf, err := tlstest.GetTLSConfigs()
+	utils.AssertEqual(t, nil, err)
+
+	ln, err := net.Listen(fiber.NetworkTCP4, "127.0.0.1:0")
+	utils.AssertEqual(t, nil, err)
+
+	ln = tls.NewListener(ln, serverTLSConf)
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+
+	app.Get("/tlsbalaner", func(c *fiber.Ctx) error {
+		return c.SendString("tls balancer")
+	})
+
+	addr := ln.Addr().String()
+	clientTLSConf = &tls.Config{InsecureSkipVerify: true}
+
+	// disable certificate verification in Balancer
+	app.Use(Balancer(Config{
+		Servers:   []string{addr},
+		TlsConfig: clientTLSConf,
+	}))
+
+	go func() { utils.AssertEqual(t, nil, app.Listener(ln)) }()
+
+	code, body, errs := fiber.Get("https://" + addr + "/tlsbalaner").TLSConfig(clientTLSConf).String()
+
+	utils.AssertEqual(t, 0, len(errs))
+	utils.AssertEqual(t, fiber.StatusOK, code)
+	utils.AssertEqual(t, "tls balancer", body)
+}
+
 // go test -run Test_Proxy_Forward
 func Test_Proxy_Forward(t *testing.T) {
 	t.Parallel()
@@ -117,23 +153,22 @@ func Test_Proxy_Forward_WithTlsConfig(t *testing.T) {
 
 	ln = tls.NewListener(ln, serverTLSConf)
 
-	app := fiber.New()
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 
 	app.Get("/tlsfwd", func(c *fiber.Ctx) error {
 		return c.SendString("tls forward")
 	})
 
+	addr := ln.Addr().String()
+	clientTLSConf = &tls.Config{InsecureSkipVerify: true}
+
 	// disable certificate verification
-	WithTlsConfig(&tls.Config{
-		InsecureSkipVerify: true,
-	})
-	app.Use(Forward("https://" + ln.Addr().String() + "/tlsfwd"))
+	WithTlsConfig(clientTLSConf)
+	app.Use(Forward("https://" + addr + "/tlsfwd"))
 
 	go func() { utils.AssertEqual(t, nil, app.Listener(ln)) }()
 
-	code, body, errs := fiber.Get("https://" + ln.Addr().String()).
-		TLSConfig(clientTLSConf).
-		String()
+	code, body, errs := fiber.Get("https://" + addr).TLSConfig(clientTLSConf).String()
 
 	utils.AssertEqual(t, 0, len(errs))
 	utils.AssertEqual(t, fiber.StatusOK, code)


### PR DESCRIPTION
In some cases, we often need to disable certificate validation, so I add `WithTlsConfig` function for proxy.
This function can be used before `Forward`, for example:
```
proxy.WithTlsConfig(tls.Config{
    InsecureSkipVerify: true,
})
```