### PR TITLE
Add one minute load avg for monitor middleware

### DIFF
--- a/internal/gopsutil/load/load.go
+++ b/internal/gopsutil/load/load.go
@@ -1,0 +1,31 @@
+package load
+
+import (
+	"encoding/json"
+)
+
+//var invoke common.Invoker = common.Invoke{}
+
+type AvgStat struct {
+	Load1  float64 `json:"load1"`
+	Load5  float64 `json:"load5"`
+	Load15 float64 `json:"load15"`
+}
+
+func (l AvgStat) String() string {
+	s, _ := json.Marshal(l)
+	return string(s)
+}
+
+type MiscStat struct {
+	ProcsTotal   int64 `json:"procsTotal"`
+	ProcsCreated int64 `json:"procsCreated"`
+	ProcsRunning int64 `json:"procsRunning"`
+	ProcsBlocked int64 `json:"procsBlocked"`
+	Ctxt         int64 `json:"ctxt"`
+}
+
+func (m MiscStat) String() string {
+	s, _ := json.Marshal(m)
+	return string(s)
+}

--- a/internal/gopsutil/load/load_bsd.go
+++ b/internal/gopsutil/load/load_bsd.go
@@ -1,0 +1,80 @@
+// +build freebsd openbsd
+
+package load
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func Avg() (*AvgStat, error) {
+	return AvgWithContext(context.Background())
+}
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	// This SysctlRaw method borrowed from
+	// https://github.com/prometheus/node_exporter/blob/master/collector/loadavg_freebsd.go
+	type loadavg struct {
+		load  [3]uint32
+		scale int
+	}
+	b, err := unix.SysctlRaw("vm.loadavg")
+	if err != nil {
+		return nil, err
+	}
+	load := *(*loadavg)(unsafe.Pointer((&b[0])))
+	scale := float64(load.scale)
+	ret := &AvgStat{
+		Load1:  float64(load.load[0]) / scale,
+		Load5:  float64(load.load[1]) / scale,
+		Load15: float64(load.load[2]) / scale,
+	}
+
+	return ret, nil
+}
+
+type forkstat struct {
+	forks    int
+	vforks   int
+	__tforks int
+}
+
+// Misc returns miscellaneous host-wide statistics.
+// darwin use ps command to get process running/blocked count.
+// Almost same as Darwin implementation, but state is different.
+func Misc() (*MiscStat, error) {
+	return MiscWithContext(context.Background())
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	bin, err := exec.LookPath("ps")
+	if err != nil {
+		return nil, err
+	}
+	out, err := invoke.CommandWithContext(ctx, bin, "axo", "state")
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(out), "\n")
+
+	ret := MiscStat{}
+	for _, l := range lines {
+		if strings.Contains(l, "R") {
+			ret.ProcsRunning++
+		} else if strings.Contains(l, "D") {
+			ret.ProcsBlocked++
+		}
+	}
+
+	f, err := getForkStat()
+	if err != nil {
+		return nil, err
+	}
+	ret.ProcsCreated = f.forks
+
+	return &ret, nil
+}

