### PR TITLE
🐛 fiber v2.20.0 darwin bug fix to load_darwin.go

### DIFF
--- a/internal/gopsutil/load/load_darwin.go
+++ b/internal/gopsutil/load/load_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package load
@@ -8,8 +9,11 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/gofiber/fiber/v2/internal/gopsutil/common"
 	"golang.org/x/sys/unix"
 )
+
+var invoke common.Invoker = common.Invoke{}
 
 func Avg() (*AvgStat, error) {
 	return AvgWithContext(context.Background())


### PR DESCRIPTION
v2.20.0 ``github.com/gofiber/fiber/v2/internal/gopsutil/load
../go/pkg/mod/github.com/gofiber/fiber/v2@v2.20.0/internal/gopsutil/load/load_darwin.go:54:14: undefined: invoke``

fix so it works on darwin
