### PR TITLE
🐛 Session Id immutable

### DIFF
--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -94,7 +94,7 @@ func (s *Store) Get(c *fiber.Ctx) (*Session, error) {
 func (s *Store) getSessionID(c *fiber.Ctx) string {
 	id := c.Cookies(s.sessionName)
 	if len(id) > 0 {
-		return id
+		return utils.CopyString(id)
 	}
 
 	if s.source == SourceHeader {
@@ -107,7 +107,7 @@ func (s *Store) getSessionID(c *fiber.Ctx) string {
 	if s.source == SourceURLQuery {
 		id = c.Query(s.sessionName)
 		if len(id) > 0 {
-			return id
+			return utils.CopyString(id)
 		}
 	}
 
@@ -130,7 +130,7 @@ func (s *Store) responseCookies(c *fiber.Ctx) (string, error) {
 
 	value := make([]byte, len(cookie.Value()))
 	copy(value, cookie.Value())
-	id := utils.UnsafeString(value)
+	id := string(value)
 	return id, nil
 }
 


### PR DESCRIPTION
Close #1585

**BEFORE**
Benchmark_Session
Benchmark_Session/default
Benchmark_Session/default-12         	   58699	     19251 ns/op	    8310 B/op	     206 allocs/op
Benchmark_Session/storage
Benchmark_Session/storage-12         	   62386	     18758 ns/op	    8310 B/op	     206 allocs/op

**AFTER**
Benchmark_Session
Benchmark_Session/default
Benchmark_Session/default-12         	   52838	     19424 ns/op	    8326 B/op	     207 allocs/op
Benchmark_Session/storage
Benchmark_Session/storage-12         	   58928	     18991 ns/op	    8327 B/op	     207 allocs/op

a bit slower but error free