--- a/internal/gopsutil/load/load_darwin.go
+++ b/internal/gopsutil/load/load_darwin.go
@@ -1,0 +1,71 @@
+// +build darwin
+
+package load
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func Avg() (*AvgStat, error) {
+	return AvgWithContext(context.Background())
+}
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	// This SysctlRaw method borrowed from
+	// https://github.com/prometheus/node_exporter/blob/master/collector/loadavg_freebsd.go
+	// this implementation is common with BSDs
+	type loadavg struct {
+		load  [3]uint32
+		scale int
+	}
+	b, err := unix.SysctlRaw("vm.loadavg")
+	if err != nil {
+		return nil, err
+	}
+	load := *(*loadavg)(unsafe.Pointer((&b[0])))
+	scale := float64(load.scale)
+	ret := &AvgStat{
+		Load1:  float64(load.load[0]) / scale,
+		Load5:  float64(load.load[1]) / scale,
+		Load15: float64(load.load[2]) / scale,
+	}
+
+	return ret, nil
+}
+
+// Misc returnes miscellaneous host-wide statistics.
+// darwin use ps command to get process running/blocked count.
+// Almost same as FreeBSD implementation, but state is different.
+// U means 'Uninterruptible Sleep'.
+func Misc() (*MiscStat, error) {
+	return MiscWithContext(context.Background())
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	bin, err := exec.LookPath("ps")
+	if err != nil {
+		return nil, err
+	}
+	out, err := invoke.CommandWithContext(ctx, bin, "axo", "state")
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(out), "\n")
+
+	ret := MiscStat{}
+	for _, l := range lines {
+		if strings.Contains(l, "R") {
+			ret.ProcsRunning++
+		} else if strings.Contains(l, "U") {
+			// uninterruptible sleep == blocked
+			ret.ProcsBlocked++
+		}
+	}
+
+	return &ret, nil
+}

--- a/internal/gopsutil/load/load_fallback.go
+++ b/internal/gopsutil/load/load_fallback.go
@@ -1,0 +1,25 @@
+// +build !darwin,!linux,!freebsd,!openbsd,!windows,!solaris
+
+package load
+
+import (
+	"context"
+
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+func Avg() (*AvgStat, error) {
+	return AvgWithContext(context.Background())
+}
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func Misc() (*MiscStat, error) {
+	return MiscWithContext(context.Background())
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	return nil, common.ErrNotImplementedError
+}

--- a/internal/gopsutil/load/load_freebsd.go
+++ b/internal/gopsutil/load/load_freebsd.go
@@ -1,0 +1,7 @@
+// +build freebsd
+
+package load
+
+func getForkStat() (forkstat, error) {
+	return forkstat{}, nil
+}

--- a/internal/gopsutil/load/load_linux.go
+++ b/internal/gopsutil/load/load_linux.go
@@ -1,0 +1,136 @@
+//go:build linux
+// +build linux
+
+package load
+
+import (
+	"context"
+	"io/ioutil"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/gofiber/fiber/v2/internal/gopsutil/common"
+)
+
+func Avg() (*AvgStat, error) {
+	return AvgWithContext(context.Background())
+}
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	stat, err := fileAvgWithContext(ctx)
+	if err != nil {
+		stat, err = sysinfoAvgWithContext(ctx)
+	}
+	return stat, err
+}
+
+func sysinfoAvgWithContext(ctx context.Context) (*AvgStat, error) {
+	var info syscall.Sysinfo_t
+	err := syscall.Sysinfo(&info)
+	if err != nil {
+		return nil, err
+	}
+
+	const si_load_shift = 16
+	return &AvgStat{
+		Load1:  float64(info.Loads[0]) / float64(1<<si_load_shift),
+		Load5:  float64(info.Loads[1]) / float64(1<<si_load_shift),
+		Load15: float64(info.Loads[2]) / float64(1<<si_load_shift),
+	}, nil
+}
+
+func fileAvgWithContext(ctx context.Context) (*AvgStat, error) {
+	values, err := readLoadAvgFromFile()
+	if err != nil {
+		return nil, err
+	}
+
+	load1, err := strconv.ParseFloat(values[0], 64)
+	if err != nil {
+		return nil, err
+	}
+	load5, err := strconv.ParseFloat(values[1], 64)
+	if err != nil {
+		return nil, err
+	}
+	load15, err := strconv.ParseFloat(values[2], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &AvgStat{
+		Load1:  load1,
+		Load5:  load5,
+		Load15: load15,
+	}
+
+	return ret, nil
+}
+
+// Misc returnes miscellaneous host-wide statistics.
+// Note: the name should be changed near future.
+func Misc() (*MiscStat, error) {
+	return MiscWithContext(context.Background())
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	filename := common.HostProc("stat")
+	out, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &MiscStat{}
+	lines := strings.Split(string(out), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		v, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		switch fields[0] {
+		case "processes":
+			ret.ProcsCreated = v
+		case "procs_running":
+			ret.ProcsRunning = v
+		case "procs_blocked":
+			ret.ProcsBlocked = v
+		case "ctxt":
+			ret.Ctxt = v
+		default:
+			continue
+		}
+
+	}
+
+	procsTotal, err := getProcsTotal()
+	if err != nil {
+		return ret, err
+	}
+	ret.ProcsTotal = procsTotal
+
+	return ret, nil
+}
+
+func getProcsTotal() (int64, error) {
+	values, err := readLoadAvgFromFile()
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(strings.Split(values[3], "/")[1], 10, 64)
+}
+
+func readLoadAvgFromFile() ([]string, error) {
+	loadavgFilename := common.HostProc("loadavg")
+	line, err := ioutil.ReadFile(loadavgFilename)
+	if err != nil {
+		return nil, err
+	}
+
+	values := strings.Fields(string(line))
+	return values, nil
+}

--- a/internal/gopsutil/load/load_openbsd.go
+++ b/internal/gopsutil/load/load_openbsd.go
@@ -1,0 +1,17 @@
+// +build openbsd
+
+package load
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func getForkStat() (forkstat, error) {
+	b, err := unix.SysctlRaw("kern.forkstat")
+	if err != nil {
+		return forkstat{}, err
+	}
+	return *(*forkstat)(unsafe.Pointer((&b[0]))), nil
+}

--- a/internal/gopsutil/load/load_solaris.go
+++ b/internal/gopsutil/load/load_solaris.go
@@ -1,0 +1,44 @@
+// +build solaris
+
+package load
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+func Avg() (*AvgStat, error) {
+	return AvgWithContext(context.Background())
+}
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func Misc() (*MiscStat, error) {
+	return MiscWithContext(context.Background())
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	bin, err := exec.LookPath("ps")
+	if err != nil {
+		return nil, err
+	}
+	out, err := invoke.CommandWithContext(ctx, bin, "-efo", "s")
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(out), "\n")
+
+	ret := MiscStat{}
+	for _, l := range lines {
+		if l == "O" {
+			ret.ProcsRunning++
+		}
+	}
+
+	return &ret, nil
+}

