### PR TITLE
:broom: client: remove beta warning

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1299,7 +1299,7 @@ func Test_Test_Timeout(t *testing.T) {
 	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
 
 	app.Get("timeout", func(c *Ctx) error {
-		time.Sleep(55 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		return nil
 	})
 

--- a/client.go
+++ b/client.go
@@ -738,14 +738,9 @@ func (a *Agent) RetryIf(retryIf RetryIfFunc) *Agent {
 }
 
 /************************** End Agent Setting **************************/
-var warnOnce sync.Once
 
 // Bytes returns the status code, bytes body and errors of url.
 func (a *Agent) Bytes() (code int, body []byte, errs []error) {
-	warnOnce.Do(func() {
-		fmt.Println("[Warning] client is still in beta, API might change in the future!")
-	})
-
 	defer a.release()
 
 	if errs = append(errs, a.errs...); len(errs) > 0 {


### PR DESCRIPTION
it seems there are no big problem in client since it was created. so we should remove the warning.

closes https://github.com/gofiber/fiber/issues/1923