### PR TITLE
:art: Fix padding around app name in startup message when containing non-ascii characters

### DIFF
--- a/app.go
+++ b/app.go
@@ -1183,11 +1183,11 @@ func (app *App) startupMessage(addr string, tls bool, pids string) {
 	}
 
 	centerValue := func(s string, width int) string {
-		pad := strconv.Itoa((width - len(s)) / 2)
+		pad := strconv.Itoa((width - len([]rune(s))) / 2)
 		str := fmt.Sprintf("%"+pad+"s", " ")
 		str += fmt.Sprintf("%s%s%s", cCyan, s, cBlack)
 		str += fmt.Sprintf("%"+pad+"s", " ")
-		if len(str)-10 < width {
+		if len([]rune(str))-10 < width {
 			str += " "
 		}
 		return str

--- a/app_test.go
+++ b/app_test.go
@@ -1528,6 +1528,16 @@ func Test_App_Master_Process_Show_Startup_MessageWithAppName(t *testing.T) {
 	utils.AssertEqual(t, true, strings.Contains(startupMessage, app.Config().AppName))
 }
 
+func Test_App_Master_Process_Show_Startup_MessageWithAppNameNonAscii(t *testing.T) {
+	appName := "Serveur de vérification des données"
+	app := New(Config{Prefork: true, AppName: appName})
+	startupMessage := captureOutput(func() {
+		app.startupMessage(":3000", false, "")
+	})
+	fmt.Println(startupMessage)
+	utils.AssertEqual(t, true, strings.Contains(startupMessage, "│        Serveur de vérification des données        │"))
+}
+
 func Test_App_Server(t *testing.T) {
 	app := New()
 

--- a/app_test.go
+++ b/app_test.go
@@ -10,16 +10,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"mime/multipart"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"reflect"
 	"regexp"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -1346,69 +1343,6 @@ func Test_App_SmallReadBuffer(t *testing.T) {
 	}()
 
 	utils.AssertEqual(t, nil, app.Listen(":4006"))
-}
-
-func captureOutput(f func()) string {
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		panic(err)
-	}
-	stdout := os.Stdout
-	stderr := os.Stderr
-	defer func() {
-		os.Stdout = stdout
-		os.Stderr = stderr
-		log.SetOutput(os.Stderr)
-	}()
-	os.Stdout = writer
-	os.Stderr = writer
-	log.SetOutput(writer)
-	out := make(chan string)
-	wg := new(sync.WaitGroup)
-	wg.Add(1)
-	go func() {
-		var buf bytes.Buffer
-		wg.Done()
-		io.Copy(&buf, reader)
-		out <- buf.String()
-	}()
-	wg.Wait()
-	f()
-	writer.Close()
-	return <-out
-}
-
-func Test_App_Master_Process_Show_Startup_Message(t *testing.T) {
-	startupMessage := captureOutput(func() {
-		New(Config{Prefork: true}).
-			startupMessage(":3000", true, strings.Repeat(",11111,22222,33333,44444,55555,60000", 10))
-	})
-	fmt.Println(startupMessage)
-	utils.AssertEqual(t, true, strings.Contains(startupMessage, "https://127.0.0.1:3000"))
-	utils.AssertEqual(t, true, strings.Contains(startupMessage, "(bound on host 0.0.0.0 and port 3000)"))
-	utils.AssertEqual(t, true, strings.Contains(startupMessage, "Child PIDs"))
-	utils.AssertEqual(t, true, strings.Contains(startupMessage, "11111, 22222, 33333, 44444, 55555, 60000"))
-	utils.AssertEqual(t, true, strings.Contains(startupMessage, "Prefork ........ Enabled"))
-}
-
-func Test_App_Master_Process_Show_Startup_MessageWithAppName(t *testing.T) {
-	app := New(Config{Prefork: true, AppName: "Test App v1.0.1"})
-	startupMessage := captureOutput(func() {
-		app.startupMessage(":3000", true, strings.Repeat(",11111,22222,33333,44444,55555,60000", 10))
-	})
-	fmt.Println(startupMessage)
-	utils.AssertEqual(t, "Test App v1.0.1", app.Config().AppName)
-	utils.AssertEqual(t, true, strings.Contains(startupMessage, app.Config().AppName))
-}
-
-func Test_App_Master_Process_Show_Startup_MessageWithAppNameNonAscii(t *testing.T) {
-	appName := "Serveur de vérification des données"
-	app := New(Config{Prefork: true, AppName: appName})
-	startupMessage := captureOutput(func() {
-		app.startupMessage(":3000", false, "")
-	})
-	fmt.Println(startupMessage)
-	utils.AssertEqual(t, true, strings.Contains(startupMessage, "│        Serveur de vérification des données        │"))
 }
 
 func Test_App_Server(t *testing.T) {

--- a/listen.go
+++ b/listen.go
@@ -208,11 +208,12 @@ func (app *App) startupMessage(addr string, tls bool, pids string) {
 	}
 
 	centerValue := func(s string, width int) string {
-		pad := strconv.Itoa((width - len(s)) / 2)
+		pad := strconv.Itoa((width - len([]rune(s))) / 2)
 		str := fmt.Sprintf("%"+pad+"s", " ")
 		str += fmt.Sprintf("%s%s%s", colors.Cyan, s, colors.Black)
 		str += fmt.Sprintf("%"+pad+"s", " ")
-		if len(str)-10 < width {
+		if len([]rune(str))-10 < width && len([]rune(str))%2 != 0 {
+			// add an ending space if the length of str is odd and str is not too long
 			str += " "
 		}
 		return str


### PR DESCRIPTION
When the app name contains non-ascii chars (that are stored on more than 1 byte) , the padding around it in the startup message becomes incorrect. The veritable length of the app name can be obtained by getting the length of the underlying rune slice, like `len([]rune(s))`.

I added a test (`Test_App_Master_Process_Show_Startup_MessageWithAppNameNonAscii`) that creates an app with a name containing accentuated letters.