### PR TITLE
🔧 fix(middleware/csrf): unmatched token returns nil error

### DIFF
--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -7,6 +7,10 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
+var (
+	errTokenNotFound = errors.New("csrf token not found")
+)
+
 // New creates a new middleware handler
 func New(config ...Config) fiber.Handler {
 	// Set default config
@@ -52,8 +56,7 @@ func New(config ...Config) fiber.Handler {
 					HTTPOnly: cfg.CookieHTTPOnly,
 					SameSite: cfg.CookieSameSite,
 				})
-				err = errors.New("csrf token not found")
-				return cfg.ErrorHandler(c, err)
+				return cfg.ErrorHandler(c, errTokenNotFound)
 			}
 		}
 

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -1,6 +1,7 @@
 package csrf
 
 import (
+	"errors"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -51,6 +52,7 @@ func New(config ...Config) fiber.Handler {
 					HTTPOnly: cfg.CookieHTTPOnly,
 					SameSite: cfg.CookieSameSite,
 				})
+				err = errors.New("csrf token not found")
 				return cfg.ErrorHandler(c, err)
 			}
 		}

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -13,7 +13,7 @@ import (
 func Test_CSRF(t *testing.T) {
 	app := fiber.New()
 
-	app.Use(New(Config{}))
+	app.Use(New())
 
 	app.Post("/", func(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusOK)


### PR DESCRIPTION
This PR closes #1666 

when the following is true

``if manager.getRaw(token) == nil ``

err will be nil otherwise it would have returned on line 40.

So we must set the error before calling `cfg.ErrorHandler(c, err)`