--- a/internal/gopsutil/load/load_test.go
+++ b/internal/gopsutil/load/load_test.go
@@ -1,0 +1,95 @@
+package load
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gofiber/fiber/v2/internal/gopsutil/common"
+)
+
+func skipIfNotImplementedErr(t testing.TB, err error) {
+	if err == common.ErrNotImplementedError {
+		t.Skip("not implemented")
+	}
+}
+
+func TestLoad(t *testing.T) {
+	v, err := Avg()
+	skipIfNotImplementedErr(t, err)
+	if err != nil {
+		t.Errorf("error %v", err)
+	}
+
+	empty := &AvgStat{}
+	if v == empty {
+		t.Errorf("error load: %v", v)
+	}
+	t.Log(v)
+}
+
+func TestLoadAvgStat_String(t *testing.T) {
+	v := AvgStat{
+		Load1:  10.1,
+		Load5:  20.1,
+		Load15: 30.1,
+	}
+	e := `{"load1":10.1,"load5":20.1,"load15":30.1}`
+	if e != fmt.Sprintf("%v", v) {
+		t.Errorf("LoadAvgStat string is invalid: %v", v)
+	}
+	t.Log(e)
+}
+
+func TestMisc(t *testing.T) {
+	v, err := Misc()
+	skipIfNotImplementedErr(t, err)
+	if err != nil {
+		t.Errorf("error %v", err)
+	}
+
+	empty := &MiscStat{}
+	if v == empty {
+		t.Errorf("error load: %v", v)
+	}
+	t.Log(v)
+}
+
+func TestMiscStatString(t *testing.T) {
+	v := MiscStat{
+		ProcsTotal:   4,
+		ProcsCreated: 5,
+		ProcsRunning: 1,
+		ProcsBlocked: 2,
+		Ctxt:         3,
+	}
+	e := `{"procsTotal":4,"procsCreated":5,"procsRunning":1,"procsBlocked":2,"ctxt":3}`
+	if e != fmt.Sprintf("%v", v) {
+		t.Errorf("TestMiscString string is invalid: %v", v)
+	}
+	t.Log(e)
+}
+
+func BenchmarkLoad(b *testing.B) {
+
+	loadAvg := func(t testing.TB) {
+		v, err := Avg()
+		skipIfNotImplementedErr(t, err)
+		if err != nil {
+			t.Errorf("error %v", err)
+		}
+		empty := &AvgStat{}
+		if v == empty {
+			t.Errorf("error load: %v", v)
+		}
+	}
+
+	b.Run("FirstCall", func(b *testing.B) {
+		loadAvg(b)
+	})
+
+	b.Run("SubsequentCalls", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			loadAvg(b)
+		}
+	})
+}

