### PR TITLE
Fix: copy the data in buffer instead of using original data.

### DIFF
--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -160,8 +160,12 @@ func (s *Session) Save() error {
 		return err
 	}
 
-	// pass raw bytes with session id to provider
-	if err := s.config.Storage.Set(s.id, s.byteBuffer.Bytes(), s.exp); err != nil {
+	// copy the data in buffer
+	encodedBytes := make([]byte, s.byteBuffer.Len())
+	copy(encodedBytes, s.byteBuffer.Bytes())
+
+	// pass copied bytes with session id to provider
+	if err := s.config.Storage.Set(s.id, encodedBytes, s.exp); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR is intended to close the #1419 issue.
The explanation of the bug is in the following comment.
https://github.com/gofiber/fiber/issues/1419#issuecomment-875422869