### PR TITLE
🐛 Fix: Reset d.Data instead of deleting keys in it

### DIFF
--- a/middleware/session/data.go
+++ b/middleware/session/data.go
@@ -27,9 +27,7 @@ func acquireData() *data {
 
 func (d *data) Reset() {
 	d.Lock()
-	for key := range d.Data {
-		delete(d.Data, key)
-	}
+	d.Data = make(map[string]interface{})
 	d.Unlock()
 }
 


### PR DESCRIPTION
## Description
This pull requests fixes possible memory leak in session middleware while golang/go#20135 is not resolved

Fixes #2149

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
- [X] I tried to make my code as fast as possible with as few allocations as possible