### PR TITLE
Improvements for logger middleware

### DIFF
--- a/middleware/logger/config.go
+++ b/middleware/logger/config.go
@@ -38,7 +38,7 @@ type Config struct {
 
 	// Output is a writter where logs are written
 	//
-	// Default: os.Stderr
+	// Default: os.Stdout
 	Output io.Writer
 
 	enableColors     bool
@@ -53,7 +53,7 @@ var ConfigDefault = Config{
 	TimeFormat:   "15:04:05",
 	TimeZone:     "Local",
 	TimeInterval: 500 * time.Millisecond,
-	Output:       os.Stderr,
+	Output:       os.Stdout,
 	enableColors: true,
 }
 

--- a/middleware/logger/config.go
+++ b/middleware/logger/config.go
@@ -64,11 +64,11 @@ func validCustomFormat(format string) bool {
 		return true
 	}
 	for _, template := range validTemplates {
-		if !strings.Contains(format, template) {
-			return false
+		if strings.Contains(format, template) {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 // Helper function to set default values

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -118,9 +118,9 @@ func New(config ...Config) fiber.Handler {
 
 	// If colors are enabled, check terminal compatibility
 	if cfg.enableColors {
-		cfg.Output = colorable.NewColorableStderr()
-		if os.Getenv("TERM") == "dumb" || os.Getenv("NO_COLOR") == "1" || (!isatty.IsTerminal(os.Stderr.Fd()) && !isatty.IsCygwinTerminal(os.Stderr.Fd())) {
-			cfg.Output = colorable.NewNonColorable(os.Stderr)
+		cfg.Output = colorable.NewColorableStdout()
+		if os.Getenv("TERM") == "dumb" || os.Getenv("NO_COLOR") == "1" || (!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd())) {
+			cfg.Output = colorable.NewNonColorable(os.Stdout)
 		}
 	}
 	errPadding := 15

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -119,7 +119,7 @@ func New(config ...Config) fiber.Handler {
 	// If colors are enabled, check terminal compatibility
 	if cfg.enableColors {
 		cfg.Output = colorable.NewColorableStderr()
-		if os.Getenv("TERM") == "dumb" || (!isatty.IsTerminal(os.Stderr.Fd()) && !isatty.IsCygwinTerminal(os.Stderr.Fd())) {
+		if os.Getenv("TERM") == "dumb" || os.Getenv("NO_COLOR") == "1" || (!isatty.IsTerminal(os.Stderr.Fd()) && !isatty.IsCygwinTerminal(os.Stderr.Fd())) {
 			cfg.Output = colorable.NewNonColorable(os.Stderr)
 		}
 	}

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -174,7 +174,7 @@ func New(config ...Config) fiber.Handler {
 		buf := bytebufferpool.Get()
 
 		// Default output when no custom Format or io.Writer is given
-		if cfg.enableColors {
+		if cfg.enableColors && cfg.Format == ConfigDefault.Format {
 			// Format error if exist
 			formatErr := ""
 			if chainErr != nil {
@@ -238,13 +238,13 @@ func New(config ...Config) fiber.Handler {
 			case TagRoute:
 				return buf.WriteString(c.Route().Path)
 			case TagStatus:
-				return appendInt(buf, c.Response().StatusCode())
+				return buf.WriteString(fmt.Sprintf("%s %3d %s", statusColor(c.Response().StatusCode(), cfg), c.Response().StatusCode(), cReset))
 			case TagResBody:
 				return buf.Write(c.Response().Body())
 			case TagQueryStringParams:
 				return buf.WriteString(c.Request().URI().QueryArgs().String())
 			case TagMethod:
-				return buf.WriteString(c.Method())
+				return buf.WriteString(fmt.Sprintf("%s %-7s %s", methodColor(c.Method(), cfg), c.Method(), cReset))
 			case TagBlack:
 				return buf.WriteString(cBlack)
 			case TagRed:

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -238,13 +238,19 @@ func New(config ...Config) fiber.Handler {
 			case TagRoute:
 				return buf.WriteString(c.Route().Path)
 			case TagStatus:
-				return buf.WriteString(fmt.Sprintf("%s %3d %s", statusColor(c.Response().StatusCode(), cfg), c.Response().StatusCode(), cReset))
+				if cfg.enableColors {
+					return buf.WriteString(fmt.Sprintf("%s %3d %s", statusColor(c.Response().StatusCode()), c.Response().StatusCode(), cReset))
+				}
+				return appendInt(buf, c.Response().StatusCode())
 			case TagResBody:
 				return buf.Write(c.Response().Body())
 			case TagQueryStringParams:
 				return buf.WriteString(c.Request().URI().QueryArgs().String())
 			case TagMethod:
-				return buf.WriteString(fmt.Sprintf("%s %-7s %s", methodColor(c.Method(), cfg), c.Method(), cReset))
+				if cfg.enableColors {
+					return buf.WriteString(fmt.Sprintf("%s %-7s %s", methodColor(c.Method()), c.Method(), cReset))
+				}
+				return buf.WriteString(c.Method())
 			case TagBlack:
 				return buf.WriteString(cBlack)
 			case TagRed:

--- a/middleware/logger/utils.go
+++ b/middleware/logger/utils.go
@@ -4,43 +4,29 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-func methodColor(method string, config ...Config) string {
-	cfg := ConfigDefault
-	if len(config) >= 1 {
-		cfg = config[0]
-	}
-
-	switch {
-	case !cfg.enableColors:
-		return ""
-	case method == fiber.MethodGet:
+func methodColor(method string) string {
+	switch method {
+	case fiber.MethodGet:
 		return cCyan
-	case method == fiber.MethodPost:
+	case fiber.MethodPost:
 		return cGreen
-	case method == fiber.MethodPut:
+	case fiber.MethodPut:
 		return cYellow
-	case method == fiber.MethodDelete:
+	case fiber.MethodDelete:
 		return cRed
-	case method == fiber.MethodPatch:
+	case fiber.MethodPatch:
 		return cWhite
-	case method == fiber.MethodHead:
+	case fiber.MethodHead:
 		return cMagenta
-	case method == fiber.MethodOptions:
+	case fiber.MethodOptions:
 		return cBlue
 	default:
 		return cReset
 	}
 }
 
-func statusColor(code int, config ...Config) string {
-	cfg := ConfigDefault
-	if len(config) >= 1 {
-		cfg = config[0]
-	}
-
+func statusColor(code int) string {
 	switch {
-	case !cfg.enableColors:
-		return ""
 	case code >= fiber.StatusOK && code < fiber.StatusMultipleChoices:
 		return cGreen
 	case code >= fiber.StatusMultipleChoices && code < fiber.StatusBadRequest:

--- a/middleware/logger/utils.go
+++ b/middleware/logger/utils.go
@@ -4,29 +4,43 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-func methodColor(method string) string {
-	switch method {
-	case fiber.MethodGet:
+func methodColor(method string, config ...Config) string {
+	cfg := ConfigDefault
+	if len(config) >= 1 {
+		cfg = config[0]
+	}
+
+	switch {
+	case !cfg.enableColors:
+		return ""
+	case method == fiber.MethodGet:
 		return cCyan
-	case fiber.MethodPost:
+	case method == fiber.MethodPost:
 		return cGreen
-	case fiber.MethodPut:
+	case method == fiber.MethodPut:
 		return cYellow
-	case fiber.MethodDelete:
+	case method == fiber.MethodDelete:
 		return cRed
-	case fiber.MethodPatch:
+	case method == fiber.MethodPatch:
 		return cWhite
-	case fiber.MethodHead:
+	case method == fiber.MethodHead:
 		return cMagenta
-	case fiber.MethodOptions:
+	case method == fiber.MethodOptions:
 		return cBlue
 	default:
 		return cReset
 	}
 }
 
-func statusColor(code int) string {
+func statusColor(code int, config ...Config) string {
+	cfg := ConfigDefault
+	if len(config) >= 1 {
+		cfg = config[0]
+	}
+
 	switch {
+	case !cfg.enableColors:
+		return ""
 	case code >= fiber.StatusOK && code < fiber.StatusMultipleChoices:
 		return cGreen
 	case code >= fiber.StatusMultipleChoices && code < fiber.StatusBadRequest:


### PR DESCRIPTION
- Add NO_COLOR compatibility.
- Use /dev/stdout as default output stream. (fixes: https://github.com/gofiber/fiber/issues/1642)
- Fix coloring with custom formats. (fixes: https://github.com/gofiber/fiber/issues/1609)