### PR TITLE
Fix: Session middleware issues

### DIFF
--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -120,7 +120,10 @@ func (s *Session) Regenerate() error {
 
 	// Create new ID
 	s.id = s.config.KeyGenerator()
-
+	
+	// We assign a new ID to the session, so the session must be fresh
+	s.fresh = true
+	
 	return nil
 }
 

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -118,13 +118,19 @@ func (s *Session) Regenerate() error {
 		return err
 	}
 
-	// Create new ID
-	s.id = s.config.KeyGenerator()
-	
-	// We assign a new ID to the session, so the session must be fresh
-	s.fresh = true
-	
+	// generate a new session, and set session.fresh to be true
+	s.refresh()
+
 	return nil
+}
+
+// refresh generates a new session, and set session.fresh to be true
+func (s *Session) refresh() {
+	// Create a new id
+	s.id = s.config.KeyGenerator()
+
+	// We assign a new id to the session, so the session must be fresh
+	s.fresh = true
 }
 
 // Save will update the storage and client cookie

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -118,7 +118,7 @@ func (s *Session) Regenerate() error {
 		return err
 	}
 
-	// generate a new session, and set session.fresh to be true
+	// Generate a new session, and set session.fresh to true
 	s.refresh()
 
 	return nil

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -79,7 +79,11 @@ func (s *Store) Get(c *fiber.Ctx) (*Session, error) {
 		} else if err != nil {
 			return nil, err
 		} else {
+			// raw is nil, which means id is not in the storage
+			// so it means that id is not valid (mainly because of id is expired or user provides an invalid id)
+			// therefore, we regenerate a id
 			sess.fresh = true
+			sess.id = s.KeyGenerator()
 		}
 	}
 

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -82,8 +82,7 @@ func (s *Store) Get(c *fiber.Ctx) (*Session, error) {
 			// raw is nil, which means id is not in the storage
 			// so it means that id is not valid (mainly because of id is expired or user provides an invalid id)
 			// therefore, we regenerate a id
-			sess.fresh = true
-			sess.id = s.KeyGenerator()
+			sess.refresh()
 		}
 	}
 


### PR DESCRIPTION
Fix: Session.Regenerate does not set Session.fresh to be true.
Fix: Session should be regenerated if the session can not be found in the storage.
This PR is intended to close #1395 issue and #1408 issue.

Tests have been added.
Some old tests have been modified.
If there are some questions, I will answer them.