### PR TITLE
:bug: bug: fix regex constraints

### DIFF
--- a/path_test.go
+++ b/path_test.go
@@ -520,11 +520,17 @@ func Test_Path_matchParams(t *testing.T) {
 		{url: "/api/v1/8728382", params: []string{"8728382"}, match: false},
 		{url: "/api/v1/2005-11-01", params: []string{"2005-11-01"}, match: true},
 	})
-	testCase("/api/v1/:param<regex(p\\([a\\-z]\\+\\)ch)>", []testparams{
+	testCase("/api/v1/:param<regex(p([a-z]+)ch)>", []testparams{
 		{url: "/api/v1/ent", params: []string{"ent"}, match: false},
 		{url: "/api/v1/15", params: []string{"15"}, match: false},
 		{url: "/api/v1/peach", params: []string{"peach"}, match: true},
 		{url: "/api/v1/p34ch", params: []string{"p34ch"}, match: false},
+	})
+	testCase("/api/v1/:param<regex(\\d{4}-\\d{2}-\\d{2})}>", []testparams{
+		{url: "/api/v1/ent", params: []string{"ent"}, match: false},
+		{url: "/api/v1/15", params: []string{"15"}, match: false},
+		{url: "/api/v1/2022-08-27", params: []string{"2022-08-27"}, match: true},
+		{url: "/api/v1/2022/08-27", params: []string{"p34ch"}, match: false},
 	})
 	testCase("/api/v1/:param<int;bool((>", []testparams{
 		{url: "/api/v1/entity", params: []string{"entity"}, match: false},
@@ -739,11 +745,17 @@ func Benchmark_Path_matchParams(t *testing.B) {
 		{url: "/api/v1/8728382", params: []string{"8728382"}, match: false},
 		{url: "/api/v1/2005-11-01", params: []string{"2005-11-01"}, match: true},
 	})
-	benchCase("/api/v1/:param<regex(p\\([a\\-z]\\+\\)ch)>", []testparams{
+	benchCase("/api/v1/:param<regex(p([a-z]+)ch)>", []testparams{
 		{url: "/api/v1/ent", params: []string{"ent"}, match: false},
 		{url: "/api/v1/15", params: []string{"15"}, match: false},
 		{url: "/api/v1/peach", params: []string{"peach"}, match: true},
 		{url: "/api/v1/p34ch", params: []string{"p34ch"}, match: false},
+	})
+	benchCase("/api/v1/:param<regex(\\d{4}-\\d{2}-\\d{2})}>", []testparams{
+		{url: "/api/v1/ent", params: []string{"ent"}, match: false},
+		{url: "/api/v1/15", params: []string{"15"}, match: false},
+		{url: "/api/v1/2022-08-27", params: []string{"2022-08-27"}, match: true},
+		{url: "/api/v1/2022/08-27", params: []string{"p34ch"}, match: false},
 	})
 	benchCase("/api/v1/:param<int;bool((>", []testparams{
 		{url: "/api/v1/entity", params: []string{"entity"}, match: false},


### PR DESCRIPTION
## Description
It was causing regex matching problem to remove `\` chars from regex constraint data for regex matchers like `\\d{4}-\\d{2}-\\d{2}`. To fix this, we don't remove escape chars for regex parameters. Also we no longer need to add escape chars before routing-specific characters for regex constraints.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - https://github.com/gofiber/docs for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [x] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
