### PR TITLE
✨ v3 (enhancement): add `[]byte` support to `utils.EqualFold`

### DIFF
--- a/utils/strings.go
+++ b/utils/strings.go
@@ -61,8 +61,12 @@ func TrimRight(s string, cutset byte) string {
 	return s[:lenStr]
 }
 
+type byteSeq interface {
+	~string | ~[]byte
+}
+
 // EqualFold tests ascii strings for equality case-insensitively
-func EqualFold(b, s string) bool {
+func EqualFold[S byteSeq](b, s S) bool {
 	if len(b) != len(s) {
 		return false
 	}

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -65,7 +65,7 @@ type byteSeq interface {
 	~string | ~[]byte
 }
 
-// EqualFold tests ascii strings for equality case-insensitively
+// EqualFold tests ascii strings or bytes for equality case-insensitively
 func EqualFold[S byteSeq](b, s S) bool {
 	if len(b) != len(s) {
 		return false


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

replace `utils.EqualFold` signature from `func EqualFold(b, s string) bool` to `func EqualFold[S byteSeq](b, s S) bool`

and add a private interface to utils.

```golang
type byteSeq interface {
	~string | ~[]byte
}
```

**Explain the *details* for making this change. What existing problem does the pull request solve?**

this will make `utils.EqualFold` support comparing bytes like `bytes.EqualFold`

And golang compiler will go monomorphization, which we will have a zero performance cost.

We can also make function like `Trim*` to be generic functions too but I'd like to just change this first for discussion.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/


before:
```text
❯❯ ~\..\..\fiber git:(bind) go test -bench EqualFold -benchmem -run=node .\utils\
goos: windows
goarch: amd64
pkg: github.com/gofiber/fiber/v3/utils
cpu: AMD Ryzen 7 5800X 8-Core Processor
Benchmark_EqualFoldBytes/fiber-16               24507901                48.94 ns/op            0 B/op          0 allocs/op
Benchmark_EqualFoldBytes/default-16              8056410               149.1 ns/op             0 B/op          0 allocs/op
Benchmark_EqualFold/fiber-16                    29971826                39.97 ns/op            0 B/op          0 allocs/op
Benchmark_EqualFold/default-16                   9706066               124.3 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/gofiber/fiber/v3/utils       5.342s
```

after:
```text
❯❯ ~\..\..\fiber git:(bind) go test -bench EqualFold -benchmem -run=node .\utils\
goos: windows
goarch: amd64
pkg: github.com/gofiber/fiber/v3/utils
cpu: AMD Ryzen 7 5800X 8-Core Processor
Benchmark_EqualFoldBytes/fiber-16               24196328                48.71 ns/op            0 B/op          0 allocs/op
Benchmark_EqualFoldBytes/default-16              8000298               149.1 ns/op             0 B/op          0 allocs/op
Benchmark_EqualFold/fiber-16                    29581348                40.24 ns/op            0 B/op          0 allocs/op
Benchmark_EqualFold/default-16                   9373461               124.6 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/gofiber/fiber/v3/utils       5.286s
```