### PR TITLE
:memo: docs: gofmt & add missing copyright texts

### DIFF
--- a/app.go
+++ b/app.go
@@ -63,17 +63,18 @@ type Storage interface {
 
 // ErrorHandler defines a function that will process all errors
 // returned from any handlers in the stack
-//  cfg := fiber.Config{}
-//  cfg.ErrorHandler = func(c *Ctx, err error) error {
-//   code := StatusInternalServerError
-//   var e *fiber.Error
-//   if errors.As(err, &e) {
-//     code = e.Code
-//   }
-//   c.Set(HeaderContentType, MIMETextPlainCharsetUTF8)
-//   return c.Status(code).SendString(err.Error())
-//  }
-//  app := fiber.New(cfg)
+//
+//	cfg := fiber.Config{}
+//	cfg.ErrorHandler = func(c *Ctx, err error) error {
+//	 code := StatusInternalServerError
+//	 var e *fiber.Error
+//	 if errors.As(err, &e) {
+//	   code = e.Code
+//	 }
+//	 c.Set(HeaderContentType, MIMETextPlainCharsetUTF8)
+//	 return c.Status(code).SendString(err.Error())
+//	}
+//	app := fiber.New(cfg)
 type ErrorHandler = func(*Ctx, error) error
 
 // Error represents an error that occurred while handling a request.
@@ -438,12 +439,15 @@ var DefaultErrorHandler = func(c *Ctx, err error) error {
 }
 
 // New creates a new Fiber named instance.
-//  app := fiber.New()
+//
+//	app := fiber.New()
+//
 // You can pass optional configuration options by passing a Config struct:
-//  app := fiber.New(fiber.Config{
-//      Prefork: true,
-//      ServerHeader: "Fiber",
-//  })
+//
+//	app := fiber.New(fiber.Config{
+//	    Prefork: true,
+//	    ServerHeader: "Fiber",
+//	})
 func New(config ...Config) *App {
 	// Create a new app
 	app := &App{
@@ -609,15 +613,15 @@ func (app *App) GetRoute(name string) Route {
 // Use registers a middleware route that will match requests
 // with the provided prefix (which is optional and defaults to "/").
 //
-//  app.Use(func(c *fiber.Ctx) error {
-//       return c.Next()
-//  })
-//  app.Use("/api", func(c *fiber.Ctx) error {
-//       return c.Next()
-//  })
-//  app.Use("/api", handler, func(c *fiber.Ctx) error {
-//       return c.Next()
-//  })
+//	app.Use(func(c *fiber.Ctx) error {
+//	     return c.Next()
+//	})
+//	app.Use("/api", func(c *fiber.Ctx) error {
+//	     return c.Next()
+//	})
+//	app.Use("/api", handler, func(c *fiber.Ctx) error {
+//	     return c.Next()
+//	})
 //
 // This method will match all HTTP verbs: GET, POST, PUT, HEAD etc...
 func (app *App) Use(args ...interface{}) Router {
@@ -710,8 +714,9 @@ func (app *App) All(path string, handlers ...Handler) Router {
 }
 
 // Group is used for Routes with common prefix to define a new sub-router with optional middleware.
-//  api := app.Group("/api")
-//  api.Get("/users", handler)
+//
+//	api := app.Group("/api")
+//	api.Get("/users", handler)
 func (app *App) Group(prefix string, handlers ...Handler) Router {
 	if len(handlers) > 0 {
 		app.register(methodUse, prefix, handlers...)

--- a/client.go
+++ b/client.go
@@ -566,7 +566,8 @@ func (a *Agent) SendFile(filename string, fieldname ...string) *Agent {
 // SendFiles reads files and appends them to multipart form request.
 //
 // Examples:
-//		SendFile("/path/to/file1", "fieldname1", "/path/to/file2")
+//
+//	SendFile("/path/to/file1", "fieldname1", "/path/to/file2")
 func (a *Agent) SendFiles(filenamesAndFieldnames ...string) *Agent {
 	pairs := len(filenamesAndFieldnames)
 	if pairs&1 == 1 {

--- a/group.go
+++ b/group.go
@@ -70,15 +70,15 @@ func (grp *Group) Name(name string) Router {
 // Use registers a middleware route that will match requests
 // with the provided prefix (which is optional and defaults to "/").
 //
-//  app.Use(func(c *fiber.Ctx) error {
-//       return c.Next()
-//  })
-//  app.Use("/api", func(c *fiber.Ctx) error {
-//       return c.Next()
-//  })
-//  app.Use("/api", handler, func(c *fiber.Ctx) error {
-//       return c.Next()
-//  })
+//	app.Use(func(c *fiber.Ctx) error {
+//	     return c.Next()
+//	})
+//	app.Use("/api", func(c *fiber.Ctx) error {
+//	     return c.Next()
+//	})
+//	app.Use("/api", handler, func(c *fiber.Ctx) error {
+//	     return c.Next()
+//	})
 //
 // This method will match all HTTP verbs: GET, POST, PUT, HEAD etc...
 func (grp *Group) Use(args ...interface{}) Router {
@@ -171,8 +171,9 @@ func (grp *Group) All(path string, handlers ...Handler) Router {
 }
 
 // Group is used for Routes with common prefix to define a new sub-router with optional middleware.
-//  api := app.Group("/api")
-//  api.Get("/users", handler)
+//
+//	api := app.Group("/api")
+//	api.Get("/users", handler)
 func (grp *Group) Group(prefix string, handlers ...Handler) Router {
 	prefix = getGroupPath(grp.Prefix, prefix)
 	if len(handlers) > 0 {

--- a/internal/fasttemplate/template.go
+++ b/internal/fasttemplate/template.go
@@ -65,9 +65,9 @@ func ExecuteFunc(template, startTag, endTag string, w io.Writer, f TagFunc) (int
 // values from the map m and writes the result to the given writer w.
 //
 // Substitution map m may contain values with the following types:
-//   * []byte - the fastest value type
-//   * string - convenient value type
-//   * TagFunc - flexible value type
+//   - []byte - the fastest value type
+//   - string - convenient value type
+//   - TagFunc - flexible value type
 //
 // Returns the number of bytes written to w.
 //
@@ -81,9 +81,9 @@ func Execute(template, startTag, endTag string, w io.Writer, m map[string]interf
 // This can be used as a drop-in replacement for strings.Replacer
 //
 // Substitution map m may contain values with the following types:
-//   * []byte - the fastest value type
-//   * string - convenient value type
-//   * TagFunc - flexible value type
+//   - []byte - the fastest value type
+//   - string - convenient value type
+//   - TagFunc - flexible value type
 //
 // Returns the number of bytes written to w.
 //
@@ -135,9 +135,9 @@ var byteBufferPool bytebufferpool.Pool
 // values from the map m and returns the result.
 //
 // Substitution map m may contain values with the following types:
-//   * []byte - the fastest value type
-//   * string - convenient value type
-//   * TagFunc - flexible value type
+//   - []byte - the fastest value type
+//   - string - convenient value type
+//   - TagFunc - flexible value type
 //
 // This function is optimized for constantly changing templates.
 // Use Template.ExecuteString for frozen templates.
@@ -149,9 +149,9 @@ func ExecuteString(template, startTag, endTag string, m map[string]interface{}) 
 // This can be used as a drop-in replacement for strings.Replacer
 //
 // Substitution map m may contain values with the following types:
-//   * []byte - the fastest value type
-//   * string - convenient value type
-//   * TagFunc - flexible value type
+//   - []byte - the fastest value type
+//   - string - convenient value type
+//   - TagFunc - flexible value type
 //
 // This function is optimized for constantly changing templates.
 // Use Template.ExecuteStringStd for frozen templates.
@@ -305,9 +305,9 @@ func (t *Template) ExecuteFunc(w io.Writer, f TagFunc) (int64, error) {
 // values from the map m and writes the result to the given writer w.
 //
 // Substitution map m may contain values with the following types:
-//   * []byte - the fastest value type
-//   * string - convenient value type
-//   * TagFunc - flexible value type
+//   - []byte - the fastest value type
+//   - string - convenient value type
+//   - TagFunc - flexible value type
 //
 // Returns the number of bytes written to w.
 func (t *Template) Execute(w io.Writer, m map[string]interface{}) (int64, error) {
@@ -318,9 +318,9 @@ func (t *Template) Execute(w io.Writer, m map[string]interface{}) (int64, error)
 // This can be used as a drop-in replacement for strings.Replacer
 //
 // Substitution map m may contain values with the following types:
-//   * []byte - the fastest value type
-//   * string - convenient value type
-//   * TagFunc - flexible value type
+//   - []byte - the fastest value type
+//   - string - convenient value type
+//   - TagFunc - flexible value type
 //
 // Returns the number of bytes written to w.
 func (t *Template) ExecuteStd(w io.Writer, m map[string]interface{}) (int64, error) {
@@ -366,9 +366,9 @@ func (t *Template) ExecuteFuncStringWithErr(f TagFunc) (string, error) {
 // values from the map m and returns the result.
 //
 // Substitution map m may contain values with the following types:
-//   * []byte - the fastest value type
-//   * string - convenient value type
-//   * TagFunc - flexible value type
+//   - []byte - the fastest value type
+//   - string - convenient value type
+//   - TagFunc - flexible value type
 //
 // This function is optimized for frozen templates.
 // Use ExecuteString for constantly changing templates.
@@ -380,9 +380,9 @@ func (t *Template) ExecuteString(m map[string]interface{}) string {
 // This can be used as a drop-in replacement for strings.Replacer
 //
 // Substitution map m may contain values with the following types:
-//   * []byte - the fastest value type
-//   * string - convenient value type
-//   * TagFunc - flexible value type
+//   - []byte - the fastest value type
+//   - string - convenient value type
+//   - TagFunc - flexible value type
 //
 // This function is optimized for frozen templates.
 // Use ExecuteStringStd for constantly changing templates.

--- a/internal/fwd/reader.go
+++ b/internal/fwd/reader.go
@@ -31,7 +31,6 @@
 // returns a slice pointing to the next `n` bytes of the writer, and increments
 // the write position by the length of the returned slice. This allows users
 // to write directly to the end of the buffer.
-//
 package fwd
 
 import "io"

--- a/internal/go-ole/guid.go
+++ b/internal/go-ole/guid.go
@@ -108,9 +108,9 @@ type GUID struct {
 //
 // The supplied string may be in any of these formats:
 //
-//  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-//  XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-//  {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}
+//	XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+//	XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+//	{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}
 //
 // The conversion of the supplied string is not case-sensitive.
 func NewGUID(guid string) *GUID {
@@ -216,11 +216,11 @@ func decodeHexChar(c byte) (byte, bool) {
 
 // String converts the GUID to string form. It will adhere to this pattern:
 //
-//  {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}
+//	{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}
 //
 // If the GUID is nil, the string representation of an empty GUID is returned:
 //
-//  {00000000-0000-0000-0000-000000000000}
+//	{00000000-0000-0000-0000-000000000000}
 func (guid *GUID) String() string {
 	if guid == nil {
 		return emptyGUID

--- a/internal/gopsutil/common/common.go
+++ b/internal/gopsutil/common/common.go
@@ -114,8 +114,9 @@ func ReadLines(filename string) ([]string, error) {
 // ReadLines reads contents from file and splits them by new line.
 // The offset tells at which line number to start.
 // The count determines the number of lines to read (starting from offset):
-//   n >= 0: at most n lines
-//   n < 0: whole file
+//
+//	n >= 0: at most n lines
+//	n < 0: whole file
 func ReadLinesOffsetN(filename string, offset uint, n int) ([]string, error) {
 	f, err := os.Open(filename)
 	if err != nil {
@@ -308,7 +309,7 @@ func PathExists(filename string) bool {
 	return false
 }
 
-//GetEnv retrieves the environment variable key. If it does not exist it returns the default.
+// GetEnv retrieves the environment variable key. If it does not exist it returns the default.
 func GetEnv(key string, dfault string, combineWith ...string) string {
 	value := os.Getenv(key)
 	if value == "" {

--- a/internal/gopsutil/common/common_windows.go
+++ b/internal/gopsutil/common/common_windows.go
@@ -211,9 +211,12 @@ func WMIQueryWithContext(ctx context.Context, query string, dst interface{}, con
 }
 
 // Convert paths using native DOS format like:
-//   "\Device\HarddiskVolume1\Windows\systemew\file.txt"
+//
+//	"\Device\HarddiskVolume1\Windows\systemew\file.txt"
+//
 // into:
-//   "C:\Windows\systemew\file.txt"
+//
+//	"C:\Windows\systemew\file.txt"
 func ConvertDOSPath(p string) string {
 	rawDrive := strings.Join(strings.Split(p, `\`)[:3], `\`)
 

--- a/internal/gopsutil/cpu/cpu_solaris.go
+++ b/internal/gopsutil/cpu/cpu_solaris.go
@@ -29,7 +29,7 @@ func init() {
 	}
 }
 
-//sum all values in a float64 map with float64 keys
+// sum all values in a float64 map with float64 keys
 func msum(x map[float64]float64) float64 {
 	total := 0.0
 	for _, y := range x {

--- a/internal/gopsutil/net/net_linux.go
+++ b/internal/gopsutil/net/net_linux.go
@@ -161,7 +161,8 @@ var netProtocols = []string{
 // If protocols is empty then all protocols are returned, otherwise
 // just the protocols in the list are returned.
 // Available protocols:
-//   ip,icmp,icmpmsg,tcp,udp,udplite
+//
+//	ip,icmp,icmpmsg,tcp,udp,udplite
 func ProtoCounters(protocols []string) ([]ProtoCountersStat, error) {
 	return ProtoCountersWithContext(context.Background(), protocols)
 }

--- a/internal/gopsutil/net/net_windows.go
+++ b/internal/gopsutil/net/net_windows.go
@@ -208,7 +208,8 @@ func IOCountersByFileWithContext(ctx context.Context, pernic bool, filename stri
 
 // Return a list of network connections
 // Available kind:
-//   reference to netConnectionKindMap
+//
+//	reference to netConnectionKindMap
 func Connections(kind string) ([]ConnectionStat, error) {
 	return ConnectionsWithContext(context.Background(), kind)
 }

--- a/internal/isatty/isatty_windows.go
+++ b/internal/isatty/isatty_windows.go
@@ -42,7 +42,8 @@ func IsTerminal(fd uintptr) bool {
 
 // Check pipe name is used for cygwin/msys2 pty.
 // Cygwin/MSYS2 PTY has a name like:
-//   \{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master
+//
+//	\{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master
 func isCygwinPipeName(name string) bool {
 	token := strings.Split(name, "-")
 	if len(token) < 5 {

--- a/internal/msgp/defs.go
+++ b/internal/msgp/defs.go
@@ -5,16 +5,19 @@
 // generator implement the Marshaler/Unmarshaler and Encodable/Decodable interfaces.
 //
 // This package defines four "families" of functions:
-// 	- AppendXxxx() appends an object to a []byte in MessagePack encoding.
-// 	- ReadXxxxBytes() reads an object from a []byte and returns the remaining bytes.
-// 	- (*Writer).WriteXxxx() writes an object to the buffered *Writer type.
-// 	- (*Reader).ReadXxxx() reads an object from a buffered *Reader type.
+//   - AppendXxxx() appends an object to a []byte in MessagePack encoding.
+//   - ReadXxxxBytes() reads an object from a []byte and returns the remaining bytes.
+//   - (*Writer).WriteXxxx() writes an object to the buffered *Writer type.
+//   - (*Reader).ReadXxxx() reads an object from a buffered *Reader type.
 //
 // Once a type has satisfied the `Encodable` and `Decodable` interfaces,
 // it can be written and read from arbitrary `io.Writer`s and `io.Reader`s using
-// 		msgp.Encode(io.Writer, msgp.Encodable)
+//
+//	msgp.Encode(io.Writer, msgp.Encodable)
+//
 // and
-//		msgp.Decode(io.Reader, msgp.Decodable)
+//
+//	msgp.Decode(io.Reader, msgp.Decodable)
 //
 // There are also methods for converting MessagePack to JSON without
 // an explicit de-serialization step.

--- a/internal/msgp/elsize.go
+++ b/internal/msgp/elsize.go
@@ -4,7 +4,6 @@ package msgp
 // plus type information. gives us
 // constant-time type information
 // for traversing composite objects.
-//
 var sizes = [256]bytespec{
 	mnil:      {size: 1, extra: constsize, typ: NilType},
 	mfalse:    {size: 1, extra: constsize, typ: BoolType},

--- a/internal/msgp/errors.go
+++ b/internal/msgp/errors.go
@@ -70,7 +70,6 @@ func Resumable(e error) bool {
 //
 // ErrShortBytes is not wrapped with any context due to backward compatibility
 // issues with the public API.
-//
 func WrapError(err error, ctx ...interface{}) error {
 	switch e := err.(type) {
 	case errShort:

--- a/internal/msgp/extension.go
+++ b/internal/msgp/extension.go
@@ -30,7 +30,7 @@ var extensionReg = make(map[int8]func() Extension)
 //
 // For example, if you wanted to register a user-defined struct:
 //
-//  msgp.RegisterExtension(10, func() msgp.Extension { &MyExtension{} })
+//	msgp.RegisterExtension(10, func() msgp.Extension { &MyExtension{} })
 //
 // RegisterExtension will panic if you call it multiple times
 // with the same 'typ' argument, or if you use a reserved

--- a/internal/msgp/file.go
+++ b/internal/msgp/file.go
@@ -21,7 +21,6 @@ import (
 // is only efficient for large files; small
 // files are best read and written using
 // the ordinary streaming interfaces.
-//
 func ReadFile(dst Unmarshaler, file *os.File) error {
 	stat, err := file.Stat()
 	if err != nil {

--- a/internal/msgp/read_bytes.go
+++ b/internal/msgp/read_bytes.go
@@ -896,7 +896,7 @@ func ReadStringBytes(b []byte) (string, []byte, error) {
 // into a slice of bytes. 'v' is the value of
 // the 'str' object, which may reside in memory
 // pointed to by 'scratch.' 'o' is the remaining bytes
-// in 'b.''
+// in 'b.”
 // Possible errors:
 // - ErrShortBytes (b not long enough)
 // - TypeError{} (not 'str' type)

--- a/internal/msgp/write.go
+++ b/internal/msgp/write.go
@@ -622,12 +622,12 @@ func (mw *Writer) WriteTime(t time.Time) error {
 
 // WriteIntf writes the concrete type of 'v'.
 // WriteIntf will error if 'v' is not one of the following:
-//  - A bool, float, string, []byte, int, uint, or complex
-//  - A map of supported types (with string keys)
-//  - An array or slice of supported types
-//  - A pointer to a supported type
-//  - A type that satisfies the msgp.Encodable interface
-//  - A type that satisfies the msgp.Extension interface
+//   - A bool, float, string, []byte, int, uint, or complex
+//   - A map of supported types (with string keys)
+//   - An array or slice of supported types
+//   - A pointer to a supported type
+//   - A type that satisfies the msgp.Encodable interface
+//   - A type that satisfies the msgp.Extension interface
 func (mw *Writer) WriteIntf(v interface{}) error {
 	if v == nil {
 		return mw.WriteNil()

--- a/internal/msgp/write_bytes.go
+++ b/internal/msgp/write_bytes.go
@@ -315,13 +315,13 @@ func AppendMapStrIntf(b []byte, m map[string]interface{}) ([]byte, error) {
 
 // AppendIntf appends the concrete type of 'i' to the
 // provided []byte. 'i' must be one of the following:
-//  - 'nil'
-//  - A bool, float, string, []byte, int, uint, or complex
-//  - A map[string]interface{} or map[string]string
-//  - A []T, where T is another supported type
-//  - A *T, where T is another supported type
-//  - A type that satisfieds the msgp.Marshaler interface
-//  - A type that satisfies the msgp.Extension interface
+//   - 'nil'
+//   - A bool, float, string, []byte, int, uint, or complex
+//   - A map[string]interface{} or map[string]string
+//   - A []T, where T is another supported type
+//   - A *T, where T is another supported type
+//   - A type that satisfieds the msgp.Marshaler interface
+//   - A type that satisfies the msgp.Extension interface
 func AppendIntf(b []byte, i interface{}) ([]byte, error) {
 	if i == nil {
 		return AppendNil(b), nil

--- a/internal/schema/doc.go
+++ b/internal/schema/doc.go
@@ -60,14 +60,14 @@ certain fields, use a dash for the name and it will be ignored:
 
 The supported field types in the destination struct are:
 
-	* bool
-	* float variants (float32, float64)
-	* int variants (int, int8, int16, int32, int64)
-	* string
-	* uint variants (uint, uint8, uint16, uint32, uint64)
-	* struct
-	* a pointer to one of the above types
-	* a slice or a pointer to a slice of one of the above types
+  - bool
+  - float variants (float32, float64)
+  - int variants (int, int8, int16, int32, int64)
+  - string
+  - uint variants (uint, uint8, uint16, uint32, uint64)
+  - struct
+  - a pointer to one of the above types
+  - a slice or a pointer to a slice of one of the above types
 
 Non-supported types are simply ignored, however custom types can be registered
 to be converted.

--- a/internal/template/html/html.go
+++ b/internal/template/html/html.go
@@ -56,7 +56,7 @@ func New(directory, extension string) *Engine {
 	return engine
 }
 
-//NewFileSystem ...
+// NewFileSystem ...
 func NewFileSystem(fs http.FileSystem, extension string) *Engine {
 	engine := &Engine{
 		left:       "{{",

--- a/internal/uuid/dce.go
+++ b/internal/uuid/dce.go
@@ -43,7 +43,7 @@ func NewDCESecurity(domain Domain, id uint32) (UUID, error) {
 // NewDCEPerson returns a DCE Security (Version 2) UUID in the person
 // domain with the id returned by os.Getuid.
 //
-//  NewDCESecurity(Person, uint32(os.Getuid()))
+//	NewDCESecurity(Person, uint32(os.Getuid()))
 func NewDCEPerson() (UUID, error) {
 	return NewDCESecurity(Person, uint32(os.Getuid()))
 }
@@ -51,7 +51,7 @@ func NewDCEPerson() (UUID, error) {
 // NewDCEGroup returns a DCE Security (Version 2) UUID in the group
 // domain with the id returned by os.Getgid.
 //
-//  NewDCESecurity(Group, uint32(os.Getgid()))
+//	NewDCESecurity(Group, uint32(os.Getgid()))
 func NewDCEGroup() (UUID, error) {
 	return NewDCESecurity(Group, uint32(os.Getgid()))
 }

--- a/internal/uuid/hash.go
+++ b/internal/uuid/hash.go
@@ -39,7 +39,7 @@ func NewHash(h hash.Hash, space UUID, data []byte, version int) UUID {
 // NewMD5 returns a new MD5 (Version 3) UUID based on the
 // supplied name space and data.  It is the same as calling:
 //
-//  NewHash(md5.New(), space, data, 3)
+//	NewHash(md5.New(), space, data, 3)
 func NewMD5(space UUID, data []byte) UUID {
 	return NewHash(md5.New(), space, data, 3)
 }
@@ -47,7 +47,7 @@ func NewMD5(space UUID, data []byte) UUID {
 // NewSHA1 returns a new SHA1 (Version 5) UUID based on the
 // supplied name space and data.  It is the same as calling:
 //
-//  NewHash(sha1.New(), space, data, 5)
+//	NewHash(sha1.New(), space, data, 5)
 func NewSHA1(space UUID, data []byte) UUID {
 	return NewHash(sha1.New(), space, data, 5)
 }

--- a/internal/uuid/version4.go
+++ b/internal/uuid/version4.go
@@ -9,7 +9,7 @@ import "io"
 // New creates a new random UUID or panics.  New is equivalent to
 // the expression
 //
-//    uuid.Must(uuid.NewRandom())
+//	uuid.Must(uuid.NewRandom())
 func New() UUID {
 	return Must(NewRandom())
 }
@@ -21,11 +21,11 @@ func New() UUID {
 //
 // A note about uniqueness derived from the UUID Wikipedia entry:
 //
-//  Randomly generated UUIDs have 122 random bits.  One's annual risk of being
-//  hit by a meteorite is estimated to be one chance in 17 billion, that
-//  means the probability is about 0.00000000006 (6 × 10−11),
-//  equivalent to the odds of creating a few tens of trillions of UUIDs in a
-//  year and having one duplicate.
+//	Randomly generated UUIDs have 122 random bits.  One's annual risk of being
+//	hit by a meteorite is estimated to be one chance in 17 billion, that
+//	means the probability is about 0.00000000006 (6 × 10−11),
+//	equivalent to the odds of creating a few tens of trillions of UUIDs in a
+//	year and having one duplicate.
 func NewRandom() (UUID, error) {
 	return NewRandomFromReader(rander)
 }

--- a/internal/wmi/swbemservices.go
+++ b/internal/wmi/swbemservices.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wmi

--- a/internal/wmi/wmi.go
+++ b/internal/wmi/wmi.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*
@@ -20,7 +21,6 @@ Example code to print names of running processes:
 			println(i, v.Name)
 		}
 	}
-
 */
 package wmi
 

--- a/listen.go
+++ b/listen.go
@@ -47,8 +47,8 @@ func (app *App) Listener(ln net.Listener) error {
 
 // Listen serves HTTP requests from the given addr.
 //
-//  app.Listen(":8080")
-//  app.Listen("127.0.0.1:8080")
+//	app.Listen(":8080")
+//	app.Listen("127.0.0.1:8080")
 func (app *App) Listen(addr string) error {
 	// Start prefork
 	if app.config.Prefork {
@@ -75,7 +75,8 @@ func (app *App) Listen(addr string) error {
 
 // ListenTLS serves HTTPS requests from the given addr.
 // certFile and keyFile are the paths to TLS certificate and key file:
-//  app.ListenTLS(":8080", "./cert.pem", "./cert.key")
+//
+//	app.ListenTLS(":8080", "./cert.pem", "./cert.key")
 func (app *App) ListenTLS(addr, certFile, keyFile string) error {
 	// Check for valid cert/key path
 	if len(certFile) == 0 || len(keyFile) == 0 {
@@ -116,7 +117,8 @@ func (app *App) ListenTLS(addr, certFile, keyFile string) error {
 
 // ListenMutualTLS serves HTTPS requests from the given addr.
 // certFile, keyFile and clientCertFile are the paths to TLS certificate and key file:
-//  app.ListenMutualTLS(":8080", "./cert.pem", "./cert.key", "./client.pem")
+//
+//	app.ListenMutualTLS(":8080", "./cert.pem", "./cert.key", "./client.pem")
 func (app *App) ListenMutualTLS(addr, certFile, keyFile, clientCertFile string) error {
 	// Check for valid cert/key path
 	if len(certFile) == 0 || len(keyFile) == 0 {

--- a/middleware/cache/manager_msgp.go
+++ b/middleware/cache/manager_msgp.go
@@ -58,7 +58,7 @@ func (z *item) DecodeMsg(dc *msgp.Reader) (err error) {
 			if z.headers == nil && zcmr > 0 {
 				z.headers = make(map[string][]byte, zcmr)
 			} else if len(z.headers) > 0 {
-				for key, _ := range z.headers {
+				for key := range z.headers {
 					delete(z.headers, key)
 				}
 			}
@@ -252,7 +252,7 @@ func (z *item) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			if z.headers == nil && zwht > 0 {
 				z.headers = make(map[string][]byte, zwht)
 			} else if len(z.headers) > 0 {
-				for key, _ := range z.headers {
+				for key := range z.headers {
 					delete(z.headers, key)
 				}
 			}


### PR DESCRIPTION
- Add missing copyrightes for some files.
- Run `gofmt -s .`