### PR TITLE
v3 (deps): update to use gofiber/utils/v2

### DIFF
--- a/app.go
+++ b/app.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 

--- a/bind.go
+++ b/bind.go
@@ -2,7 +2,7 @@ package fiber
 
 import (
 	"github.com/gofiber/fiber/v3/binder"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 // An interface to register custom binders.

--- a/binder/cookie.go
+++ b/binder/cookie.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 

--- a/binder/form.go
+++ b/binder/form.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 

--- a/binder/header.go
+++ b/binder/header.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 

--- a/binder/json.go
+++ b/binder/json.go
@@ -1,7 +1,7 @@
 package binder
 
 import (
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 type jsonBinding struct{}

--- a/binder/mapping.go
+++ b/binder/mapping.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/gofiber/fiber/v3/internal/schema"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/bytebufferpool"
 )
 

--- a/binder/query.go
+++ b/binder/query.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 

--- a/binder/resp_header.go
+++ b/binder/resp_header.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 

--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 

--- a/ctx.go
+++ b/ctx.go
@@ -21,7 +21,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/savsgio/dictpool"
 	"github.com/valyala/bytebufferpool"
 	"github.com/valyala/fasthttp"

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3/internal/storage/memory"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/bytebufferpool"
 	"github.com/valyala/fasthttp"

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/gofiber/fiber/v3
 go 1.19
 
 require (
-	github.com/gofiber/utils v1.0.0
+	github.com/gofiber/utils/v2 v2.0.0-beta.1
 	github.com/google/uuid v1.3.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.16
 	github.com/savsgio/dictpool v0.0.0-20221023140959-7bf2e61cea94
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
 	github.com/tinylib/msgp v1.1.6
 	github.com/valyala/bytebufferpool v1.0.0
 	github.com/valyala/fasthttp v1.41.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gofiber/utils v1.0.0 h1:goxlTmYidOhsCvuZuTLzT224DELpnz9c/+iw5eN9FJw=
-github.com/gofiber/utils v1.0.0/go.mod h1:RYennBgjLkuNtU+dxg7QgBEU8tmixFQHQ2GE1ioZlxw=
+github.com/gofiber/utils/v2 v2.0.0-beta.1 h1:ACfPdqeclx+BFIja19UjkKx7k3r5tmpILpNgzrfPLKs=
+github.com/gofiber/utils/v2 v2.0.0-beta.1/go.mod h1:CG89nDoIkEFIJaw5LdLO9AmBM11odse/LC79KQujm74=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
@@ -24,9 +24,11 @@ github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d h1:Q+gqLBOPkFGHyCJx
 github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d/go.mod h1:Gy+0tqhJvgGlqnTF8CVGP0AaGRjwBtXs/a5PA0Y3+A4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tinylib/msgp v1.1.6 h1:i+SbKraHhnrf9M5MYmvQhFnbLhAXSDWF8WWsuyRdocw=
 github.com/tinylib/msgp v1.1.6/go.mod h1:75BAfg2hauQhs3qedfdDZmWAPcFMAvJE5b9rGOMufyw=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 )

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 type Storage struct {

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 // Storage interface that is implemented by storage providers

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/stretchr/testify/require"
 )
 

--- a/middleware/adaptor/adopter.go
+++ b/middleware/adaptor/adopter.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttpadaptor"
 )

--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 // New creates a new middleware handler

--- a/middleware/basicauth/config.go
+++ b/middleware/basicauth/config.go
@@ -4,7 +4,7 @@ import (
 	"crypto/subtle"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 // Config defines the config for middleware.

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 // timestampUpdatePeriod is the period which is used to check the cache expiration.

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/internal/storage/memory"
 	"github.com/gofiber/fiber/v3/middleware/etag"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 )

--- a/middleware/cache/config.go
+++ b/middleware/cache/config.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 // Config defines the config for middleware.

--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 // Config defines the config for middleware.

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 )

--- a/middleware/csrf/manager.go
+++ b/middleware/csrf/manager.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/internal/memory"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 // go:generate msgp

--- a/middleware/limiter/limiter_fixed.go
+++ b/middleware/limiter/limiter_fixed.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 type FixedWindow struct{}

--- a/middleware/limiter/limiter_sliding.go
+++ b/middleware/limiter/limiter_sliding.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 type SlidingWindow struct{}

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/internal/tlstest"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 )

--- a/middleware/requestid/config.go
+++ b/middleware/requestid/config.go
@@ -2,7 +2,7 @@ package requestid
 
 import (
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 // Config defines the config for middleware.

--- a/middleware/session/config.go
+++ b/middleware/session/config.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 )
 
 // Config defines the config for middleware.

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/internal/storage/memory"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 

--- a/redirect.go
+++ b/redirect.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/gofiber/fiber/v3/binder"
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/bytebufferpool"
 )
 

--- a/router.go
+++ b/router.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 

--- a/router_test.go
+++ b/router_test.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gofiber/utils"
+	"github.com/gofiber/utils/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 )


### PR DESCRIPTION
## Description

Updates v3-beta to use the `gofiber/utils/v2` package.
testify seems to have also been indirectly bumped up to 1.8.1 from 1.8.0 as part of this.

This is required as the latest version of `v3-beta` requires aspects of v2. `utils.StartTimeStampUpdater`, `utils.Timestamp` `utils.JSONUnmarshal` etc.

## Type of change

- [x] Bug fix (dependency compatibility) (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
