### PR TITLE
fix infinitely `app.Test`

### DIFF
--- a/app.go
+++ b/app.go
@@ -848,7 +848,7 @@ func (app *App) Test(req *http.Request, msTimeout ...int) (resp *http.Response, 
 		var returned bool
 		defer func() {
 			if !returned {
-				channel <- fmt.Errorf("runtime.Goexit() called in handler")
+				channel <- fmt.Errorf("runtime.Goexit() called in handler or server panic")
 			}
 		}()
 

--- a/app.go
+++ b/app.go
@@ -852,9 +852,8 @@ func (app *App) Test(req *http.Request, msTimeout ...int) (resp *http.Response, 
 			}
 		}()
 
-		r := app.server.ServeConn(conn)
+		channel <- app.server.ServeConn(conn)
 		returned = true
-		channel <- r
 	}()
 
 	// Wait for callback

--- a/app.go
+++ b/app.go
@@ -845,7 +845,16 @@ func (app *App) Test(req *http.Request, msTimeout ...int) (resp *http.Response, 
 	// Serve conn to server
 	channel := make(chan error)
 	go func() {
-		channel <- app.server.ServeConn(conn)
+		var returned bool
+		defer func() {
+			if !returned {
+				channel <- fmt.Errorf("runtime.Goexit() called in handler")
+			}
+		}()
+
+		r := app.server.ServeConn(conn)
+		returned = true
+		channel <- r
 	}()
 
 	// Wait for callback

--- a/app_test.go
+++ b/app_test.go
@@ -1530,9 +1530,10 @@ func Test_App_UseMountedErrorHandlerForBestPrefixMatch(t *testing.T) {
 }
 
 func Test_App_Test_no_timeout_infinitely(t *testing.T) {
-	start := time.Now()
 	var err error
+	start := time.Now()
 	c := make(chan bool)
+	
 	go func() {
 		time.Sleep(5 * time.Second)
 		c <- true

--- a/app_test.go
+++ b/app_test.go
@@ -1532,11 +1532,11 @@ func Test_App_UseMountedErrorHandlerForBestPrefixMatch(t *testing.T) {
 func Test_App_Test_no_timeout_infinitely(t *testing.T) {
 	var err error
 	start := time.Now()
-	c := make(chan bool)
+	c := make(chan int)
 
 	go func() {
 		time.Sleep(5 * time.Second)
-		c <- true
+		c <- 0
 	}()
 	go func() {
 		defer func() { c <- 0 }()

--- a/app_test.go
+++ b/app_test.go
@@ -1533,13 +1533,13 @@ func Test_App_Test_no_timeout_infinitely(t *testing.T) {
 	var err error
 	start := time.Now()
 	c := make(chan bool)
-	
+
 	go func() {
 		time.Sleep(5 * time.Second)
 		c <- true
 	}()
 	go func() {
-		defer close(c)
+		defer func() { c <- 0 }()
 		app := New()
 		app.Get("/", func(c *Ctx) error {
 			runtime.Goexit()


### PR DESCRIPTION

**Explain the *details* for making this change. What existing problem does the pull request solve?**

details are explained in #1996

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

add a `defer` in `app.Test` so `runtime.Goexit` can be handled.