### PR TITLE
:fire: Feature: Add Route() method like Chi router.

### DIFF
--- a/app.go
+++ b/app.go
@@ -693,6 +693,21 @@ func (app *App) Group(prefix string, handlers ...Handler) Router {
 	return &Group{prefix: prefix, app: app}
 }
 
+// Route is used to define routes with a common prefix inside the common function.
+// Uses Group method to define new sub-router.
+func (app *App) Route(prefix string, fn func(router Router), name ...string) Router {
+	// Create new group
+	group := app.Group(prefix)
+	if len(name) > 0 {
+		group.Name(name[0])
+	}
+
+	// Define routes
+	fn(group)
+
+	return group
+}
+
 // Error makes it compatible with the `error` interface.
 func (e *Error) Error() string {
 	return e.Message

--- a/app_test.go
+++ b/app_test.go
@@ -994,6 +994,55 @@ func Test_App_Group(t *testing.T) {
 	// utils.AssertEqual(t, "/test/v1/users", resp.Header.Get("Location"), "Location")
 }
 
+func Test_App_Route(t *testing.T) {
+	dummyHandler := testEmptyHandler
+
+	app := New()
+
+	grp := app.Route("/test", func(grp Router) {
+		grp.Get("/", dummyHandler)
+		grp.Get("/:demo?", dummyHandler)
+		grp.Connect("/CONNECT", dummyHandler)
+		grp.Put("/PUT", dummyHandler)
+		grp.Post("/POST", dummyHandler)
+		grp.Delete("/DELETE", dummyHandler)
+		grp.Head("/HEAD", dummyHandler)
+		grp.Patch("/PATCH", dummyHandler)
+		grp.Options("/OPTIONS", dummyHandler)
+		grp.Trace("/TRACE", dummyHandler)
+		grp.All("/ALL", dummyHandler)
+		grp.Use(dummyHandler)
+		grp.Use("/USE", dummyHandler)
+	})
+
+	testStatus200(t, app, "/test", MethodGet)
+	testStatus200(t, app, "/test/john", MethodGet)
+	testStatus200(t, app, "/test/CONNECT", MethodConnect)
+	testStatus200(t, app, "/test/PUT", MethodPut)
+	testStatus200(t, app, "/test/POST", MethodPost)
+	testStatus200(t, app, "/test/DELETE", MethodDelete)
+	testStatus200(t, app, "/test/HEAD", MethodHead)
+	testStatus200(t, app, "/test/PATCH", MethodPatch)
+	testStatus200(t, app, "/test/OPTIONS", MethodOptions)
+	testStatus200(t, app, "/test/TRACE", MethodTrace)
+	testStatus200(t, app, "/test/ALL", MethodPost)
+	testStatus200(t, app, "/test/oke", MethodGet)
+	testStatus200(t, app, "/test/USE/oke", MethodGet)
+
+	grp.Route("/v1", func(grp Router) {
+		grp.Post("/", dummyHandler)
+		grp.Get("/users", dummyHandler)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodPost, "/test/v1/", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
+
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test/v1/UsErS", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
+}
+
 func Test_App_Deep_Group(t *testing.T) {
 	runThroughCount := 0
 	dummyHandler := func(c *Ctx) error {

--- a/group.go
+++ b/group.go
@@ -167,3 +167,18 @@ func (grp *Group) Group(prefix string, handlers ...Handler) Router {
 	}
 	return grp.app.Group(prefix)
 }
+
+// Route is used to define routes with a common prefix inside the common function.
+// Uses Group method to define new sub-router.
+func (grp *Group) Route(prefix string, fn func(router Router), name ...string) Router {
+	// Create new group
+	group := grp.Group(prefix)
+	if len(name) > 0 {
+		group.Name(name[0])
+	}
+
+	// Define routes
+	fn(group)
+
+	return group
+}

--- a/router.go
+++ b/router.go
@@ -36,6 +36,8 @@ type Router interface {
 
 	Group(prefix string, handlers ...Handler) Router
 
+	Route(prefix string, fn func(router Router), name ...string) Router
+
 	Mount(prefix string, fiber *App) Router
 
 	Name(name string) Router


### PR DESCRIPTION
Add Route method like [Chi router](https://github.com/go-chi/chi#router-interface).

**Signature:**

`Route(prefix string, fn func(router Router), name ...string) Router`

**Using Example:** 

```
app.Route("/test", func(router fiber.Router) {
	router.Get("/john", func(c *fiber.Ctx) error {
		return c.SendString("doe")
	}).Name("john")
}, "test.")
```