### PR TITLE
:memo: docs: make Hooks public

### DIFF
--- a/app.go
+++ b/app.go
@@ -63,17 +63,18 @@ type Storage interface {
 
 // ErrorHandler defines a function that will process all errors
 // returned from any handlers in the stack
-//  cfg := fiber.Config{}
-//  cfg.ErrorHandler = func(c *Ctx, err error) error {
-//   code := StatusInternalServerError
-//   var e *fiber.Error
-//   if errors.As(err, &e) {
-//     code = e.Code
-//   }
-//   c.Set(HeaderContentType, MIMETextPlainCharsetUTF8)
-//   return c.Status(code).SendString(err.Error())
-//  }
-//  app := fiber.New(cfg)
+//
+//	cfg := fiber.Config{}
+//	cfg.ErrorHandler = func(c *Ctx, err error) error {
+//	 code := StatusInternalServerError
+//	 var e *fiber.Error
+//	 if errors.As(err, &e) {
+//	   code = e.Code
+//	 }
+//	 c.Set(HeaderContentType, MIMETextPlainCharsetUTF8)
+//	 return c.Status(code).SendString(err.Error())
+//	}
+//	app := fiber.New(cfg)
 type ErrorHandler = func(*Ctx, error) error
 
 // Error represents an error that occurred while handling a request.
@@ -108,7 +109,7 @@ type App struct {
 	// Mounted and main apps
 	appList map[string]*App
 	// Hooks
-	hooks *hooks
+	hooks *Hooks
 	// Latest route & group
 	latestRoute *Route
 	latestGroup *Group
@@ -438,12 +439,15 @@ var DefaultErrorHandler = func(c *Ctx, err error) error {
 }
 
 // New creates a new Fiber named instance.
-//  app := fiber.New()
+//
+//	app := fiber.New()
+//
 // You can pass optional configuration options by passing a Config struct:
-//  app := fiber.New(fiber.Config{
-//      Prefork: true,
-//      ServerHeader: "Fiber",
-//  })
+//
+//	app := fiber.New(fiber.Config{
+//	    Prefork: true,
+//	    ServerHeader: "Fiber",
+//	})
 func New(config ...Config) *App {
 	// Create a new app
 	app := &App{
@@ -609,15 +613,15 @@ func (app *App) GetRoute(name string) Route {
 // Use registers a middleware route that will match requests
 // with the provided prefix (which is optional and defaults to "/").
 //
-//  app.Use(func(c *fiber.Ctx) error {
-//       return c.Next()
-//  })
-//  app.Use("/api", func(c *fiber.Ctx) error {
-//       return c.Next()
-//  })
-//  app.Use("/api", handler, func(c *fiber.Ctx) error {
-//       return c.Next()
-//  })
+//	app.Use(func(c *fiber.Ctx) error {
+//	     return c.Next()
+//	})
+//	app.Use("/api", func(c *fiber.Ctx) error {
+//	     return c.Next()
+//	})
+//	app.Use("/api", handler, func(c *fiber.Ctx) error {
+//	     return c.Next()
+//	})
 //
 // This method will match all HTTP verbs: GET, POST, PUT, HEAD etc...
 func (app *App) Use(args ...interface{}) Router {
@@ -710,8 +714,9 @@ func (app *App) All(path string, handlers ...Handler) Router {
 }
 
 // Group is used for Routes with common prefix to define a new sub-router with optional middleware.
-//  api := app.Group("/api")
-//  api.Get("/users", handler)
+//
+//	api := app.Group("/api")
+//	api.Get("/users", handler)
 func (app *App) Group(prefix string, handlers ...Handler) Router {
 	if len(handlers) > 0 {
 		app.register(methodUse, prefix, handlers...)
@@ -803,7 +808,7 @@ func (app *App) Server() *fasthttp.Server {
 }
 
 // Hooks returns the hook struct to register hooks.
-func (app *App) Hooks() *hooks {
+func (app *App) Hooks() *Hooks {
 	return app.hooks
 }
 

--- a/hooks.go
+++ b/hooks.go
@@ -9,7 +9,8 @@ type OnListenHandler = func() error
 type OnShutdownHandler = OnListenHandler
 type OnForkHandler = func(int) error
 
-type hooks struct {
+// Hooks is a struct to use it with App.
+type Hooks struct {
 	// Embed app
 	app *App
 
@@ -23,8 +24,8 @@ type hooks struct {
 	onFork      []OnForkHandler
 }
 
-func newHooks(app *App) *hooks {
-	return &hooks{
+func newHooks(app *App) *Hooks {
+	return &Hooks{
 		app:         app,
 		onRoute:     make([]OnRouteHandler, 0),
 		onGroup:     make([]OnGroupHandler, 0),
@@ -38,7 +39,7 @@ func newHooks(app *App) *hooks {
 
 // OnRoute is a hook to execute user functions on each route registeration.
 // Also you can get route properties by route parameter.
-func (h *hooks) OnRoute(handler ...OnRouteHandler) {
+func (h *Hooks) OnRoute(handler ...OnRouteHandler) {
 	h.app.mutex.Lock()
 	h.onRoute = append(h.onRoute, handler...)
 	h.app.mutex.Unlock()
@@ -48,7 +49,7 @@ func (h *hooks) OnRoute(handler ...OnRouteHandler) {
 // Also you can get route properties by route parameter.
 //
 // WARN: OnName only works with naming routes, not groups.
-func (h *hooks) OnName(handler ...OnNameHandler) {
+func (h *Hooks) OnName(handler ...OnNameHandler) {
 	h.app.mutex.Lock()
 	h.onName = append(h.onName, handler...)
 	h.app.mutex.Unlock()
@@ -56,7 +57,7 @@ func (h *hooks) OnName(handler ...OnNameHandler) {
 
 // OnGroup is a hook to execute user functions on each group registeration.
 // Also you can get group properties by group parameter.
-func (h *hooks) OnGroup(handler ...OnGroupHandler) {
+func (h *Hooks) OnGroup(handler ...OnGroupHandler) {
 	h.app.mutex.Lock()
 	h.onGroup = append(h.onGroup, handler...)
 	h.app.mutex.Unlock()
@@ -66,34 +67,34 @@ func (h *hooks) OnGroup(handler ...OnGroupHandler) {
 // Also you can get group properties by group parameter.
 //
 // WARN: OnGroupName only works with naming groups, not routes.
-func (h *hooks) OnGroupName(handler ...OnGroupNameHandler) {
+func (h *Hooks) OnGroupName(handler ...OnGroupNameHandler) {
 	h.app.mutex.Lock()
 	h.onGroupName = append(h.onGroupName, handler...)
 	h.app.mutex.Unlock()
 }
 
 // OnListen is a hook to execute user functions on Listen, ListenTLS, Listener.
-func (h *hooks) OnListen(handler ...OnListenHandler) {
+func (h *Hooks) OnListen(handler ...OnListenHandler) {
 	h.app.mutex.Lock()
 	h.onListen = append(h.onListen, handler...)
 	h.app.mutex.Unlock()
 }
 
 // OnShutdown is a hook to execute user functions after Shutdown.
-func (h *hooks) OnShutdown(handler ...OnShutdownHandler) {
+func (h *Hooks) OnShutdown(handler ...OnShutdownHandler) {
 	h.app.mutex.Lock()
 	h.onShutdown = append(h.onShutdown, handler...)
 	h.app.mutex.Unlock()
 }
 
 // OnFork is a hook to execute user function after fork process.
-func (h *hooks) OnFork(handler ...OnForkHandler) {
+func (h *Hooks) OnFork(handler ...OnForkHandler) {
 	h.app.mutex.Lock()
 	h.onFork = append(h.onFork, handler...)
 	h.app.mutex.Unlock()
 }
 
-func (h *hooks) executeOnRouteHooks(route Route) error {
+func (h *Hooks) executeOnRouteHooks(route Route) error {
 	for _, v := range h.onRoute {
 		if err := v(route); err != nil {
 			return err
@@ -103,7 +104,7 @@ func (h *hooks) executeOnRouteHooks(route Route) error {
 	return nil
 }
 
-func (h *hooks) executeOnNameHooks(route Route) error {
+func (h *Hooks) executeOnNameHooks(route Route) error {
 	for _, v := range h.onName {
 		if err := v(route); err != nil {
 			return err
@@ -113,7 +114,7 @@ func (h *hooks) executeOnNameHooks(route Route) error {
 	return nil
 }
 
-func (h *hooks) executeOnGroupHooks(group Group) error {
+func (h *Hooks) executeOnGroupHooks(group Group) error {
 	for _, v := range h.onGroup {
 		if err := v(group); err != nil {
 			return err
@@ -123,7 +124,7 @@ func (h *hooks) executeOnGroupHooks(group Group) error {
 	return nil
 }
 
-func (h *hooks) executeOnGroupNameHooks(group Group) error {
+func (h *Hooks) executeOnGroupNameHooks(group Group) error {
 	for _, v := range h.onGroupName {
 		if err := v(group); err != nil {
 			return err
@@ -133,7 +134,7 @@ func (h *hooks) executeOnGroupNameHooks(group Group) error {
 	return nil
 }
 
-func (h *hooks) executeOnListenHooks() error {
+func (h *Hooks) executeOnListenHooks() error {
 	for _, v := range h.onListen {
 		if err := v(); err != nil {
 			return err
@@ -143,13 +144,13 @@ func (h *hooks) executeOnListenHooks() error {
 	return nil
 }
 
-func (h *hooks) executeOnShutdownHooks() {
+func (h *Hooks) executeOnShutdownHooks() {
 	for _, v := range h.onShutdown {
 		_ = v()
 	}
 }
 
-func (h *hooks) executeOnForkHooks(pid int) {
+func (h *Hooks) executeOnForkHooks(pid int) {
 	for _, v := range h.onFork {
 		_ = v(pid)
 	}


### PR DESCRIPTION
Hook methods aren't shown in https://pkg.go.dev/github.com/gofiber/fiber/v2#pkg-overview. This PR fixes it by making `hook` -> `Hook`.