### PR TITLE
Restore Original URL of the context after changing it

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1301,7 +1301,7 @@ func (c *Ctx) SendFile(file string, compress ...bool) error {
 		}
 	}
 	// Restore the original requested URL
-	originalURL := utils.ImmutableString(c.OriginalURL())
+	originalURL := utils.CopyString(c.OriginalURL())
 	defer c.fasthttp.Request.SetRequestURI(originalURL)
 	// Set new URI for fileHandler
 	c.fasthttp.Request.SetRequestURI(file)

--- a/ctx.go
+++ b/ctx.go
@@ -1301,7 +1301,7 @@ func (c *Ctx) SendFile(file string, compress ...bool) error {
 		}
 	}
 	// Restore the original requested URL
-	originalURL := c.OriginalURL()
+	originalURL := utils.ImmutableString(c.OriginalURL())
 	defer c.fasthttp.Request.SetRequestURI(originalURL)
 	// Set new URI for fileHandler
 	c.fasthttp.Request.SetRequestURI(file)

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1856,7 +1856,7 @@ func Test_Ctx_SendFile_RestoreOriginalURL(t *testing.T) {
 	t.Parallel()
 	app := New()
 	app.Get("/", func(c *Ctx) error {
-		originalURL := utils.ImmutableString(c.OriginalURL())
+		originalURL := utils.CopyString(c.OriginalURL())
 		err := c.SendFile("ctx.go")
 		utils.AssertEqual(t, originalURL, c.OriginalURL())
 		return err

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1856,14 +1856,18 @@ func Test_Ctx_SendFile_RestoreOriginalURL(t *testing.T) {
 	t.Parallel()
 	app := New()
 	app.Get("/", func(c *Ctx) error {
-		originalURL := c.OriginalURL()
+		originalURL := utils.ImmutableString(c.OriginalURL())
 		err := c.SendFile("ctx.go")
 		utils.AssertEqual(t, originalURL, c.OriginalURL())
 		return err
 	})
 
-	_, err := app.Test(httptest.NewRequest("GET", "/?test=true", nil))
-	utils.AssertEqual(t, nil, err)
+	_, err1 := app.Test(httptest.NewRequest("GET", "/?test=true", nil))
+	// second request required to confirm with zero allocation
+	_, err2 := app.Test(httptest.NewRequest("GET", "/?test=true", nil))
+
+	utils.AssertEqual(t, nil, err1)
+	utils.AssertEqual(t, nil, err2)
 }
 
 // go test -run Test_Ctx_JSON

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -121,6 +121,8 @@ func Forward(addr string) fiber.Handler {
 func Do(c *fiber.Ctx, addr string) error {
 	req := c.Request()
 	res := c.Response()
+	originalURL := utils.ImmutableString(c.OriginalURL())
+	defer req.SetRequestURI(originalURL)
 	req.SetRequestURI(addr)
 	// NOTE: if req.isTLS is true, SetRequestURI keeps the scheme as https.
 	// issue reference:

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -121,7 +121,7 @@ func Forward(addr string) fiber.Handler {
 func Do(c *fiber.Ctx, addr string) error {
 	req := c.Request()
 	res := c.Response()
-	originalURL := utils.ImmutableString(c.OriginalURL())
+	originalURL := utils.CopyString(c.OriginalURL())
 	defer req.SetRequestURI(originalURL)
 	req.SetRequestURI(addr)
 	// NOTE: if req.isTLS is true, SetRequestURI keeps the scheme as https.

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -339,3 +339,26 @@ func Test_Proxy_Buffer_Size_Response(t *testing.T) {
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
 }
+
+// go test -race -run Test_Proxy_Do_RestoreOriginalURL
+func Test_Proxy_Do_RestoreOriginalURL(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	app.Get("/proxy", func(c *fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+	app.Get("/test", func(c *fiber.Ctx) error {
+		originalURL := utils.ImmutableString(c.OriginalURL())
+		if err := Do(c, "/proxy"); err != nil {
+			return err
+		}
+		utils.AssertEqual(t, originalURL, c.OriginalURL())
+		return c.SendString("ok")
+	})
+	_, err1 := app.Test(httptest.NewRequest("GET", "/test", nil))
+	// This test requires multiple requests due to zero allocation used in fiber
+	_, err2 := app.Test(httptest.NewRequest("GET", "/test", nil))
+
+	utils.AssertEqual(t, nil, err1)
+	utils.AssertEqual(t, nil, err2)
+}

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -348,7 +348,7 @@ func Test_Proxy_Do_RestoreOriginalURL(t *testing.T) {
 		return c.SendString("ok")
 	})
 	app.Get("/test", func(c *fiber.Ctx) error {
-		originalURL := utils.ImmutableString(c.OriginalURL())
+		originalURL := utils.CopyString(c.OriginalURL())
 		if err := Do(c, "/proxy"); err != nil {
 			return err
 		}


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
This PR fixes two issues.

1.  Restore original URL after proxy.Do [issue](https://github.com/gofiber/fiber/issues/1786)
The proxy.Do method changes the c.OriginalURL() while setting the requestURI  `req.SetRequestURI(addr)`
Since  `proxy.Do` can be used inside the fiber handlers, it will change the origialURL() since the reference to the context is passed.  To fix this behaviour, I am resetting it once the proxy is done.

2. The similar [issue](https://github.com/gofiber/fiber/issues/1499) was raised for `sendFile` and  a fix was merged. However. I find that the fix is not working.
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

Because of the current behaviour, if we use `c.OriginalURL()`  after invoking the proxy.Do() or sendFile() it will cause side effects as `c.OriginalURL()` will continue to point to the url changed in the proxy.Do() or sendFile() method.
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Note**: using ImmutableString for persisting strings has a slight **performance cost**. Mentioned in the welcome page of fiber under Zero allocation
(This is my first PR in this project. Please let me know if I need to make some changes)