### PR TITLE
Fix nothing to cache if custom expiration < 0

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -46,7 +46,7 @@ func New(config ...Config) fiber.Handler {
 	cfg := configDefault(config...)
 
 	// Nothing to cache
-	if cfg.ExpirationGenerator == nil && int(cfg.Expiration.Seconds()) < 0 {
+	if cfg.ExpirationGenerator == nil && int(cfg.Expiration.Seconds()) <= 0 {
 		return func(c *fiber.Ctx) error {
 			return c.Next()
 		}
@@ -71,7 +71,7 @@ func New(config ...Config) fiber.Handler {
 	// Return new handler
 	return func(c *fiber.Ctx) error {
 		// Nothing to cache
-		if cfg.ExpirationGenerator != nil && int(cfg.ExpirationGenerator.Seconds()) < 0 {
+		if cfg.ExpirationGenerator != nil && int(cfg.ExpirationGenerator.Seconds()) <= 0 {
 			c.Set(cfg.CacheHeader, cacheUnreachable)
 			return c.Next()
 		}


### PR DESCRIPTION
There was no check for nothing to cache if custom expiration < 0. This PR adds that check.

Also, the current implementation checks if `expiration < 0` for nothing to cache. However nothing must be cached also in the case `expiration = 0`. Hence, improved the current implementation to `expiration <= 0` for nothing to cache.