--- a/internal/gopsutil/load/load_windows.go
+++ b/internal/gopsutil/load/load_windows.go
@@ -1,0 +1,85 @@
+//go:build windows
+// +build windows
+
+package load
+
+import (
+	"context"
+	"log"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2/internal/gopsutil/common"
+)
+
+var (
+	loadErr              error
+	loadAvg1M            float64 = 0.0
+	loadAvg5M            float64 = 0.0
+	loadAvg15M           float64 = 0.0
+	loadAvgMutex         sync.RWMutex
+	loadAvgGoroutineOnce sync.Once
+)
+
+// loadAvgGoroutine updates avg data by fetching current load by interval
+// TODO instead of this goroutine, we can register a Win32 counter just as psutil does
+// see https://psutil.readthedocs.io/en/latest/#psutil.getloadavg
+// code https://github.com/giampaolo/psutil/blob/8415355c8badc9c94418b19bdf26e622f06f0cce/psutil/arch/windows/wmi.c
+func loadAvgGoroutine() {
+	var (
+		samplingFrequency time.Duration = 5 * time.Second
+		loadAvgFactor1M   float64       = 1 / math.Exp(samplingFrequency.Seconds()/time.Minute.Seconds())
+		loadAvgFactor5M   float64       = 1 / math.Exp(samplingFrequency.Seconds()/(5*time.Minute).Seconds())
+		loadAvgFactor15M  float64       = 1 / math.Exp(samplingFrequency.Seconds()/(15*time.Minute).Seconds())
+		currentLoad       float64
+	)
+
+	counter, err := common.ProcessorQueueLengthCounter()
+	if err != nil || counter == nil {
+		log.Println("gopsutil: unexpected processor queue length counter error, please file an issue on github: err")
+		return
+	}
+
+	tick := time.NewTicker(samplingFrequency).C
+	for {
+		currentLoad, err = counter.GetValue()
+		loadAvgMutex.Lock()
+		loadErr = err
+		loadAvg1M = loadAvg1M*loadAvgFactor1M + currentLoad*(1-loadAvgFactor1M)
+		loadAvg5M = loadAvg5M*loadAvgFactor5M + currentLoad*(1-loadAvgFactor5M)
+		loadAvg15M = loadAvg15M*loadAvgFactor15M + currentLoad*(1-loadAvgFactor15M)
+		loadAvgMutex.Unlock()
+		<-tick
+	}
+}
+
+// Avg for Windows may return 0 values for the first few 5 second intervals
+func Avg() (*AvgStat, error) {
+	return AvgWithContext(context.Background())
+}
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	loadAvgGoroutineOnce.Do(func() {
+		go loadAvgGoroutine()
+	})
+	loadAvgMutex.RLock()
+	defer loadAvgMutex.RUnlock()
+	ret := AvgStat{
+		Load1:  loadAvg1M,
+		Load5:  loadAvg5M,
+		Load15: loadAvg15M,
+	}
+
+	return &ret, loadErr
+}
+
+func Misc() (*MiscStat, error) {
+	return MiscWithContext(context.Background())
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	ret := MiscStat{}
+
+	return &ret, common.ErrNotImplementedError
+}

