### PR TITLE
🚀 Make IP validation 2x faster

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -684,72 +684,108 @@ func (c *Ctx) IP() string {
 	return c.fasthttp.RemoteIP().String()
 }
 
-// validateIPIfEnabled will return the input IP when validation is disabled.
-// when validation is enabled, it will return an empty string if the input is not a valid IP.
-func (c *Ctx) validateIPIfEnabled(ip string) string {
-	if c.app.config.EnableIPValidation && net.ParseIP(ip) == nil {
-		return ""
-	}
-	return ip
-}
-
 // extractIPsFromHeader will return a slice of IPs it found given a header name in the order they appear.
 // When IP validation is enabled, any invalid IPs will be omitted.
-func (c *Ctx) extractIPsFromHeader(header string) (ipsFound []string) {
+func (c *Ctx) extractIPsFromHeader(header string) []string {
 	headerValue := c.Get(header)
 
-	// try to gather IPs in the input with minimal allocations to improve performance
-	ips := make([]string, bytes.Count([]byte(headerValue), []byte(","))+1)
-	var commaPos, i, validCount int
-	for {
-		commaPos = bytes.IndexByte([]byte(headerValue), ',')
-		if commaPos != -1 {
-			ips[i] = c.validateIPIfEnabled(utils.Trim(headerValue[:commaPos], ' '))
-			if ips[i] != "" {
-				validCount++
-			}
-			headerValue, i = headerValue[commaPos+1:], i+1
-		} else {
-			ips[i] = c.validateIPIfEnabled(utils.Trim(headerValue, ' '))
-			if ips[i] != "" {
-				validCount++
-			}
-			break
-		}
+	// We can't know how many IPs we will return, but we will try to guess with this constant division.
+	// Counting ',' makes function slower for about 50ns in general case.
+	estimatedCount := len(headerValue) / 8
+	if estimatedCount > 8 {
+		estimatedCount = 8 // Avoid big allocation on big header
 	}
 
-	// filter out any invalid IP(s) that we found
-	if len(ips) == validCount {
-		ipsFound = ips
-	} else {
-		ipsFound = make([]string, validCount)
-		var validIndex int
-		for n := range ips {
-			if ips[n] != "" {
-				ipsFound[validIndex] = ips[n]
-				validIndex++
+	ipsFound := make([]string, 0, estimatedCount)
+
+	i := 0
+	j := -1
+
+iploop:
+	for {
+		v4 := false
+		v6 := false
+
+		// Manually splitting string without allocating slice, working with parts directly
+		i, j = j+1, j+2
+
+		if j > len(headerValue) {
+			break
+		}
+
+		for j < len(headerValue) && headerValue[j] != ',' {
+			if headerValue[j] == ':' {
+				v6 = true
+			} else if headerValue[j] == '.' {
+				v4 = true
+			}
+			j++
+		}
+
+		for i < j && headerValue[i] == ' ' {
+			i++
+		}
+
+		s := utils.TrimRight(headerValue[i:j], ' ')
+
+		if c.app.config.EnableIPValidation {
+			// Skip validation if IP is clearly not IPv4/IPv6, otherwise validate without allocations
+			if (!v6 && !v4) || (v6 && !utils.IsIPv6(s)) || (v4 && !utils.IsIPv4(s)) {
+				continue iploop
 			}
 		}
+
+		ipsFound = append(ipsFound, s)
 	}
-	return
+
+	return ipsFound
 }
 
 // extractIPFromHeader will attempt to pull the real client IP from the given header when IP validation is enabled.
 // currently, it will return the first valid IP address in header.
 // when IP validation is disabled, it will simply return the value of the header without any inspection.
+// Implementation is almost the same as in extractIPsFromHeader, but without allocation of []string.
 func (c *Ctx) extractIPFromHeader(header string) string {
 	if c.app.config.EnableIPValidation {
-		// extract all IPs from the header's value
-		ips := c.extractIPsFromHeader(header)
+		headerValue := c.Get(header)
 
-		// since X-Forwarded-For has no RFC, it's really up to the proxy to decide whether to append
-		// or prepend IPs to this list. For example, the AWS ALB will prepend but the F5 BIG-IP will append ;(
-		// for now lets just go with the first value in the list...
-		if len(ips) > 0 {
-			return ips[0]
+		i := 0
+		j := -1
+
+	iploop:
+		for {
+			v4 := false
+			v6 := false
+			i, j = j+1, j+2
+
+			if j > len(headerValue) {
+				break
+			}
+
+			for j < len(headerValue) && headerValue[j] != ',' {
+				if headerValue[j] == ':' {
+					v6 = true
+				} else if headerValue[j] == '.' {
+					v4 = true
+				}
+				j++
+			}
+
+			for i < j && headerValue[i] == ' ' {
+				i++
+			}
+
+			s := utils.TrimRight(headerValue[i:j], ' ')
+
+			if c.app.config.EnableIPValidation {
+				if (!v6 && !v4) || (v6 && !utils.IsIPv6(s)) || (v4 && !utils.IsIPv4(s)) {
+					continue iploop
+				}
+			}
+
+			return s
 		}
 
-		// return the IP from the stack if we could not find any valid Ips
 		return c.fasthttp.RemoteIP().String()
 	}
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1252,6 +1252,10 @@ func Test_Ctx_IPs(t *testing.T) {
 	c.Request().Header.Set(HeaderXForwardedFor, "127.0.0.3, 127.0.0.1, 127.0.0.2")
 	utils.AssertEqual(t, []string{"127.0.0.3", "127.0.0.1", "127.0.0.2"}, c.IPs())
 
+	// ensure for IPv6
+	c.Request().Header.Set(HeaderXForwardedFor, "9396:9549:b4f7:8ed0:4791:1330:8c06:e62d, invalid, 2345:0425:2CA1::0567:5673:23b5")
+	utils.AssertEqual(t, []string{"9396:9549:b4f7:8ed0:4791:1330:8c06:e62d", "invalid", "2345:0425:2CA1::0567:5673:23b5"}, c.IPs())
+
 	// empty header
 	c.Request().Header.Set(HeaderXForwardedFor, "")
 	utils.AssertEqual(t, 0, len(c.IPs()))
@@ -1285,6 +1289,10 @@ func Test_Ctx_IPs_With_IP_Validation(t *testing.T) {
 	c.Request().Header.Set(HeaderXForwardedFor, "127.0.0.3, 127.0.0.1, 127.0.0.2")
 	utils.AssertEqual(t, []string{"127.0.0.3", "127.0.0.1", "127.0.0.2"}, c.IPs())
 
+	// ensure for IPv6
+	c.Request().Header.Set(HeaderXForwardedFor, "f037:825e:eadb:1b7b:1667:6f0a:5356:f604, invalid, 9396:9549:b4f7:8ed0:4791:1330:8c06:e62d")
+	utils.AssertEqual(t, []string{"f037:825e:eadb:1b7b:1667:6f0a:5356:f604", "9396:9549:b4f7:8ed0:4791:1330:8c06:e62d"}, c.IPs())
+
 	// empty header
 	c.Request().Header.Set(HeaderXForwardedFor, "")
 	utils.AssertEqual(t, 0, len(c.IPs()))
@@ -1309,6 +1317,20 @@ func Benchmark_Ctx_IPs(b *testing.B) {
 	utils.AssertEqual(b, []string{"127.0.0.1", "invalid", "127.0.0.1"}, res)
 }
 
+func Benchmark_Ctx_IPs_v6(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	c.Request().Header.Set(HeaderXForwardedFor, "f037:825e:eadb:1b7b:1667:6f0a:5356:f604, invalid, 2345:0425:2CA1::0567:5673:23b5")
+	var res []string
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		res = c.IPs()
+	}
+	utils.AssertEqual(b, []string{"f037:825e:eadb:1b7b:1667:6f0a:5356:f604", "invalid", "2345:0425:2CA1::0567:5673:23b5"}, res)
+}
+
 func Benchmark_Ctx_IPs_With_IP_Validation(b *testing.B) {
 	app := New(Config{EnableIPValidation: true})
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
@@ -1321,6 +1343,20 @@ func Benchmark_Ctx_IPs_With_IP_Validation(b *testing.B) {
 		res = c.IPs()
 	}
 	utils.AssertEqual(b, []string{"127.0.0.1", "127.0.0.1"}, res)
+}
+
+func Benchmark_Ctx_IPs_v6_With_IP_Validation(b *testing.B) {
+	app := New(Config{EnableIPValidation: true})
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	c.Request().Header.Set(HeaderXForwardedFor, "2345:0425:2CA1:0000:0000:0567:5673:23b5, invalid, 2345:0425:2CA1::0567:5673:23b5")
+	var res []string
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		res = c.IPs()
+	}
+	utils.AssertEqual(b, []string{"2345:0425:2CA1:0000:0000:0567:5673:23b5", "2345:0425:2CA1::0567:5673:23b5"}, res)
 }
 
 func Benchmark_Ctx_IP_With_ProxyHeader(b *testing.B) {

--- a/utils/ips.go
+++ b/utils/ips.go
@@ -1,0 +1,137 @@
+package utils
+
+import "net"
+
+// IsIPv4 is plagiarism of net.ParseIP,
+// but without check for IPv6 case and without returning net.IP slice, whereby IsIPv4 makes no allocations.
+func IsIPv4(s string) bool {
+	for i := 0; i < net.IPv4len; i++ {
+		if i > 0 {
+			if s[0] != '.' {
+				return false
+			}
+			s = s[1:]
+		}
+
+		n, ci := 0, 0
+
+		for ci = 0; ci < len(s) && '0' <= s[ci] && s[ci] <= '9'; ci++ {
+			n = n*10 + int(s[ci]-'0')
+			if n >= 0xFF {
+				return false
+			}
+		}
+
+		if ci == 0 || n > 0xFF || (ci > 1 && s[0] == '0') {
+			return false
+		}
+
+		s = s[ci:]
+	}
+
+	return true
+}
+
+// IsIPv6 is plagiarism of net.ParseIP,
+// but without check for IPv4 case and without returning net.IP slice, whereby IsIPv6 makes no allocations.
+func IsIPv6(s string) bool {
+	ellipsis := -1 // position of ellipsis in ip
+
+	// Might have leading ellipsis
+	if len(s) >= 2 && s[0] == ':' && s[1] == ':' {
+		ellipsis = 0
+		s = s[2:]
+		// Might be only ellipsis
+		if len(s) == 0 {
+			return true
+		}
+	}
+
+	// Loop, parsing hex numbers followed by colon.
+	i := 0
+	for i < net.IPv6len {
+		// Hex number.
+		n, ci := 0, 0
+
+		for ci = 0; ci < len(s); ci++ {
+			if '0' <= s[ci] && s[ci] <= '9' {
+				n *= 16
+				n += int(s[ci] - '0')
+			} else if 'a' <= s[ci] && s[ci] <= 'f' {
+				n *= 16
+				n += int(s[ci]-'a') + 10
+			} else if 'A' <= s[ci] && s[ci] <= 'F' {
+				n *= 16
+				n += int(s[ci]-'A') + 10
+			} else {
+				break
+			}
+			if n > 0xFFFF {
+				return false
+			}
+		}
+		if ci == 0 || n > 0xFFFF {
+			return false
+		}
+
+		if ci < len(s) && s[ci] == '.' {
+			if ellipsis < 0 && i != net.IPv6len-net.IPv4len {
+				return false
+			}
+			if i+net.IPv4len > net.IPv6len {
+				return false
+			}
+
+			if !IsIPv4(s) {
+				return false
+			}
+
+			s = ""
+			i += net.IPv4len
+			break
+		}
+
+		// Save this 16-bit chunk.
+		i += 2
+
+		// Stop at end of string.
+		s = s[ci:]
+		if len(s) == 0 {
+			break
+		}
+
+		// Otherwise must be followed by colon and more.
+		if s[0] != ':' || len(s) == 1 {
+			return false
+		}
+		s = s[1:]
+
+		// Look for ellipsis.
+		if s[0] == ':' {
+			if ellipsis >= 0 { // already have one
+				return false
+			}
+			ellipsis = i
+			s = s[1:]
+			if len(s) == 0 { // can be at end
+				break
+			}
+		}
+	}
+
+	// Must have used entire string.
+	if len(s) != 0 {
+		return false
+	}
+
+	// If didn't parse enough, expand ellipsis.
+	if i < net.IPv6len {
+		if ellipsis < 0 {
+			return false
+		}
+	} else if ellipsis >= 0 {
+		// Ellipsis must represent at least one 0 group.
+		return false
+	}
+	return true
+}

--- a/utils/ips.go
+++ b/utils/ips.go
@@ -2,7 +2,7 @@ package utils
 
 import "net"
 
-// IsIPv4 is plagiarism of net.ParseIP,
+// IsIPv4 works the same way as net.ParseIP,
 // but without check for IPv6 case and without returning net.IP slice, whereby IsIPv4 makes no allocations.
 func IsIPv4(s string) bool {
 	for i := 0; i < net.IPv4len; i++ {
@@ -33,14 +33,10 @@ func IsIPv4(s string) bool {
 		s = s[ci:]
 	}
 
-	if len(s) != 0 {
-		return false
-	}
-
-	return true
+	return len(s) == 0
 }
 
-// IsIPv6 is plagiarism of net.ParseIP,
+// IsIPv6 works the same way as net.ParseIP,
 // but without check for IPv4 case and without returning net.IP slice, whereby IsIPv6 makes no allocations.
 func IsIPv6(s string) bool {
 	ellipsis := -1 // position of ellipsis in ip

--- a/utils/ips.go
+++ b/utils/ips.go
@@ -6,6 +6,10 @@ import "net"
 // but without check for IPv6 case and without returning net.IP slice, whereby IsIPv4 makes no allocations.
 func IsIPv4(s string) bool {
 	for i := 0; i < net.IPv4len; i++ {
+		if len(s) == 0 {
+			return false
+		}
+
 		if i > 0 {
 			if s[0] != '.' {
 				return false
@@ -27,6 +31,10 @@ func IsIPv4(s string) bool {
 		}
 
 		s = s[ci:]
+	}
+
+	if len(s) != 0 {
+		return false
 	}
 
 	return true

--- a/utils/ips_test.go
+++ b/utils/ips_test.go
@@ -7,26 +7,24 @@ package utils
 import (
 	"net"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func Test_IsIPv4(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, true, IsIPv4("174.23.33.100"))
-	require.Equal(t, true, IsIPv4("127.0.0.1"))
-	require.Equal(t, true, IsIPv4("0.0.0.0"))
+	AssertEqual(t, true, IsIPv4("174.23.33.100"))
+	AssertEqual(t, true, IsIPv4("127.0.0.1"))
+	AssertEqual(t, true, IsIPv4("0.0.0.0"))
 
-	require.Equal(t, false, IsIPv4(".0.0.0"))
-	require.Equal(t, false, IsIPv4("0.0.0."))
-	require.Equal(t, false, IsIPv4("0.0.0"))
-	require.Equal(t, false, IsIPv4(".0.0.0."))
-	require.Equal(t, false, IsIPv4("0.0.0.0.0"))
-	require.Equal(t, false, IsIPv4("0"))
-	require.Equal(t, false, IsIPv4(""))
-	require.Equal(t, false, IsIPv4("2345:0425:2CA1::0567:5673:23b5"))
-	require.Equal(t, false, IsIPv4("invalid"))
+	AssertEqual(t, false, IsIPv4(".0.0.0"))
+	AssertEqual(t, false, IsIPv4("0.0.0."))
+	AssertEqual(t, false, IsIPv4("0.0.0"))
+	AssertEqual(t, false, IsIPv4(".0.0.0."))
+	AssertEqual(t, false, IsIPv4("0.0.0.0.0"))
+	AssertEqual(t, false, IsIPv4("0"))
+	AssertEqual(t, false, IsIPv4(""))
+	AssertEqual(t, false, IsIPv4("2345:0425:2CA1::0567:5673:23b5"))
+	AssertEqual(t, false, IsIPv4("invalid"))
 }
 
 // go test -v -run=^$ -bench=UnsafeString -benchmem -count=2
@@ -39,30 +37,30 @@ func Benchmark_IsIPv4(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			res = IsIPv4(ip)
 		}
-		require.Equal(b, true, res)
+		AssertEqual(b, true, res)
 	})
 
 	b.Run("default", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			res = net.ParseIP(ip) != nil
 		}
-		require.Equal(b, true, res)
+		AssertEqual(b, true, res)
 	})
 }
 
 func Test_IsIPv6(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, true, IsIPv6("9396:9549:b4f7:8ed0:4791:1330:8c06:e62d"))
-	require.Equal(t, true, IsIPv6("2345:0425:2CA1::0567:5673:23b5"))
-	require.Equal(t, true, IsIPv6("2001:1:2:3:4:5:6:7"))
+	AssertEqual(t, true, IsIPv6("9396:9549:b4f7:8ed0:4791:1330:8c06:e62d"))
+	AssertEqual(t, true, IsIPv6("2345:0425:2CA1::0567:5673:23b5"))
+	AssertEqual(t, true, IsIPv6("2001:1:2:3:4:5:6:7"))
 
-	require.Equal(t, false, IsIPv6("1.1.1.1"))
-	require.Equal(t, false, IsIPv6("2001:1:2:3:4:5:6:"))
-	require.Equal(t, false, IsIPv6(":1:2:3:4:5:6:"))
-	require.Equal(t, false, IsIPv6("1:2:3:4:5:6:"))
-	require.Equal(t, false, IsIPv6(""))
-	require.Equal(t, false, IsIPv6("invalid"))
+	AssertEqual(t, false, IsIPv6("1.1.1.1"))
+	AssertEqual(t, false, IsIPv6("2001:1:2:3:4:5:6:"))
+	AssertEqual(t, false, IsIPv6(":1:2:3:4:5:6:"))
+	AssertEqual(t, false, IsIPv6("1:2:3:4:5:6:"))
+	AssertEqual(t, false, IsIPv6(""))
+	AssertEqual(t, false, IsIPv6("invalid"))
 }
 
 // go test -v -run=^$ -bench=UnsafeString -benchmem -count=2
@@ -75,13 +73,13 @@ func Benchmark_IsIPv6(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			res = IsIPv6(ip)
 		}
-		require.Equal(b, true, res)
+		AssertEqual(b, true, res)
 	})
 
 	b.Run("default", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			res = net.ParseIP(ip) != nil
 		}
-		require.Equal(b, true, res)
+		AssertEqual(b, true, res)
 	})
 }

--- a/utils/ips_test.go
+++ b/utils/ips_test.go
@@ -1,0 +1,87 @@
+// ⚡️ Fiber is an Express inspired web framework written in Go with ☕️
+// 🤖 Github Repository: https://github.com/gofiber/fiber
+// 📌 API Documentation: https://docs.gofiber.io
+
+package utils
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_IsIPv4(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, true, IsIPv4("174.23.33.100"))
+	require.Equal(t, true, IsIPv4("127.0.0.1"))
+	require.Equal(t, true, IsIPv4("0.0.0.0"))
+
+	require.Equal(t, false, IsIPv4(".0.0.0"))
+	require.Equal(t, false, IsIPv4("0.0.0."))
+	require.Equal(t, false, IsIPv4("0.0.0"))
+	require.Equal(t, false, IsIPv4(".0.0.0."))
+	require.Equal(t, false, IsIPv4("0.0.0.0.0"))
+	require.Equal(t, false, IsIPv4("0"))
+	require.Equal(t, false, IsIPv4(""))
+	require.Equal(t, false, IsIPv4("2345:0425:2CA1::0567:5673:23b5"))
+	require.Equal(t, false, IsIPv4("invalid"))
+}
+
+// go test -v -run=^$ -bench=UnsafeString -benchmem -count=2
+
+func Benchmark_IsIPv4(b *testing.B) {
+	ip := "174.23.33.100"
+	var res bool
+
+	b.Run("fiber", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = IsIPv4(ip)
+		}
+		require.Equal(b, true, res)
+	})
+
+	b.Run("default", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = net.ParseIP(ip) != nil
+		}
+		require.Equal(b, true, res)
+	})
+}
+
+func Test_IsIPv6(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, true, IsIPv6("9396:9549:b4f7:8ed0:4791:1330:8c06:e62d"))
+	require.Equal(t, true, IsIPv6("2345:0425:2CA1::0567:5673:23b5"))
+	require.Equal(t, true, IsIPv6("2001:1:2:3:4:5:6:7"))
+
+	require.Equal(t, false, IsIPv6("1.1.1.1"))
+	require.Equal(t, false, IsIPv6("2001:1:2:3:4:5:6:"))
+	require.Equal(t, false, IsIPv6(":1:2:3:4:5:6:"))
+	require.Equal(t, false, IsIPv6("1:2:3:4:5:6:"))
+	require.Equal(t, false, IsIPv6(""))
+	require.Equal(t, false, IsIPv6("invalid"))
+}
+
+// go test -v -run=^$ -bench=UnsafeString -benchmem -count=2
+
+func Benchmark_IsIPv6(b *testing.B) {
+	ip := "9396:9549:b4f7:8ed0:4791:1330:8c06:e62d"
+	var res bool
+
+	b.Run("fiber", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = IsIPv6(ip)
+		}
+		require.Equal(b, true, res)
+	})
+
+	b.Run("default", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = net.ParseIP(ip) != nil
+		}
+		require.Equal(b, true, res)
+	})
+}


