### PR TITLE
🐛 fix: actual error not forwarded if request is not timed out.

### DIFF
--- a/middleware/timeout/timeout.go
+++ b/middleware/timeout/timeout.go
@@ -23,12 +23,12 @@ func New(handler fiber.Handler, timeout time.Duration) fiber.Handler {
 	// logic is from fasthttp.TimeoutWithCodeHandler https://github.com/valyala/fasthttp/blob/master/server.go#L418
 	return func(ctx *fiber.Ctx) error {
 		ch := make(chan struct{}, 1)
-
+		var err error
 		go func() {
 			defer func() {
 				_ = recover()
 			}()
-			_ = handler(ctx)
+			err = handler(ctx)
 			ch <- struct{}{}
 		}()
 
@@ -38,6 +38,6 @@ func New(handler fiber.Handler, timeout time.Duration) fiber.Handler {
 			return fiber.ErrRequestTimeout
 		}
 
-		return nil
+		return err
 	}
 }

--- a/middleware/timeout/timeout_test.go
+++ b/middleware/timeout/timeout_test.go
@@ -1,55 +1,183 @@
 package timeout
 
-// // go test -run Test_Middleware_Timeout
-// func Test_Middleware_Timeout(t *testing.T) {
-// 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+import (
+	"errors"
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+	"time"
 
-// 	h := New(func(c *fiber.Ctx) error {
-// 		sleepTime, _ := time.ParseDuration(c.Params("sleepTime") + "ms")
-// 		time.Sleep(sleepTime)
-// 		return c.SendString("After " + c.Params("sleepTime") + "ms sleeping")
-// 	}, 5*time.Millisecond)
-// 	app.Get("/test/:sleepTime", h)
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/utils"
+)
 
-// 	testTimeout := func(timeoutStr string) {
-// 		resp, err := app.Test(httptest.NewRequest("GET", "/test/"+timeoutStr, nil))
-// 		utils.AssertEqual(t, nil, err, "app.Test(req)")
-// 		utils.AssertEqual(t, fiber.StatusRequestTimeout, resp.StatusCode, "Status code")
+/*
+	NOTE: You have to reasonable while setting timeout values.
+	Some tests will fail in subsequent runs if execution time
+	and timeout value are same OR close enough.
+*/
 
