### PR TITLE
Recover middleware: Added, fiber.Ctx as a first paremeter to StackTra…

### DIFF
--- a/middleware/recover/README.md
+++ b/middleware/recover/README.md
@@ -50,7 +50,7 @@ type Config struct {
 	// StackTraceHandler defines a function to handle stack trace
 	//
 	// Optional. Default: defaultStackTraceHandler
-	StackTraceHandler func(e interface{})
+	StackTraceHandler func(c *fiber.Ctx, e interface{})
 }
 ```
 

--- a/middleware/recover/config.go
+++ b/middleware/recover/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	// StackTraceHandler defines a function to handle stack trace
 	//
 	// Optional. Default: defaultStackTraceHandler
-	StackTraceHandler func(e interface{})
+	StackTraceHandler func(c *fiber.Ctx, e interface{})
 }
 
 var defaultStackTraceBufLen = 1024

--- a/middleware/recover/recover.go
+++ b/middleware/recover/recover.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-func defaultStackTraceHandler(e interface{}) {
+func defaultStackTraceHandler(c *fiber.Ctx, e interface{}) {
 	buf := make([]byte, defaultStackTraceBufLen)
 	buf = buf[:runtime.Stack(buf, false)]
 	_, _ = os.Stderr.WriteString(fmt.Sprintf("panic: %v\n%s\n", e, buf))
@@ -30,7 +30,7 @@ func New(config ...Config) fiber.Handler {
 		defer func() {
 			if r := recover(); r != nil {
 				if cfg.EnableStackTrace {
-					cfg.StackTraceHandler(r)
+					cfg.StackTraceHandler(c, r)
 				}
 
 				var ok bool


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Added, fiber.Ctx as a first paremeter of the recover middleware StackTraceHandler.

**Explain the *details* for making this change. What existing problem does the pull request solve?**

Adding a fiber.Ctx as a parameter of StackTraceHandler function allow us to set stack trace string to c.Locals(). So, we will be able to log the stack trace on the ErrorHandler instead of putting that log twice for the stack trace.
