### PR TITLE
v3: fix benchmark results related to handler, next

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -728,7 +728,11 @@ func (c *DefaultCtx) Next() (err error) {
 		err = c.route.Handlers[c.indexHandler](c)
 	} else {
 		// Continue handler stack
-		_, err = c.app.next(c, c.app.newCtxFunc != nil)
+		if c.app.newCtxFunc != nil {
+			_, err = c.app.nextCustom(c)
+		} else {
+			_, err = c.app.next(c)
+		}
 	}
 	return err
 }
@@ -736,8 +740,14 @@ func (c *DefaultCtx) Next() (err error) {
 // RestartRouting instead of going to the next handler. This may be usefull after
 // changing the request path. Note that handlers might be executed again.
 func (c *DefaultCtx) RestartRouting() error {
+	var err error
+
 	c.indexRoute = -1
-	_, err := c.app.next(c, c.app.newCtxFunc != nil)
+	if c.app.newCtxFunc != nil {
+		_, err = c.app.nextCustom(c)
+	} else {
+		_, err = c.app.next(c)
+	}
 	return err
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -596,7 +596,7 @@ func Benchmark_Router_Next(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		c.indexRoute = -1
-		res, err = app.next(c, false)
+		res, err = app.next(c)
 	}
 	require.NoError(b, err)
 	require.True(b, res)
@@ -772,10 +772,10 @@ func Benchmark_Router_Github_API(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			c.URI().SetPath(routesFixture.TestRoutes[i].Path)
 
-			ctx := app.AcquireCtx().(CustomCtx)
+			ctx := app.AcquireCtx().(*DefaultCtx)
 			ctx.Reset(c)
 
-			match, err = app.next(ctx, false)
+			match, err = app.next(ctx)
 			app.ReleaseCtx(ctx)
 		}
 


### PR DESCRIPTION
Improve benchmarks related to next, handler

- Benchmark_Router_Handler-2 191.4 ns/op -> v3-fix-benchmarks
- Benchmark_Router_Handler-2 276.3 ns/op -> v3-beta 
- Benchmark_Router_Handler-2 164.6 ns/op -> master
