### PR TITLE
✨feature: Pass all locals to ctx.Render

### DIFF
--- a/app.go
+++ b/app.go
@@ -183,6 +183,11 @@ type Config struct {
 	// Default: ""
 	ViewsLayout string `json:"views_layout"`
 
+	// PassLocalsToViews Enables passing of the locals set on a fiber.Ctx to the template engine
+	//
+	// Default: false
+	PassLocalsToViews bool `json:"pass_locals_to_views"`
+
 	// The amount of time allowed to read the full request including body.
 	// It is reset after the request handler has returned.
 	// The connection's read deadline is reset when the connection opens.

--- a/ctx.go
+++ b/ctx.go
@@ -1017,16 +1017,20 @@ func (c *Ctx) Render(name string, bind interface{}, layouts ...string) error {
 	buf := bytebufferpool.Get()
 	defer bytebufferpool.Put(buf)
 
-	// Safely cast the bind interface to a ma
-	bindMap, ok := bind.(Map)
-	// Check if the bind is a map
-	if ok {
-		// Loop through each local and set it in the map
-		c.fasthttp.VisitUserValues(func(key []byte, val interface{}) {
-			bindMap[string(key)] = val
-		})
-		// set the original bind to the map
-		bind = bindMap
+	// Check if the PassLocalsToViews option is enabled (By default it is disabled)
+	if c.app.config.PassLocalsToViews {
+		// Safely cast the bind interface to a map
+		bindMap, ok := bind.(Map)
+		// Check if the bind is a map
+		if ok {
+			// Loop through each local and set it in the map
+			c.fasthttp.VisitUserValues(func(key []byte, val interface{}) {
+				bindMap[string(key)] = val
+			})
+			// set the original bind to the map
+			bind = bindMap
+		}
+
 	}
 
 	if c.app.config.Views != nil {

--- a/ctx.go
+++ b/ctx.go
@@ -1017,6 +1017,18 @@ func (c *Ctx) Render(name string, bind interface{}, layouts ...string) error {
 	buf := bytebufferpool.Get()
 	defer bytebufferpool.Put(buf)
 
+	// Safely cast the bind interface to a ma
+	bindMap, ok := bind.(Map)
+	// Check if the bind is a map
+	if ok {
+		// Loop through each local and set it in the map
+		c.fasthttp.VisitUserValues(func(key []byte, val interface{}) {
+			bindMap[string(key)] = val
+		})
+		// set the original bind to the map
+		bind = bindMap
+	}
+
 	if c.app.config.Views != nil {
 		// Render template based on global layout if exists
 		if len(layouts) == 0 && c.app.config.ViewsLayout != "" {

--- a/ctx.go
+++ b/ctx.go
@@ -1025,7 +1025,11 @@ func (c *Ctx) Render(name string, bind interface{}, layouts ...string) error {
 		if ok {
 			// Loop through each local and set it in the map
 			c.fasthttp.VisitUserValues(func(key []byte, val interface{}) {
-				bindMap[string(key)] = val
+				// check if bindMap doesn't contain the key
+				if _, ok := bindMap[string(key)]; !ok {
+					// Set the key and value in the bindMap
+					bindMap[string(key)] = val
+				}
 			})
 			// set the original bind to the map
 			bind = bindMap

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2044,6 +2044,26 @@ func Test_Ctx_RenderWithLocals(t *testing.T) {
 	utils.AssertEqual(t, "<h1>Hello, World!</h1>", string(c.Response().Body()))
 
 }
+func Test_Ctx_RenderWithLocalsAndBinding(t *testing.T) {
+	t.Parallel()
+	app := New(Config{
+		PassLocalsToViews: true,
+	})
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	c.Locals("Title", "This is a test.")
+	defer app.ReleaseCtx(c)
+	err := c.Render("./.github/testdata/template.html", Map{
+		"Title": "Hello, World!",
+	})
+
+	buf := bytebufferpool.Get()
+	_, _ = buf.WriteString("overwrite")
+	defer bytebufferpool.Put(buf)
+
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "<h1>Hello, World!</h1>", string(c.Response().Body()))
+}
 
 type testTemplateEngine struct {
 	templates *template.Template

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2006,6 +2006,23 @@ func Test_Ctx_Render(t *testing.T) {
 	err = c.Render("./.github/testdata/template-invalid.html", nil)
 	utils.AssertEqual(t, false, err == nil)
 }
+func Test_Ctx_RenderLocals(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	c.Locals("Title", "Hello, World!")
+	defer app.ReleaseCtx(c)
+	err := c.Render("./.github/testdata/template.html", Map{})
+
+	buf := bytebufferpool.Get()
+	_, _ = buf.WriteString("overwrite")
+	defer bytebufferpool.Put(buf)
+
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "<h1>Hello, World!</h1>", string(c.Response().Body()))
+
+}
 
 type testTemplateEngine struct {
 	templates *template.Template

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2006,9 +2006,30 @@ func Test_Ctx_Render(t *testing.T) {
 	err = c.Render("./.github/testdata/template-invalid.html", nil)
 	utils.AssertEqual(t, false, err == nil)
 }
-func Test_Ctx_RenderLocals(t *testing.T) {
+func Test_Ctx_RenderWithoutLocals(t *testing.T) {
 	t.Parallel()
-	app := New()
+	app := New(Config{
+		PassLocalsToViews: false,
+	})
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	c.Locals("Title", "Hello, World!")
+	defer app.ReleaseCtx(c)
+	err := c.Render("./.github/testdata/template.html", Map{})
+
+	buf := bytebufferpool.Get()
+	_, _ = buf.WriteString("overwrite")
+	defer bytebufferpool.Put(buf)
+
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "<h1><no value></h1>", string(c.Response().Body()))
+}
+
+func Test_Ctx_RenderWithLocals(t *testing.T) {
+	t.Parallel()
+	app := New(Config{
+		PassLocalsToViews: true,
+	})
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 
 	c.Locals("Title", "Hello, World!")


### PR DESCRIPTION
**✨feature: Pass all locals to ctx.Render**

This will by default pass all locals set user ctx.Local to the Template engine.

This could be usefull for setting variables using a middleware.