### PR TITLE
:recycle: Leverage runtime/debug to print the full stack trace info

### DIFF
--- a/middleware/recover/config.go
+++ b/middleware/recover/config.go
@@ -22,8 +22,6 @@ type Config struct {
 	StackTraceHandler func(c *fiber.Ctx, e interface{})
 }
 
-var defaultStackTraceBufLen = 1024
-
 // ConfigDefault is the default config
 var ConfigDefault = Config{
 	Next:              nil,

--- a/middleware/recover/recover.go
+++ b/middleware/recover/recover.go
@@ -3,15 +3,13 @@ package recover
 import (
 	"fmt"
 	"os"
-	"runtime"
+	"runtime/debug"
 
 	"github.com/gofiber/fiber/v2"
 )
 
-func defaultStackTraceHandler(c *fiber.Ctx, e interface{}) {
-	buf := make([]byte, defaultStackTraceBufLen)
-	buf = buf[:runtime.Stack(buf, false)]
-	_, _ = os.Stderr.WriteString(fmt.Sprintf("panic: %v\n%s\n", e, buf))
+func defaultStackTraceHandler(_ *fiber.Ctx, e interface{}) {
+	_, _ = os.Stderr.WriteString(fmt.Sprintf("panic: %v\n%s\n", e, debug.Stack()))
 }
 
 // New creates a new middleware handler


### PR DESCRIPTION
## Description

Use `Stack()` in `runtime/debug`, not in `runtime`, to get the panic stack trace info cuz the one in `runtime/debug` is a more convenient wrapper provided by Go team to print stack trace info, see https://github.com/golang/go/issues/12363, besides, the current implementation only prints the first 1024 bytes, which might result in the missing vital information in the content after 1024 bytes, and the new approach resolves this issue by printing the full stack trace info.

## Type of change

Please delete options that are not relevant.

- [x] Enhancement 

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - https://github.com/gofiber/docs for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
