### PR TITLE
:bug: session should not regenerate the ID in case Get() returned nil

### DIFF
--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -64,8 +64,8 @@ func Test_Session(t *testing.T) {
 	// we do not get id here
 	// since the original id is not in the db
 	// sess.id must be a new-generated uuid, which is not equivalent to "123"
-	// id := sess.ID()
-	// utils.AssertEqual(t, "123", id)
+	id := sess.ID()
+	utils.AssertEqual(t, "123", id)
 
 	// delete cookie
 	ctx.Request().Header.Del(fiber.HeaderCookie)
@@ -76,8 +76,8 @@ func Test_Session(t *testing.T) {
 	utils.AssertEqual(t, true, sess.Fresh())
 
 	// get id
-	id := sess.ID()
-	utils.AssertEqual(t, 36, len(id))
+	// id := sess.ID()
+	// utils.AssertEqual(t, 36, len(id))
 
 	// when we use the session for the second time
 	// the session be should be same if the session is not expired
@@ -124,7 +124,7 @@ func Test_Session_Types(t *testing.T) {
 		Name string
 	}
 	store.RegisterType(User{})
-	var vuser = User{
+	vuser := User{
 		Name: "John",
 	}
 	// set value

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -61,30 +61,32 @@ func Test_Session(t *testing.T) {
 	keys = sess.Keys()
 	utils.AssertEqual(t, []string{}, keys)
 
-	// we do not get id here
-	// since the original id is not in the db
-	// sess.id must be a new-generated uuid, which is not equivalent to "123"
+	// get id
 	id := sess.ID()
 	utils.AssertEqual(t, "123", id)
-
-	// delete cookie
-	ctx.Request().Header.Del(fiber.HeaderCookie)
-
-	// get session
-	sess, err = store.Get(ctx)
-	utils.AssertEqual(t, nil, err)
-	utils.AssertEqual(t, true, sess.Fresh())
-
-	// get id
-	// id := sess.ID()
-	// utils.AssertEqual(t, 36, len(id))
-
-	// when we use the session for the second time
-	// the session be should be same if the session is not expired
 
 	// save the old session first
 	err = sess.Save()
 	utils.AssertEqual(t, nil, err)
+
+	// delete cookie
+	ctx.Request().Header.Del(fiber.HeaderCookie)
+
+	// manually release context so that it has to be renewed from pool - preventing falsy tests
+	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+
+	sess, err = store.Get(ctx)
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, true, sess.Fresh())
+
+	// this id should be randomly generated as session key was deleted
+	utils.AssertEqual(t, 36, len(sess.ID()))
+
+	// when we use the original session for the second time
+	// the session be should be same if the session is not expired
+	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
 
 	// request the server with the old session
 	ctx.Request().Header.SetCookie(store.sessionName, id)

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -69,10 +69,7 @@ func Test_Session(t *testing.T) {
 	err = sess.Save()
 	utils.AssertEqual(t, nil, err)
 
-	// delete cookie
-	ctx.Request().Header.Del(fiber.HeaderCookie)
-
-	// manually release context so that it has to be renewed from pool - preventing falsy tests
+	// requesting entirely new context to prevent falsy tests
 	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 	defer app.ReleaseCtx(ctx)
 

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -38,7 +38,7 @@ func (s *Store) RegisterType(i interface{}) {
 // Get will get/create a session
 func (s *Store) Get(c *fiber.Ctx) (*Session, error) {
 	var fresh bool
-	var loadData = true
+	loadData := true
 
 	id := s.getSessionID(c)
 
@@ -79,10 +79,8 @@ func (s *Store) Get(c *fiber.Ctx) (*Session, error) {
 		} else if err != nil {
 			return nil, err
 		} else {
-			// raw is nil, which means id is not in the storage
-			// so it means that id is not valid (mainly because of id is expired or user provides an invalid id)
-			// therefore, we regenerate a id
-			sess.refresh()
+			// both raw and err is nil, which means id is not in the storage
+			sess.fresh = true
 		}
 	}
 

--- a/middleware/session/store_test.go
+++ b/middleware/session/store_test.go
@@ -63,7 +63,7 @@ func TestStore_Get(t *testing.T) {
 	unexpectedID := "test-session-id"
 	// fiber instance
 	app := fiber.New()
-	t.Run("regenerate a session when session is invalid", func(t *testing.T) {
+	t.Run("session should persisted even session is invalid", func(t *testing.T) {
 		// session store
 		store := New()
 		// fiber context
@@ -75,7 +75,7 @@ func TestStore_Get(t *testing.T) {
 		acquiredSession, err := store.Get(ctx)
 		utils.AssertEqual(t, err, nil)
 
-		if acquiredSession.ID() == unexpectedID {
+		if acquiredSession.ID() != unexpectedID {
 			t.Fatal("server should not accept the unexpectedID which is not in the store")
 		}
 	})


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Should fix #1492 

**Explain the *details* for making this change. What existing problem does the pull request solve?**

returned session should not have gotten their ID refreshed if `s.Storage.Get(id)` return nil, otherwise it is unable for session to be `Save()`