### PR TITLE
✨ support logging color for custom logging formats

### DIFF
--- a/middleware/logger/config.go
+++ b/middleware/logger/config.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -56,6 +57,20 @@ var ConfigDefault = Config{
 	enableColors: true,
 }
 
+// Function to check if the logger format is compatible for coloring
+func validCustomFormat(format string) bool {
+	var validTemplates = []string{"${status}", "${method}"}
+	if format == "" {
+		return true
+	}
+	for _, template := range validTemplates {
+		if !strings.Contains(format, template) {
+			return false
+		}
+	}
+	return true
+}
+
 // Helper function to set default values
 func configDefault(config ...Config) Config {
 	// Return default config if nothing provided
@@ -67,7 +82,7 @@ func configDefault(config ...Config) Config {
 	cfg := config[0]
 
 	// Enable colors if no custom format or output is given
-	if cfg.Format == "" && cfg.Output == nil {
+	if validCustomFormat(cfg.Format) && cfg.Output == nil {
 		cfg.enableColors = true
 	}
 


### PR DESCRIPTION

**Support logger coloring for custom logging formats**

Add a function to check for a valid custom format. A valid format is one having both `${status}` and `${method}`. Fixed #1467 
