### PR TITLE
🔥 Feature: Add ability to restart route handling

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -782,6 +782,14 @@ func (c *Ctx) Next() (err error) {
 	return err
 }
 
+// RestartRouting instead of going to the next handler. This may be usefull after
+// changing the request path. Note that handlers might be executed again.
+func (c *Ctx) RestartRouting() error {
+	c.indexRoute = -1
+	_, err := c.app.next(c)
+	return err
+}
+
 // OriginalURL contains the original request URL.
 // Returned value is only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting to use the value outside the Handler.

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2065,8 +2065,8 @@ func Test_Ctx_RenderWithLocalsAndBinding(t *testing.T) {
 	utils.AssertEqual(t, "<h1>Hello, World!</h1>", string(c.Response().Body()))
 }
 
-// go test -run Test_Ctx_Restart
-func Test_Ctx_Restart(t *testing.T) {
+// go test -run Test_Ctx_RestartRouting
+func Test_Ctx_RestartRouting(t *testing.T) {
 	app := New()
 	calls := 0
 	app.Get("/", func(c *Ctx) error {
@@ -2082,8 +2082,8 @@ func Test_Ctx_Restart(t *testing.T) {
 	utils.AssertEqual(t, 3, calls, "Number of calls")
 }
 
-// go test -run Test_Ctx_RestartWithChangedPath
-func Test_Ctx_RestartWithChangedPath(t *testing.T) {
+// go test -run Test_Ctx_RestartRoutingWithChangedPath
+func Test_Ctx_RestartRoutingWithChangedPath(t *testing.T) {
 	app := New()
 	executedOldHandler := false
 	executedNewHandler := false
@@ -2108,8 +2108,8 @@ func Test_Ctx_RestartWithChangedPath(t *testing.T) {
 	utils.AssertEqual(t, true, executedNewHandler, "Executed new handler")
 }
 
-// go test -run Test_Ctx_RestartWithChangedPathAnd404
-func Test_Ctx_RestartWithChangedPathAndCatchAll(t *testing.T) {
+// go test -run Test_Ctx_RestartRoutingWithChangedPathAnd404
+func Test_Ctx_RestartRoutingWithChangedPathAndCatchAll(t *testing.T) {
 	app := New()
 	app.Get("/new", func(c *Ctx) error {
 		return nil

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2065,6 +2065,69 @@ func Test_Ctx_RenderWithLocalsAndBinding(t *testing.T) {
 	utils.AssertEqual(t, "<h1>Hello, World!</h1>", string(c.Response().Body()))
 }
 
+// go test -run Test_Ctx_Restart
+func Test_Ctx_Restart(t *testing.T) {
+	app := New()
+	calls := 0
+	app.Get("/", func(c *Ctx) error {
+		calls++
+		if calls < 3 {
+			return c.RestartRouting()
+		}
+		return nil
+	})
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "http://example.com/", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
+	utils.AssertEqual(t, 3, calls, "Number of calls")
+}
+
+// go test -run Test_Ctx_RestartWithChangedPath
+func Test_Ctx_RestartWithChangedPath(t *testing.T) {
+	app := New()
+	executedOldHandler := false
+	executedNewHandler := false
+
+	app.Get("/old", func(c *Ctx) error {
+		c.Path("/new")
+		return c.RestartRouting()
+	})
+	app.Get("/old", func(c *Ctx) error {
+		executedOldHandler = true
+		return nil
+	})
+	app.Get("/new", func(c *Ctx) error {
+		executedNewHandler = true
+		return nil
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "http://example.com/old", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
+	utils.AssertEqual(t, false, executedOldHandler, "Executed old handler")
+	utils.AssertEqual(t, true, executedNewHandler, "Executed new handler")
+}
+
+// go test -run Test_Ctx_RestartWithChangedPathAnd404
+func Test_Ctx_RestartWithChangedPathAndCatchAll(t *testing.T) {
+	app := New()
+	app.Get("/new", func(c *Ctx) error {
+		return nil
+	})
+	app.Use(func(c *Ctx) error {
+		c.Path("/new")
+		// c.Next() would fail this test as a 404 is returned from the next handler
+		return c.RestartRouting()
+	})
+	app.Use(func(c *Ctx) error {
+		return ErrNotFound
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "http://example.com/old", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
+}
+
 type testTemplateEngine struct {
 	templates *template.Template
 }


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Adds the ability to restart the route handling e.g. after an internal redirect.

Fixes #1731

**Explain the *details* for making this change. What existing problem does the pull request solve?**

The example from #1731 is changed in the following way:

```go
package main

import "github.com/gofiber/fiber/v2"

func main() {
	app := fiber.New()

	app.Get("/new", func(c *fiber.Ctx) error {
		return c.SendString("new")
	})

	app.Use(func(c *fiber.Ctx) error {
		c.Path("/new")
		// instead of c.Next() as this would execute the catch-all handler
		// note that this example works because GET /new is registered first. Infinit loops are possible with RestartRouting.
		return c.RestartRouting()
	})

	app.Use(func(c *fiber.Ctx) error {
		// e.g. catch-all for 404
		return fiber.ErrNotFound
	})

	app.Listen(":3000")
}
```

Edit 1: changed method name to `RestartRouting`