### PR TITLE
v3: fix benchmark results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 name: Test
 jobs:
   Build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,16 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 name: Test
 jobs:
   Build:
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.19.x]
         platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/ctx.go
+++ b/ctx.go
@@ -761,7 +761,7 @@ func (c *DefaultCtx) Next() (err error) {
 		err = c.route.Handlers[c.indexHandler](c)
 	} else {
 		// Continue handler stack
-		_, err = c.app.next(c)
+		_, err = c.app.next(c, c.app.newCtxFunc != nil)
 	}
 	return err
 }
@@ -770,7 +770,7 @@ func (c *DefaultCtx) Next() (err error) {
 // changing the request path. Note that handlers might be executed again.
 func (c *DefaultCtx) RestartRouting() error {
 	c.indexRoute = -1
-	_, err := c.app.next(c)
+	_, err := c.app.next(c, c.app.newCtxFunc != nil)
 	return err
 }
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -63,7 +63,7 @@ func Test_Ctx_Accepts(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_Accepts -benchmem -count=4
 func Benchmark_Ctx_Accepts(b *testing.B) {
 	app := New()
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	c.Request().Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9")
 	var res string
@@ -141,7 +141,7 @@ func Test_Ctx_AcceptsCharsets(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_AcceptsCharsets -benchmem -count=4
 func Benchmark_Ctx_AcceptsCharsets(b *testing.B) {
 	app := New()
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	c.Request().Header.Set("Accept-Charset", "utf-8, iso-8859-1;q=0.5")
 	var res string
@@ -167,7 +167,7 @@ func Test_Ctx_AcceptsEncodings(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_AcceptsEncodings -benchmem -count=4
 func Benchmark_Ctx_AcceptsEncodings(b *testing.B) {
 	app := New()
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	c.Request().Header.Set(HeaderAcceptEncoding, "deflate, gzip;q=1.0, *;q=0.5")
 	var res string
@@ -192,7 +192,7 @@ func Test_Ctx_AcceptsLanguages(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_AcceptsLanguages -benchmem -count=4
 func Benchmark_Ctx_AcceptsLanguages(b *testing.B) {
 	app := New()
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	c.Request().Header.Set(HeaderAcceptLanguage, "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5")
 	var res string
@@ -253,7 +253,7 @@ func Test_Ctx_Append(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_Append -benchmem -count=4
 func Benchmark_Ctx_Append(b *testing.B) {
 	app := New()
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -286,7 +286,7 @@ func Test_Ctx_Attachment(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_Attachment -benchmem -count=4
 func Benchmark_Ctx_Attachment(b *testing.B) {
 	app := New()
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -312,7 +312,7 @@ func Test_Ctx_BaseURL(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_BaseURL -benchmem
 func Benchmark_Ctx_BaseURL(b *testing.B) {
 	app := New()
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	c.Request().SetHost("google.com:1337")
 	c.Request().URI().SetPath("/haha/oke/lol")
@@ -722,7 +722,7 @@ func Test_Ctx_Cookie(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_Cookie -benchmem -count=4
 func Benchmark_Ctx_Cookie(b *testing.B) {
 	app := New()
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -2539,7 +2539,7 @@ func Benchmark_Ctx_RedirectToRoute(b *testing.B) {
 		return c.JSON(c.Params("name"))
 	}).Name("user")
 
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -3018,7 +3018,7 @@ func Benchmark_Ctx_Type(b *testing.B) {
 // go test -v  -run=^$ -bench=Benchmark_Ctx_Type_Charset -benchmem -count=4
 func Benchmark_Ctx_Type_Charset(b *testing.B) {
 	app := New()
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2100,7 +2100,7 @@ func Test_Ctx_JSONP(t *testing.T) {
 // go test -v  -run=^$ -bench=Benchmark_Ctx_JSONP -benchmem -count=4
 func Benchmark_Ctx_JSONP(b *testing.B) {
 	app := New()
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	type SomeStruct struct {
 		Name string
@@ -2140,7 +2140,7 @@ func Test_Ctx_Links(t *testing.T) {
 // go test -v  -run=^$ -bench=Benchmark_Ctx_Links -benchmem -count=4
 func Benchmark_Ctx_Links(b *testing.B) {
 	app := New()
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -2560,7 +2560,7 @@ func Benchmark_Ctx_RedirectToRouteWithQueries(b *testing.B) {
 		return c.JSON(c.Params("name"))
 	}).Name("user")
 
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -3043,7 +3043,7 @@ func Test_Ctx_Vary(t *testing.T) {
 // go test -v  -run=^$ -bench=Benchmark_Ctx_Vary -benchmem -count=4
 func Benchmark_Ctx_Vary(b *testing.B) {
 	app := New()
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -3090,7 +3090,7 @@ func Test_Ctx_Writef(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_Writef -benchmem -count=4
 func Benchmark_Ctx_Writef(b *testing.B) {
 	app := New()
-	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx)
 
 	world := "World!"
 	b.ReportAllocs()

--- a/router_test.go
+++ b/router_test.go
@@ -595,7 +595,7 @@ func Benchmark_Router_Next(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		c.indexRoute = -1
-		res, err = app.next(c)
+		res, err = app.next(c, false)
 	}
 	utils.AssertEqual(b, nil, err)
 	utils.AssertEqual(b, true, res)
@@ -774,7 +774,7 @@ func Benchmark_Router_Github_API(b *testing.B) {
 			ctx := app.AcquireCtx().(CustomCtx)
 			ctx.Reset(c)
 
-			match, err = app.next(ctx)
+			match, err = app.next(ctx, false)
 			app.ReleaseCtx(ctx)
 		}
 

--- a/router_test.go
+++ b/router_test.go
@@ -770,9 +770,14 @@ func Benchmark_Router_Github_API(b *testing.B) {
 		c.Request.Header.SetMethod(routesFixture.TestRoutes[i].Method)
 		for n := 0; n < b.N; n++ {
 			c.URI().SetPath(routesFixture.TestRoutes[i].Path)
-			ctx := app.NewCtx(c)
-			match, err = app.next(ctx.(CustomCtx))
+
+			ctx := app.AcquireCtx().(CustomCtx)
+			ctx.Reset(c)
+
+			match, err = app.next(ctx)
+			app.ReleaseCtx(ctx)
 		}
+
 		utils.AssertEqual(b, nil, err)
 		utils.AssertEqual(b, true, match)
 	}


### PR DESCRIPTION
Some benchmarks make extra allocs after https://github.com/gofiber/fiber/pull/1928 because of new context's type is interface. This PR aims to fix these benchmarks.

## Check:
- [ ] Benchmark_Ctx_MultipartForm
- [ ] Benchmark_Startup_Process
- [x] Benchmark_Router_Github_API
- [ ] Benchmark_Middleware_BasicAuth
- [ ] Benchmark_Cache
- [ ] Benchmark_Cache_Storage
- [ ] Benchmark_Cache_AdditionalHeaders
- [ ] Benchmark_Cache_MaxSize
- [ ] Benchmark_Limiter

**Comparision of master/v3-fix-benchmarks**
```sh
Benchmark_AcquireCtx-4                                                                    5              0              -100.00%
Benchmark_Ctx_Accepts-4                                                                   0              0              +0.00%
Benchmark_Ctx_AcceptsCharsets-4                                                           0              0              +0.00%
Benchmark_Ctx_AcceptsEncodings-4                                                          0              0              +0.00%
Benchmark_Ctx_AcceptsLanguages-4                                                          0              0              +0.00%
Benchmark_Ctx_Append-4                                                                    0              0              +0.00%
Benchmark_Ctx_Attachment-4                                                                1              1              +0.00%
Benchmark_Ctx_BaseURL-4                                                                   0              0              +0.00%
Benchmark_Ctx_Body_With_Compression-4                                                     7              7              +0.00%
Benchmark_Ctx_BodyParser_JSON-4                                                           6              6              +0.00%
Benchmark_Ctx_BodyParser_XML-4                                                            24             24             +0.00%
Benchmark_Ctx_BodyParser_Form-4                                                           13             13             +0.00%
Benchmark_Ctx_BodyParser_MultipartForm-4                                                  12             12             +0.00%
Benchmark_Ctx_Cookie-4                                                                    0              0              +0.00%
Benchmark_Ctx_Format-4                                                                    0              0              +0.00%
Benchmark_Ctx_Format_HTML-4                                                               0              0              +0.00%
Benchmark_Ctx_Format_JSON-4                                                               1              1              +0.00%
Benchmark_Ctx_Format_XML-4                                                                7              7              +0.00%
Benchmark_Ctx_Fresh_StaleEtag-4                                                           0              0              +0.00%
Benchmark_Ctx_Fresh_WithNoCache-4                                                         0              0              +0.00%
Benchmark_Ctx_IPs-4                                                                       1              1              +0.00%
Benchmark_Ctx_Is-4                                                                        0              0              +0.00%
Benchmark_Ctx_MultipartForm-4                                                             4              8              +100.00%
Benchmark_Ctx_Params-4                                                                    0              0              +0.00%
Benchmark_Ctx_AllParams-4                                                                 2              2              +0.00%
Benchmark_Ctx_Protocol-4                                                                  0              0              +0.00%
Benchmark_Ctx_Subdomains-4                                                                1              1              +0.00%
Benchmark_Ctx_JSON-4                                                                      2              2              +0.00%
Benchmark_Ctx_JSONP-4                                                                     2              2              +0.00%
Benchmark_Ctx_Links-4                                                                     0              0              +0.00%
Benchmark_Ctx_RenderWithLocalsAndBinding-4                                                7              7              +0.00%
Benchmark_Ctx_RedirectToRoute-4                                                           1              1              +0.00%
Benchmark_Ctx_RedirectToRouteWithQueries-4                                                4              4              +0.00%
Benchmark_Ctx_RenderLocals-4                                                              5              5              +0.00%
Benchmark_Ctx_RenderBind-4                                                                5              5              +0.00%
Benchmark_Ctx_Render_Engine-4                                                             5              5              +0.00%
Benchmark_Ctx_Get_Location_From_Route-4                                                   1              1              +0.00%
Benchmark_Ctx_Send-4                                                                      0              0              +0.00%
Benchmark_Ctx_Set-4                                                                       0              0              +0.00%
Benchmark_Ctx_Type-4                                                                      0              0              +0.00%
Benchmark_Ctx_Type_Charset-4                                                              0              0              +0.00%
Benchmark_Ctx_Vary-4                                                                      0              0              +0.00%
Benchmark_Ctx_Write-4                                                                     0              0              +0.00%
Benchmark_Ctx_Writef-4                                                                    1              1              +0.00%
Benchmark_Ctx_XHR-4                                                                       0              0              +0.00%
Benchmark_Ctx_SendString_B-4                                                              0              0              +0.00%
Benchmark_Ctx_QueryParser-4                                                               38             38             +0.00%
Benchmark_Ctx_parseQuery-4                                                                29             29             +0.00%
Benchmark_Ctx_QueryParser_Comma-4                                                         44             44             +0.00%
Benchmark_Ctx_ReqHeaderParser-4                                                           44             44             +0.00%
Benchmark_Ctx_BodyStreamWriter-4                                                          8              8              +0.00%
Benchmark_Utils_getGroupPath-4                                                            2              2              +0.00%
Benchmark_Utils_Unescape-4                                                                1              1              +0.00%
Benchmark_Utils_IsNoCache-4                                                               0              0              +0.00%
Benchmark_SlashRecognition/indexBytes-4                                                   0              0              +0.00%
Benchmark_SlashRecognition/forEach-4                                                      0              0              +0.00%
Benchmark_SlashRecognition/IndexRune-4                                                    0              0              +0.00%
Benchmark_Path_matchParams//api/:param/fixedEnd_|_match_|_/api/abc/fixedEnd-4             0              0              +0.00%
Benchmark_Path_matchParams//api/:param/fixedEnd_|_not_match_|_/api/abc/def/fixedEnd-4     0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param/*_|_match_|_/api/v1/entity-4                    0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param/*_|_match_|_/api/v1/entity/-4                   0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param/*_|_match_|_/api/v1/entity/1-4                  0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param/*_|_not_match_|_/api/v-4                        0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param/*_|_not_match_|_/api/v2-4                       0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param/*_|_not_match_|_/api/v1/-4                      0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param_|_match_|_/api/v1/entity-4                      0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param_|_not_match_|_/api/v1/entity/8728382-4          0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param_|_not_match_|_/api/v1-4                         0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param_|_not_match_|_/api/v1/-4                        0              0              +0.00%
Benchmark_Path_matchParams//api/v1_|_match_|_/api/v1-4                                    0              0              +0.00%
Benchmark_Path_matchParams//api/v1_|_not_match_|_/api/v2-4                                0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param/*_|_match_|_/api/v1/entity#01-4                 0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param/*_|_match_|_/api/v1/entity/#01-4                0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param/*_|_match_|_/api/v1/entity/1#01-4               0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param/*_|_not_match_|_/api/v#01-4                     0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param/*_|_not_match_|_/api/v2#01-4                    0              0              +0.00%
Benchmark_Path_matchParams//api/v1/:param/*_|_not_match_|_/api/v1/#01-4                   0              0              +0.00%
Benchmark_App_MethodNotAllowed-4                                                          3              8              +166.67%
Benchmark_Router_NotFound-4                                                               3              6              +100.00%
Benchmark_Router_Handler-4                                                                0              0              +0.00%
Benchmark_Router_Handler_Strict_Case-4                                                    0              0              +0.00%
Benchmark_Router_Chain-4                                                                  3              6              +100.00%
Benchmark_Router_WithCompression-4                                                        3              6              +100.00%
Benchmark_Startup_Process-4                                                               5606           5607           +0.02%
Benchmark_Router_Next-4                                                                   0              0              +0.00%
Benchmark_Route_Match-4                                                                   0              0              +0.00%
Benchmark_Route_Match_Star-4                                                              0              0              +0.00%
Benchmark_Route_Match_Root-4                                                              0              0              +0.00%
Benchmark_Router_Handler_CaseSensitive-4                                                  0              0              +0.00%
Benchmark_Router_Handler_Unescape-4                                                       0              0              +0.00%
Benchmark_Router_Handler_StrictRouting-4                                                  0              0              +0.00%
Benchmark_Router_Github_API-4                                                             0              0              +0.00%
Benchmark_Middleware_BasicAuth-4                                                          3              5              +66.67%
Benchmark_Cache-4                                                                         2              6              +200.00%
Benchmark_Cache_Storage-4                                                                 5              6              +20.00%
Benchmark_Cache_AdditionalHeaders-4                                                       2              9              +350.00%
Benchmark_Cache_MaxSize/Disabled-4                                                        7              8              +14.29%
Benchmark_Cache_MaxSize/Unlim-4                                                           7              8              +14.29%
Benchmark_Cache_MaxSize/LowBounded-4                                                      7              8              +14.29%
Benchmark_Etag-4                                                                          0              0              +0.00%
Benchmark_Middleware_Favicon-4                                                            1              1              +0.00%
Benchmark_Limiter_Custom_Store-4                                                          2              2              +0.00%
Benchmark_Limiter-4                                                                       1              2              +100.00%
Benchmark_Logger-4                                                                        0              0              +0.00%
Benchmark_Monitor-4                                                                       1              1              +0.00%
Benchmark_Session/default-4                                                               206            206            +0.00%
Benchmark_Session/storage-4                                                               206            206            +0.00%
Benchmark_ToLowerBytes/fiber-4                                                            0              0              +0.00%
Benchmark_ToLowerBytes/default-4                                                          1              1              +0.00%
Benchmark_ToUpperBytes/fiber-4                                                            0              0              +0.00%
Benchmark_ToUpperBytes/default-4                                                          1              1              +0.00%
Benchmark_TrimRightBytes/fiber-4                                                          1              1              +0.00%
Benchmark_TrimRightBytes/default-4                                                        1              1              +0.00%
Benchmark_TrimLeftBytes/fiber-4                                                           1              1              +0.00%
Benchmark_TrimLeftBytes/default-4                                                         1              1              +0.00%
Benchmark_TrimBytes/fiber-4                                                               1              1              +0.00%
Benchmark_TrimBytes/default-4                                                             1              1              +0.00%
Benchmark_EqualFoldBytes/fiber-4                                                          0              0              +0.00%
Benchmark_EqualFoldBytes/default-4                                                        0              0              +0.00%
Benchmark_UUID/fiber-4                                                                    1              1              +0.00%
Benchmark_UUID/default-4                                                                  6              6              +0.00%
Benchmark_ConvertToBytes/fiber-4                                                          0              0              +0.00%
Benchmark_UnsafeString/unsafe-4                                                           0              0              +0.00%
Benchmark_UnsafeString/default-4                                                          1              1              +0.00%
Benchmark_UnsafeBytes/unsafe-4                                                            0              0              +0.00%
Benchmark_UnsafeBytes/default-4                                                           1              1              +0.00%
Benchmark_ToString-4                                                                      2              2              +0.00%
Benchmark_GetMIME/fiber-4                                                                 0              0              +0.00%
Benchmark_GetMIME/default-4                                                               0              0              +0.00%
Benchmark_ParseVendorSpecificContentType/vendorContentType-4                              1              1              +0.00%
Benchmark_ParseVendorSpecificContentType/defaultContentType-4                             0              0              +0.00%
Benchmark_StatusMessage/fiber-4                                                           0              0              +0.00%
Benchmark_StatusMessage/default-4                                                         0              0              +0.00%
Benchmark_ToUpper/fiber-4                                                                 1              1              +0.00%
Benchmark_ToUpper/default-4                                                               1              1              +0.00%
Benchmark_ToLower/fiber-4                                                                 1              1              +0.00%
Benchmark_ToLower/default-4                                                               1              1              +0.00%
Benchmark_TrimRight/fiber-4                                                               0              0              +0.00%
Benchmark_TrimRight/default-4                                                             0              0              +0.00%
Benchmark_TrimLeft/fiber-4                                                                0              0              +0.00%
Benchmark_TrimLeft/default-4                                                              0              0              +0.00%
Benchmark_Trim/fiber-4                                                                    0              0              +0.00%
Benchmark_Trim/default-4                                                                  0              0              +0.00%
Benchmark_Trim/default.trimspace-4                                                        0              0              +0.00%
Benchmark_EqualFold/fiber-4                                                               0              0              +0.00%
Benchmark_EqualFold/default-4                                                             0              0              +0.00%
```