### PR TITLE
chore(docs): fix example encoding issue in READMD.md of logger middle…

### DIFF
--- a/middleware/logger/README.md
+++ b/middleware/logger/README.md
@@ -47,9 +47,9 @@ app.Use(logger.New(logger.Config{
 ```go
 app.Use(requestid.New())
 
-​app​.​Use​(​logger​.​New​(logger.​Config​{
+app.Use(logger.New(logger.Config{
 	// For more options, see the Config section
-  Format​: "${pid} ${locals:requestid} ${status} - ${method} ${path}​\n​"​,
+	Format: "${pid} ${locals:requestid} ${status} - ${method} ${path}​\n",
 }))
 ```
 


### PR DESCRIPTION
When I copied `Logging Request ID` example to my host for testing
I found that it has some errors about UTF8 encoding
And error message like below:

```
# command-line-arguments
./main.go:16:2: invalid character U+200B in identifier
./main.go:16:45: cannot refer to unexported name logger.​Config​
./main.go:18:9: invalid character U+200B in identifier
./main.go:18:80: syntax error: unexpected ​, expecting comma or }
```

Then I tried to use UTF8 GBK encoding
And got the result like below:

```
鈥媋pp鈥�.鈥婾se鈥�(鈥媗ogger鈥�.鈥婲ew鈥�(logger.鈥婥onfig鈥媨
	// For more options, see the Config section
  Format鈥�: "${pid} ${locals:requestid} ${status} - ${method} ${path}鈥媆n鈥�"鈥�,
}))
```

So, I fixed it.