### PR TITLE
added HEAD method to caching

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -58,7 +58,7 @@ func New(config ...Config) fiber.Handler {
 	// Return new handler
 	return func(c *fiber.Ctx) error {
 		// Only cache GET methods
-		if c.Method() != fiber.MethodGet {
+		if c.Method() != fiber.MethodGet && c.Method() != fiber.MethodHead {
 			c.Set(cfg.CacheHeader, cacheUnreachable)
 			return c.Next()
 		}

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -341,6 +341,31 @@ func Test_CacheHeader(t *testing.T) {
 	utils.AssertEqual(t, cacheUnreachable, errRespCached.Header.Get("X-Cache"))
 }
 
+func Test_Cache_WithHead(t *testing.T) {
+	app := fiber.New()
+	app.Use(New())
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		now := fmt.Sprintf("%d", time.Now().UnixNano())
+		return c.SendString(now)
+	})
+
+	req := httptest.NewRequest("HEAD", "/", nil)
+	resp, err := app.Test(req)
+	utils.AssertEqual(t, cacheMiss, resp.Header.Get("X-Cache"))
+
+	cachedReq := httptest.NewRequest("HEAD", "/", nil)
+	cachedResp, err := app.Test(cachedReq)
+	utils.AssertEqual(t, cacheHit, cachedResp.Header.Get("X-Cache"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	utils.AssertEqual(t, nil, err)
+	cachedBody, err := ioutil.ReadAll(cachedResp.Body)
+	utils.AssertEqual(t, nil, err)
+
+	utils.AssertEqual(t, cachedBody, body)
+}
+
 func Test_CustomCacheHeader(t *testing.T) {
 	app := fiber.New()
 


### PR DESCRIPTION
When using the curl -I statement, the HEAD method, is invoked. However, only the GET method is being cached. To overcome this limitation an additional clause was added to the `cache.go` to all the HEAD method to also cache.