### PR DESCRIPTION
## Description

This commit makes `c.IP()` and `c.IPs()` faster, especially when IP validation is enabled.

Benchmarks on my machine after this commit:
```
> go test -v -run=ctx_test.go -bench=Benchmark_Ctx_IP
goos: darwin
goarch: amd64
pkg: github.com/gofiber/fiber/v2
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
Benchmark_Ctx_IPs
Benchmark_Ctx_IPs-12                                             5892488               202.4 ns/op            48 B/op          1 allocs/op
Benchmark_Ctx_IPs_v6
Benchmark_Ctx_IPs_v6-12                                          3978466               302.2 ns/op           128 B/op          1 allocs/op
Benchmark_Ctx_IPs_With_IP_Validation
Benchmark_Ctx_IPs_With_IP_Validation-12                          4453332               268.4 ns/op            48 B/op          1 allocs/op
Benchmark_Ctx_IPs_v6_With_IP_Validation
Benchmark_Ctx_IPs_v6_With_IP_Validation-12                       2458620               488.3 ns/op           128 B/op          1 allocs/op
Benchmark_Ctx_IP_With_ProxyHeader
Benchmark_Ctx_IP_With_ProxyHeader-12                            24604593                48.82 ns/op            0 B/op          0 allocs/op
Benchmark_Ctx_IP_With_ProxyHeader_and_IP_Validation
Benchmark_Ctx_IP_With_ProxyHeader_and_IP_Validation-12          12709902                93.63 ns/op            0 B/op          0 allocs/op
Benchmark_Ctx_IP
Benchmark_Ctx_IP-12                                             27120162                43.37 ns/op            8 B/op          1 allocs/op
```

