### PR TITLE
:sparkles: feat:  support to set client in proxy mw

### DIFF
--- a/internal/gopsutil/net/net_darwin.go
+++ b/internal/gopsutil/net/net_darwin.go
@@ -7,11 +7,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/gofiber/fiber/v2/internal/gopsutil/common"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/gofiber/fiber/v2/internal/gopsutil/common"
 )
 
 var (

--- a/middleware/proxy/README.md
+++ b/middleware/proxy/README.md
@@ -13,8 +13,8 @@ Proxy middleware for [Fiber](https://github.com/gofiber/fiber) that allows you t
 
 ```go
 func Balancer(config Config) fiber.Handler
-func Forward(addr string) fiber.Handler
-func Do(c *fiber.Ctx, addr string) error
+func Forward(addr string, clients ...*fasthttp.Client) fiber.Handler
+func Do(c *fiber.Ctx, addr string, clients ...*fasthttp.Client) error
 ```
 
 ### Examples
@@ -37,8 +37,20 @@ proxy.WithTlsConfig(&tls.Config{
     InsecureSkipVerify: true,
 })
 
+// if you need to use global self-custom client, you should use proxy.WithClient.
+proxy.WithClient(&fasthttp.Client{
+	NoDefaultUserAgentHeader: true, 
+	DisablePathNormalizing:   true,
+})
+
 // Forward to url
 app.Get("/gif", proxy.Forward("https://i.imgur.com/IWaBepg.gif"))
+
+// Forward to url with local custom client
+app.Get("/gif", proxy.Forward("https://i.imgur.com/IWaBepg.gif", &fasthttp.Client{
+	NoDefaultUserAgentHeader: true, 
+	DisablePathNormalizing:   true,
+}))
 
 // Make request within handler
 app.Get("/:id", func(c *fiber.Ctx) error {
@@ -120,8 +132,13 @@ type Config struct {
 	// Per-connection buffer size for responses' writing.
 	WriteBufferSize int
 
-	// tls config for the http client
-	TlsConfig *tls.Config
+	// tls config for the http client.
+	TlsConfig *tls.Config 
+	
+	// Client is custom client when client config is complex. 
+	// Note that Servers, Timeout, WriteBufferSize, ReadBufferSize and TlsConfig 
+	// will not be used if the client are set.
+	Client *fasthttp.LBClient
 }
 ```
 

--- a/middleware/proxy/config.go
+++ b/middleware/proxy/config.go
@@ -47,8 +47,13 @@ type Config struct {
 	// Per-connection buffer size for responses' writing.
 	WriteBufferSize int
 
-	// tls config for the http client
+	// tls config for the http client.
 	TlsConfig *tls.Config
+
+	// Client is custom client when client config is complex.
+	// Note that Servers, Timeout, WriteBufferSize, ReadBufferSize and TlsConfig
+	// will not be used if the client are set.
+	Client *fasthttp.LBClient
 }
 
 // ConfigDefault is the default config
@@ -75,7 +80,7 @@ func configDefault(config ...Config) Config {
 	}
 
 	// Set default values
-	if len(cfg.Servers) == 0 {
+	if len(cfg.Servers) == 0 && cfg.Client == nil {
 		panic("Servers cannot be empty")
 	}
 	return cfg

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -24,34 +24,39 @@ func Balancer(config Config) fiber.Handler {
 	cfg := configDefault(config)
 
 	// Load balanced client
-	var lbc fasthttp.LBClient
-	// Set timeout
-	lbc.Timeout = cfg.Timeout
+	var lbc = &fasthttp.LBClient{}
+	// Note that Servers, Timeout, WriteBufferSize, ReadBufferSize and TlsConfig
+	// will not be used if the client are set.
+	if config.Client == nil {
+		// Set timeout
+		lbc.Timeout = cfg.Timeout
+		// Scheme must be provided, falls back to http
+		for _, server := range cfg.Servers {
+			if !strings.HasPrefix(server, "http") {
+				server = "http://" + server
+			}
 
-	// Scheme must be provided, falls back to http
-	// TODO add https support
-	for _, server := range cfg.Servers {
-		if !strings.HasPrefix(server, "http") {
-			server = "http://" + server
+			u, err := url.Parse(server)
+			if err != nil {
+				panic(err)
+			}
+
+			client := &fasthttp.HostClient{
+				NoDefaultUserAgentHeader: true,
+				DisablePathNormalizing:   true,
+				Addr:                     u.Host,
+
+				ReadBufferSize:  config.ReadBufferSize,
+				WriteBufferSize: config.WriteBufferSize,
+
+				TLSConfig: config.TlsConfig,
+			}
+
+			lbc.Clients = append(lbc.Clients, client)
 		}
-
-		u, err := url.Parse(server)
-		if err != nil {
-			panic(err)
-		}
-
-		client := &fasthttp.HostClient{
-			NoDefaultUserAgentHeader: true,
-			DisablePathNormalizing:   true,
-			Addr:                     u.Host,
-
-			ReadBufferSize:  config.ReadBufferSize,
-			WriteBufferSize: config.WriteBufferSize,
-
-			TLSConfig: config.TlsConfig,
-		}
-
-		lbc.Clients = append(lbc.Clients, client)
+	} else {
+		// Set custom client
+		lbc = config.Client
 	}
 
 	// Return new handler
@@ -97,28 +102,43 @@ func Balancer(config Config) fiber.Handler {
 	}
 }
 
-var client = fasthttp.Client{
+var client = &fasthttp.Client{
 	NoDefaultUserAgentHeader: true,
 	DisablePathNormalizing:   true,
 }
 
 // WithTlsConfig update http client with a user specified tls.config
 // This function should be called before Do and Forward.
+// Deprecated: use WithClient instead.
 func WithTlsConfig(tlsConfig *tls.Config) {
 	client.TLSConfig = tlsConfig
 }
 
+// WithClient sets the global proxy client.
+// This function should be called before Do and Forward.
+func WithClient(cli *fasthttp.Client) {
+	client = cli
+}
+
 // Forward performs the given http request and fills the given http response.
 // This method will return an fiber.Handler
-func Forward(addr string) fiber.Handler {
+func Forward(addr string, clients ...*fasthttp.Client) fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		return Do(c, addr)
+		return Do(c, addr, clients...)
 	}
 }
 
 // Do performs the given http request and fills the given http response.
 // This method can be used within a fiber.Handler
-func Do(c *fiber.Ctx, addr string) error {
+func Do(c *fiber.Ctx, addr string, clients ...*fasthttp.Client) error {
+	var cli *fasthttp.Client
+	if len(clients) != 0 {
+		// Set local client
+		cli = clients[0]
+	} else {
+		// Set global client
+		cli = client
+	}
 	req := c.Request()
 	res := c.Response()
 	originalURL := utils.CopyString(c.OriginalURL())
@@ -134,7 +154,7 @@ func Do(c *fiber.Ctx, addr string) error {
 	}
 
 	req.Header.Del(fiber.HeaderConnection)
-	if err := client.Do(req, res); err != nil {
+	if err := cli.Do(req, res); err != nil {
 		return err
 	}
 	res.Header.Del(fiber.HeaderConnection)


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
Explain the *details* for making this change. What existing problem does the pull request solve?

Fixes https://github.com/gofiber/fiber/issues/2116
- In some scenarios the user need set up some complex client config via custom client
- The case of a global client only gives the user no way to set up special configurations for only one middleware

so this pr allow to use custom client and  distinguish global client and custom client in proxy mw and compatible with previous logic.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x]  update of the docs repository

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
