### PR TITLE
🐛 Fix go-json generator.

### DIFF
--- a/internal/go-json/cmd/generator/main.go
+++ b/internal/go-json/cmd/generator/main.go
@@ -268,7 +268,7 @@ func (t OpType) FieldToOmitEmptyField() OpType {
 	}); err != nil {
 		return err
 	}
-	path := filepath.Join(repoRoot(), "internal", "encoder", "optype.go")
+	path := filepath.Join(repoRoot(), "internal", "go-json", "encoder", "optype.go")
 	buf, err := format.Source(b.Bytes())
 	if err != nil {
 		return err
@@ -290,7 +290,7 @@ func generateVM() error {
 		f.Name.Name = pkg
 		var buf bytes.Buffer
 		printer.Fprint(&buf, fset, f)
-		path := filepath.Join(repoRoot(), "internal", "encoder", pkg, "vm.go")
+		path := filepath.Join(repoRoot(), "internal", "go-json", "encoder", pkg, "vm.go")
 		source, err := format.Source(buf.Bytes())
 		if err != nil {
 			return err
@@ -304,7 +304,7 @@ func generateVM() error {
 
 func repoRoot() string {
 	_, file, _, _ := runtime.Caller(0)
-	relativePathFromRepoRoot := filepath.Join("internal", "cmd", "generator")
+	relativePathFromRepoRoot := filepath.Join("internal", "go-json", "cmd", "generator")
 	return strings.TrimSuffix(filepath.Dir(file), relativePathFromRepoRoot)
 }
 


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

`$ go generate ./...` generates panic as import paths have changed over time.
This commit free this command execution from panics.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

When running `$ go generate ./...`, the command panics with the following error message :
```
panic: open <parent_of_fiber_root_directory>/fiber/internal/encoder/vm/vm.go: no such file or directory

goroutine 1 [running]:
main.main()
        <parent_of_fiber_root_directory>/fiber/internal/go-json/cmd/generator/main.go:314 +0x6c
exit status 2
internal/go-json/cmd/generator/main.go:311: running "go": exit status 1
```
The culprits reside in the filepath.Join() statements in :
```go
filepath.Join(repoRoot(), "internal", "encoder", pkg, "vm.go")
# and
filepath.Join("internal", "cmd", "generator")

# those constructed paths do not exist anymore !
```

By adding `go-json` directory in the join statements, the generated paths exists. The generator can now freely write/override the `vm.go` file 🙂 