### PR TITLE
Switch to text/javascript as per RFC9239

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -813,7 +813,7 @@ func (c *Ctx) JSONP(data interface{}, callback ...string) error {
 	result = cb + "(" + c.app.getString(raw) + ");"
 
 	c.setCanonical(HeaderXContentTypeOptions, "nosniff")
-	c.fasthttp.Response.Header.SetContentType(MIMEApplicationJavaScriptCharsetUTF8)
+	c.fasthttp.Response.Header.SetContentType(MIMETextJavaScriptCharsetUTF8)
 	return c.SendString(result)
 }
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2399,7 +2399,7 @@ func Test_Ctx_JSONP(t *testing.T) {
 	})
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, `callback({"Age":20,"Name":"Grame"});`, string(c.Response().Body()))
-	utils.AssertEqual(t, "application/javascript; charset=utf-8", string(c.Response().Header.Peek("content-type")))
+	utils.AssertEqual(t, "text/javascript; charset=utf-8", string(c.Response().Header.Peek("content-type")))
 
 	err = c.JSONP(Map{
 		"Name": "Grame",
@@ -2407,7 +2407,7 @@ func Test_Ctx_JSONP(t *testing.T) {
 	}, "john")
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, `john({"Age":20,"Name":"Grame"});`, string(c.Response().Body()))
-	utils.AssertEqual(t, "application/javascript; charset=utf-8", string(c.Response().Header.Peek("content-type")))
+	utils.AssertEqual(t, "text/javascript; charset=utf-8", string(c.Response().Header.Peek("content-type")))
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Ctx_JSONP -benchmem -count=4

--- a/helpers.go
+++ b/helpers.go
@@ -391,9 +391,11 @@ const (
 	MIMETextJavaScript  = "text/javascript"
 	MIMEApplicationXML  = "application/xml"
 	MIMEApplicationJSON = "application/json"
-	MIMEApplicationForm = "application/x-www-form-urlencoded"
-	MIMEOctetStream     = "application/octet-stream"
-	MIMEMultipartForm   = "multipart/form-data"
+	// Deprecated: use MIMETextJavaScript instead
+	MIMEApplicationJavaScript = "application/javascript"
+	MIMEApplicationForm       = "application/x-www-form-urlencoded"
+	MIMEOctetStream           = "application/octet-stream"
+	MIMEMultipartForm         = "multipart/form-data"
 
 	MIMETextXMLCharsetUTF8         = "text/xml; charset=utf-8"
 	MIMETextHTMLCharsetUTF8        = "text/html; charset=utf-8"
@@ -401,6 +403,8 @@ const (
 	MIMETextJavaScriptCharsetUTF8  = "text/javascript; charset=utf-8"
 	MIMEApplicationXMLCharsetUTF8  = "application/xml; charset=utf-8"
 	MIMEApplicationJSONCharsetUTF8 = "application/json; charset=utf-8"
+	// Deprecated: use MIMETextJavaScriptCharsetUTF8 instead
+	MIMEApplicationJavaScriptCharsetUTF8 = "application/javascript; charset=utf-8"
 )
 
 // HTTP status codes were copied from net/http.

--- a/helpers.go
+++ b/helpers.go
@@ -385,22 +385,22 @@ const (
 
 // MIME types that are commonly used
 const (
-	MIMETextXML               = "text/xml"
-	MIMETextHTML              = "text/html"
-	MIMETextPlain             = "text/plain"
-	MIMEApplicationXML        = "application/xml"
-	MIMEApplicationJSON       = "application/json"
-	MIMEApplicationJavaScript = "application/javascript"
-	MIMEApplicationForm       = "application/x-www-form-urlencoded"
-	MIMEOctetStream           = "application/octet-stream"
-	MIMEMultipartForm         = "multipart/form-data"
+	MIMETextXML         = "text/xml"
+	MIMETextHTML        = "text/html"
+	MIMETextPlain       = "text/plain"
+	MIMETextJavaScript  = "text/javascript"
+	MIMEApplicationXML  = "application/xml"
+	MIMEApplicationJSON = "application/json"
+	MIMEApplicationForm = "application/x-www-form-urlencoded"
+	MIMEOctetStream     = "application/octet-stream"
+	MIMEMultipartForm   = "multipart/form-data"
 
-	MIMETextXMLCharsetUTF8               = "text/xml; charset=utf-8"
-	MIMETextHTMLCharsetUTF8              = "text/html; charset=utf-8"
-	MIMETextPlainCharsetUTF8             = "text/plain; charset=utf-8"
-	MIMEApplicationXMLCharsetUTF8        = "application/xml; charset=utf-8"
-	MIMEApplicationJSONCharsetUTF8       = "application/json; charset=utf-8"
-	MIMEApplicationJavaScriptCharsetUTF8 = "application/javascript; charset=utf-8"
+	MIMETextXMLCharsetUTF8         = "text/xml; charset=utf-8"
+	MIMETextHTMLCharsetUTF8        = "text/html; charset=utf-8"
+	MIMETextPlainCharsetUTF8       = "text/plain; charset=utf-8"
+	MIMETextJavaScriptCharsetUTF8  = "text/javascript; charset=utf-8"
+	MIMEApplicationXMLCharsetUTF8  = "application/xml; charset=utf-8"
+	MIMEApplicationJSONCharsetUTF8 = "application/json; charset=utf-8"
 )
 
 // HTTP status codes were copied from net/http.

--- a/utils/http.go
+++ b/utils/http.go
@@ -134,6 +134,7 @@ var statusMessage = []string{
 
 // MIME types were copied from https://github.com/nginx/nginx/blob/67d2a9541826ecd5db97d604f23460210fd3e517/conf/mime.types with the following updates:
 // - Use "application/xml" instead of "text/xml" as recommended per https://datatracker.ietf.org/doc/html/rfc7303#section-4.1
+// - Use "text/javascript" instead of "application/javascript" as recommended per https://www.rfc-editor.org/rfc/rfc9239#name-text-javascript
 var mimeExtensions = map[string]string{
 	"html":    "text/html",
 	"htm":     "text/html",
@@ -143,7 +144,7 @@ var mimeExtensions = map[string]string{
 	"gif":     "image/gif",
 	"jpeg":    "image/jpeg",
 	"jpg":     "image/jpeg",
-	"js":      "application/javascript",
+	"js":      "text/javascript",
 	"atom":    "application/atom+xml",
 	"rss":     "application/rss+xml",
 	"mml":     "text/mathml",


### PR DESCRIPTION
## Description

`application/javascript` MIMEtype has been changed to `text/javascript` as per [RFC 9239](https://www.rfc-editor.org/rfc/rfc9239#name-text-javascript) which obsoletes [RFC 4329](https://www.rfc-editor.org/rfc/rfc4329).  As per this RFC, `text/javascript` is now COMMON whereas all the other media types including `application/javascript` have been marked as OBSOLETE.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - https://github.com/gofiber/docs for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
