### PR TITLE
🐛 fix parse gzipped body

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -291,7 +291,7 @@ func (c *Ctx) BodyParser(out interface{}) error {
 	// Parse body accordingly
 	if strings.HasPrefix(ctype, MIMEApplicationJSON) {
 		schemaDecoder.SetAliasTag("json")
-		return json.Unmarshal(c.fasthttp.Request.Body(), out)
+		return json.Unmarshal(c.Body(), out)
 	}
 	if strings.HasPrefix(ctype, MIMEApplicationForm) {
 		schemaDecoder.SetAliasTag("form")
@@ -311,7 +311,7 @@ func (c *Ctx) BodyParser(out interface{}) error {
 	}
 	if strings.HasPrefix(ctype, MIMETextXML) || strings.HasPrefix(ctype, MIMEApplicationXML) {
 		schemaDecoder.SetAliasTag("xml")
-		return xml.Unmarshal(c.fasthttp.Request.Body(), out)
+		return xml.Unmarshal(c.Body(), out)
 	}
 	// No suitable content type found
 	return ErrUnprocessableEntity

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -358,6 +358,22 @@ func Test_Ctx_BodyParser(t *testing.T) {
 		Name string `json:"name" xml:"name" form:"name" query:"name"`
 	}
 
+	 {
+		 var gzipJSON bytes.Buffer
+		 w := gzip.NewWriter(&gzipJSON)
+		 _, _ = w.Write([]byte(`{"name":"john"}`))
+		 _ = w.Close()
+
+		 c.Request().Header.SetContentType(MIMEApplicationJSON)
+		 c.Request().Header.Set(HeaderContentEncoding, "gzip")
+		 c.Request().SetBody(gzipJSON.Bytes())
+		 c.Request().Header.SetContentLength(len(gzipJSON.Bytes()))
+		 d := new(Demo)
+		 utils.AssertEqual(t, nil, c.BodyParser(d))
+		 utils.AssertEqual(t, "john", d.Name)
+		 c.Request().Header.Del(HeaderContentEncoding)
+	 }
+
 	testDecodeParser := func(contentType, body string) {
 		c.Request().Header.SetContentType(contentType)
 		c.Request().SetBody([]byte(body))


### PR DESCRIPTION
Now when we use `filber.Ctx.BodyParser` to deserialize JSON, it uses `filber.Ctx.fasthttp.Request.Body` method internally to take the raw body data, which works fine in most cases.

But when the request body is gzip-compressed, `filber.Ctx.fasthttp.Request.Body` takes the compressed data and there is no way to deserialize it directly.
![image](https://user-images.githubusercontent.com/3659110/127593497-1bff50ca-a7e0-49d5-afca-6b3a69349935.png)

So in this PR I changed the method inside `filber.Ctx.BodyParser` that takes the request body to `filber.Ctx.Body` method, which automatically detects the encoding of the request body and decompresses it itself. I have also added test cases for compression requests.