### PR TITLE
:sparkles:feat: add retryIf function to client agent

### DIFF
--- a/client.go
+++ b/client.go
@@ -48,6 +48,11 @@ type Response = fasthttp.Response
 // Copy from fasthttp
 type Args = fasthttp.Args
 
+// RetryIfFunc signature of retry if function
+// Request argument passed to RetryIfFunc, if there are any request errors.
+// Copy from fasthttp
+type RetryIfFunc = fasthttp.RetryIfFunc
+
 var defaultClient Client
 
 // Client implements http client.
@@ -715,6 +720,14 @@ func (a *Agent) SetResponse(customResp *Response) *Agent {
 func (a *Agent) Dest(dest []byte) *Agent {
 	a.dest = dest
 
+	return a
+}
+
+// RetryIf controls whether a retry should be attempted after an error.
+//
+// By default, will use isIdempotent function from fasthttp
+func (a *Agent) RetryIf(retryIf RetryIfFunc) *Agent {
+	a.HostClient.RetryIf = retryIf
 	return a
 }
 


### PR DESCRIPTION
RetryIf function for client agent.
```go
func (a *Agent) RetryIf(retryIf RetryIfFunc) *Agent {
	a.HostClient.RetryIf = retryIf
	return a
}
```
Examples:
```go
agent.Get("https://example.com").RetryIf(func (req *fiber.Request) bool {
	return req.URI() == "https://example.com"
}
```