### PR TITLE
:up: bump goccy/go-json to 0.9.6

### DIFF
--- a/internal/go-json/decoder/int.go
+++ b/internal/go-json/decoder/int.go
@@ -192,15 +192,15 @@ func (d *intDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) erro
 	}
 	switch d.kind {
 	case reflect.Int8:
-		if i64 <= -1*(1<<7) || (1<<7) <= i64 {
+		if i64 < -1*(1<<7) || (1<<7) <= i64 {
 			return d.typeError(bytes, s.totalOffset())
 		}
 	case reflect.Int16:
-		if i64 <= -1*(1<<15) || (1<<15) <= i64 {
+		if i64 < -1*(1<<15) || (1<<15) <= i64 {
 			return d.typeError(bytes, s.totalOffset())
 		}
 	case reflect.Int32:
-		if i64 <= -1*(1<<31) || (1<<31) <= i64 {
+		if i64 < -1*(1<<31) || (1<<31) <= i64 {
 			return d.typeError(bytes, s.totalOffset())
 		}
 	}
@@ -225,15 +225,15 @@ func (d *intDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.P
 	}
 	switch d.kind {
 	case reflect.Int8:
-		if i64 <= -1*(1<<7) || (1<<7) <= i64 {
+		if i64 < -1*(1<<7) || (1<<7) <= i64 {
 			return 0, d.typeError(bytes, cursor)
 		}
 	case reflect.Int16:
-		if i64 <= -1*(1<<15) || (1<<15) <= i64 {
+		if i64 < -1*(1<<15) || (1<<15) <= i64 {
 			return 0, d.typeError(bytes, cursor)
 		}
 	case reflect.Int32:
-		if i64 <= -1*(1<<31) || (1<<31) <= i64 {
+		if i64 < -1*(1<<31) || (1<<31) <= i64 {
 			return 0, d.typeError(bytes, cursor)
 		}
 	}

--- a/internal/go-json/decoder/stream.go
+++ b/internal/go-json/decoder/stream.go
@@ -103,7 +103,7 @@ func (s *Stream) statForRetry() ([]byte, int64, unsafe.Pointer) {
 
 func (s *Stream) Reset() {
 	s.reset()
-	s.bufSize = initBufSize
+	s.bufSize = int64(len(s.buf))
 }
 
 func (s *Stream) More() bool {

--- a/internal/go-json/encoder/compiler_norace.go
+++ b/internal/go-json/encoder/compiler_norace.go
@@ -4,7 +4,7 @@
 package encoder
 
 func CompileToGetCodeSet(ctx *RuntimeContext, typeptr uintptr) (*OpcodeSet, error) {
-	if typeptr > typeAddr.MaxTypeAddr {
+	if typeptr > typeAddr.MaxTypeAddr || typeptr < typeAddr.BaseTypeAddr {
 		return compileToGetCodeSetSlowPath(typeptr)
 	}
 	index := (typeptr - typeAddr.BaseTypeAddr) >> typeAddr.AddrShift

--- a/internal/go-json/encoder/compiler_race.go
+++ b/internal/go-json/encoder/compiler_race.go
@@ -10,7 +10,7 @@ import (
 var setsMu sync.RWMutex
 
 func CompileToGetCodeSet(ctx *RuntimeContext, typeptr uintptr) (*OpcodeSet, error) {
-	if typeptr > typeAddr.MaxTypeAddr {
+	if typeptr > typeAddr.MaxTypeAddr || typeptr < typeAddr.BaseTypeAddr {
 		return compileToGetCodeSetSlowPath(typeptr)
 	}
 	index := (typeptr - typeAddr.BaseTypeAddr) >> typeAddr.AddrShift


### PR DESCRIPTION
The updates in json library [seems](https://github.com/goccy/go-json/blob/master/CHANGELOG.md#v096---20220322) to justify a patch release as well.