### PR TITLE
:bug: Fix Mutability issue of UserContext in fiber.Ctx

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -53,7 +53,7 @@ type Ctx struct {
 	values              [maxParams]string    // Route parameter values
 	fasthttp            *fasthttp.RequestCtx // Reference to *fasthttp.RequestCtx
 	matched             bool                 // Non use route matched
-	userContext         context.Context
+	userContext         context.Context      // User-defined context.Context
 }
 
 // Range data for c.Range

--- a/ctx.go
+++ b/ctx.go
@@ -34,6 +34,9 @@ const maxParams = 30
 
 const queryTag = "query"
 
+// userContextKey define the key name for storing context.Context in *fasthttp.RequestCtx
+const userContextKey = "__local_user_context__"
+
 // Ctx represents the Context which hold the HTTP request and response.
 // It has methods for the request query string, parameters, body, HTTP headers and so on.
 type Ctx struct {
@@ -53,7 +56,6 @@ type Ctx struct {
 	values              [maxParams]string    // Route parameter values
 	fasthttp            *fasthttp.RequestCtx // Reference to *fasthttp.RequestCtx
 	matched             bool                 // Non use route matched
-	userContext         context.Context      // User-defined context.Context
 }
 
 // Range data for c.Range
@@ -342,15 +344,18 @@ func (c *Ctx) Context() *fasthttp.RequestCtx {
 // UserContext returns a context implementation that was set by
 // user earlier or returns a non-nil, empty context,if it was not set earlier.
 func (c *Ctx) UserContext() context.Context {
-	if c.userContext == nil {
-		c.userContext = context.Background()
+	ctx, ok := c.fasthttp.UserValue(userContextKey).(context.Context)
+	if !ok {
+		ctx = context.Background()
+		c.SetUserContext(ctx)
 	}
-	return c.userContext
+
+	return ctx
 }
 
 // SetUserContext sets a context implementation by user.
 func (c *Ctx) SetUserContext(ctx context.Context) {
-	c.userContext = ctx
+	c.fasthttp.SetUserValue(userContextKey, ctx)
 }
 
 // Cookie sets a cookie by passing a cookie struct.

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -358,21 +358,21 @@ func Test_Ctx_BodyParser(t *testing.T) {
 		Name string `json:"name" xml:"name" form:"name" query:"name"`
 	}
 
-	 {
-		 var gzipJSON bytes.Buffer
-		 w := gzip.NewWriter(&gzipJSON)
-		 _, _ = w.Write([]byte(`{"name":"john"}`))
-		 _ = w.Close()
+	{
+		var gzipJSON bytes.Buffer
+		w := gzip.NewWriter(&gzipJSON)
+		_, _ = w.Write([]byte(`{"name":"john"}`))
+		_ = w.Close()
 
-		 c.Request().Header.SetContentType(MIMEApplicationJSON)
-		 c.Request().Header.Set(HeaderContentEncoding, "gzip")
-		 c.Request().SetBody(gzipJSON.Bytes())
-		 c.Request().Header.SetContentLength(len(gzipJSON.Bytes()))
-		 d := new(Demo)
-		 utils.AssertEqual(t, nil, c.BodyParser(d))
-		 utils.AssertEqual(t, "john", d.Name)
-		 c.Request().Header.Del(HeaderContentEncoding)
-	 }
+		c.Request().Header.SetContentType(MIMEApplicationJSON)
+		c.Request().Header.Set(HeaderContentEncoding, "gzip")
+		c.Request().SetBody(gzipJSON.Bytes())
+		c.Request().Header.SetContentLength(len(gzipJSON.Bytes()))
+		d := new(Demo)
+		utils.AssertEqual(t, nil, c.BodyParser(d))
+		utils.AssertEqual(t, "john", d.Name)
+		c.Request().Header.Del(HeaderContentEncoding)
+	}
 
 	testDecodeParser := func(contentType, body string) {
 		c.Request().Header.SetContentType(contentType)
@@ -518,16 +518,19 @@ func Test_Ctx_UserContext(t *testing.T) {
 		testKey := "Test Key"
 		testValue := "Test Value"
 		ctx := context.WithValue(context.Background(), testKey, testValue)
-		utils.AssertEqual(t, ctx.Value(testKey), testValue)
+		utils.AssertEqual(t, testValue, ctx.Value(testKey))
 	})
 
 }
 
-// go test -run Test_Ctx_UserContext
+// go test -run Test_Ctx_SetUserContext
 func Test_Ctx_SetUserContext(t *testing.T) {
 	c := Ctx{}
-	c.SetUserContext(context.Background())
-	utils.AssertEqual(t, c.UserContext(), context.Background())
+	testKey := "Test Key"
+	testValue := "Test Value"
+	ctx := context.WithValue(context.Background(), testKey, testValue)
+	c.SetUserContext(ctx)
+	utils.AssertEqual(t, testValue, c.UserContext().Value(testKey))
 }
 
 // go test -run Test_Ctx_Cookie


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Fix #1518

**Explain the *details* for making this change. What existing problem does the pull request solve?**

I've not much experience in FastHTTP, especially in Mutability nature, so this fix put user-defined `context.Context` into `*fasthttp.RequestCtx` with constant key `__local_user_context__`, instead of `fiber.Ctx` struct field, and keeping the `fiber.Ctx` API intact