-// 		body, err := ioutil.ReadAll(resp.Body)
-// 		utils.AssertEqual(t, nil, err)
-// 		utils.AssertEqual(t, "Request Timeout", string(body))
-// 	}
-// 	testSucces := func(timeoutStr string) {
-// 		resp, err := app.Test(httptest.NewRequest("GET", "/test/"+timeoutStr, nil))
-// 		utils.AssertEqual(t, nil, err, "app.Test(req)")
-// 		utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode, "Status code")
+func TestNewWithDefaultTimeout(t *testing.T) {
+	const defaultTimeout = 10 * time.Millisecond
 
-// 		body, err := ioutil.ReadAll(resp.Body)
-// 		utils.AssertEqual(t, nil, err)
-// 		utils.AssertEqual(t, "After "+timeoutStr+"ms sleeping", string(body))
-// 	}
+	th := New(func(c *fiber.Ctx) error {
+		sleepTime, _ := time.ParseDuration(c.Params("sleepTime") + "ms")
 
-// 	testTimeout("15")
-// 	testSucces("2")
-// 	testTimeout("30")
-// 	testSucces("3")
-// }
+		time.Sleep(sleepTime)
 
-// // go test -run -v Test_Timeout_Panic
-// func Test_Timeout_Panic(t *testing.T) {
-// 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+		return nil
+	}, defaultTimeout)
 
-// 	app.Get("/panic", recover.New(), New(func(c *fiber.Ctx) error {
-// 		c.Set("dummy", "this should not be here")
-// 		panic("panic in timeout handler")
-// 	}, 5*time.Millisecond))
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Get("/test/:sleepTime", th)
 
-// 	resp, err := app.Test(httptest.NewRequest("GET", "/panic", nil))
-// 	utils.AssertEqual(t, nil, err, "app.Test(req)")
-// 	utils.AssertEqual(t, fiber.StatusRequestTimeout, resp.StatusCode, "Status code")
+	type args struct {
+		sleepTime string
+	}
 
-// 	body, err := ioutil.ReadAll(resp.Body)
-// 	utils.AssertEqual(t, nil, err)
-// 	utils.AssertEqual(t, "Request Timeout", string(body))
-// }
+	type expected struct {
+		reqErr     error
+		bdyErr     error
+		statusCode int
+	}
+
+	tests := []struct {
+		name     string
+		args     args
+		expected expected
+	}{
+		{
+			name: "Execution time > timeout",
+			args: args{sleepTime: "30"},
+			expected: expected{
+				reqErr:     nil,
+				bdyErr:     nil,
+				statusCode: fiber.StatusRequestTimeout,
+			},
+		},
+		{
+			name: "Execution time < timeout",
+			args: args{sleepTime: "0"},
+			expected: expected{
+				reqErr:     nil,
+				bdyErr:     nil,
+				statusCode: fiber.StatusOK,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := app.Test(httptest.NewRequest("GET", "/test/"+tt.args.sleepTime, nil), -1)
+			utils.AssertEqual(t, tt.expected.reqErr, err, "app.Test(req)")
+			utils.AssertEqual(t, tt.expected.statusCode, resp.StatusCode, "Status code")
+
+			_, err = ioutil.ReadAll(resp.Body)
+			utils.AssertEqual(t, tt.expected.bdyErr, err)
+		})
+	}
+}
+
+func TestNewWithDefaultTimeoutAndError(t *testing.T) {
+	const defaultTimeout = 30 * time.Millisecond
+	funcErr := errors.New("something went wrong")
+
+	th := New(func(c *fiber.Ctx) error {
+		sleepTime, _ := time.ParseDuration(c.Params("sleepTime") + "ms")
+
+		time.Sleep(sleepTime)
+
+		return funcErr
+	}, defaultTimeout)
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Get("/test/:sleepTime", th)
+
+	type args struct {
+		sleepTime string
+	}
+
+	type expected struct {
+		reqErr     error
+		bdyErr     error
+		body       string
+		statusCode int
+	}
+
+	tests := []struct {
+		name     string
+		args     args
+		expected expected
+	}{
+		{
+			name: "Error in actual handler",
+			args: args{sleepTime: "1"},
+			expected: expected{
+				reqErr:     nil,
+				bdyErr:     nil,
+				statusCode: fiber.StatusInternalServerError,
+				body:       funcErr.Error(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := app.Test(httptest.NewRequest("GET", "/test/"+tt.args.sleepTime, nil), -1)
+			utils.AssertEqual(t, tt.expected.reqErr, err, "app.Test(req)")
+			utils.AssertEqual(t, tt.expected.statusCode, resp.StatusCode, "Status code")
+
+			body, err := ioutil.ReadAll(resp.Body)
+			utils.AssertEqual(t, tt.expected.bdyErr, err)
+			utils.AssertEqual(t, tt.expected.body, string(body))
+		})
+	}
+}
+
+func TestNewWithNoTimeout(t *testing.T) {
+	th := New(func(c *fiber.Ctx) error {
+		sleepTime, _ := time.ParseDuration(c.Params("sleepTime") + "ms")
+
+		time.Sleep(sleepTime)
+
+		return nil
+	}, 0)
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Get("/test/:sleepTime", th)
+
+	type args struct {
+		sleepTime string
+	}
+
+	type expected struct {
+		reqErr     error
+		bdyErr     error
+		statusCode int
+	}
+
+	tests := []struct {
+		name     string
+		args     args
+		expected expected
+	}{
+		{
+			name: "No Timeout",
+			args: args{sleepTime: "15"},
+			expected: expected{
+				reqErr:     nil,
+				bdyErr:     nil,
+				statusCode: fiber.StatusOK,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := app.Test(httptest.NewRequest("GET", "/test/"+tt.args.sleepTime, nil), -1)
+			utils.AssertEqual(t, tt.expected.reqErr, err, "app.Test(req)")
+			utils.AssertEqual(t, tt.expected.statusCode, resp.StatusCode, "Status code")
+
+			_, err = ioutil.ReadAll(resp.Body)
+			utils.AssertEqual(t, tt.expected.bdyErr, err)
+		})
+	}
+}


### PR DESCRIPTION
Forwarded the actual error if request succeeds/fails in given timeout window.

fixes #1496 