### PR TITLE
✨feature: add default address for app.Listen()

### DIFF
--- a/app.go
+++ b/app.go
@@ -733,16 +733,21 @@ func (app *App) Listener(ln net.Listener) error {
 }
 
 // Listen serves HTTP requests from the given addr.
+// If there is no given address, it will use environment
+// variable or serve at port ":8080" by defautl.
 //
+//  app.Listen()
 //  app.Listen(":8080")
 //  app.Listen("127.0.0.1:8080")
-func (app *App) Listen(addr string) error {
+func (app *App) Listen(addr ...string) error {
+	// Resolve address
+	address := utils.ResolveAddress(addr)
 	// Start prefork
 	if app.config.Prefork {
-		return app.prefork(app.config.Network, addr, nil)
+		return app.prefork(app.config.Network, address, nil)
 	}
 	// Setup listener
-	ln, err := net.Listen(app.config.Network, addr)
+	ln, err := net.Listen(app.config.Network, address)
 	if err != nil {
 		return err
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -1044,6 +1044,13 @@ func Test_App_Listen(t *testing.T) {
 	utils.AssertEqual(t, nil, app.Listen(":4003"))
 }
 
+// go test -run Test_App_Listen_with_empty_address
+func Test_App_Listen_with_empty_address(t *testing.T) {
+	app := New(Config{DisableStartupMessage: true})
+
+	utils.AssertEqual(t, nil, app.Listen())
+}
+
 // go test -run Test_App_Listen_Prefork
 func Test_App_Listen_Prefork(t *testing.T) {
 	testPreforkMaster = true

--- a/utils/common.go
+++ b/utils/common.go
@@ -118,10 +118,10 @@ func ResolveAddress(addr []string) string {
 	switch len(addr) {
 	case 0:
 		if port := os.Getenv("PORT"); port != "" {
-			fmt.Sprintf("Environment variable PORT=\"%s\"", port)
+			_, _ = fmt.Printf("Environment variable PORT=\"%s\"", port)
 			return ":" + port
 		}
-		fmt.Sprintf("Environment variable PORT is undefined. The default port :8080 will be used.")
+		_, _ = fmt.Printf("Environment variable PORT is undefined. The default port :8080 will be used.")
 		return ":8080"
 	case 1:
 		return addr[0]

--- a/utils/common.go
+++ b/utils/common.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 
 	"net"
 	"os"
@@ -107,5 +108,24 @@ func IncrementIPRange(ip net.IP) {
 		if ip[j] > 0 {
 			break
 		}
+	}
+}
+
+// ResolveAddress return true address from the given address slice.
+// If the slice is nil, it returns a environment variable or the
+// default address ":8080"
+func ResolveAddress(addr []string) string {
+	switch len(addr) {
+	case 0:
+		if port := os.Getenv("PORT"); port != "" {
+			fmt.Sprintf("Environment variable PORT=\"%s\"", port)
+			return ":" + port
+		}
+		fmt.Sprintf("Environment variable PORT is undefined. A port number is automatically chosen.")
+		return ":8080"
+	case 1:
+		return addr[0]
+	default:
+		panic("too many parameters")
 	}
 }

--- a/utils/common.go
+++ b/utils/common.go
@@ -121,7 +121,7 @@ func ResolveAddress(addr []string) string {
 			fmt.Sprintf("Environment variable PORT=\"%s\"", port)
 			return ":" + port
 		}
-		fmt.Sprintf("Environment variable PORT is undefined. A port number is automatically chosen.")
+		fmt.Sprintf("Environment variable PORT is undefined. The default port :8080 will be used.")
 		return ":8080"
 	case 1:
 		return addr[0]

--- a/utils/common_test.go
+++ b/utils/common_test.go
@@ -7,6 +7,7 @@ package utils
 import (
 	"crypto/rand"
 	"fmt"
+	"os"
 	"testing"
 )
 
@@ -71,7 +72,6 @@ func Test_UUIDv4_Concurrency(t *testing.T) {
 }
 
 // go test -v -run=^$ -bench=Benchmark_UUID -benchmem -count=2
-
 func Benchmark_UUID(b *testing.B) {
 	var res string
 	b.Run("fiber", func(b *testing.B) {
@@ -88,4 +88,15 @@ func Benchmark_UUID(b *testing.B) {
 		}
 		AssertEqual(b, 36, len(res))
 	})
+}
+
+func Test_resolve_address(t *testing.T) {
+	addr := []string{":3000"}
+	AssertEqual(t, ResolveAddress(addr), ":3000")
+	addr = []string{}
+	os.Setenv("PORT", "8080")
+	port := os.Getenv("PORT")
+	AssertEqual(t, ResolveAddress(addr), ":" + port)
+	os.Unsetenv("PORT")
+	AssertEqual(t, ResolveAddress(addr), ":8080")
 }


### PR DESCRIPTION
I add a default address for app.Listen().
If there is no given address, it will use environment variable or serve at port ":8080" by default.
You can use this:
```go
app = fiber.New()
app.Listen() // Serve at default port ":8080"
```