### PR TITLE
:bug:fix: rename handlerCount to handlersCount

### DIFF
--- a/app.go
+++ b/app.go
@@ -98,7 +98,7 @@ type App struct {
 	// Amount of registered routes
 	routesCount uint32
 	// Amount of registered handlers
-	handlerCount uint32
+	handlersCount uint32
 	// Ctx pool
 	pool sync.Pool
 	// Fasthttp server
@@ -540,7 +540,7 @@ func (app *App) Mount(prefix string, fiber *App) Router {
 		app.errorHandlers[prefix+mountedPrefixes] = errHandler
 	}
 
-	atomic.AddUint32(&app.handlerCount, fiber.handlerCount)
+	atomic.AddUint32(&app.handlersCount, fiber.handlersCount)
 
 	return app
 }
@@ -800,7 +800,7 @@ func (app *App) Stack() [][]*Route {
 
 // HandlersCount returns the amount of registered handlers.
 func (app *App) HandlersCount() uint32 {
-	return app.handlerCount
+	return app.handlersCount
 }
 
 // Shutdown gracefully shuts down the server without interrupting any active connections.
@@ -1104,7 +1104,7 @@ func (app *App) startupMessage(addr string, tls bool, pids string) {
 			" │ Prefork .%s  PID ....%s │\n"+
 			" └───────────────────────────────────────────────────┘"+
 			cReset,
-		value(strconv.Itoa(int(app.handlerCount)), 14), value(procs, 12),
+		value(strconv.Itoa(int(app.handlersCount)), 14), value(procs, 12),
 		value(isPrefork, 14), value(strconv.Itoa(os.Getpid()), 14),
 	)
 

--- a/app_test.go
+++ b/app_test.go
@@ -300,7 +300,7 @@ func Test_App_Mount(t *testing.T) {
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/john/doe", nil))
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
-	utils.AssertEqual(t, uint32(2), app.handlerCount)
+	utils.AssertEqual(t, uint32(2), app.handlersCount)
 }
 
 func Test_App_Use_Params(t *testing.T) {
@@ -931,7 +931,7 @@ func Test_App_Group_Mount(t *testing.T) {
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/v1/john/doe", nil))
 	utils.AssertEqual(t, nil, err, "app.Test(req)")
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
-	utils.AssertEqual(t, uint32(2), app.handlerCount)
+	utils.AssertEqual(t, uint32(2), app.handlersCount)
 }
 
 func Test_App_Group(t *testing.T) {

--- a/group.go
+++ b/group.go
@@ -41,7 +41,7 @@ func (grp *Group) Mount(prefix string, fiber *App) Router {
 		grp.app.errorHandlers[groupPath+mountedPrefixes] = errHandler
 	}
 
-	atomic.AddUint32(&grp.app.handlerCount, fiber.handlerCount)
+	atomic.AddUint32(&grp.app.handlersCount, fiber.handlersCount)
 
 	return grp
 }

--- a/router.go
+++ b/router.go
@@ -266,7 +266,7 @@ func (app *App) register(method, pathRaw string, handlers ...Handler) Router {
 		Handlers: handlers,
 	}
 	// Increment global handler count
-	atomic.AddUint32(&app.handlerCount, uint32(len(handlers)))
+	atomic.AddUint32(&app.handlersCount, uint32(len(handlers)))
 
 	// Middleware route matches all HTTP methods
 	if isUse {
@@ -403,7 +403,7 @@ func (app *App) registerStatic(prefix, root string, config ...Static) Router {
 		Handlers: []Handler{handler},
 	}
 	// Increment global handler count
-	atomic.AddUint32(&app.handlerCount, 1)
+	atomic.AddUint32(&app.handlersCount, 1)
 	// Add route to stack
 	app.addRoute(MethodGet, &route)
 	// Add HEAD route


### PR DESCRIPTION
It seems that https://github.com/gofiber/fiber/pull/1672 add a function named HandlersCount.
But the field of App struct is called hanlderCount, so I rename them to handlersCount.