### PR TITLE
:memo: Fix: typo

### DIFF
--- a/app.go
+++ b/app.go
@@ -320,7 +320,7 @@ type Config struct {
 	// When set by an external client of Fiber it will use the provided implementation of a
 	// JSONUnmarshal
 	//
-	// Allowing for flexibility in using another json library for encoding
+	// Allowing for flexibility in using another json library for decoding
 	// Default: json.Unmarshal
 	JSONDecoder utils.JSONUnmarshal `json:"-"`
 


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Fixed documentation typo of JSONDecoder field in Config (server settings) structure.

json library for **encoding** => json library for **decoding**