### PR TITLE
client: fix `Agent` use after free

### DIFF
--- a/client.go
+++ b/client.go
@@ -856,8 +856,12 @@ func (a *Agent) reset() {
 }
 
 var (
-	clientPool   sync.Pool
-	agentPool    sync.Pool
+	clientPool sync.Pool
+	agentPool  = sync.Pool{
+		New: func() any {
+			return &Agent{req: &Request{}}
+		},
+	}
 	responsePool sync.Pool
 	argsPool     sync.Pool
 	formFilePool sync.Pool
@@ -895,11 +899,7 @@ func ReleaseClient(c *Client) {
 // no longer needed. This allows Agent recycling, reduces GC pressure
 // and usually improves performance.
 func AcquireAgent() *Agent {
-	v := agentPool.Get()
-	if v == nil {
-		return &Agent{req: &Request{}}
-	}
-	return v.(*Agent)
+	return agentPool.Get().(*Agent)
 }
 
 // ReleaseAgent returns a acquired via AcquireAgent to Agent pool.

--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,10 +17,10 @@ import (
 	"testing"
 	"time"
 
-	"encoding/json"
-
 	"github.com/gofiber/fiber/v2/internal/tlstest"
 	"github.com/gofiber/fiber/v2/utils"
+	"github.com/gofiber/fiber/v3/internal/tlstest"
+	"github.com/gofiber/fiber/v3/utils"
 	"github.com/valyala/fasthttp/fasthttputil"
 )
 

--- a/client_test.go
+++ b/client_test.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/gofiber/fiber/v2/internal/tlstest"
 	"github.com/gofiber/fiber/v2/utils"
-	"github.com/gofiber/fiber/v3/internal/tlstest"
-	"github.com/gofiber/fiber/v3/utils"
 	"github.com/valyala/fasthttp/fasthttputil"
 )
 


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

test may fail with race problem.

```text
==================
--- FAIL: Test_Client_Unsupported_Protocol (0.00s)
    testing.go:1319: race detected during execution of test
--- FAIL: Test_Client_Agent_Custom_Response (0.01s)
    testing.go:1319: race detected during execution of test
--- FAIL: Test_Ctx_ClientHelloInfo (0.00s)
    testing.go:1319: race detected during execution of test
--- FAIL: Test_Client_Agent_RetryIf (0.00s)
    testing.go:1319: race detected during execution of test
    --- FAIL: Test_Client_Agent_Dest/enough_dest (0.00s)
        testing.go:1319: race detected during execution of test
    testing.go:1319: race detected during execution of test
--- FAIL: Test_Client_Agent_MaxRedirectsCount (0.01s)
    --- FAIL: Test_Client_Agent_MaxRedirectsCount/error (0.00s)
    testing.go:1319: race detected during execution of test
--- FAIL: Test_Client_Put (0.01s)
--- FAIL: Test_Client_Patch (0.01s)
    testing.go:1319: race detected during execution of test
--- FAIL: Test_Client_Agent_Struct (0.00s)
--- FAIL: Test_Client_Delete (0.00s)
    testing.go:1319: race detected during execution of test
--- FAIL: Test_Client_Post (0.00s)
    testing.go:1319: race detected during execution of test
--- FAIL: Test_Client_Head (0.00s)
    testing.go:1319: race detected during execution of test
--- FAIL: Test_Client_UserAgent (0.01s)
    --- FAIL: Test_Client_UserAgent/default (0.01s)
        testing.go:1319: race detected during execution of test
    testing.go:1319: race detected during execution of test
--- FAIL: Test_Client_Agent_InsecureSkipVerify (0.01s)
    testing.go:1319: race detected during execution of test
--- FAIL: Test_Client_Agent_Timeout (0.31s)
FAIL
```

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**Explain the *details* for making this change. What existing problem does the pull request solve?**

Use After Free:

`Agent.Struct` may read `Agent.jsonDecoder` after `agent.Bytes` calling `agent.release`

