### PR TITLE
:sparkles: feat: add sliding window as option for limiter middleware

### DIFF
--- a/middleware/limiter/config.go
+++ b/middleware/limiter/config.go
@@ -53,6 +53,11 @@ type Config struct {
 	// Default: an in memory store for this process only
 	Storage fiber.Storage
 
+	// LimiterMiddleware is the struct that implements a limiter middleware.
+	//
+	// Default: a new Fixed Window Rate Limiter
+	LimiterMiddleware LimiterHandler
+
 	// DEPRECATED: Use Expiration instead
 	Duration time.Duration
 
@@ -75,6 +80,7 @@ var ConfigDefault = Config{
 	},
 	SkipFailedRequests:     false,
 	SkipSuccessfulRequests: false,
+	LimiterMiddleware:      FixedWindow{},
 }
 
 // Helper function to set default values
@@ -114,6 +120,9 @@ func configDefault(config ...Config) Config {
 	}
 	if cfg.LimitReached == nil {
 		cfg.LimitReached = ConfigDefault.LimitReached
+	}
+	if cfg.LimiterMiddleware == nil {
+		cfg.LimiterMiddleware = ConfigDefault.LimiterMiddleware
 	}
 	return cfg
 }

--- a/middleware/limiter/limited_fixed.go
+++ b/middleware/limiter/limited_fixed.go
@@ -1,0 +1,109 @@
+package limiter
+
+import (
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type FixedWindow struct{}
+
+// New creates a new fixed window middleware handler
+func (FixedWindow) New(cfg Config) fiber.Handler {
+	var (
+		// Limiter variables
+		mux        = &sync.RWMutex{}
+		max        = strconv.Itoa(cfg.Max)
+		timestamp  = uint64(time.Now().Unix())
+		expiration = uint64(cfg.Expiration.Seconds())
+	)
+
+	// Create manager to simplify storage operations ( see manager.go )
+	manager := newManager(cfg.Storage)
+
+	// Update timestamp every second
+	go func() {
+		for {
+			atomic.StoreUint64(&timestamp, uint64(time.Now().Unix()))
+			time.Sleep(1 * time.Second)
+		}
+	}()
+
+	// Return new handler
+	return func(c *fiber.Ctx) error {
+		// Don't execute middleware if Next returns true
+		if cfg.Next != nil && cfg.Next(c) {
+			return c.Next()
+		}
+
+		// Get key from request
+		key := cfg.KeyGenerator(c)
+
+		// Lock entry
+		mux.Lock()
+
+		// Get entry from pool and release when finished
+		e := manager.get(key)
+
+		// Get timestamp
+		ts := atomic.LoadUint64(&timestamp)
+
+		// Set expiration if entry does not exist
+		if e.exp == 0 {
+			e.exp = ts + expiration
+
+		} else if ts >= e.exp {
+			// Check if entry is expired
+			e.currHits = 0
+			e.exp = ts + expiration
+		}
+
+		// Increment hits
+		e.currHits++
+
+		// Calculate when it resets in seconds
+		expire := e.exp - ts
+
+		// Set how many hits we have left
+		remaining := cfg.Max - e.currHits
+
+		// Update storage
+		manager.set(key, e, cfg.Expiration)
+
+		// Unlock entry
+		mux.Unlock()
+
+		// Check if hits exceed the cfg.Max
+		if remaining < 0 {
+			// Return response with Retry-After header
+			// https://tools.ietf.org/html/rfc6584
+			c.Set(fiber.HeaderRetryAfter, strconv.FormatUint(expire, 10))
+
+			// Call LimitReached handler
+			return cfg.LimitReached(c)
+		}
+
+		// Continue stack for reaching c.Response().StatusCode()
+		// Store err for returning
+		err := c.Next()
+
+		// Check for SkipFailedRequests and SkipSuccessfulRequests
+		if (cfg.SkipSuccessfulRequests && c.Response().StatusCode() < fiber.StatusBadRequest) ||
+			(cfg.SkipFailedRequests && c.Response().StatusCode() >= fiber.StatusBadRequest) {
+			mux.Lock()
+			e.currHits--
+			remaining++
+			mux.Unlock()
+		}
+
+		// We can continue, update RateLimit headers
+		c.Set(xRateLimitLimit, max)
+		c.Set(xRateLimitRemaining, strconv.Itoa(remaining))
+		c.Set(xRateLimitReset, strconv.FormatUint(expire, 10))
+
+		return err
+	}
+}

--- a/middleware/limiter/limited_sliding.go
+++ b/middleware/limiter/limited_sliding.go
@@ -1,0 +1,139 @@
+package limiter
+
+import (
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type SlidingWindow struct{}
+
+// New creates a new sliding window middleware handler
+func (SlidingWindow) New(cfg Config) fiber.Handler {
+	var (
+		// Limiter variables
+		mux        = &sync.RWMutex{}
+		max        = strconv.Itoa(cfg.Max)
+		timestamp  = uint64(time.Now().Unix())
+		expiration = uint64(cfg.Expiration.Seconds())
+	)
+
+	// Create manager to simplify storage operations ( see manager.go )
+	manager := newManager(cfg.Storage)
+
+	// Update timestamp every second
+	go func() {
+		for {
+			atomic.StoreUint64(&timestamp, uint64(time.Now().Unix()))
+			time.Sleep(1 * time.Second)
+		}
+	}()
+
+	// Return new handler
+	return func(c *fiber.Ctx) error {
+		// Don't execute middleware if Next returns true
+		if cfg.Next != nil && cfg.Next(c) {
+			return c.Next()
+		}
+
+		// Get key from request
+		key := cfg.KeyGenerator(c)
+
+		// Lock entry
+		mux.Lock()
+
+		// Get entry from pool and release when finished
+		e := manager.get(key)
+
+		// Get timestamp
+		ts := atomic.LoadUint64(&timestamp)
+
+		// Set expiration if entry does not exist
+		if e.exp == 0 {
+			e.exp = ts + expiration
+
+		} else if ts >= e.exp {
+			// The entry has expired, handle the expiration.
+			// Set the prevHits to the current hits and reset the hits to 0.
+			e.prevHits = e.currHits
+
+			// Reset the current hits to 0.
+			e.currHits = 0
+
+			// Check how much into the current window it currently is and sets the
+			// expiry based on that, otherwise this would only reset on
+			// the next request and not show the correct expiry.
+			elapsed := ts - e.exp
+			if elapsed >= expiration {
+				e.exp = ts + expiration
+			} else {
+				e.exp = ts + expiration - elapsed
+			}
+		}
+
+		// Increment hits
+		e.currHits++
+
+		// Calculate when it resets in seconds
+		expire := e.exp - ts
+
+		// weight = time until current window reset / total window length
+		weight := float64(expire) / float64(expiration)
+
+		// rate = request count in previous window - weight + request count in current window
+		rate := int(float64(e.prevHits)*weight) + e.currHits
+
+		// Calculate how many hits can be made based on the current rate
+		remaining := cfg.Max - rate
+
+		// Update storage. Garbage collect when the next window ends.
+		// |-------------------------|-------------------------|
+		//               ^           ^              ^          ^
+		//              ts        e.exp  End sample window   End next window
+		//               <----------->
+		// 				    expire
+		// expire = e.exp - ts - time until end of current window.
+		// duration + expiration = end of next window.
+		// Because we don't want to garbage collect in the middle of a window
+		// we add the expiration to the duration.
+		// Otherwise after the end of "sample window", attackers could launch
+		// a new request with the full window length.
+		manager.set(key, e, time.Duration(expire+expiration)*time.Second)
+
+		// Unlock entry
+		mux.Unlock()
+
+		// Check if hits exceed the cfg.Max
+		if remaining < 0 {
+			// Return response with Retry-After header
+			// https://tools.ietf.org/html/rfc6584
+			c.Set(fiber.HeaderRetryAfter, strconv.FormatUint(expire, 10))
+
+			// Call LimitReached handler
+			return cfg.LimitReached(c)
+		}
+
+		// Continue stack for reaching c.Response().StatusCode()
+		// Store err for returning
+		err := c.Next()
+
+		// Check for SkipFailedRequests and SkipSuccessfulRequests
+		if (cfg.SkipSuccessfulRequests && c.Response().StatusCode() < fiber.StatusBadRequest) ||
+			(cfg.SkipFailedRequests && c.Response().StatusCode() >= fiber.StatusBadRequest) {
+			mux.Lock()
+			e.currHits--
+			remaining++
+			mux.Unlock()
+		}
+
+		// We can continue, update RateLimit headers
+		c.Set(xRateLimitLimit, max)
+		c.Set(xRateLimitRemaining, strconv.Itoa(remaining))
+		c.Set(xRateLimitReset, strconv.FormatUint(expire, 10))
+
+		return err
+	}
+}

--- a/middleware/limiter/limiter.go
+++ b/middleware/limiter/limiter.go
@@ -1,120 +1,25 @@
 package limiter
 
 import (
-	"strconv"
-	"sync"
-	"sync/atomic"
-	"time"
-
 	"github.com/gofiber/fiber/v2"
 )
 
 const (
-	// Storage ErrNotExist
-	errNotExist = "key does not exist"
-
 	// X-RateLimit-* headers
 	xRateLimitLimit     = "X-RateLimit-Limit"
 	xRateLimitRemaining = "X-RateLimit-Remaining"
 	xRateLimitReset     = "X-RateLimit-Reset"
 )
 
+type LimiterHandler interface {
+	New(config Config) fiber.Handler
+}
+
 // New creates a new middleware handler
 func New(config ...Config) fiber.Handler {
 	// Set default config
 	cfg := configDefault(config...)
 
-	var (
-		// Limiter variables
-		mux        = &sync.RWMutex{}
-		max        = strconv.Itoa(cfg.Max)
-		timestamp  = uint64(time.Now().Unix())
-		expiration = uint64(cfg.Expiration.Seconds())
-	)
-
-	// Create manager to simplify storage operations ( see manager.go )
-	manager := newManager(cfg.Storage)
-
-	// Update timestamp every second
-	go func() {
-		for {
-			atomic.StoreUint64(&timestamp, uint64(time.Now().Unix()))
-			time.Sleep(1 * time.Second)
-		}
-	}()
-
-	// Return new handler
-	return func(c *fiber.Ctx) error {
-		// Don't execute middleware if Next returns true
-		if cfg.Next != nil && cfg.Next(c) {
-			return c.Next()
-		}
-
-		// Get key from request
-		key := cfg.KeyGenerator(c)
-
-		// Lock entry
-		mux.Lock()
-
-		// Get entry from pool and release when finished
-		e := manager.get(key)
-
-		// Get timestamp
-		ts := atomic.LoadUint64(&timestamp)
-
-		// Set expiration if entry does not exist
-		if e.exp == 0 {
-			e.exp = ts + expiration
-
-		} else if ts >= e.exp {
-			// Check if entry is expired
-			e.hits = 0
-			e.exp = ts + expiration
-		}
-
-		// Increment hits
-		e.hits++
-
-		// Calculate when it resets in seconds
-		expire := e.exp - ts
-
-		// Set how many hits we have left
-		remaining := cfg.Max - e.hits
-
-		// Update storage
-		manager.set(key, e, cfg.Expiration)
-
-		// Unlock entry
-		mux.Unlock()
-
-		// Check if hits exceed the cfg.Max
-		if remaining < 0 {
-			// Return response with Retry-After header
-			// https://tools.ietf.org/html/rfc6584
-			c.Set(fiber.HeaderRetryAfter, strconv.FormatUint(expire, 10))
-
-			// Call LimitReached handler
-			return cfg.LimitReached(c)
-		}
-
-		// Continue stack for reaching c.Response().StatusCode()
-		// Store err for returning
-		err := c.Next()
-
-		// Check for SkipFailedRequests and SkipSuccessfulRequests
-		if (cfg.SkipSuccessfulRequests && c.Response().StatusCode() < fiber.StatusBadRequest) ||
-			(cfg.SkipFailedRequests && c.Response().StatusCode() >= fiber.StatusBadRequest) {
-			mux.Lock()
-			e.hits--
-			remaining++
-			mux.Unlock()
-		}
-
-		// We can continue, update RateLimit headers
-		c.Set(xRateLimitLimit, max)
-		c.Set(xRateLimitRemaining, strconv.Itoa(remaining))
-		c.Set(xRateLimitReset, strconv.FormatUint(expire, 10))
-
-		return err
-	}
+	// Return the specified middleware handler.
+	return cfg.LimiterMiddleware.New(cfg)
 }

--- a/middleware/limiter/limiter_test.go
+++ b/middleware/limiter/limiter_test.go
@@ -311,3 +311,125 @@ func Benchmark_Limiter(b *testing.B) {
 		h(fctx)
 	}
 }
+
+// go test -run Test_Limiter_Cheat -race -v
+// Attempt to cheat the rate limiter by waiting until the window ends and sending more requests
+func Test_Limiter_Cheat(t *testing.T) {
+	app := fiber.New()
+	app.Use(New(Config{
+		Max:               10,
+		Expiration:        4 * time.Second,
+		Storage:           memory.New(),
+		LimiterMiddleware: SlidingWindow{},
+	}))
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("Hello tester!")
+	})
+
+	var wg sync.WaitGroup
+	singleRequest := func(wg *sync.WaitGroup, shouldFail bool) {
+		if wg != nil {
+			defer wg.Done()
+		}
+		resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/", nil))
+		if shouldFail {
+			utils.AssertEqual(t, nil, err)
+			utils.AssertEqual(t, 429, resp.StatusCode)
+		} else {
+			utils.AssertEqual(t, nil, err)
+			utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
+		}
+	}
+
+	t1 := time.Now()
+	singleRequest(nil, false)           // one request to start our window
+	time.Sleep(1000 * time.Millisecond) // Wait to make sure we are well into the current window
+
+	// Send requests
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go singleRequest(&wg, false)
+	}
+
+	wg.Wait()
+
+	// wait until the current window is finished and we are into the next window
+	t2 := time.Until(t1.Add(time.Millisecond * 5250))
+	time.Sleep(t2)
+
+	// Send more requests
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go singleRequest(&wg, false)
+	}
+	wg.Wait()
+
+	// these should fail
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go singleRequest(&wg, true)
+	}
+
+	wg.Wait()
+
+	time.Sleep(8 * time.Second) // wait 2 windows to ensure our rate has
+	// Verify that we are able to send requests again
+	for i := 0; i < 9; i++ {
+		wg.Add(1)
+		go singleRequest(&wg, false)
+	}
+	wg.Wait()
+}
+
+// go test -run Test_Sliding_Window -race -v
+func Test_Sliding_Window(t *testing.T) {
+	app := fiber.New()
+	app.Use(New(Config{
+		Max:               10,
+		Expiration:        2 * time.Second,
+		Storage:           memory.New(),
+		LimiterMiddleware: SlidingWindow{},
+	}))
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("Hello tester!")
+	})
+
+	//var wg sync.WaitGroup
+	singleRequest := func(wg *sync.WaitGroup, shouldFail bool) {
+		if wg != nil {
+			defer wg.Done()
+		}
+		resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/", nil))
+		if shouldFail {
+			utils.AssertEqual(t, nil, err)
+			utils.AssertEqual(t, 429, resp.StatusCode)
+		} else {
+			utils.AssertEqual(t, nil, err)
+			utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
+		}
+	}
+
+	for i := 0; i < 5; i++ {
+		singleRequest(nil, false)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	for i := 0; i < 5; i++ {
+		singleRequest(nil, false)
+	}
+
+	time.Sleep(3 * time.Second)
+
+	for i := 0; i < 5; i++ {
+		singleRequest(nil, false)
+	}
+
+	time.Sleep(4 * time.Second)
+
+	for i := 0; i < 9; i++ {
+		singleRequest(nil, false)
+	}
+}

