### PR TITLE
fix middleware/session update cookie.

### DIFF
--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -144,10 +144,8 @@ func (s *Session) Save() error {
 		s.exp = s.config.Expiration
 	}
 
-	// Create session with the session ID if fresh
-	if s.fresh {
-		s.setSession()
-	}
+	// Update client cookie
+	s.setSession()
 
 	// Convert data to bytes
 	mux.Lock()


### PR DESCRIPTION
Session middleware should always update client cookie so that cookie expires at the same time as session.