### PR TITLE
fix: `utils.Trim` should trim all string content

### DIFF
--- a/utils/strings.go
+++ b/utils/strings.go
@@ -43,15 +43,9 @@ func Trim(s string, cutset byte) string {
 			break
 		}
 	}
-	for ; i < j; j-- {
+	for ; i <= j; j-- {
 		if s[j] != cutset {
 			break
-		}
-	}
-
-	if i == j {
-		if s[i] == cutset {
-			return ""
 		}
 	}
 

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -49,6 +49,12 @@ func Trim(s string, cutset byte) string {
 		}
 	}
 
+	if i == j {
+		if s[i] == cutset {
+			return ""
+		}
+	}
+
 	return s[i : j+1]
 }
 

--- a/utils/strings_test.go
+++ b/utils/strings_test.go
@@ -126,6 +126,12 @@ func Test_Trim(t *testing.T) {
 
 	res = Trim(".test", '.')
 	AssertEqual(t, "test", res)
+
+	res = Trim(" ", ' ')
+	AssertEqual(t, "", res)
+
+	res = Trim("  ", ' ')
+	AssertEqual(t, "", res)
 }
 
 func Benchmark_Trim(b *testing.B) {

--- a/utils/strings_test.go
+++ b/utils/strings_test.go
@@ -132,6 +132,9 @@ func Test_Trim(t *testing.T) {
 
 	res = Trim("  ", ' ')
 	AssertEqual(t, "", res)
+
+	res = Trim("", ' ')
+	AssertEqual(t, "", res)
 }
 
 func Benchmark_Trim(b *testing.B) {


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

This PR fix a edge case of `utils.Trim(" ", ' ')` returning `" "` instead of `""`.


close #1774

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

fix edge case `utils.Trim(" ", ' ')` and `Trim("  ", ' ')`


**Commit formatting** 

not a fan of emojis, choose whatever you like when merging.