### PR TITLE
✨ Add ability to specify default value for ParamsInt

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -734,9 +734,20 @@ func (c *Ctx) Params(key string, defaultValue ...string) string {
 // ParamsInt is used to get an integer from the route parameters
 // it defaults to zero if the parameter is not found or if the
 // parameter cannot be converted to an integer
-func (c *Ctx) ParamsInt(key string) (int, error) {
+// If a default value is given, it will returb that value in case the param
+// doesn't exist or cannot be converted to an integrer
+func (c *Ctx) ParamsInt(key string, defaultValue ...int) (int, error) {
 	// Use Atoi to convert the param to an int or return zero and an error
-	return strconv.Atoi(c.Params(key))
+	value, err := strconv.Atoi(c.Params(key))
+	if err != nil {
+		if len(defaultValue) > 0 {
+			return defaultValue[0], nil
+		} else {
+			return 0, err
+		}
+	}
+
+	return value, nil
 }
 
 // Path returns the path part of the request URL.

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2503,7 +2503,49 @@ func TestCtx_ParamsInt(t *testing.T) {
 		return nil
 	})
 
+	// For the user id I will use the number 2222, so I should be able to get the number
+	// 2222 from the Ctx even when the default value is specified
+	app.Get("/testignoredefault/:user", func(c *Ctx) error {
+		// utils.AssertEqual(t, "john", c.Params("user"))
+
+		num, err := c.ParamsInt("user", 1111)
+
+		// Check the number matches
+		if num != 2222 {
+			t.Fatalf("Expected number 2222 from the path, got %d", num)
+		}
+
+		// Check no errors are returned, because we want NO errors in this one
+		if err != nil {
+			t.Fatalf("Expected nil error for 2222 test, got " + err.Error())
+		}
+
+		return nil
+	})
+
+	// In this test case, there will be a bad request where the expected number is NOT
+	// a number in the path, default value of 1111 should be used instead
+	app.Get("/testdefault/:user", func(c *Ctx) error {
+		// utils.AssertEqual(t, "john", c.Params("user"))
+
+		num, err := c.ParamsInt("user", 1111)
+
+		// Check the number matches
+		if num != 1111 {
+			t.Fatalf("Expected number 1111 from the path, got %d", num)
+		}
+
+		// Check an error is returned, because we want NO errors in this one
+		if err != nil {
+			t.Fatalf("Expected nil error for 1111 test, got " + err.Error())
+		}
+
+		return nil
+	})
+
 	app.Test(httptest.NewRequest(MethodGet, "/test/1111", nil))
 	app.Test(httptest.NewRequest(MethodGet, "/testnoint/xd", nil))
+	app.Test(httptest.NewRequest(MethodGet, "/testignoredefault/2222", nil))
+	app.Test(httptest.NewRequest(MethodGet, "/testdefault/xd", nil))
 
 }


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

I have added an option to specify default value when using ParamsInt, similar to Params method.

**Explain the *details* for making this change. What existing problem does the pull request solve?**

This allows us to remove the boilerplate code when default value needs to be applied on error but still keeps the behavior when no default is supplied. 

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/