### PR TITLE
:bug: Fix: ctx.BodyParser was not able to parse vendor specific content type

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -288,6 +288,8 @@ func (c *Ctx) BodyParser(out interface{}) error {
 	// Get content-type
 	ctype := utils.ToLower(utils.UnsafeString(c.fasthttp.Request.Header.ContentType()))
 
+	ctype = utils.ParseVendorSpecificContentType(ctype)
+
 	// Parse body accordingly
 	if strings.HasPrefix(ctype, MIMEApplicationJSON) {
 		schemaDecoder.SetAliasTag("json")

--- a/utils/http.go
+++ b/utils/http.go
@@ -4,6 +4,8 @@
 
 package utils
 
+import "strings"
+
 const MIMEOctetStream = "application/octet-stream"
 
 // GetMIME returns the content-type of a file extension
@@ -20,6 +22,32 @@ func GetMIME(extension string) (mime string) {
 		return MIMEOctetStream
 	}
 	return mime
+}
+
+// ParseVendorSpecificContentType check if content type is vendor specific and
+// if it is parsable to any known types. If its not vendor specific then returns
+// the original content type.
+func ParseVendorSpecificContentType(cType string) string {
+	plusIndex := strings.Index(cType, "+")
+
+	if plusIndex == -1 {
+		return cType
+	}
+
+	var parsableType string
+	if semiColonIndex := strings.Index(cType, ";"); semiColonIndex == -1 {
+		parsableType = cType[plusIndex+1:]
+	} else {
+		parsableType = cType[plusIndex+1 : semiColonIndex]
+	}
+
+	slashIndex := strings.Index(cType, "/")
+
+	if slashIndex == -1 {
+		return cType
+	}
+
+	return cType[0:slashIndex+1] + parsableType
 }
 
 // limits for HTTP statuscodes

--- a/utils/http_test.go
+++ b/utils/http_test.go
@@ -53,6 +53,42 @@ func Benchmark_GetMIME(b *testing.B) {
 	})
 }
 
+func Test_ParseVendorSpecificContentType(t *testing.T) {
+	t.Parallel()
+
+	cType := ParseVendorSpecificContentType("application/json")
+	AssertEqual(t, "application/json", cType)
+
+	cType = ParseVendorSpecificContentType("application/vnd.api+json; version=1")
+	AssertEqual(t, "application/json", cType)
+
+	cType = ParseVendorSpecificContentType("application/vnd.api+json")
+	AssertEqual(t, "application/json", cType)
+
+	cType = ParseVendorSpecificContentType("application/vnd.dummy+x-www-form-urlencoded")
+	AssertEqual(t, "application/x-www-form-urlencoded", cType)
+
+	cType = ParseVendorSpecificContentType("something invalid")
+	AssertEqual(t, "something invalid", cType)
+}
+
+func Benchmark_ParseVendorSpecificContentType(b *testing.B) {
+	var cType string
+	b.Run("vendorContentType", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			cType = ParseVendorSpecificContentType("application/vnd.api+json; version=1")
+		}
+		AssertEqual(b, "application/json", cType)
+	})
+
+	b.Run("defaultContentType", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			cType = ParseVendorSpecificContentType("application/json")
+		}
+		AssertEqual(b, "application/json", cType)
+	})
+}
+
 func Test_StatusMessage(t *testing.T) {
 	t.Parallel()
 	res := StatusMessage(204)


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

`ctx.BodyParser` was not able to parse vendor specific content types like `application/vnd.api+json; version=1` even though its a valid type of JSON

**Explain the *details* for making this change. What existing problem does the pull request solve?**

This solves #1505 

Benchmark details related to this change

```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^(Benchmark_ParseVendorSpecificContentType)$ github.com/gofiber/fiber/v2/utils

goos: darwin
goarch: amd64
pkg: github.com/gofiber/fiber/v2/utils
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Benchmark_ParseVendorSpecificContentType/vendorContentType-12         	23002122	        52.34 ns/op	      16 B/op	       1 allocs/op
Benchmark_ParseVendorSpecificContentType/defaultContentType-12        	175375113	         6.869 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/gofiber/fiber/v2/utils	4.599s
```

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/