--- a/middleware/limiter/manager.go
+++ b/middleware/limiter/manager.go
@@ -13,8 +13,9 @@ import (
 // don't forget to replace the msgp import path to:
 // "github.com/gofiber/fiber/v2/internal/msgp"
 type item struct {
-	hits int
-	exp  uint64
+	currHits int
+	prevHits int
+	exp      uint64
 }
 
 //msgp:ignore manager
@@ -50,7 +51,8 @@ func (m *manager) acquire() *item {
 
 // release and reset *entry to sync.Pool
 func (m *manager) release(e *item) {
-	e.hits = 0
+	e.prevHits = 0
+	e.currHits = 0
 	e.exp = 0
 	m.pool.Put(e)
 }

--- a/middleware/limiter/manager_msgp.go
+++ b/middleware/limiter/manager_msgp.go
@@ -24,10 +24,16 @@ func (z *item) DecodeMsg(dc *msgp.Reader) (err error) {
 			return
 		}
 		switch msgp.UnsafeString(field) {
-		case "hits":
-			z.hits, err = dc.ReadInt()
+		case "currHits":
+			z.currHits, err = dc.ReadInt()
 			if err != nil {
-				err = msgp.WrapError(err, "hits")
+				err = msgp.WrapError(err, "currHits")
+				return
+			}
+		case "prevHits":
+			z.prevHits, err = dc.ReadInt()
+			if err != nil {
+				err = msgp.WrapError(err, "prevHits")
 				return
 			}
 		case "exp":
@@ -49,15 +55,25 @@ func (z *item) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z item) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 2
-	// write "hits"
-	err = en.Append(0x82, 0xa4, 0x68, 0x69, 0x74, 0x73)
+	// map header, size 3
+	// write "currHits"
+	err = en.Append(0x83, 0xa8, 0x63, 0x75, 0x72, 0x72, 0x48, 0x69, 0x74, 0x73)
 	if err != nil {
 		return
 	}
-	err = en.WriteInt(z.hits)
+	err = en.WriteInt(z.currHits)
 	if err != nil {
-		err = msgp.WrapError(err, "hits")
+		err = msgp.WrapError(err, "currHits")
+		return
+	}
+	// write "prevHits"
+	err = en.Append(0xa8, 0x70, 0x72, 0x65, 0x76, 0x48, 0x69, 0x74, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt(z.prevHits)
+	if err != nil {
+		err = msgp.WrapError(err, "prevHits")
 		return
 	}
 	// write "exp"
@@ -76,10 +92,13 @@ func (z item) EncodeMsg(en *msgp.Writer) (err error) {
 // MarshalMsg implements msgp.Marshaler
 func (z item) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 2
-	// string "hits"
-	o = append(o, 0x82, 0xa4, 0x68, 0x69, 0x74, 0x73)
-	o = msgp.AppendInt(o, z.hits)
+	// map header, size 3
+	// string "currHits"
+	o = append(o, 0x83, 0xa8, 0x63, 0x75, 0x72, 0x72, 0x48, 0x69, 0x74, 0x73)
+	o = msgp.AppendInt(o, z.currHits)
+	// string "prevHits"
+	o = append(o, 0xa8, 0x70, 0x72, 0x65, 0x76, 0x48, 0x69, 0x74, 0x73)
+	o = msgp.AppendInt(o, z.prevHits)
 	// string "exp"
 	o = append(o, 0xa3, 0x65, 0x78, 0x70)
 	o = msgp.AppendUint64(o, z.exp)
@@ -104,10 +123,16 @@ func (z *item) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			return
 		}
 		switch msgp.UnsafeString(field) {
-		case "hits":
-			z.hits, bts, err = msgp.ReadIntBytes(bts)
+		case "currHits":
+			z.currHits, bts, err = msgp.ReadIntBytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "hits")
+				err = msgp.WrapError(err, "currHits")
+				return
+			}
+		case "prevHits":
+			z.prevHits, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "prevHits")
 				return
 			}
 		case "exp":
@@ -130,6 +155,6 @@ func (z *item) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z item) Msgsize() (s int) {
-	s = 1 + 5 + msgp.IntSize + 4 + msgp.Uint64Size
+	s = 1 + 9 + msgp.IntSize + 9 + msgp.IntSize + 4 + msgp.Uint64Size
 	return
 }


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Add the options to use your own Limiter middleware(should become more modular over time to only have a subset of the limiter be handled by a extern function).

**Explain the *details* for making this change. What existing problem does the pull request solve?**

Sliding window algorithm offers significant improvement over the fixed window algorithm and has very little overhead for this gain. Fixed window makes it possible for an API consumer to wait for a reset window and then send more requests, cheating the allowed limit.

- Stolen from #1247