--- a/middleware/monitor/README.md
+++ b/middleware/monitor/README.md
@@ -3,7 +3,7 @@ Monitor middleware for [Fiber](https://github.com/gofiber/fiber) that reports se
 
 :warning: **Warning:** Monitor is still in beta, API might change in the future!
 
-![](https://i.imgur.com/4NfRCDm.gif)
+![](https://i.imgur.com/nHAtBpJ.gif)
 
 ### Signatures
 ```go

--- a/middleware/monitor/index.html
+++ b/middleware/monitor/index.html
@@ -107,6 +107,16 @@
 
                 <div class="row">
                     <div class="column">
+                        <div class="metric">One Minute Load Avg</div>
+                        <h2 id="loadavgMetric">0.00</h2>
+                    </div>
+                    <div class="column">
+                        <canvas id="loadavgChart"></canvas>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="column">
                         <div class="metric">Response Time</div>
                         <h2 id="rtimeMetric">0ms</h2>
                     </div>
@@ -175,20 +185,23 @@
 
         const cpuMetric = document.querySelector('#cpuMetric');
         const ramMetric = document.querySelector('#ramMetric');
+        const loadavgMetric = document.querySelector('#loadavgMetric');
         const rtimeMetric = document.querySelector('#rtimeMetric');
         const connsMetric = document.querySelector('#connsMetric');
 
         const cpuChartCtx = document.querySelector('#cpuChart').getContext('2d');
         const ramChartCtx = document.querySelector('#ramChart').getContext('2d');
+        const loadavgChartCtx = document.querySelector('#loadavgChart').getContext('2d');
         const rtimeChartCtx = document.querySelector('#rtimeChart').getContext('2d');
         const connsChartCtx = document.querySelector('#connsChart').getContext('2d');
 
         const cpuChart = createChart(cpuChartCtx);
         const ramChart = createChart(ramChartCtx);
+        const loadavgChart = createChart(loadavgChartCtx);
         const rtimeChart = createChart(rtimeChartCtx);
         const connsChart = createChart(connsChartCtx);
 
-        const charts = [cpuChart, ramChart, rtimeChart, connsChart];
+        const charts = [cpuChart, ramChart, loadavgChart, rtimeChart, connsChart];
 
         function createChart(ctx) {
             return new Chart(ctx, {
@@ -231,9 +244,11 @@
         function update(json, rtime) {
             cpu = json.pid.cpu.toFixed(1);
             cpuOS = json.os.cpu.toFixed(1);
+            loadavg = json.os.load_avg.toFixed(1)
 
             cpuMetric.innerHTML = cpu + '% <span>' + cpuOS + '%</span>';
             ramMetric.innerHTML = formatBytes(json.pid.ram) + '<span> / </span><span class="ram_os">' + formatBytes(json.os.ram) + '<span><span> / </span><span class="ram_total">' + formatBytes(json.os.total_ram) + '</span>';
+            loadavgMetric.innerHTML = loadavg;
             rtimeMetric.innerHTML = rtime + 'ms <span>client</span>';
             connsMetric.innerHTML = json.pid.conns + ' <span>' + json.os.conns + '</span>';
 
@@ -241,6 +256,7 @@
             ramChart.data.datasets[2].data.push((json.os.total_ram / 1e6).toFixed(2));
             ramChart.data.datasets[1].data.push((json.os.ram / 1e6).toFixed(2));
             ramChart.data.datasets[0].data.push((json.pid.ram / 1e6).toFixed(2));
+            loadavgChart.data.datasets[0].data.push(loadavg);
             rtimeChart.data.datasets[0].data.push(rtime);
             connsChart.data.datasets[0].data.push(json.pid.conns);
 


### PR DESCRIPTION
Now we have same features as [express-status-monitor](https://github.com/RafalWilinski/express-status-monitor).

![](https://i.imgur.com/nHAtBpJ.gif)
