### PR TITLE
fix(middleware/csrf): CookieSameSite default "Lax"

### DIFF
--- a/middleware/csrf/README.md
+++ b/middleware/csrf/README.md
@@ -46,7 +46,7 @@ app.Use(csrf.New()) // Default config
 app.Use(csrf.New(csrf.Config{
 	KeyLookup:      "header:X-Csrf-Token",
 	CookieName:     "csrf_",
-	CookieSameSite: "Strict",
+	CookieSameSite: "Lax",
 	Expiration:     1 * time.Hour,
 	KeyGenerator:   utils.UUID,
 }))
@@ -106,7 +106,7 @@ type Config struct {
 	CookieHTTPOnly bool
 
 	// Indicates if CSRF cookie is requested by SameSite.
-	// Optional. Default value "Strict".
+	// Optional. Default value "Lax".
 	CookieSameSite string
 
 	// Expiration is the duration before csrf token will expire
@@ -138,7 +138,7 @@ type Config struct {
 var ConfigDefault = Config{
 	KeyLookup:      "header:X-Csrf-Token",
 	CookieName:     "csrf_",
-	CookieSameSite: "Strict",
+	CookieSameSite: "Lax",
 	Expiration:     1 * time.Hour,
 	KeyGenerator:   utils.UUID,
 }

--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	CookieHTTPOnly bool
 
 	// Value of SameSite cookie.
-	// Optional. Default value "Strict".
+	// Optional. Default value "Lax".
 	CookieSameSite string
 
 	// Expiration is the duration before csrf token will expire
@@ -96,7 +96,7 @@ type Config struct {
 var ConfigDefault = Config{
 	KeyLookup:      "header:X-Csrf-Token",
 	CookieName:     "csrf_",
-	CookieSameSite: "Strict",
+	CookieSameSite: "Lax",
 	Expiration:     1 * time.Hour,
 	KeyGenerator:   utils.UUID,
 	ErrorHandler:   defaultErrorHandler,


### PR DESCRIPTION
Default is "Strict", it should be "Lax"

Browser defaults are Lax. Fiber using a default of "Strict" is unadvisable as it will cause unexpected behavior. Strict requires HTTP first-party context and disregards requests initiated by third parties. So after navigating to the site from a third party site the safe HTTP methods (GET, HEAD, or OPTIONS) will not set the cookie. For example, a login page would not work by default when navigating to it from google or any other non-first party link.

"With Strict, the cookie is only sent to the site where it originated. Lax is similar, except that cookies are sent when the user navigates to the cookie's origin site. For example, by following a link from an external site. None specifies that cookies are sent on both originating and cross-site requests, but only in secure contexts (i.e., if SameSite=None then the Secure attribute must also be set). If no SameSite attribute is set, the cookie is treated as Lax."

https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#samesite_attribute

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite

The behaviour the team likely sought to prevent is SameSite=None, which blocks cookie set on cross-origin requests.

This PR closes #1639 