### PR TITLE
:bug: Fix `c.OriginalURL()` changed after `SendFile`

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1074,6 +1074,9 @@ func (c *Ctx) SendFile(file string, compress ...bool) error {
 			file += "/"
 		}
 	}
+	// Restore the original requested URL
+	originalURL := c.OriginalURL()
+	defer c.fasthttp.Request.SetRequestURI(originalURL)
 	// Set new URI for fileHandler
 	c.fasthttp.Request.SetRequestURI(file)
 	// Save status code

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1656,6 +1656,21 @@ func Test_Ctx_SendFile_Immutable(t *testing.T) {
 	utils.AssertEqual(t, StatusOK, resp.StatusCode)
 }
 
+// go test -race -run Test_Ctx_SendFile_RestoreOriginalURL
+func Test_Ctx_SendFile_RestoreOriginalURL(t *testing.T) {
+	t.Parallel()
+	app := New()
+	app.Get("/", func(c *Ctx) error {
+		originalURL := c.OriginalURL()
+		err := c.SendFile("ctx.go")
+		utils.AssertEqual(t, originalURL, c.OriginalURL())
+		return err
+	})
+
+	_, err := app.Test(httptest.NewRequest("GET", "/?test=true", nil))
+	utils.AssertEqual(t, nil, err)
+}
+
 // go test -run Test_Ctx_JSON
 func Test_Ctx_JSON(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

This PR fixes #1499.

**Explain the *details* for making this change. What existing problem does the pull request solve?**

As described in the bug, after the `sendFile()` is called, `c.OriginalURL()` doesn't get restored. This PR fixes that issue.

Note: This is my first PR in this project, let me know if it needs any changes :v: 