### PR TITLE
v3: fix logger benchmarks

### DIFF
--- a/middleware/logger/README.md
+++ b/middleware/logger/README.md
@@ -95,7 +95,7 @@ func main() {
 
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 
-	app.Use(logger.New(logger.Config{LoggerFunc: func(c fiber.Ctx, data logger.LoggerData, cfg logger.Config) error {
+	app.Use(logger.New(logger.Config{LoggerFunc: func(c fiber.Ctx, data *logger.LoggerData, cfg logger.Config) error {
 		log.Info().
 			Str("path", c.Path()).
 			Str("method", c.Method()).
@@ -158,7 +158,7 @@ type Config struct {
 	// If you don't define anything for this field, it'll use classical logger of Fiber.
 	//
 	// Optional. Default: defaultLogger
-	LoggerFunc func(c fiber.Ctx, data LoggerData, cfg Config) error
+	LoggerFunc func(c fiber.Ctx, data *LoggerData, cfg Config) error
 }
 ```
 

--- a/middleware/logger/config.go
+++ b/middleware/logger/config.go
@@ -51,7 +51,7 @@ type Config struct {
 	// If you don't define anything for this field, it'll use default logger of Fiber.
 	//
 	// Optional. Default: defaultLogger
-	LoggerFunc func(c fiber.Ctx, data LoggerData, cfg Config) error
+	LoggerFunc func(c fiber.Ctx, data *LoggerData, cfg Config) error
 
 	enableColors     bool
 	enableLatency    bool

--- a/middleware/logger/default_logger.go
+++ b/middleware/logger/default_logger.go
@@ -28,11 +28,10 @@ type LoggerData struct {
 }
 
 var tmpl *fasttemplate.Template
+var mu sync.Mutex
 
 // default logger for fiber
-func defaultLogger(c fiber.Ctx, data LoggerData, cfg Config) error {
-	var mu sync.Mutex
-
+func defaultLogger(c fiber.Ctx, data *LoggerData, cfg Config) error {
 	// Alias colors
 	colors := c.App().Config().ColorScheme
 

--- a/middleware/logger/default_logger.go
+++ b/middleware/logger/default_logger.go
@@ -19,6 +19,7 @@ import (
 
 // LoggerData is a struct to define some variables to use in custom logger function.
 type LoggerData struct {
+	mu            sync.Mutex
 	Pid           string
 	ErrPaddingStr string
 	ChainErr      error
@@ -28,7 +29,6 @@ type LoggerData struct {
 }
 
 var tmpl *fasttemplate.Template
-var mu sync.Mutex
 
 // default logger for fiber
 func defaultLogger(c fiber.Ctx, data *LoggerData, cfg Config) error {
@@ -184,7 +184,7 @@ func defaultLogger(c fiber.Ctx, data *LoggerData, cfg Config) error {
 	if err != nil {
 		_, _ = buf.WriteString(err.Error())
 	}
-	mu.Lock()
+	data.mu.Lock()
 	// Write buffer to output
 	if _, err := cfg.Output.Write(buf.Bytes()); err != nil {
 		// Write error to output
@@ -193,7 +193,7 @@ func defaultLogger(c fiber.Ctx, data *LoggerData, cfg Config) error {
 			fmt.Fprintf(os.Stderr, "Failed to write to log, %v\n", err)
 		}
 	}
-	mu.Unlock()
+	data.mu.Unlock()
 	// Put buffer back to pool
 	bytebufferpool.Put(buf)
 

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -88,6 +88,7 @@ func New(config ...Config) fiber.Handler {
 
 	// Set variables
 	var (
+		mu         sync.Mutex
 		once       sync.Once
 		errHandler fiber.ErrorHandler
 	)
@@ -152,11 +153,11 @@ func New(config ...Config) fiber.Handler {
 		}
 
 		// Logger instance & update some logger data fields
-		data.mu.Lock()
+		mu.Lock()
 		data.ChainErr = chainErr
 		data.Start = start
 		data.Stop = stop
-		data.mu.Unlock()
+		mu.Unlock()
 
 		if err = cfg.LoggerFunc(c, data, cfg); err != nil {
 			return err

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -99,6 +99,13 @@ func New(config ...Config) fiber.Handler {
 	// Before handling func
 	cfg.BeforeHandlerFunc(cfg)
 
+	// Logger data
+	data := &LoggerData{
+		Pid:           pid,
+		ErrPaddingStr: errPaddingStr,
+		Timestamp:     timestamp,
+	}
+
 	// Return new handler
 	return func(c fiber.Ctx) (err error) {
 		// Don't execute middleware if Next returns true
@@ -144,15 +151,12 @@ func New(config ...Config) fiber.Handler {
 			stop = time.Now()
 		}
 
-		// Logger instance
-		if err = cfg.LoggerFunc(c, LoggerData{
-			Pid:           pid,
-			ErrPaddingStr: errPaddingStr,
-			ChainErr:      chainErr,
-			Start:         start,
-			Stop:          stop,
-			Timestamp:     timestamp,
-		}, cfg); err != nil {
+		// Logger instance & update some logger data fields
+		data.ChainErr = chainErr
+		data.Start = start
+		data.Stop = stop
+
+		if err = cfg.LoggerFunc(c, data, cfg); err != nil {
 			return err
 		}
 

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -157,11 +157,11 @@ func New(config ...Config) fiber.Handler {
 		data.ChainErr = chainErr
 		data.Start = start
 		data.Stop = stop
-		mu.Unlock()
 
 		if err = cfg.LoggerFunc(c, data, cfg); err != nil {
 			return err
 		}
+		mu.Unlock()
 
 		return nil
 	}

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -152,9 +152,11 @@ func New(config ...Config) fiber.Handler {
 		}
 
 		// Logger instance & update some logger data fields
+		data.mu.Lock()
 		data.ChainErr = chainErr
 		data.Start = start
 		data.Stop = stop
+		data.mu.Unlock()
 
 		if err = cfg.LoggerFunc(c, data, cfg); err != nil {
 			return err


### PR DESCRIPTION
- Don't create mutex in each request.
- Use pointer to define LoggerData. Otherwise, we always copy it