### PR TITLE
:bug: bug: remove prefork support from custom listeners

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -25,37 +25,6 @@ import (
 )
 
 /* #nosec */
-// lnMetadata will close the listener and return the addr and tls config
-func lnMetadata(network string, ln net.Listener) (addr string, cfg *tls.Config) {
-	// Get addr
-	addr = ln.Addr().String()
-
-	// Close listener
-	if err := ln.Close(); err != nil {
-		return
-	}
-
-	// Wait for the listener to be closed
-	var closed bool
-	for i := 0; i < 10; i++ {
-		conn, err := net.DialTimeout(network, addr, 3*time.Second)
-		if err != nil || conn == nil {
-			closed = true
-			break
-		}
-		_ = conn.Close()
-		time.Sleep(100 * time.Millisecond)
-	}
-	if !closed {
-		panic("listener: " + addr + ": Only one usage of each socket address (protocol/network address/port) is normally permitted.")
-	}
-
-	cfg = getTlsConfig(ln)
-
-	return
-}
-
-/* #nosec */
 // getTlsConfig returns a net listener's tls config
 func getTlsConfig(ln net.Listener) *tls.Config {
 	// Get listener type

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -5,9 +5,7 @@
 package fiber
 
 import (
-	"crypto/tls"
 	"fmt"
-	"net"
 	"strings"
 	"testing"
 	"time"
@@ -258,48 +256,6 @@ func Benchmark_Utils_IsNoCache(b *testing.B) {
 		ok = isNoCache("max-age=30, no-cache,public")
 	}
 	utils.AssertEqual(b, true, ok)
-}
-
-func Test_Utils_lnMetadata(t *testing.T) {
-	t.Run("closed listen", func(t *testing.T) {
-		ln, err := net.Listen(NetworkTCP, ":0")
-		utils.AssertEqual(t, nil, err)
-
-		utils.AssertEqual(t, nil, ln.Close())
-
-		addr, config := lnMetadata(NetworkTCP, ln)
-
-		utils.AssertEqual(t, ln.Addr().String(), addr)
-		utils.AssertEqual(t, true, config == nil)
-	})
-
-	t.Run("non tls", func(t *testing.T) {
-		ln, err := net.Listen(NetworkTCP, ":0")
-
-		utils.AssertEqual(t, nil, err)
-
-		addr, config := lnMetadata(NetworkTCP4, ln)
-
-		utils.AssertEqual(t, ln.Addr().String(), addr)
-		utils.AssertEqual(t, true, config == nil)
-	})
-
-	t.Run("tls", func(t *testing.T) {
-		cer, err := tls.LoadX509KeyPair("./.github/testdata/ssl.pem", "./.github/testdata/ssl.key")
-		utils.AssertEqual(t, nil, err)
-
-		config := &tls.Config{Certificates: []tls.Certificate{cer}}
-
-		ln, err := net.Listen(NetworkTCP4, ":0")
-		utils.AssertEqual(t, nil, err)
-
-		ln = tls.NewListener(ln, config)
-
-		addr, config := lnMetadata(NetworkTCP4, ln)
-
-		utils.AssertEqual(t, ln.Addr().String(), addr)
-		utils.AssertEqual(t, true, config != nil)
-	})
 }
 
 // go test -v -run=^$ -bench=Benchmark_SlashRecognition -benchmem -count=4

--- a/listen.go
+++ b/listen.go
@@ -26,12 +26,6 @@ import (
 
 // Listener can be used to pass a custom listener.
 func (app *App) Listener(ln net.Listener) error {
-	// Prefork is supported for custom listeners
-	if app.config.Prefork {
-		addr, tlsConfig := lnMetadata(app.config.Network, ln)
-		return app.prefork(app.config.Network, addr, tlsConfig)
-	}
-
 	// prepare the server for the start
 	app.startupProcess()
 
@@ -43,6 +37,11 @@ func (app *App) Listener(ln net.Listener) error {
 	// Print routes
 	if app.config.EnablePrintRoutes {
 		app.printRoutesMessage()
+	}
+
+	// Prefork is not supported for custom listeners
+	if app.config.Prefork {
+		fmt.Println("[Warning] Prefork isn't supported for custom listeners.")
 	}
 
 	// Start listening

--- a/listen_test.go
+++ b/listen_test.go
@@ -114,16 +114,6 @@ func Test_App_Listener(t *testing.T) {
 	utils.AssertEqual(t, nil, app.Listener(ln))
 }
 
-// go test -run Test_App_Listener_Prefork
-func Test_App_Listener_Prefork(t *testing.T) {
-	testPreforkMaster = true
-
-	app := New(Config{DisableStartupMessage: true, Prefork: true})
-
-	ln := fasthttputil.NewInmemoryListener()
-	utils.AssertEqual(t, nil, app.Listener(ln))
-}
-
 func Test_App_Listener_TLS_Listener(t *testing.T) {
 	// Create tls certificate
 	cer, err := tls.LoadX509KeyPair("./.github/testdata/ssl.pem", "./.github/testdata/ssl.key")


### PR DESCRIPTION
## Description
We can't reuse old listeners for prefork. So it means, we're not able to use prefork with Listener(). I removed this part because of it's broken. 
`Fasthttp also doesn't support it.`

Fixes https://github.com/gofiber/fiber/issues/1254

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
