### PR TITLE
Add URL prefix to pprof middleware

### DIFF
--- a/middleware/pprof/README.md
+++ b/middleware/pprof/README.md
@@ -24,7 +24,7 @@ After you initiate your Fiber app, you can use the following possibilities:
 app.Use(pprof.New())
 ```
 
-In systems where you have multiple ingress points, it is common to add a URL prefix, like so:
+In systems where you have multiple ingress endpoints, it is common to add a URL prefix, like so:
 
 ```go
 // Default middleware

--- a/middleware/pprof/README.md
+++ b/middleware/pprof/README.md
@@ -24,6 +24,16 @@ After you initiate your Fiber app, you can use the following possibilities:
 app.Use(pprof.New())
 ```
 
+In systems where you have multiple ingress points, it is common to add a URL prefix, like so:
+
+```go
+// Default middleware
+app.Use(pprof.New(pprof.Config{Prefix: "/endpoint-prefix"}))
+```
+
+This prefix will be added to the default path of "/debug/pprof/", for a resulting URL of:
+"/endpoint-prefix/debug/pprof/".
+
 ## Config
 
 ```go
@@ -33,6 +43,13 @@ type Config struct {
 	//
 	// Optional. Default: nil
 	Next func(c *fiber.Ctx) bool
+
+	// Prefix defines a URL prefix added before "/debug/pprof".
+	// Note that it should start with (but not end with) a slash.
+	// Example: "/federated-fiber"
+	//
+	// Optional. Default: ""
+	Prefix string
 }
 ```
 

--- a/middleware/pprof/config.go
+++ b/middleware/pprof/config.go
@@ -8,6 +8,13 @@ type Config struct {
 	//
 	// Optional. Default: nil
 	Next func(c *fiber.Ctx) bool
+
+	// Prefix defines a URL prefix added before "/debug/pprof".
+	// Note that it should start with (but not end with) a slash.
+	// Example: "/federated-fiber"
+	//
+	// Optional. Default: ""
+	Prefix string
 }
 
 var ConfigDefault = Config{

--- a/middleware/pprof/pprof.go
+++ b/middleware/pprof/pprof.go
@@ -37,39 +37,39 @@ func New(config ...Config) fiber.Handler {
 
 		path := c.Path()
 		// We are only interested in /debug/pprof routes
-		if len(path) < 12 || !strings.HasPrefix(path, "/debug/pprof") {
+		if len(path) < 12 || !strings.HasPrefix(path, cfg.Prefix+"/debug/pprof") {
 			return c.Next()
 		}
 		// Switch to original path without stripped slashes
 		switch path {
-		case "/debug/pprof/":
+		case cfg.Prefix + "/debug/pprof/":
 			pprofIndex(c.Context())
-		case "/debug/pprof/cmdline":
+		case cfg.Prefix + "/debug/pprof/cmdline":
 			pprofCmdline(c.Context())
-		case "/debug/pprof/profile":
+		case cfg.Prefix + "/debug/pprof/profile":
 			pprofProfile(c.Context())
-		case "/debug/pprof/symbol":
+		case cfg.Prefix + "/debug/pprof/symbol":
 			pprofSymbol(c.Context())
-		case "/debug/pprof/trace":
+		case cfg.Prefix + "/debug/pprof/trace":
 			pprofTrace(c.Context())
-		case "/debug/pprof/allocs":
+		case cfg.Prefix + "/debug/pprof/allocs":
 			pprofAllocs(c.Context())
-		case "/debug/pprof/block":
+		case cfg.Prefix + "/debug/pprof/block":
 			pprofBlock(c.Context())
-		case "/debug/pprof/goroutine":
+		case cfg.Prefix + "/debug/pprof/goroutine":
 			pprofGoroutine(c.Context())
-		case "/debug/pprof/heap":
+		case cfg.Prefix + "/debug/pprof/heap":
 			pprofHeap(c.Context())
-		case "/debug/pprof/mutex":
+		case cfg.Prefix + "/debug/pprof/mutex":
 			pprofMutex(c.Context())
-		case "/debug/pprof/threadcreate":
+		case cfg.Prefix + "/debug/pprof/threadcreate":
 			pprofThreadcreate(c.Context())
 		default:
 			// pprof index only works with trailing slash
 			if strings.HasSuffix(path, "/") {
 				path = strings.TrimRight(path, "/")
 			} else {
-				path = "/debug/pprof/"
+				path = cfg.Prefix + "/debug/pprof/"
 			}
 
 			return c.Redirect(path, fiber.StatusFound)

--- a/middleware/pprof/pprof_test.go
+++ b/middleware/pprof/pprof_test.go
@@ -28,6 +28,24 @@ func Test_Non_Pprof_Path(t *testing.T) {
 	utils.AssertEqual(t, "escaped", string(b))
 }
 
+func Test_Non_Pprof_Path_WithPrefix(t *testing.T) {
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+
+	app.Use(New(Config{Prefix: "/federated-fiber"}))
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("escaped")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+
+	b, err := io.ReadAll(resp.Body)
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "escaped", string(b))
+}
+
 func Test_Pprof_Index(t *testing.T) {
 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 
@@ -38,6 +56,25 @@ func Test_Pprof_Index(t *testing.T) {
 	})
 
 	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/debug/pprof/", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+	utils.AssertEqual(t, fiber.MIMETextHTMLCharsetUTF8, resp.Header.Get(fiber.HeaderContentType))
+
+	b, err := io.ReadAll(resp.Body)
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, true, bytes.Contains(b, []byte("<title>/debug/pprof/</title>")))
+}
+
+func Test_Pprof_Index_WithPrefix(t *testing.T) {
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+
+	app.Use(New(Config{Prefix: "/federated-fiber"}))
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("escaped")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/federated-fiber/debug/pprof/", nil))
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, 200, resp.StatusCode)
 	utils.AssertEqual(t, fiber.MIMETextHTMLCharsetUTF8, resp.Header.Get(fiber.HeaderContentType))
@@ -74,6 +111,33 @@ func Test_Pprof_Subs(t *testing.T) {
 	}
 }
 
+func Test_Pprof_Subs_WithPrefix(t *testing.T) {
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+
+	app.Use(New(Config{Prefix: "/federated-fiber"}))
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("escaped")
+	})
+
+	subs := []string{
+		"cmdline", "profile", "symbol", "trace", "allocs", "block",
+		"goroutine", "heap", "mutex", "threadcreate",
+	}
+
+	for _, sub := range subs {
+		t.Run(sub, func(t *testing.T) {
+			target := "/federated-fiber/debug/pprof/" + sub
+			if sub == "profile" {
+				target += "?seconds=1"
+			}
+			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, target, nil), 5000)
+			utils.AssertEqual(t, nil, err)
+			utils.AssertEqual(t, 200, resp.StatusCode)
+		})
+	}
+}
+
 func Test_Pprof_Other(t *testing.T) {
 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 
@@ -84,6 +148,20 @@ func Test_Pprof_Other(t *testing.T) {
 	})
 
 	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/debug/pprof/302", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 302, resp.StatusCode)
+}
+
+func Test_Pprof_Other_WithPrefix(t *testing.T) {
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+
+	app.Use(New(Config{Prefix: "/federated-fiber"}))
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("escaped")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/federated-fiber/debug/pprof/302", nil))
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, 302, resp.StatusCode)
 }
@@ -101,6 +179,24 @@ func Test_Pprof_Next(t *testing.T) {
 	}))
 
 	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/debug/pprof/", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 404, resp.StatusCode)
+}
+
+// go test -run Test_Pprof_Next_WithPrefix
+func Test_Pprof_Next_WithPrefix(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Next: func(_ *fiber.Ctx) bool {
+			return true
+		},
+		Prefix: "/federated-fiber",
+	}))
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/federated-fiber/debug/pprof/", nil))
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, 404, resp.StatusCode)
 }


### PR DESCRIPTION
## Description

In systems with multiple ingress endpoints all sharing the same load balancer and base URL, it is common to place servers behind a URL prefix. To facilitate this, this PR allows the pprof middleware to define a URL Prefix during configuration so that the endpoints are served on an appropriate URL.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - https://github.com/gofiber/docs for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
