### PR TITLE
Logging Middleware - TagLatency doesn't have standard format between modes

### DIFF
--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -229,7 +229,7 @@ func New(config ...Config) fiber.Handler {
 			case TagUA:
 				return buf.WriteString(c.Get(fiber.HeaderUserAgent))
 			case TagLatency:
-				return buf.WriteString(stop.Sub(start).String())
+				return buf.WriteString(fmt.Sprintf("%7v", stop.Sub(start).Round(time.Millisecond)))
 			case TagBody:
 				return buf.Write(c.Body())
 			case TagBytesReceived:


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

This change affects TagLatency in middleware logging. 
Currently if you don't change the default format the latency output is using millisecond as rounding, however if you configure a custom logging message format it outputs using time.Duration (string) serialization.

I can enumerate two problems:
- Standard between the two options (Default and Custom Format)
- time.Duration will output characters in UTF8 and UNICODE (UTF-16) according to its serialization unit (microseconds)

This PR suggests replacing time.Duration serialization to millisecond, the same used in DefaultFormat.

