### PR TITLE
:fire: Feature: Add ReqHeaderParser.

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -32,8 +32,12 @@ import (
 // maxParams defines the maximum number of parameters per route.
 const maxParams = 30
 
-const queryTag = "query"
-const reqHeaderTag = "reqHeader"
+// Some constants for BodyParser, QueryParser and ReqHeaderParser.
+const (
+	queryTag     = "query"
+	reqHeaderTag = "reqHeader"
+	bodyTag      = "form"
+)
 
 // userContextKey define the key name for storing context.Context in *fasthttp.RequestCtx
 const userContextKey = "__local_user_context__"
@@ -319,10 +323,6 @@ func decoderBuilder(parserConfig ParserConfig) interface{} {
 // application/json, application/xml, application/x-www-form-urlencoded, multipart/form-data
 // If none of the content types above are matched, it will return a ErrUnprocessableEntity error
 func (c *Ctx) BodyParser(out interface{}) error {
-	// Get decoder from pool
-	schemaDecoder := decoderPool.Get().(*schema.Decoder)
-	defer decoderPool.Put(schemaDecoder)
-
 	// Get content-type
 	ctype := utils.ToLower(utils.UnsafeString(c.fasthttp.Request.Header.ContentType()))
 
@@ -330,27 +330,22 @@ func (c *Ctx) BodyParser(out interface{}) error {
 
 	// Parse body accordingly
 	if strings.HasPrefix(ctype, MIMEApplicationJSON) {
-		schemaDecoder.SetAliasTag("json")
 		return c.app.config.JSONDecoder(c.Body(), out)
 	}
 	if strings.HasPrefix(ctype, MIMEApplicationForm) {
-		schemaDecoder.SetAliasTag("form")
-		data := make(map[string][]string)
-		c.fasthttp.PostArgs().VisitAll(func(key []byte, val []byte) {
-			data[utils.UnsafeString(key)] = append(data[utils.UnsafeString(key)], utils.UnsafeString(val))
-		})
-		return schemaDecoder.Decode(out, data)
+		fn, data := collectVisitAllData(out)
+		c.fasthttp.PostArgs().VisitAll(fn)
+
+		return c.parseToStruct(bodyTag, out, data)
 	}
 	if strings.HasPrefix(ctype, MIMEMultipartForm) {
-		schemaDecoder.SetAliasTag("form")
 		data, err := c.fasthttp.MultipartForm()
 		if err != nil {
 			return err
 		}
-		return schemaDecoder.Decode(out, data.Value)
+		return c.parseToStruct(bodyTag, out, data.Value)
 	}
 	if strings.HasPrefix(ctype, MIMETextXML) || strings.HasPrefix(ctype, MIMEApplicationXML) {
-		schemaDecoder.SetAliasTag("xml")
 		return xml.Unmarshal(c.Body(), out)
 	}
 	// No suitable content type found
@@ -878,41 +873,35 @@ func (c *Ctx) Query(key string, defaultValue ...string) string {
 
 // QueryParser binds the query string to a struct.
 func (c *Ctx) QueryParser(out interface{}) error {
-	// Get decoder from pool
-	decoder := decoderPool.Get().(*schema.Decoder)
-	defer decoderPool.Put(decoder)
+	fn, data := collectVisitAllData(out)
+	c.fasthttp.QueryArgs().VisitAll(fn)
 
-	// Set correct alias tag
-	decoder.SetAliasTag(queryTag)
-
-	data := make(map[string][]string)
-	c.fasthttp.QueryArgs().VisitAll(func(key []byte, val []byte) {
-		k := utils.UnsafeString(key)
-		v := utils.UnsafeString(val)
-		if strings.Contains(v, ",") && equalFieldType(out, reflect.Slice, k) {
-			values := strings.Split(v, ",")
-			for i := 0; i < len(values); i++ {
-				data[k] = append(data[k], values[i])
-			}
-		} else {
-			data[k] = append(data[k], v)
-		}
-	})
-
-	return decoder.Decode(out, data)
+	return c.parseToStruct(queryTag, out, data)
 }
 
 // ReqHeaderParser binds the request header strings to a struct.
 func (c *Ctx) ReqHeaderParser(out interface{}) error {
+	fn, data := collectVisitAllData(out)
+	c.fasthttp.Request.Header.VisitAll(fn)
+
+	return c.parseToStruct(reqHeaderTag, out, data)
+}
+
+func (c *Ctx) parseToStruct(aliasTag string, out interface{}, data map[string][]string) error {
 	// Get decoder from pool
-	decoder := decoderPool.Get().(*schema.Decoder)
-	defer decoderPool.Put(decoder)
+	schemaDecoder := decoderPool.Get().(*schema.Decoder)
+	defer decoderPool.Put(schemaDecoder)
 
-	// Set correct alias tag
-	decoder.SetAliasTag(reqHeaderTag)
+	// Set alias tag
+	schemaDecoder.SetAliasTag(aliasTag)
 
+	return schemaDecoder.Decode(out, data)
+}
+
+func collectVisitAllData(out interface{}) (func(key, val []byte), map[string][]string) {
 	data := make(map[string][]string)
-	c.fasthttp.Request.Header.VisitAll(func(key, val []byte) {
+
+	return func(key, val []byte) {
 		k := utils.UnsafeString(key)
 		v := utils.UnsafeString(val)
 
@@ -925,9 +914,7 @@ func (c *Ctx) ReqHeaderParser(out interface{}) error {
 			data[k] = append(data[k], v)
 		}
 
-	})
-
-	return decoder.Decode(out, data)
+	}, data
 }
 
 func equalFieldType(out interface{}, kind reflect.Kind, key string) bool {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2861,6 +2861,32 @@ func Benchmark_Ctx_QueryParser_Comma(b *testing.B) {
 	utils.AssertEqual(b, nil, c.QueryParser(q))
 }
 
+// go test -v  -run=^$ -bench=Benchmark_Ctx_ReqHeaderParser -benchmem -count=4
+func Benchmark_Ctx_ReqHeaderParser(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	type ReqHeader struct {
+		ID    int
+		Name  string
+		Hobby []string
+	}
+	c.Request().SetBody([]byte(``))
+	c.Request().Header.SetContentType("")
+
+	c.Request().Header.Add("id", "1")
+	c.Request().Header.Add("Name", "John Doe")
+	c.Request().Header.Add("Hobby", "golang,fiber")
+
+	q := new(ReqHeader)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c.ReqHeaderParser(q)
+	}
+	utils.AssertEqual(b, nil, c.ReqHeaderParser(q))
+}
+
 // go test -run Test_Ctx_BodyStreamWriter
 func Test_Ctx_BodyStreamWriter(t *testing.T) {
 	t.Parallel()

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2579,6 +2579,220 @@ func Test_Ctx_QueryParser_Schema(t *testing.T) {
 	utils.AssertEqual(t, 0, n.Next.Value)
 }
 
+// go test -run Test_Ctx_ReqHeaderParser -v
+func Test_Ctx_ReqHeaderParser(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	type Header struct {
+		ID    int
+		Name  string
+		Hobby []string
+	}
+	c.Request().SetBody([]byte(``))
+	c.Request().Header.SetContentType("")
+
+	c.Request().Header.Add("id", "1")
+	c.Request().Header.Add("Name", "John Doe")
+	c.Request().Header.Add("Hobby", "golang,fiber")
+	q := new(Header)
+	utils.AssertEqual(t, nil, c.ReqHeaderParser(q))
+	utils.AssertEqual(t, 2, len(q.Hobby))
+
+	c.Request().Header.Del("hobby")
+	c.Request().Header.Add("Hobby", "golang,fiber,go")
+	q = new(Header)
+	utils.AssertEqual(t, nil, c.ReqHeaderParser(q))
+	utils.AssertEqual(t, 3, len(q.Hobby))
+
+	empty := new(Header)
+	c.Request().Header.Del("hobby")
+	utils.AssertEqual(t, nil, c.QueryParser(empty))
+	utils.AssertEqual(t, 0, len(empty.Hobby))
+
+	type Header2 struct {
+		Bool            bool
+		ID              int
+		Name            string
+		Hobby           string
+		FavouriteDrinks []string
+		Empty           []string
+		Alloc           []string
+		No              []int64
+	}
+
+	c.Request().Header.Add("id", "2")
+	c.Request().Header.Add("Name", "Jane Doe")
+	c.Request().Header.Del("hobby")
+	c.Request().Header.Add("Hobby", "go,fiber")
+	c.Request().Header.Add("favouriteDrinks", "milo,coke,pepsi")
+	c.Request().Header.Add("alloc", "")
+	c.Request().Header.Add("no", "1")
+
+	h2 := new(Header2)
+	h2.Bool = true
+	h2.Name = "hello world"
+	utils.AssertEqual(t, nil, c.ReqHeaderParser(h2))
+	utils.AssertEqual(t, "go,fiber", h2.Hobby)
+	utils.AssertEqual(t, true, h2.Bool)
+	utils.AssertEqual(t, "Jane Doe", h2.Name) // check value get overwritten
+	utils.AssertEqual(t, []string{"milo", "coke", "pepsi"}, h2.FavouriteDrinks)
+	var nilSlice []string
+	utils.AssertEqual(t, nilSlice, h2.Empty)
+	utils.AssertEqual(t, []string{""}, h2.Alloc)
+	utils.AssertEqual(t, []int64{1}, h2.No)
+
+	type RequiredHeader struct {
+		Name string `reqHeader:"name,required"`
+	}
+	rh := new(RequiredHeader)
+	c.Request().Header.Del("name")
+	utils.AssertEqual(t, "name is empty", c.ReqHeaderParser(rh).Error())
+}
+
+// go test -run Test_Ctx_ReqHeaderParser_WithSetParserDecoder -v
+func Test_Ctx_ReqHeaderParser_WithSetParserDecoder(t *testing.T) {
+	type NonRFCTime time.Time
+
+	NonRFCConverter := func(value string) reflect.Value {
+		if v, err := time.Parse("2006-01-02", value); err == nil {
+			return reflect.ValueOf(v)
+		}
+		return reflect.Value{}
+	}
+
+	nonRFCTime := ParserType{
+		Customtype: NonRFCTime{},
+		Converter:  NonRFCConverter,
+	}
+
+	SetParserDecoder(ParserConfig{
+		IgnoreUnknownKeys: true,
+		ParserType:        []ParserType{nonRFCTime},
+		ZeroEmpty:         true,
+		SetAliasTag:       "req",
+	})
+
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+
+	type NonRFCTimeInput struct {
+		Date  NonRFCTime `req:"date"`
+		Title string     `req:"title"`
+		Body  string     `req:"body"`
+	}
+
+	c.Request().SetBody([]byte(``))
+	c.Request().Header.SetContentType("")
+	r := new(NonRFCTimeInput)
+
+	c.Request().Header.Add("Date", "2021-04-10")
+	c.Request().Header.Add("Title", "CustomDateTest")
+	c.Request().Header.Add("Body", "October")
+
+	utils.AssertEqual(t, nil, c.ReqHeaderParser(r))
+	fmt.Println(r.Date, "q.Date")
+	utils.AssertEqual(t, "CustomDateTest", r.Title)
+	date := fmt.Sprintf("%v", r.Date)
+	utils.AssertEqual(t, "{0 63753609600 <nil>}", date)
+	utils.AssertEqual(t, "October", r.Body)
+
+	c.Request().Header.Add("Title", "")
+	r = &NonRFCTimeInput{
+		Title: "Existing title",
+		Body:  "Existing Body",
+	}
+	utils.AssertEqual(t, nil, c.ReqHeaderParser(r))
+	utils.AssertEqual(t, "", r.Title)
+}
+
+// go test -run Test_Ctx_ReqHeaderParser_Schema -v
+func Test_Ctx_ReqHeaderParser_Schema(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	type Header1 struct {
+		Name   string `reqHeader:"Name,required"`
+		Nested struct {
+			Age int `reqHeader:"Age"`
+		} `reqHeader:"Nested,required"`
+	}
+	c.Request().SetBody([]byte(``))
+	c.Request().Header.SetContentType("")
+
+	c.Request().Header.Add("Name", "tom")
+	c.Request().Header.Add("Nested.Age", "10")
+	q := new(Header1)
+	utils.AssertEqual(t, nil, c.ReqHeaderParser(q))
+
+	c.Request().Header.Del("Name")
+	q = new(Header1)
+	utils.AssertEqual(t, "Name is empty", c.ReqHeaderParser(q).Error())
+
+	c.Request().Header.Add("Name", "tom")
+	c.Request().Header.Del("Nested.Age")
+	c.Request().Header.Add("Nested.Agex", "10")
+	q = new(Header1)
+	utils.AssertEqual(t, nil, c.ReqHeaderParser(q))
+
+	c.Request().Header.Del("Nested.Agex")
+	q = new(Header1)
+	utils.AssertEqual(t, "Nested is empty", c.ReqHeaderParser(q).Error())
+
+	c.Request().Header.Del("Nested.Agex")
+	c.Request().Header.Del("Name")
+
+	type Header2 struct {
+		Name   string `reqHeader:"Name"`
+		Nested struct {
+			Age int `reqHeader:"age,required"`
+		} `reqHeader:"Nested"`
+	}
+
+	c.Request().Header.Add("Name", "tom")
+	c.Request().Header.Add("Nested.Age", "10")
+
+	h2 := new(Header2)
+	utils.AssertEqual(t, nil, c.ReqHeaderParser(h2))
+
+	c.Request().Header.Del("Name")
+	h2 = new(Header2)
+	utils.AssertEqual(t, nil, c.ReqHeaderParser(h2))
+
+	c.Request().Header.Del("Name")
+	c.Request().Header.Del("Nested.Age")
+	c.Request().Header.Add("Nested.Agex", "10")
+	h2 = new(Header2)
+	utils.AssertEqual(t, "Nested.age is empty", c.ReqHeaderParser(h2).Error())
+
+	type Node struct {
+		Value int   `reqHeader:"Val,required"`
+		Next  *Node `reqHeader:"Next,required"`
+	}
+	c.Request().Header.Add("Val", "1")
+	c.Request().Header.Add("Next.Val", "3")
+	n := new(Node)
+	utils.AssertEqual(t, nil, c.ReqHeaderParser(n))
+	utils.AssertEqual(t, 1, n.Value)
+	utils.AssertEqual(t, 3, n.Next.Value)
+
+	c.Request().Header.Del("Val")
+	n = new(Node)
+	utils.AssertEqual(t, "Val is empty", c.ReqHeaderParser(n).Error())
+
+	c.Request().Header.Add("Val", "3")
+	c.Request().Header.Del("Next.Val")
+	c.Request().Header.Add("Next.Value", "2")
+	n = new(Node)
+	n.Next = new(Node)
+	utils.AssertEqual(t, nil, c.ReqHeaderParser(n))
+	utils.AssertEqual(t, 3, n.Value)
+	utils.AssertEqual(t, 0, n.Next.Value)
+}
+
 func Test_Ctx_EqualFieldType(t *testing.T) {
 	var out int
 	utils.AssertEqual(t, false, equalFieldType(&out, reflect.Int, "key"))


### PR DESCRIPTION
**Benchmarks:**

_Old_
```
Benchmark_Ctx_Body_With_Compression-4      	  849862	      1233 ns/op	     145 B/op	       7 allocs/op
Benchmark_Ctx_BodyParser_JSON-4            	 4025719	       313.4 ns/op	      32 B/op	       2 allocs/op
Benchmark_Ctx_BodyParser_XML-4             	  314671	      3698 ns/op	    1160 B/op	      24 allocs/op
Benchmark_Ctx_BodyParser_Form-4            	  464664	      3494 ns/op	     360 B/op	      13 allocs/op
Benchmark_Ctx_BodyParser_MultipartForm-4   	  715200	      2160 ns/op	     328 B/op	      12 allocs/op
Benchmark_Ctx_QueryParser-4                	  244102	      4782 ns/op	     856 B/op	      38 allocs/op
Benchmark_Ctx_QueryParser_Comma-4          	  226207	      5551 ns/op	     928 B/op	      44 allocs/op
```

_New_
```
Benchmark_Ctx_Body_With_Compression-4             899160              1345 ns/op             145 B/op          7 allocs/op
Benchmark_Ctx_BodyParser_JSON-4                  4736698               260.0 ns/op            32 B/op          2 allocs/op
Benchmark_Ctx_BodyParser_XML-4                    363993              3336 ns/op            1160 B/op         24 allocs/op
Benchmark_Ctx_BodyParser_Form-4                   679537              1649 ns/op             360 B/op         13 allocs/op
Benchmark_Ctx_BodyParser_MultipartForm-4          729796              1525 ns/op             328 B/op         12 allocs/op
Benchmark_Ctx_QueryParser-4                       220290              5403 ns/op             856 B/op         38 allocs/op
Benchmark_Ctx_QueryParser_Comma-4                 204379              6221 ns/op             928 B/op         44 allocs/op
Benchmark_Ctx_ReqHeaderParser-4                   199575              6579 ns/op             928 B/op         44 allocs/op
```
