### PR TITLE
🩹 Fix: handle multiple X-Forwarded header

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -661,7 +661,7 @@ func (c *Ctx) GetRespHeaders() map[string]string {
 func (c *Ctx) Hostname() string {
 	if c.IsProxyTrusted() {
 		if host := c.Get(HeaderXForwardedHost); len(host) > 0 {
-			return host
+			return strings.Split(host, ",")[0]
 		}
 	}
 	return c.app.getString(c.fasthttp.Request.URI().Host())
@@ -1015,9 +1015,9 @@ func (c *Ctx) Protocol() string {
 			return // X-Forwarded-
 		} else if bytes.HasPrefix(key, []byte("X-Forwarded-")) {
 			if bytes.Equal(key, []byte(HeaderXForwardedProto)) {
-				scheme = c.app.getString(val)
+				scheme = strings.Split(c.app.getString(val), ",")[0]
 			} else if bytes.Equal(key, []byte(HeaderXForwardedProtocol)) {
-				scheme = c.app.getString(val)
+				scheme = strings.Split(c.app.getString(val), ",")[0]
 			} else if bytes.Equal(key, []byte(HeaderXForwardedSsl)) && bytes.Equal(val, []byte("on")) {
 				scheme = "https"
 			}

--- a/ctx.go
+++ b/ctx.go
@@ -661,7 +661,11 @@ func (c *Ctx) GetRespHeaders() map[string]string {
 func (c *Ctx) Hostname() string {
 	if c.IsProxyTrusted() {
 		if host := c.Get(HeaderXForwardedHost); len(host) > 0 {
-			return strings.Split(host, ",")[0]
+			commaPos := strings.Index(host, ",")
+			if commaPos != -1 {
+				return host[:commaPos]
+			}
+			return host
 		}
 	}
 	return c.app.getString(c.fasthttp.Request.URI().Host())
@@ -1014,10 +1018,21 @@ func (c *Ctx) Protocol() string {
 		if len(key) < 12 {
 			return // X-Forwarded-
 		} else if bytes.HasPrefix(key, []byte("X-Forwarded-")) {
+			v := c.app.getString(val)
 			if bytes.Equal(key, []byte(HeaderXForwardedProto)) {
-				scheme = strings.Split(c.app.getString(val), ",")[0]
+				commaPos := strings.Index(v, ",")
+				if commaPos != -1 {
+					scheme = v[:commaPos]
+				} else {
+					scheme = v
+				}
 			} else if bytes.Equal(key, []byte(HeaderXForwardedProtocol)) {
-				scheme = strings.Split(c.app.getString(val), ",")[0]
+				commaPos := strings.Index(v, ",")
+				if commaPos != -1 {
+					scheme = v[:commaPos]
+				} else {
+					scheme = v
+				}
 			} else if bytes.Equal(key, []byte(HeaderXForwardedSsl)) && bytes.Equal(val, []byte("on")) {
 				scheme = "https"
 			}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1071,6 +1071,19 @@ func Test_Ctx_Hostname_TrustedProxy(t *testing.T) {
 	}
 }
 
+// go test -run Test_Ctx_Hostname_Trusted_Multiple
+func Test_Ctx_Hostname_TrustedProxy_Multiple(t *testing.T) {
+	t.Parallel()
+	{
+		app := New(Config{EnableTrustedProxyCheck: true, TrustedProxies: []string{"0.0.0.0", "0.8.0.1"}})
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		c.Request().SetRequestURI("http://google.com/test")
+		c.Request().Header.Set(HeaderXForwardedHost, "google1.com, google2.com")
+		utils.AssertEqual(t, "google1.com", c.Hostname())
+		app.ReleaseCtx(c)
+	}
+}
+
 // go test -run Test_Ctx_Hostname_UntrustedProxyRange
 func Test_Ctx_Hostname_TrustedProxyRange(t *testing.T) {
 	t.Parallel()
@@ -1821,6 +1834,14 @@ func Test_Ctx_Protocol(t *testing.T) {
 	c.Request().Header.Reset()
 
 	c.Request().Header.Set(HeaderXForwardedProtocol, "https")
+	utils.AssertEqual(t, "https", c.Protocol())
+	c.Request().Header.Reset()
+
+	c.Request().Header.Set(HeaderXForwardedProto, "https, http")
+	utils.AssertEqual(t, "https", c.Protocol())
+	c.Request().Header.Reset()
+
+	c.Request().Header.Set(HeaderXForwardedProtocol, "https, http")
 	utils.AssertEqual(t, "https", c.Protocol())
 	c.Request().Header.Reset()
 


### PR DESCRIPTION
## Description

Fix the problem when the server is behind more than 2 proxies and c.BaseURL(), c.Protocol(), c.Hostname() will return the list instead of the first variable.
```go
func LoginHandler(c *fiber.Ctx) error {
	fmt.Println("BaseURL: "+c.BaseURL())
	fmt.Println("Protocol: "+c.Protocol())
        fmt.Println("Hostname: "+c.Hostname())
}
```

### Result
```
BaseURL: https, https://hello.world.com, hello.world.com
Protocol: https, https
Hostname: hello.world.com, hello.world.com
```
So this PR will fix these functions to return only first variable from list
### Result
```
BaseURL: https://hello.world.com
Protocol: https
Hostname: hello.world.com
```
Fixes https://github.com/gofiber/fiber/issues/2151

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - https://github.com/gofiber/docs for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
