### PR TITLE
:sparkles: feature: support adding queries to RedirectToRoute

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1163,10 +1163,29 @@ func (c *Ctx) GetRouteURL(routeName string, params Map) (string, error) {
 
 // RedirectToRoute to the Route registered in the app with appropriate parameters
 // If status is not specified, status defaults to 302 Found.
+// If you want to send queries to route, you must add "queries" key typed as map[string]string to params.
 func (c *Ctx) RedirectToRoute(routeName string, params Map, status ...int) error {
 	location, err := c.getLocationFromRoute(c.App().GetRoute(routeName), params)
 	if err != nil {
 		return err
+	}
+
+	// Check queries
+	if queries, ok := params["queries"].(map[string]string); ok {
+		queryText := bytebufferpool.Get()
+		defer bytebufferpool.Put(queryText)
+
+		i := 1
+		for k, v := range queries {
+			queryText.WriteString(k + "=" + v)
+
+			if i != len(queries) {
+				queryText.WriteString("&")
+			}
+			i++
+		}
+
+		return c.Redirect(location+"?"+queryText.String(), status...)
 	}
 	return c.Redirect(location, status...)
 }

--- a/ctx.go
+++ b/ctx.go
@@ -1177,10 +1177,10 @@ func (c *Ctx) RedirectToRoute(routeName string, params Map, status ...int) error
 
 		i := 1
 		for k, v := range queries {
-			queryText.WriteString(k + "=" + v)
+			_, _ = queryText.WriteString(k + "=" + v)
 
 			if i != len(queries) {
-				queryText.WriteString("&")
+				_, _ = queryText.WriteString("&")
 			}
 			i++
 		}

--- a/ctx.go
+++ b/ctx.go
@@ -7,6 +7,7 @@ package fiber
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -22,8 +23,6 @@ import (
 	"sync"
 	"text/template"
 	"time"
-
-	"encoding/json"
 
 	"github.com/gofiber/fiber/v2/internal/bytebufferpool"
 	"github.com/gofiber/fiber/v2/internal/dictpool"

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"mime/multipart"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"reflect"
 	"strconv"
@@ -2269,7 +2270,11 @@ func Test_Ctx_RedirectToRouteWithQueries(t *testing.T) {
 		"queries": map[string]string{"data[0][name]": "john", "data[0][age]": "10", "test": "doe"},
 	})
 	utils.AssertEqual(t, 302, c.Response().StatusCode())
-	utils.AssertEqual(t, "/user/fiber?data[0][name]=john&data[0][age]=10&test=doe", string(c.Response().Header.Peek(HeaderLocation)))
+	// analysis of query parameters with url parsing, since a map pass is always randomly ordered
+	location, err := url.Parse(string(c.Response().Header.Peek(HeaderLocation)))
+	utils.AssertEqual(t, nil, err, "url.Parse(location)")
+	utils.AssertEqual(t, "/user/fiber", location.Path)
+	utils.AssertEqual(t, url.Values{"data[0][name]": []string{"john"}, "data[0][age]": []string{"10"}, "test": []string{"doe"}}, location.Query())
 }
 
 // go test -run Test_Ctx_RedirectToRouteWithOptionalParams
@@ -2603,7 +2608,11 @@ func Benchmark_Ctx_RedirectToRouteWithQueries(b *testing.B) {
 	}
 
 	utils.AssertEqual(b, 302, c.Response().StatusCode())
-	utils.AssertEqual(b, "/user/fiber?a=a&b=b", string(c.Response().Header.Peek(HeaderLocation)))
+	// analysis of query parameters with url parsing, since a map pass is always randomly ordered
+	location, err := url.Parse(string(c.Response().Header.Peek(HeaderLocation)))
+	utils.AssertEqual(b, nil, err, "url.Parse(location)")
+	utils.AssertEqual(b, "/user/fiber", location.Path)
+	utils.AssertEqual(b, url.Values{"a": []string{"a"}, "b": []string{"b"}}, location.Query())
 }
 
 func Benchmark_Ctx_RenderLocals(b *testing.B) {


### PR DESCRIPTION
**Closes:** https://github.com/gofiber/fiber/issues/1850
**Example:**
```go
// /user/fiber?data[0][name]=john&data[0][age]=10&test=doe
c.RedirectToRoute("user", Map{
	"name":    "fiber",
	"queries": map[string]string{"data[0][name]": "john", "data[0][age]": "10", "test": "doe"},
})
```
**Benchmark Results:**
```
Benchmark_Ctx_RedirectToRoute-4   	 3782589	       306.6 ns/op	      16 B/op	       1 allocs/op
Benchmark_Ctx_RedirectToRouteWithQueries-4   	  981728	      1315 ns/op	     376 B/op	       4 allocs/op
```

I didn't use "url" lib because of it makes extra allocations (+5 allocs). I think this way is faster and more elegant.