### PR TITLE
Add ctx.Scheme() and update ctx.Protocol() methods [🎌 breaking change]

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1415,3 +1415,8 @@ func (c *Ctx) IsFromLocal() bool {
 	}
 	return c.isLocalHost(ips[0])
 }
+
+// Protocol returns the request's HTTP protocol: HTTP/1.1,  HTTP/1.0
+func (c *Ctx) Protocol() string {
+	return string(c.fasthttp.Request.Header.Protocol())
+}

--- a/ctx.go
+++ b/ctx.go
@@ -255,7 +255,7 @@ func (c *Ctx) BaseURL() string {
 	if c.baseURI != "" {
 		return c.baseURI
 	}
-	c.baseURI = c.Protocol() + "://" + c.Hostname()
+	c.baseURI = c.Scheme() + "://" + c.Hostname()
 	return c.baseURI
 }
 
@@ -848,9 +848,9 @@ func (c *Ctx) Path(override ...string) string {
 	return c.path
 }
 
-// Protocol contains the request protocol string: http or https for TLS requests.
+// Scheme contains the request scheme: http or https for TLS requests.
 // Use Config.EnableTrustedProxyCheck to prevent header spoofing, in case when your app is behind the proxy.
-func (c *Ctx) Protocol() string {
+func (c *Ctx) Scheme() string {
 	if c.fasthttp.IsTLS() {
 		return "https"
 	}

--- a/ctx.go
+++ b/ctx.go
@@ -1418,5 +1418,5 @@ func (c *Ctx) IsFromLocal() bool {
 
 // Protocol returns the request's HTTP protocol: HTTP/1.1,  HTTP/1.0
 func (c *Ctx) Protocol() string {
-	return string(c.fasthttp.Request.Header.Protocol())
+	return utils.UnsafeString(c.fasthttp.Request.Header.Protocol())
 }

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1486,6 +1486,39 @@ func Test_Ctx_Scheme_UnTrustedProxy(t *testing.T) {
 	utils.AssertEqual(t, "http", c.Scheme())
 }
 
+// go test -run Test_Ctx_Protocol
+func Test_Ctx_Protocol(t *testing.T) {
+	app := New()
+
+	freq := &fasthttp.RequestCtx{}
+
+	c := app.AcquireCtx(freq)
+	defer app.ReleaseCtx(c)
+
+	utils.AssertEqual(t, "HTTP/1.1", c.Protocol())
+
+	protocols := []string{"HTTP/1.0", "HTTP/1.1", "HTTP/2"}
+
+	for _, protocol := range protocols {
+		freq.Request.Header.SetProtocol(protocol)
+		utils.AssertEqual(t, protocol, c.Protocol())
+	}
+}
+
+// go test -v -run=^$ -bench=Benchmark_Ctx_Scheme -benchmem -count=4
+func Benchmark_Ctx_Protocol(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	var res string
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		res = c.Protocol()
+	}
+	utils.AssertEqual(b, "HTTP/1.1", res)
+}
+
 // go test -run Test_Ctx_Query
 func Test_Ctx_Query(t *testing.T) {
 	t.Parallel()

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1505,7 +1505,7 @@ func Test_Ctx_Protocol(t *testing.T) {
 	}
 }
 
-// go test -v -run=^$ -bench=Benchmark_Ctx_Scheme -benchmem -count=4
+// go test -v -run=^$ -bench=Benchmark_Ctx_Protocol -benchmem -count=4
 func Benchmark_Ctx_Protocol(b *testing.B) {
 	app := New()
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1340,8 +1340,8 @@ func Test_Ctx_Path(t *testing.T) {
 	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
 }
 
-// go test -run Test_Ctx_Protocol
-func Test_Ctx_Protocol(t *testing.T) {
+// go test -run Test_Ctx_Scheme
+func Test_Ctx_Scheme(t *testing.T) {
 	app := New()
 
 	freq := &fasthttp.RequestCtx{}
@@ -1350,26 +1350,26 @@ func Test_Ctx_Protocol(t *testing.T) {
 	c := app.AcquireCtx(freq)
 	defer app.ReleaseCtx(c)
 	c.Request().Header.Set(HeaderXForwardedProto, "https")
-	utils.AssertEqual(t, "https", c.Protocol())
+	utils.AssertEqual(t, "https", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXForwardedProtocol, "https")
-	utils.AssertEqual(t, "https", c.Protocol())
+	utils.AssertEqual(t, "https", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXForwardedSsl, "on")
-	utils.AssertEqual(t, "https", c.Protocol())
+	utils.AssertEqual(t, "https", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXUrlScheme, "https")
-	utils.AssertEqual(t, "https", c.Protocol())
+	utils.AssertEqual(t, "https", c.Scheme())
 	c.Request().Header.Reset()
 
-	utils.AssertEqual(t, "http", c.Protocol())
+	utils.AssertEqual(t, "http", c.Scheme())
 }
 
-// go test -v -run=^$ -bench=Benchmark_Ctx_Protocol -benchmem -count=4
-func Benchmark_Ctx_Protocol(b *testing.B) {
+// go test -v -run=^$ -bench=Benchmark_Ctx_Scheme -benchmem -count=4
+func Benchmark_Ctx_Scheme(b *testing.B) {
 	app := New()
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 	defer app.ReleaseCtx(c)
@@ -1377,113 +1377,113 @@ func Benchmark_Ctx_Protocol(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		res = c.Protocol()
+		res = c.Scheme()
 	}
 	utils.AssertEqual(b, "http", res)
 }
 
-// go test -run Test_Ctx_Protocol_TrustedProxy
-func Test_Ctx_Protocol_TrustedProxy(t *testing.T) {
+// go test -run Test_Ctx_Scheme_TrustedProxy
+func Test_Ctx_Scheme_TrustedProxy(t *testing.T) {
 	t.Parallel()
 	app := New(Config{EnableTrustedProxyCheck: true, TrustedProxies: []string{"0.0.0.0"}})
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 	defer app.ReleaseCtx(c)
 
 	c.Request().Header.Set(HeaderXForwardedProto, "https")
-	utils.AssertEqual(t, "https", c.Protocol())
+	utils.AssertEqual(t, "https", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXForwardedProtocol, "https")
-	utils.AssertEqual(t, "https", c.Protocol())
+	utils.AssertEqual(t, "https", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXForwardedSsl, "on")
-	utils.AssertEqual(t, "https", c.Protocol())
+	utils.AssertEqual(t, "https", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXUrlScheme, "https")
-	utils.AssertEqual(t, "https", c.Protocol())
+	utils.AssertEqual(t, "https", c.Scheme())
 	c.Request().Header.Reset()
 
-	utils.AssertEqual(t, "http", c.Protocol())
+	utils.AssertEqual(t, "http", c.Scheme())
 }
 
-// go test -run Test_Ctx_Protocol_TrustedProxyRange
-func Test_Ctx_Protocol_TrustedProxyRange(t *testing.T) {
+// go test -run Test_Ctx_Scheme_TrustedProxyRange
+func Test_Ctx_Scheme_TrustedProxyRange(t *testing.T) {
 	t.Parallel()
 	app := New(Config{EnableTrustedProxyCheck: true, TrustedProxies: []string{"0.0.0.0/30"}})
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 	defer app.ReleaseCtx(c)
 
 	c.Request().Header.Set(HeaderXForwardedProto, "https")
-	utils.AssertEqual(t, "https", c.Protocol())
+	utils.AssertEqual(t, "https", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXForwardedProtocol, "https")
-	utils.AssertEqual(t, "https", c.Protocol())
+	utils.AssertEqual(t, "https", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXForwardedSsl, "on")
-	utils.AssertEqual(t, "https", c.Protocol())
+	utils.AssertEqual(t, "https", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXUrlScheme, "https")
-	utils.AssertEqual(t, "https", c.Protocol())
+	utils.AssertEqual(t, "https", c.Scheme())
 	c.Request().Header.Reset()
 
-	utils.AssertEqual(t, "http", c.Protocol())
+	utils.AssertEqual(t, "http", c.Scheme())
 }
 
-// go test -run Test_Ctx_Protocol_UntrustedProxyRange
-func Test_Ctx_Protocol_UntrustedProxyRange(t *testing.T) {
+// go test -run Test_Ctx_Scheme_UntrustedProxyRange
+func Test_Ctx_Scheme_UntrustedProxyRange(t *testing.T) {
 	t.Parallel()
 	app := New(Config{EnableTrustedProxyCheck: true, TrustedProxies: []string{"1.1.1.1/30"}})
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 	defer app.ReleaseCtx(c)
 
 	c.Request().Header.Set(HeaderXForwardedProto, "https")
-	utils.AssertEqual(t, "http", c.Protocol())
+	utils.AssertEqual(t, "http", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXForwardedProtocol, "https")
-	utils.AssertEqual(t, "http", c.Protocol())
+	utils.AssertEqual(t, "http", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXForwardedSsl, "on")
-	utils.AssertEqual(t, "http", c.Protocol())
+	utils.AssertEqual(t, "http", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXUrlScheme, "https")
-	utils.AssertEqual(t, "http", c.Protocol())
+	utils.AssertEqual(t, "http", c.Scheme())
 	c.Request().Header.Reset()
 
-	utils.AssertEqual(t, "http", c.Protocol())
+	utils.AssertEqual(t, "http", c.Scheme())
 }
 
-// go test -run Test_Ctx_Protocol_UnTrustedProxy
-func Test_Ctx_Protocol_UnTrustedProxy(t *testing.T) {
+// go test -run Test_Ctx_Scheme_UnTrustedProxy
+func Test_Ctx_Scheme_UnTrustedProxy(t *testing.T) {
 	t.Parallel()
 	app := New(Config{EnableTrustedProxyCheck: true, TrustedProxies: []string{"0.8.0.1"}})
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 	defer app.ReleaseCtx(c)
 
 	c.Request().Header.Set(HeaderXForwardedProto, "https")
-	utils.AssertEqual(t, "http", c.Protocol())
+	utils.AssertEqual(t, "http", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXForwardedProtocol, "https")
-	utils.AssertEqual(t, "http", c.Protocol())
+	utils.AssertEqual(t, "http", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXForwardedSsl, "on")
-	utils.AssertEqual(t, "http", c.Protocol())
+	utils.AssertEqual(t, "http", c.Scheme())
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXUrlScheme, "https")
-	utils.AssertEqual(t, "http", c.Protocol())
+	utils.AssertEqual(t, "http", c.Scheme())
 	c.Request().Header.Reset()
 
-	utils.AssertEqual(t, "http", c.Protocol())
+	utils.AssertEqual(t, "http", c.Scheme())
 }
 
 // go test -run Test_Ctx_Query

--- a/middleware/logger/README.md
+++ b/middleware/logger/README.md
@@ -132,6 +132,7 @@ const (
 	TagTime					= "time"
 	TagReferer				= "referer"
 	TagProtocol				= "protocol"
+	TagScheme				= "scheme"
 	TagPort                                 = "port"
 	TagIP					= "ip"
 	TagIPs					= "ips"

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -23,6 +23,7 @@ const (
 	TagPid               = "pid"
 	TagTime              = "time"
 	TagReferer           = "referer"
+	TagScheme            = "scheme"
 	TagProtocol          = "protocol"
 	TagPort              = "port"
 	TagIP                = "ip"
@@ -210,6 +211,8 @@ func New(config ...Config) fiber.Handler {
 				return buf.WriteString(timestamp.Load().(string))
 			case TagReferer:
 				return buf.WriteString(c.Get(fiber.HeaderReferer))
+			case TagScheme:
+				return buf.WriteString(c.Scheme())
 			case TagProtocol:
 				return buf.WriteString(c.Protocol())
 			case TagPid:

--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -140,7 +140,7 @@ func Test_Logger_All(t *testing.T) {
 
 	app := fiber.New()
 	app.Use(New(Config{
-		Format: "${pid}${reqHeaders}${referer}${protocol}${ip}${ips}${host}${url}${ua}${body}${route}${black}${red}${green}${yellow}${blue}${magenta}${cyan}${white}${reset}${error}${header:test}${query:test}${form:test}${cookie:test}${non}",
+		Format: "${pid}${reqHeaders}${referer}${protocol}${scheme}${ip}${ips}${host}${url}${ua}${body}${route}${black}${red}${green}${yellow}${blue}${magenta}${cyan}${white}${reset}${error}${header:test}${query:test}${form:test}${cookie:test}${non}",
 		Output: buf,
 	}))
 
@@ -148,7 +148,7 @@ func Test_Logger_All(t *testing.T) {
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, fiber.StatusNotFound, resp.StatusCode)
 
-	expected := fmt.Sprintf("%dHost=example.comhttp0.0.0.0example.com/?foo=bar/%s%s%s%s%s%s%s%s%s-", os.Getpid(), cBlack, cRed, cGreen, cYellow, cBlue, cMagenta, cCyan, cWhite, cReset)
+	expected := fmt.Sprintf("%dHost=example.comHTTP/1.1http0.0.0.0example.com/?foo=bar/%s%s%s%s%s%s%s%s%s-", os.Getpid(), cBlack, cRed, cGreen, cYellow, cBlue, cMagenta, cCyan, cWhite, cReset)
 	utils.AssertEqual(t, expected, buf.String())
 }
 


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Updating the `ctx.Protocol` method to return HTTP protocol (like HTTP/1.0, HTTP/1.1) and changing `ctx.Scheme` method to return the request scheme (like http, https).

**Explain the *details* for making this change. What existing problem does the pull request solve?**
Closes #1712 

`c.Scheme()` usage:
```go
app.Get("/", func(c *Ctx) error {
    return c.JSON(c.Scheme()) // return "http" or "https"
})
```

`c.Protocol()` usage:
```go
app.Get("/", func(c *Ctx) error {
    return c.JSON(c.Protocol()) // return "HTTP/1.1"
})
```