### PR TITLE
:sparkles: feature: add multiple-prefix support to app.Use() and group.Use()

### DIFF
--- a/app.go
+++ b/app.go
@@ -669,19 +669,30 @@ func (app *App) GetRoutes(filterUseOption ...bool) []Route {
 // This method will match all HTTP verbs: GET, POST, PUT, HEAD etc...
 func (app *App) Use(args ...interface{}) Router {
 	var prefix string
+	var prefixes []string
 	var handlers []Handler
 
 	for i := 0; i < len(args); i++ {
 		switch arg := args[i].(type) {
 		case string:
 			prefix = arg
+		case []string:
+			prefixes = arg
 		case Handler:
 			handlers = append(handlers, arg)
 		default:
 			panic(fmt.Sprintf("use: invalid handler %v\n", reflect.TypeOf(arg)))
 		}
 	}
-	app.register(methodUse, prefix, nil, handlers...)
+
+	if len(prefixes) == 0 {
+		prefixes = append(prefixes, prefix)
+	}
+
+	for _, prefix := range prefixes {
+		app.register(methodUse, prefix, nil, handlers...)
+	}
+
 	return app
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -401,6 +401,52 @@ func Test_App_Not_Use_StrictRouting(t *testing.T) {
 	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
 }
 
+func Test_App_Use_MultiplePrefix(t *testing.T) {
+	app := New()
+
+	app.Use([]string{"/john", "/doe"}, func(c *Ctx) error {
+		return c.SendString(c.Path())
+	})
+
+	g := app.Group("/test")
+	g.Use([]string{"/john", "/doe"}, func(c *Ctx) error {
+		return c.SendString(c.Path())
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/john", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
+
+	body, err := io.ReadAll(resp.Body)
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "/john", string(body))
+
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/doe", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
+
+	body, err = io.ReadAll(resp.Body)
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "/doe", string(body))
+
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test/john", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
+
+	body, err = io.ReadAll(resp.Body)
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "/test/john", string(body))
+
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test/doe", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, StatusOK, resp.StatusCode, "Status code")
+
+	body, err = io.ReadAll(resp.Body)
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "/test/doe", string(body))
+
+}
+
 func Test_App_Use_StrictRouting(t *testing.T) {
 	app := New(Config{StrictRouting: true})
 

--- a/group.go
+++ b/group.go
@@ -51,19 +51,31 @@ func (grp *Group) Name(name string) Router {
 //
 // This method will match all HTTP verbs: GET, POST, PUT, HEAD etc...
 func (grp *Group) Use(args ...interface{}) Router {
-	prefix := ""
+	var prefix string
+	var prefixes []string
 	var handlers []Handler
+
 	for i := 0; i < len(args); i++ {
 		switch arg := args[i].(type) {
 		case string:
 			prefix = arg
+		case []string:
+			prefixes = arg
 		case Handler:
 			handlers = append(handlers, arg)
 		default:
 			panic(fmt.Sprintf("use: invalid handler %v\n", reflect.TypeOf(arg)))
 		}
 	}
-	grp.app.register(methodUse, getGroupPath(grp.Prefix, prefix), grp, handlers...)
+
+	if len(prefixes) == 0 {
+		prefixes = append(prefixes, prefix)
+	}
+
+	for _, prefix := range prefixes {
+		grp.app.register(methodUse, getGroupPath(grp.Prefix, prefix), grp, handlers...)
+	}
+
 	return grp
 }
 


### PR DESCRIPTION
## Description
Express-like multiple-prefix support for Use methods.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - https://github.com/gofiber/docs for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
