### PR TITLE
:zap: change default gc interval of internal/memory

### DIFF
--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -23,7 +23,7 @@ func New() *Storage {
 		data: make(map[string]item),
 		ts:   uint32(time.Now().Unix()),
 	}
-	go store.gc(10 * time.Millisecond)
+	go store.gc(1 * time.Second)
 	go store.updater(1 * time.Second)
 	return store
 }


### PR DESCRIPTION
10ms interval time causes big performance degradation. So i made it 1 second. Potentially closes https://github.com/gofiber/fiber/issues/1371. 

**Before:**
```
Running 10s test @ http://127.0.0.1:5000
  12 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.99s     1.91s    6.69s    52.54%
    Req/Sec       -nan      -nan   0.00      0.00%
  396049 requests in 10.00s, 94.05MB read
Requests/sec:  39612.49
Transfer/sec:      9.41MB
```

**After:**
```
Running 10s test @ http://127.0.0.1:5000
  12 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.12s     1.24s    4.61s    55.31%
    Req/Sec       -nan      -nan   0.00      0.00%
  602860 requests in 10.00s, 143.16MB read
Requests/sec:  60310.52
Transfer/sec:     14.32MB
```