### PR TITLE
Support for sub fiber's error handlers

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1414,3 +1414,80 @@ func Test_App_DisablePreParseMultipartForm(t *testing.T) {
 
 	utils.AssertEqual(t, testString, string(body))
 }
+
+func Test_App_UseMountedErrorHandler(t *testing.T) {
+	app := New()
+
+	fiber := New(Config{
+		ErrorHandler: func(ctx *Ctx, err error) error {
+			return ctx.Status(200).SendString("hi, i'm a custom error")
+		},
+	})
+	fiber.Get("/", func(c *Ctx) error {
+		return errors.New("something happened")
+	})
+
+	app.Mount("/api", fiber)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/api", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
+
+	b, err := ioutil.ReadAll(resp.Body)
+	utils.AssertEqual(t, nil, err, "iotuil.ReadAll()")
+	utils.AssertEqual(t, "hi, i'm a custom error", string(b), "Response body")
+}
+
+func Test_App_UseMountedErrorHandlerForBestPrefixMatch(t *testing.T) {
+	app := New()
+
+	tsf := func(ctx *Ctx, err error) error {
+		return ctx.Status(200).SendString("hi, i'm a custom sub sub fiber error")
+	}
+	tripleSubFiber := New(Config{
+		ErrorHandler: tsf,
+	})
+	tripleSubFiber.Get("/", func(c *Ctx) error {
+		return errors.New("something happened")
+	})
+
+	sf := func(ctx *Ctx, err error) error {
+		return ctx.Status(200).SendString("hi, i'm a custom sub fiber error")
+	}
+	subfiber := New(Config{
+		ErrorHandler: sf,
+	})
+	subfiber.Get("/", func(c *Ctx) error {
+		return errors.New("something happened")
+	})
+	subfiber.Mount("/third", tripleSubFiber)
+
+	f := func(ctx *Ctx, err error) error {
+		return ctx.Status(200).SendString("hi, i'm a custom error")
+	}
+	fiber := New(Config{
+		ErrorHandler: f,
+	})
+	fiber.Get("/", func(c *Ctx) error {
+		return errors.New("something happened")
+	})
+	fiber.Mount("/sub", subfiber)
+
+	app.Mount("/api", fiber)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/api/sub", nil))
+	utils.AssertEqual(t, nil, err, "/api/sub req")
+	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
+
+	b, err := ioutil.ReadAll(resp.Body)
+	utils.AssertEqual(t, nil, err, "iotuil.ReadAll()")
+	utils.AssertEqual(t, "hi, i'm a custom sub fiber error", string(b), "Response body")
+
+	resp2, err := app.Test(httptest.NewRequest(MethodGet, "/api/sub/third", nil))
+	utils.AssertEqual(t, nil, err, "/api/sub/third req")
+	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
+
+	b, err = ioutil.ReadAll(resp2.Body)
+	utils.AssertEqual(t, nil, err, "iotuil.ReadAll()")
+	utils.AssertEqual(t, "hi, i'm a custom sub sub fiber error", string(b), "Third fiber Response body")
+}

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -145,7 +145,7 @@ func New(config ...Config) fiber.Handler {
 				}
 			}
 			// override error handler
-			errHandler = c.App().Config().ErrorHandler
+			errHandler = c.App().ErrorHandler
 		})
 
 		var start, stop time.Time

--- a/router.go
+++ b/router.go
@@ -154,7 +154,7 @@ func (app *App) handler(rctx *fasthttp.RequestCtx) {
 	// Find match in stack
 	match, err := app.next(c)
 	if err != nil {
-		if catch := c.app.config.ErrorHandler(c, err); catch != nil {
+		if catch := c.app.ErrorHandler(c, err); catch != nil {
 			_ = c.SendStatus(StatusInternalServerError)
 		}
 	}


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Closes https://github.com/gofiber/fiber/issues/1438

**Explain the *details* for making this change. What existing problem does the pull request solve?**

- Mounted fiber and its sub-apps error handlers are now saved in a new `App.errorHandlers` map
- New public `App.ErrorHandler` method that wraps the logic for which error handler to use on any given context
- Error handler match logic based on request path <=> prefix accuracy
- Typo fixes
- Tests

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 

✨ 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/