### PR TITLE
:bug: fix: route naming when to use group in group.

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -561,10 +561,14 @@ func Test_App_Route_Naming(t *testing.T) {
 
 	app.Post("/post", handler).Name("post")
 
+	subGroup := jane.Group("/sub-group").Name("sub.")
+	subGroup.Get("/done", handler).Name("done")
+
 	utils.AssertEqual(t, "post", app.GetRoute("post").Name)
 	utils.AssertEqual(t, "john", app.GetRoute("john").Name)
 	utils.AssertEqual(t, "jane.test", app.GetRoute("jane.test").Name)
 	utils.AssertEqual(t, "jane.trace", app.GetRoute("jane.trace").Name)
+	utils.AssertEqual(t, "jane.sub.done", app.GetRoute("jane.sub.done").Name)
 	utils.AssertEqual(t, "test", app.GetRoute("test").Name)
 }
 

--- a/group.go
+++ b/group.go
@@ -48,7 +48,12 @@ func (grp *Group) Mount(prefix string, fiber *App) Router {
 
 // Assign name to specific route.
 func (grp *Group) Name(name string) Router {
-	grp.name = name
+	if strings.HasPrefix(grp.prefix, latestGroup.prefix) {
+		grp.name = latestGroup.name + name
+	} else {
+		grp.name = name
+	}
+
 	latestGroup = *grp
 
 	return grp


### PR DESCRIPTION
If we use group in group, name of first group won't appear.

**Code:**
```go
func main() {
	app := fiber.New()

	a := app.Group("/a").Name("a.")

	b := a.Group("/b").Name("b.")
	b.Get("/hello/", func(c *fiber.Ctx) error {
		return c.SendString("d")
	}).Name("c")

	data, _ := json.MarshalIndent(app.Stack(), "", "  ")
	fmt.Print(string(data))
}
```

**Old Output:**
```go
[
  [
    {
      "method": "GET",
      "name": "b.c",
      "path": "/a/b/hello/",
      "params": null
    }
  ],
  [
    {
      "method": "HEAD",
      "name": "",
      "path": "/a/b/hello/",
      "params": null
    }
  ],
  ...
]
```                                                                                                                                                                                     
**New Output:**
```json
[
  [
    {
      "method": "GET",
      "name": "a.b.c",
      "path": "/a/b/hello/",
      "params": null
    }
  ],
  [
    {
      "method": "HEAD",
      "name": "",
      "path": "/a/b/hello/",
      "params": null
    }
  ],
  ...
]
```                                                                                                                                                                                  