### PR TITLE
🔥 Add OnPrefork Hooks so you can get the PID of the child process.

### DIFF
--- a/hooks_test.go
+++ b/hooks_test.go
@@ -176,3 +176,23 @@ func Test_Hook_OnListen(t *testing.T) {
 
 	utils.AssertEqual(t, "ready", buf.String())
 }
+
+func Test_Hook_OnHook(t *testing.T) {
+	// Reset test var
+	testPreforkMaster = true
+	testOnPrefork = true
+
+	app := New()
+
+	go func() {
+		time.Sleep(1000 * time.Millisecond)
+		utils.AssertEqual(t, nil, app.Shutdown())
+	}()
+
+	app.Hooks().OnFork(func(pid int) error {
+		utils.AssertEqual(t, 1, pid)
+		return nil
+	})
+
+	utils.AssertEqual(t, nil, app.prefork(NetworkTCP4, ":3000", nil))
+}

--- a/prefork.go
+++ b/prefork.go
@@ -20,6 +20,7 @@ const (
 )
 
 var testPreforkMaster = false
+var testOnPrefork = false
 
 // IsChild determines if the current process is a child of Prefork
 func IsChild() bool {
@@ -102,6 +103,15 @@ func (app *App) prefork(network, addr string, tlsConfig *tls.Config) (err error)
 		childs[pid] = cmd
 		pids = append(pids, strconv.Itoa(pid))
 
+		// execute fork hook
+		if app.hooks != nil {
+			if testOnPrefork {
+				app.hooks.executeOnForkHooks(dummyPid)
+			} else {
+				app.hooks.executeOnForkHooks(pid)
+			}
+		}
+
 		// notify master if child crashes
 		go func() {
 			channel <- child{pid, cmd.Wait()}
@@ -146,3 +156,5 @@ func dummyCmd() *exec.Cmd {
 	}
 	return exec.Command(dummyChildCmd, "version")
 }
+
+var dummyPid = 1


### PR DESCRIPTION
Add Hooks that can get the PID of a child process forked from the master process.
Currently, in the Prefork mode of fiber, the PID of the child process forked from the master process cannot be obtained, so CPU Affinity cannot be set automatically using commands such as taskset.
To maximize performance in Prefork mode, each child process should be pinned to a specific CPU core.
To make this possible, I will add a new Hooks.

## Usage
```go
func main() {
	app := fiber.New(fiber.Config{
		Prefork: true,
	})

	app.Hooks().OnFork(func(pid int) error {
		fmt.Printf("Forked child process %d\n", pid)
		return nil
	})

	app.Get("/", func(c *fiber.Ctx) error {
		return c.SendString("Hello, World 👋!")
	})

	app.Listen(":3000")
}
```

### output
```
Forked child process 18331
Forked child process 18332
Forked child process 18333
Forked child process 18334
Forked child process 18336
Forked child process 18338
Forked child process 18341
Forked child process 18350
Forked child process 18355
Forked child process 18365
Forked child process 18383
Forked child process 18388

 ┌───────────────────────────────────────────────────┐  ┌───────────────────────────────────────────────────┐
 │                   Fiber v2.35.0                   │  │ Child PIDs ... 18331, 18332, 18333, 18334, 18336  │
 │               http://127.0.0.1:3000               │  │ 18338, 18341, 18350, 18355, 18365, 18383, 18388   │
 │       (bound on host 0.0.0.0 and port 3000)       │  └───────────────────────────────────────────────────┘
 │                                                   │
 │ Handlers ............. 2  Processes .......... 12 │
 │ Prefork ........ Enabled  PID ............. 18325 │
 └───────────────────────────────────────────────────┘
```