Before this commit:
```
> go test -v -run=ctx_test.go -bench=Benchmark_Ctx_IP
goos: darwin
goarch: amd64
pkg: github.com/gofiber/fiber/v2
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
Benchmark_Ctx_IPs
Benchmark_Ctx_IPs-12                                             4376821               265.9 ns/op            48 B/op          1 allocs/op
Benchmark_Ctx_IPs_v6
Benchmark_Ctx_IPs_v6-12                                          2381112               503.9 ns/op           256 B/op          4 allocs/op
Benchmark_Ctx_IPs_With_IP_Validation
Benchmark_Ctx_IPs_With_IP_Validation-12                          2151280               495.0 ns/op           112 B/op          4 allocs/op
Benchmark_Ctx_IPs_v6_With_IP_Validation
Benchmark_Ctx_IPs_v6_With_IP_Validation-12                       1527709               781.4 ns/op           320 B/op          7 allocs/op
Benchmark_Ctx_IP_With_ProxyHeader
Benchmark_Ctx_IP_With_ProxyHeader-12                            24476161                48.81 ns/op            0 B/op          0 allocs/op
Benchmark_Ctx_IP_With_ProxyHeader_and_IP_Validation
Benchmark_Ctx_IP_With_ProxyHeader_and_IP_Validation-12           5742741               208.6 ns/op            32 B/op          2 allocs/op
Benchmark_Ctx_IP
Benchmark_Ctx_IP-12                                             27599205                43.04 ns/op            8 B/op          1 allocs/op
```

## Type of change

- [+] New feature (non-breaking change which adds functionality)

## Checklist:

- [+] I have performed a self-review of my own code
- [+] I have commented my code, particularly in hard-to-understand areas
- [+] I have added tests that prove my fix is effective or that my feature works
- [+] New and existing unit tests pass locally with my changes
- [+] I tried to make my code as fast as possible with as few allocations as possible
- [+] For new code I have written benchmarks so that they can be analyzed and improved