### PR TITLE
[Bug] Fix query string parameter pass to fiber context

### DIFF
--- a/app.go
+++ b/app.go
@@ -883,11 +883,6 @@ func (app *App) Test(req *http.Request, msTimeout ...int) (resp *http.Response, 
 		return nil, err
 	}
 
-	// adding back the query from URL, since dump cleans it
-	dumps := bytes.Split(dump, []byte(" "))
-	dumps[1] = []byte(req.URL.String())
-	dump = bytes.Join(dumps, []byte(" "))
-
 	// Create test connection
 	conn := new(testConn)
 

--- a/app.go
+++ b/app.go
@@ -9,7 +9,6 @@ package fiber
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"net"


### PR DESCRIPTION
## Description

Remove this change (https://github.com/gofiber/fiber/pull/1909).

Fix test when using query string parameter.   

When you use `/foo?bar=boo`, your test case should able to QueryParser parameter from fiber.Ctx:

```
func ListResource(c *fiber.Ctx) error {
        mrf := new(models ResouceFilter)
	if err = c.QueryParser(mrf); err != nil {
		return sendError(c, http.StatusBadRequest, err)
	}
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - https://github.com/gofiber/docs for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [X] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved