### PR TITLE
Fix NewErrors() and Improve NewError()

### DIFF
--- a/app.go
+++ b/app.go
@@ -705,7 +705,18 @@ func NewError(code int, message ...interface{}) *Error {
 		Message: utils.StatusMessage(code),
 	}
 	if len(message) > 0 {
-		e.Message = message
+		e.Message = message[0]
+	}
+	return e
+}
+
+func NewErrors(code int, messages ...interface{}) *Error {
+	e := &Error{
+		Code:    code,
+		Message: utils.StatusMessage(code),
+	}
+	if len(messages) > 0 {
+		e.Message = messages
 	}
 	return e
 }

--- a/app.go
+++ b/app.go
@@ -84,13 +84,8 @@ type ErrorHandler = func(*Ctx, error) error
 
 // Error represents an error that occurred while handling a request.
 type Error struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
-}
-
-type Errors struct {
-	Code     int      `json:"code"`
-	Messages []string `json:"messages"`
+	Code    int         `json:"code"`
+	Message interface{} `json:"message"`
 }
 
 // App denotes the Fiber application.
@@ -700,34 +695,17 @@ func (app *App) Group(prefix string, handlers ...Handler) Router {
 
 // Error makes it compatible with the `error` interface.
 func (e *Error) Error() string {
-	return e.Message
-}
-
-// Errors make it compatible with the `multiple errors` interface.
-func (e *Errors) Errors() []string {
-	return e.Messages
+	return fmt.Sprintf("%v", e.Message)
 }
 
 // NewError creates a new Error instance with an optional message
-func NewError(code int, message ...string) *Error {
+func NewError(code int, message ...interface{}) *Error {
 	e := &Error{
-		Code: code,
+		Code:    code,
+		Message: utils.StatusMessage(code),
 	}
 	if len(message) > 0 {
-		e.Message = message[0]
-	} else {
-		e.Message = utils.StatusMessage(code)
-	}
-	return e
-}
-
-// NewErrors creates multiple new Error messages
-func NewErrors(code int, messages ...string) *Errors {
-	e := &Errors{
-		Code: code,
-	}
-	if len(messages) > 0 {
-		e.Messages = append(e.Messages, messages...)
+		e.Message = message
 	}
 	return e
 }

--- a/app.go
+++ b/app.go
@@ -710,6 +710,7 @@ func NewError(code int, message ...interface{}) *Error {
 	return e
 }
 
+// NewErrors creates multiple new Error messages
 func NewErrors(code int, messages ...interface{}) *Error {
 	e := &Error{
 		Code:    code,

--- a/app.go
+++ b/app.go
@@ -88,6 +88,11 @@ type Error struct {
 	Message string `json:"message"`
 }
 
+type Errors struct {
+	Code     int      `json:"code"`
+	Messages []string `json:"messages"`
+}
+
 // App denotes the Fiber application.
 type App struct {
 	mutex sync.Mutex
@@ -698,6 +703,11 @@ func (e *Error) Error() string {
 	return e.Message
 }
 
+// Errors make it compatible with the `multiple errors` interface.
+func (e *Errors) Errors() []string {
+	return e.Messages
+}
+
 // NewError creates a new Error instance with an optional message
 func NewError(code int, message ...string) *Error {
 	e := &Error{
@@ -711,27 +721,15 @@ func NewError(code int, message ...string) *Error {
 	return e
 }
 
-// NewErrors creates multiple new Errors instance with some message
-func NewErrors(code int, messages ...string) []*Error {
-	var errors []*Error
-	if len(messages) > 0 {
-		for _, message := range messages {
-			e := &Error{
-				Code: code,
-			}
-			e.Message = message
-			errors = append(errors, e)
-		}
-	} else {
-		// Use default messages
-		e := &Error{
-			Code: code,
-		}
-		e.Message = utils.StatusMessage(code)
-		errors = append(errors, e)
+// NewErrors creates multiple new Error messages
+func NewErrors(code int, messages ...string) *Errors {
+	e := &Errors{
+		Code: code,
 	}
-
-	return errors
+	if len(messages) > 0 {
+		e.Messages = append(e.Messages, messages...)
+	}
+	return e
 }
 
 // Listener can be used to pass a custom listener.

--- a/app.go
+++ b/app.go
@@ -695,7 +695,7 @@ func (app *App) Group(prefix string, handlers ...Handler) Router {
 
 // Error makes it compatible with the `error` interface.
 func (e *Error) Error() string {
-	return fmt.Sprintf("%v", e.Message)
+	return fmt.Sprint(e.Message)
 }
 
 // NewError creates a new Error instance with an optional message

--- a/app_test.go
+++ b/app_test.go
@@ -1163,7 +1163,7 @@ func Benchmark_App_ETag_Weak(b *testing.B) {
 func Test_NewError(t *testing.T) {
 	e := NewError(StatusForbidden, "permission denied")
 	utils.AssertEqual(t, StatusForbidden, e.Code)
-	utils.AssertEqual(t, "permission denied", e.Message)
+	utils.AssertEqual(t, "permission denied", fmt.Sprintf("%v", e.Message))
 }
 
 // go test -run Test_Test_Timeout

--- a/app_test.go
+++ b/app_test.go
@@ -1168,11 +1168,9 @@ func Test_NewError(t *testing.T) {
 
 func Test_NewErrors(t *testing.T) {
 	errors := NewErrors(StatusBadRequest, []string{"error 1", "error 2"}...)
-	utils.AssertEqual(t, StatusBadRequest, errors[0].Code)
-	utils.AssertEqual(t, "error 1", errors[0].Message)
-
-	utils.AssertEqual(t, StatusBadRequest, errors[1].Code)
-	utils.AssertEqual(t, "error 2", errors[1].Message)
+	utils.AssertEqual(t, StatusBadRequest, errors.Code)
+	utils.AssertEqual(t, "error 1", errors.Messages[0])
+	utils.AssertEqual(t, "error 2", errors.Messages[1])
 }
 
 // go test -run Test_Test_Timeout

--- a/app_test.go
+++ b/app_test.go
@@ -1163,15 +1163,15 @@ func Benchmark_App_ETag_Weak(b *testing.B) {
 func Test_NewError(t *testing.T) {
 	e := NewError(StatusForbidden, "permission denied")
 	utils.AssertEqual(t, StatusForbidden, e.Code)
-	utils.AssertEqual(t, "permission denied", fmt.Sprintf("%v", e.Message))
+	utils.AssertEqual(t, "permission denied", fmt.Sprint(e.Message))
 }
 
 func Test_NewErrors(t *testing.T) {
 	e := NewErrors(StatusBadRequest, "error 1", "error 2")
 	messages := e.Message.([]interface{})
 	utils.AssertEqual(t, StatusBadRequest, e.Code)
-	utils.AssertEqual(t, "error 1", fmt.Sprintf("%v", messages[0]))
-	utils.AssertEqual(t, "error 2", fmt.Sprintf("%v", messages[1]))
+	utils.AssertEqual(t, "error 1", fmt.Sprint(messages[0]))
+	utils.AssertEqual(t, "error 2", fmt.Sprint(messages[1]))
 }
 
 // go test -run Test_Test_Timeout

--- a/app_test.go
+++ b/app_test.go
@@ -1166,6 +1166,14 @@ func Test_NewError(t *testing.T) {
 	utils.AssertEqual(t, "permission denied", fmt.Sprintf("%v", e.Message))
 }
 
+func Test_NewErrors(t *testing.T) {
+	e := NewErrors(StatusBadRequest, "error 1", "error 2")
+	messages := e.Message.([]interface{})
+	utils.AssertEqual(t, StatusBadRequest, e.Code)
+	utils.AssertEqual(t, "error 1", fmt.Sprintf("%v", messages[0]))
+	utils.AssertEqual(t, "error 2", fmt.Sprintf("%v", messages[1]))
+}
+
 // go test -run Test_Test_Timeout
 func Test_Test_Timeout(t *testing.T) {
 	app := New()

--- a/app_test.go
+++ b/app_test.go
@@ -1166,13 +1166,6 @@ func Test_NewError(t *testing.T) {
 	utils.AssertEqual(t, "permission denied", e.Message)
 }
 
-func Test_NewErrors(t *testing.T) {
-	errors := NewErrors(StatusBadRequest, []string{"error 1", "error 2"}...)
-	utils.AssertEqual(t, StatusBadRequest, errors.Code)
-	utils.AssertEqual(t, "error 1", errors.Messages[0])
-	utils.AssertEqual(t, "error 2", errors.Messages[1])
-}
-
 // go test -run Test_Test_Timeout
 func Test_Test_Timeout(t *testing.T) {
 	app := New()


### PR DESCRIPTION
If error message's type happens interface{}, It can return multiple error strings etc.

### NewErrors()
```go
func main() {
	app := New(fiber.Config{
		ErrorHandler: func(c *fiber.Ctx, err error) error {
			code := fiber.StatusInternalServerError
			var messages interface{}

			if e, ok := err.(*fiber.Error); ok {
				code = e.Code
				messages = e.Message
			}

			return c.Status(code).JSON(fiber.Map{
				"status_code": code,
				"status_text": utils.StatusMessage(code),
				"messages":    messages,
			})
		},
	})

	app.Get("/", func(c *fiber.Ctx) error {
		return NewErrors(fiber.StatusBadRequest, "validatien error 1", "validation error 2")
	})

	app.Listen(":3000")
}
```

### JSON is going to be 
```json
{
  "messages": [
    "validatien error 1",
    "validation error 2"
  ],
  "status_code": 400,
  "status_text": "Bad Request"
}
```
---
### Different Example
```go
func main() {
	app := New(fiber.Config{
		ErrorHandler: func(c *fiber.Ctx, err error) error {
			code := fiber.StatusInternalServerError
			var messages interface{}

			if e, ok := err.(*fiber.Error); ok {
				code = e.Code
				messages = e.Message
			}

			return c.Status(code).JSON(fiber.Map{
				"status_code": code,
				"status_text": utils.StatusMessage(code),
				"messages":    messages,
			})
		},
	})

	app.Get("/", func(c *fiber.Ctx) error {
		return NewErrors(StatusBadRequest,
			fiber.Map{
				"type":        "validation",
				"description": "password must be longer than 6 characters",
			},
			fiber.Map{
				"type":        "validation",
				"description": "invalid e-mail",
			})
	})

	app.Listen(":3000")
}
```

### JSON is going to be 
```json
{
  "messages": [
    {
      "description": "password must be longer than 6 characters",
      "type": "validation"
    },
    {
      "description": "invalid e-mail",
      "type": "validation"
    }
  ],
  "status_code": 400,
  "status_text": "Bad Request"
}
```