### PR TITLE
:pencil2: Cache Middleware - Fix comment

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -48,7 +48,7 @@ func New(config ...Config) fiber.Handler {
 	// Create manager to simplify storage operations ( see manager.go )
 	manager := newManager(cfg.Storage)
 
-	// Update timestamp every second
+	// Update timestamp in the configured interval
 	go func() {
 		for {
 			atomic.StoreUint64(&timestamp, uint64(time.Now().Unix()))


### PR DESCRIPTION
When merging #1310, the corresponding adaptation of a code comment appears to have gone forgotten.