### PR TITLE
✨ feature: add callShutdownHooksOnSigInt function

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -94,7 +94,6 @@ func (h *hooks) executeOnRouteHooks(route Route) error {
 }
 
 func (h *hooks) executeOnNameHooks(route Route) error {
-
 	for _, v := range h.onName {
 		if err := v(route); err != nil {
 			return err


### PR DESCRIPTION
* Adds `callShutdownHooksOnSigInt` function to App
* Edits `OnShutdownHandler` to take `*os.Signal` argument

When fiber app is killed by SIGINT or SIGTERM, fiber doesn't call shutdown hooks when should.
This pull request solves it by adding a channel to `Listen`, `ListenTLS` and `ListenMutualTLS` and calling `callShutdownHooksOnSigInt` as a goroutine that listens on SIGINT and SIGTERM signals thanks to go's build in `os/signal`.
After calling the shutdown hooks, function exists the program with `os.Exit(0)`.

When calling all the on shutdown handlers, they might now want to execute when a specific signel is used to kill the app, so now they take `*os.Signal` as argument and can implement their own logic.