### PR TITLE
Fix: file opening path and directory browsing path of filesystem

### DIFF
--- a/middleware/filesystem/README.md
+++ b/middleware/filesystem/README.md
@@ -44,7 +44,7 @@ Then create a Fiber app with `app := fiber.New()`.
 ```go
 // Provide a minimal config
 app.Use(filesystem.New(filesystem.Config{
-	Root: http.Dir("./assets")
+	Root: http.Dir("./assets"),
 }))
 
 // Or extend your config for customization
@@ -96,7 +96,7 @@ func main() {
 	// `http://<server>/static/static/image.png`.
 	app.Use("/static", filesystem.New(filesystem.Config{
 		Root: http.FS(embedDirStatic),
-		PathPrefix: "static"
+		PathPrefix: "static",
 		Browse: true,
 	}))
 

--- a/middleware/filesystem/filesystem.go
+++ b/middleware/filesystem/filesystem.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/utils"
 )
 
 // Config defines the config for middleware.
@@ -132,7 +133,7 @@ func New(config ...Config) fiber.Handler {
 		)
 
 		if len(path) > 1 {
-			path = strings.TrimSuffix(path, "/")
+			path = utils.TrimRight(path, '/')
 		}
 		file, err = cfg.Root.Open(path)
 		if err != nil && os.IsNotExist(err) && cfg.NotFoundFile != "" {
@@ -152,7 +153,7 @@ func New(config ...Config) fiber.Handler {
 
 		// Serve index if path is directory
 		if stat.IsDir() {
-			indexPath := strings.TrimSuffix(path, "/") + cfg.Index
+			indexPath := utils.TrimRight(path, '/') + cfg.Index
 			index, err := cfg.Root.Open(indexPath)
 			if err == nil {
 				indexStat, err := index.Stat()
@@ -225,7 +226,7 @@ func SendFile(c *fiber.Ctx, fs http.FileSystem, path string) (err error) {
 
 	// Serve index if path is directory
 	if stat.IsDir() {
-		indexPath := strings.TrimSuffix(path, "/") + ConfigDefault.Index
+		indexPath := utils.TrimRight(path, '/') + ConfigDefault.Index
 		index, err := fs.Open(indexPath)
 		if err == nil {
 			indexStat, err := index.Stat()

--- a/middleware/filesystem/filesystem.go
+++ b/middleware/filesystem/filesystem.go
@@ -131,6 +131,9 @@ func New(config ...Config) fiber.Handler {
 			stat os.FileInfo
 		)
 
+		if len(path) > 1 {
+			path = strings.TrimSuffix(path, "/")
+		}
 		file, err = cfg.Root.Open(path)
 		if err != nil && os.IsNotExist(err) && cfg.NotFoundFile != "" {
 			file, err = cfg.Root.Open(cfg.NotFoundFile)

--- a/middleware/filesystem/filesystem_test.go
+++ b/middleware/filesystem/filesystem_test.go
@@ -90,6 +90,12 @@ func Test_FileSystem(t *testing.T) {
 			contentType: "text/html",
 		},
 		{
+			name:        "Should list the directory contents",
+			url:         "/dir/img/",
+			statusCode:  200,
+			contentType: "text/html",
+		},
+		{
 			name:        "Should be returns status 200",
 			url:         "/dir/img/fiber.png",
 			statusCode:  200,

--- a/middleware/filesystem/utils.go
+++ b/middleware/filesystem/utils.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/utils"
 )
 
 func getFileExtension(path string) string {
@@ -40,7 +41,7 @@ func dirList(c *fiber.Ctx, f http.File) error {
 	fmt.Fprint(c, "<ul>")
 
 	if len(basePathEscaped) > 1 {
-		parentPathEscaped := html.EscapeString(strings.TrimSuffix(c.Path(), "/") + "/..")
+		parentPathEscaped := html.EscapeString(utils.TrimRight(c.Path(), '/') + "/..")
 		fmt.Fprintf(c, `<li><a href="%s" class="dir">..</a></li>`, parentPathEscaped)
 	}
 

--- a/middleware/filesystem/utils.go
+++ b/middleware/filesystem/utils.go
@@ -40,7 +40,7 @@ func dirList(c *fiber.Ctx, f http.File) error {
 	fmt.Fprint(c, "<ul>")
 
 	if len(basePathEscaped) > 1 {
-		parentPathEscaped := html.EscapeString(c.Path() + "/..")
+		parentPathEscaped := html.EscapeString(strings.TrimSuffix(c.Path(), "/") + "/..")
 		fmt.Fprintf(c, `<li><a href="%s" class="dir">..</a></li>`, parentPathEscaped)
 	}
 


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Fixes: #1546 

```go
github.com/fufuok/fiber/middleware/filesystem# go test -v
=== RUN   Test_FileSystem
=== RUN   Test_FileSystem/Should_be_returns_status_200_with_suitable_content-type
=== RUN   Test_FileSystem/Should_be_returns_status_200_with_suitable_content-type#01
=== RUN   Test_FileSystem/Should_be_returns_status_200_with_suitable_content-type#02
=== RUN   Test_FileSystem/Should_be_returns_status_404
=== RUN   Test_FileSystem/Should_be_returns_status_404#01
=== RUN   Test_FileSystem/Should_be_returns_status_200
=== RUN   Test_FileSystem/Should_be_returns_status_403
=== RUN   Test_FileSystem/Should_list_the_directory_contents
=== RUN   Test_FileSystem/Should_list_the_directory_contents#01
=== RUN   Test_FileSystem/Should_be_returns_status_200#01
=== RUN   Test_FileSystem/Should_be_return_status_200
=== RUN   Test_FileSystem/PathPrefix_should_be_applied
--- PASS: Test_FileSystem (0.01s)
    --- PASS: Test_FileSystem/Should_be_returns_status_200_with_suitable_content-type (0.00s)
    --- PASS: Test_FileSystem/Should_be_returns_status_200_with_suitable_content-type#01 (0.00s)
    --- PASS: Test_FileSystem/Should_be_returns_status_200_with_suitable_content-type#02 (0.00s)
    --- PASS: Test_FileSystem/Should_be_returns_status_404 (0.00s)
    --- PASS: Test_FileSystem/Should_be_returns_status_404#01 (0.00s)
    --- PASS: Test_FileSystem/Should_be_returns_status_200 (0.00s)
    --- PASS: Test_FileSystem/Should_be_returns_status_403 (0.00s)
    --- PASS: Test_FileSystem/Should_list_the_directory_contents (0.00s)
    --- PASS: Test_FileSystem/Should_list_the_directory_contents#01 (0.00s)
    --- PASS: Test_FileSystem/Should_be_returns_status_200#01 (0.00s)
    --- PASS: Test_FileSystem/Should_be_return_status_200 (0.00s)
    --- PASS: Test_FileSystem/PathPrefix_should_be_applied (0.00s)
=== RUN   Test_FileSystem_Next
--- PASS: Test_FileSystem_Next (0.00s)
=== RUN   Test_FileSystem_NonGetAndHead
--- PASS: Test_FileSystem_NonGetAndHead (0.00s)
=== RUN   Test_FileSystem_Head
--- PASS: Test_FileSystem_Head (0.00s)
=== RUN   Test_FileSystem_NoRoot
--- PASS: Test_FileSystem_NoRoot (0.00s)
=== RUN   Test_FileSystem_UsingParam
--- PASS: Test_FileSystem_UsingParam (0.00s)
=== RUN   Test_FileSystem_UsingParam_NonFile
--- PASS: Test_FileSystem_UsingParam_NonFile (0.00s)
PASS
ok      github.com/gofiber/fiber/v2/middleware/filesystem       0.065s
```