### PR TITLE
Fix for "Why net.Addr is fiber.testAddr, not *net.TCPAddr?🤗 #1574"

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1028,6 +1028,24 @@ func Test_Ctx_Port(t *testing.T) {
 	utils.AssertEqual(t, "0", c.Port())
 }
 
+// go test -run Test_Ctx_PortInHandler
+func Test_Ctx_PortInHandler(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	app.Get("/port", func(c *Ctx) error {
+		return c.SendString(c.Port())
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/port", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
+
+	body, err := ioutil.ReadAll(resp.Body)
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "0", string(body))
+}
+
 // go test -run Test_Ctx_IP
 func Test_Ctx_IP(t *testing.T) {
 	t.Parallel()

--- a/helpers.go
+++ b/helpers.go
@@ -338,18 +338,6 @@ func isNoCache(cacheControl string) bool {
 	return true
 }
 
-// https://golang.org/src/net/net.go#L113
-// Helper methods for application#test
-type testAddr string
-
-func (a testAddr) Network() string {
-	return string(a)
-}
-
-func (a testAddr) String() string {
-	return string(a)
-}
-
 type testConn struct {
 	r bytes.Buffer
 	w bytes.Buffer
@@ -359,8 +347,8 @@ func (c *testConn) Read(b []byte) (int, error)  { return c.r.Read(b) }
 func (c *testConn) Write(b []byte) (int, error) { return c.w.Write(b) }
 func (c *testConn) Close() error                { return nil }
 
-func (c *testConn) LocalAddr() net.Addr                { return testAddr("local-addr") }
-func (c *testConn) RemoteAddr() net.Addr               { return testAddr("remote-addr") }
+func (c *testConn) LocalAddr() net.Addr                { return &net.TCPAddr{Port: 0, Zone: "", IP: net.IPv4zero} }
+func (c *testConn) RemoteAddr() net.Addr               { return &net.TCPAddr{Port: 0, Zone: "", IP: net.IPv4zero} }
 func (c *testConn) SetDeadline(_ time.Time) error      { return nil }
 func (c *testConn) SetReadDeadline(_ time.Time) error  { return nil }
 func (c *testConn) SetWriteDeadline(_ time.Time) error { return nil }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -212,11 +212,6 @@ func Test_Utils_GetOffset(t *testing.T) {
 	utils.AssertEqual(t, "", getOffer("2", "1"))
 }
 
-func Test_Utils_TestAddr_Network(t *testing.T) {
-	var addr testAddr = "addr"
-	utils.AssertEqual(t, "addr", addr.Network())
-}
-
 func Test_Utils_TestConn_Deadline(t *testing.T) {
 	conn := &testConn{}
 	utils.AssertEqual(t, nil, conn.SetDeadline(time.Time{}))


### PR DESCRIPTION
Pull request should fix the problem from #1574 