### PR TITLE
✨ feature: custom validator 

### DIFF
--- a/app.go
+++ b/app.go
@@ -88,6 +88,11 @@ type Error struct {
 	Message interface{} `json:"message"`
 }
 
+// Validator is the interface that wraps the Validate function.
+type Validator interface {
+	Validate(i interface{}) error
+}
+
 // App denotes the Fiber application.
 type App struct {
 	mutex sync.Mutex
@@ -363,6 +368,9 @@ type Config struct {
 	// If set to true, will print all routes with their method, path and handler.
 	// Default: false
 	EnablePrintRoutes bool `json:"enable_print_routes"`
+
+	// Register custom validator
+	Validator Validator
 }
 
 // Static defines configuration options when defining static assets.

--- a/ctx.go
+++ b/ctx.go
@@ -1485,3 +1485,10 @@ func (c *Ctx) IsFromLocal() bool {
 	}
 	return c.isLocalHost(ips[0])
 }
+
+func (c *Ctx) Validate(i interface{}) error {
+	if c.app.config.Validator == nil {
+		return ErrValidatorNotRegistered
+	}
+	return c.app.config.Validator.Validate(i)
+}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -3478,3 +3478,18 @@ func Test_Ctx_IsFromLocal(t *testing.T) {
 		utils.AssertEqual(t, false, c.IsFromLocal())
 	}
 }
+
+type validator struct{}
+
+func (*validator) Validate(i interface{}) error {
+	return nil
+}
+func Test_Ctx_Validate(t *testing.T) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	utils.AssertEqual(t, c.Validate(struct{}{}), ErrValidatorNotRegistered)
+
+	app.config.Validator = &validator{}
+	utils.AssertEqual(t, c.Validate(struct{}{}), nil)
+}

--- a/helpers.go
+++ b/helpers.go
@@ -7,6 +7,7 @@ package fiber
 import (
 	"bytes"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -554,6 +555,7 @@ var (
 	ErrLoopDetected                  = NewError(StatusLoopDetected)                  // RFC 5842, 7.2
 	ErrNotExtended                   = NewError(StatusNotExtended)                   // RFC 2774, 7
 	ErrNetworkAuthenticationRequired = NewError(StatusNetworkAuthenticationRequired) // RFC 6585, 6
+	ErrValidatorNotRegistered        = errors.New("validator not registered")
 )
 
 // HTTP Headers were copied from net/http.


### PR DESCRIPTION
Usage:

```go
package main

import (  
	"github.com/go-playground/validator/v10"
	"github.com/gofiber/fiber/v2"
)

type User struct {
    Name  string `json:"name" validate:"required"`
    Email string `json:"email" validate:"required,email"`
}

type CustomValidator struct {
    validator *validator.Validate
}


func (cv *CustomValidator) Validate(i interface{}) error {
  return cv.validator.Struct(i)
}

func main() {
  app := fiber.New(fiber.Config{
     Validator: &CustomValidator{validator: validator.New()},
  })

  app.Post("/users", func(c *fiber.Ctx) error {
    u := new(User)

    if err := c.BodyParser(u); err != nil {
      return fiber.NewError(StatusBadRequest, err.Error())
    }

    if err := c.Validate(u); err != nil {
      return fiber.NewError(StatusBadRequest, err.Error())
    }

    return c.JSON(u)
  })

  app.Listen(":3000")
}
```