### PR TITLE
RFC: Return an instance of `*fiber.Error` when no handler found

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1089,9 +1089,9 @@ func Test_App_Next_Method(t *testing.T) {
 
 	app.Use(func(c *Ctx) error {
 		utils.AssertEqual(t, MethodGet, c.Method())
-		c.Next()
+		err := c.Next()
 		utils.AssertEqual(t, MethodGet, c.Method())
-		return nil
+		return err
 	})
 
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/", nil))

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -391,32 +391,32 @@ func Test_Cache_WithHead(t *testing.T) {
 func Test_Cache_WithHeadThenGet(t *testing.T) {
 	app := fiber.New()
 	app.Use(New())
-	app.Get("/get", func(c *fiber.Ctx) error {
+	app.Get("/", func(c *fiber.Ctx) error {
 		return c.SendString(c.Query("cache"))
 	})
 
-	headResp, err := app.Test(httptest.NewRequest("HEAD", "/head?cache=123", nil))
+	headResp, err := app.Test(httptest.NewRequest("HEAD", "/?cache=123", nil))
 	utils.AssertEqual(t, nil, err)
 	headBody, err := ioutil.ReadAll(headResp.Body)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, "", string(headBody))
 	utils.AssertEqual(t, cacheMiss, headResp.Header.Get("X-Cache"))
 
-	headResp, err = app.Test(httptest.NewRequest("HEAD", "/head?cache=123", nil))
+	headResp, err = app.Test(httptest.NewRequest("HEAD", "/?cache=123", nil))
 	utils.AssertEqual(t, nil, err)
 	headBody, err = ioutil.ReadAll(headResp.Body)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, "", string(headBody))
 	utils.AssertEqual(t, cacheHit, headResp.Header.Get("X-Cache"))
 
-	getResp, err := app.Test(httptest.NewRequest("GET", "/get?cache=123", nil))
+	getResp, err := app.Test(httptest.NewRequest("GET", "/?cache=123", nil))
 	utils.AssertEqual(t, nil, err)
 	getBody, err := ioutil.ReadAll(getResp.Body)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, "123", string(getBody))
 	utils.AssertEqual(t, cacheMiss, getResp.Header.Get("X-Cache"))
 
-	getResp, err = app.Test(httptest.NewRequest("GET", "/get?cache=123", nil))
+	getResp, err = app.Test(httptest.NewRequest("GET", "/?cache=123", nil))
 	utils.AssertEqual(t, nil, err)
 	getBody, err = ioutil.ReadAll(getResp.Body)
 	utils.AssertEqual(t, nil, err)

--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -148,7 +148,7 @@ func Test_Logger_All(t *testing.T) {
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, fiber.StatusNotFound, resp.StatusCode)
 
-	expected := fmt.Sprintf("%dHost=example.comhttp0.0.0.0example.com/?foo=bar/%s%s%s%s%s%s%s%s%s-", os.Getpid(), cBlack, cRed, cGreen, cYellow, cBlue, cMagenta, cCyan, cWhite, cReset)
+	expected := fmt.Sprintf("%dHost=example.comhttp0.0.0.0example.com/?foo=bar/%s%s%s%s%s%s%s%s%sCannot GET /", os.Getpid(), cBlack, cRed, cGreen, cYellow, cBlue, cMagenta, cCyan, cWhite, cReset)
 	utils.AssertEqual(t, expected, buf.String())
 }
 

--- a/router.go
+++ b/router.go
@@ -134,8 +134,7 @@ func (app *App) next(c *Ctx) (match bool, err error) {
 	}
 
 	// If c.Next() does not match, return 404
-	_ = c.SendStatus(StatusNotFound)
-	_ = c.SendString("Cannot " + c.method + " " + c.pathOriginal)
+	err = NewError(StatusNotFound, "Cannot " + c.method + " " + c.pathOriginal)
 
 	// If no match, scan stack again if other methods match the request
 	// Moved from app.handler because middleware may break the route chain


### PR DESCRIPTION
## What does this change?

**This pull request alters the routing behaviour of Fiber to return an instance of `*fiber.Error` when a handler cannot be found to service a given request.** Prior to this commit, Fiber formed a plain-text response on-the-fly that cannot be modified by users of the framework.

This change means that errors resulting from no matching handlers being found would be routed via `fiber.App.config.ErrorHandler`, just like other errors are within Fiber.

## Why might we want this change?

**This change allows users to customise the look of their 404 page**, for example, to serve a proper HTML page instead of serving plain-text.

**Additionally, this would remove the need to add a custom 404 handler to the end of the call stack [as documented here](https://docs.gofiber.io/extra/faq#how-do-i-handle-custom-404-responses), which prevents `405 Method Not Allowed` responses [from here](https://github.com/gofiber/fiber/blob/16b8717a29cf9606f58df601f595f82decd1c23a/router.go#L143=) being correctly served.** This is due to the 404 handler matching every request that otherwise exhausts the list of currently registered handlers. By switching to returning an error instead of making an on-the-fly response, we remove the need for the catch-all 404 handler to exist, hence meaning `405 Method Not Allowed` responses will be dealt with correctly.

## Precedent

Returning `*fiber.Error` types to form an appropriate error response is already done in the codebase, for example when serving [`405 Method Not Allowed` responses](https://github.com/gofiber/fiber/blob/16b8717a29cf9606f58df601f595f82decd1c23a/router.go#L143=).

## Considerations

1. **Could this count as a breaking change?** Theorietically, any user using the framework should already have an adequate error handler in place. If they chose to continue using the default error handler, nothing would appear to change - responses generated by this change and by the previous code are identical when using the default error handler. 

   It is not impossible to think that this could be a breaking change, as the `fiber.App.config.ErrorHandler` function is now being called with errors that it was not once called with. However, I believe that this change should not cause an issue as it is assumed that any user of the framework has a functional error handler already impemented, be it the default one or a custom one.

2. **This error cannot be checked for using `errors.Is`**. Instead, you'd have to do something like this:
   ```go
   
   if e, ok := err.(*fiber.Error); ok && e.Code == fiber.StatusNotFound {
       // ...
   }
   ```
---

I'd be interested to hear everyone's opinions and feedback on this proposal.

:)