### PR TITLE
🩹 Fix: Add `csrf_` to default encrypt cookie exception (#1631)

### DIFF
--- a/middleware/encryptcookie/README.md
+++ b/middleware/encryptcookie/README.md
@@ -64,7 +64,7 @@ type Config struct {
 
 	// Array of cookie keys that should not be encrypted.
 	//
-	// Optional. Default: []
+	// Optional. Default: ["csrf_"]
 	Except []string
 
 	// Base64 encoded unique key to encode & decode cookies.

--- a/middleware/encryptcookie/config.go
+++ b/middleware/encryptcookie/config.go
@@ -34,7 +34,7 @@ type Config struct {
 // ConfigDefault is the default config
 var ConfigDefault = Config{
 	Next:      nil,
-	Except:    make([]string, 0),
+	Except:    []string{"csrf_"},
 	Key:       "",
 	Encryptor: EncryptCookie,
 	Decryptor: DecryptCookie,


### PR DESCRIPTION
This PR fixes issue #1631