### PR TITLE
Track Configured Values

### DIFF
--- a/app.go
+++ b/app.go
@@ -114,6 +114,8 @@ type App struct {
 	customMethod bool
 	// Mount fields
 	mountFields *mountFields
+	// True if the ErrorHandler is explicitly configured
+	errorHandlerConfigured bool
 }
 
 // Config is a struct holding the server settings.
@@ -247,9 +249,6 @@ type Config struct {
 	//
 	// Default: DefaultErrorHandler
 	ErrorHandler ErrorHandler `json:"-"`
-
-	// ErrorHandlerConfigured is true when the fiber.ErrorHandler is configured explicitly.
-	ErrorHandlerConfigured bool `json:"-"`
 
 	// When set to true, disables keep-alive connections.
 	// The server will close incoming connections after sending the first response to client.
@@ -545,7 +544,7 @@ func New(config ...Config) *App {
 	if app.config.ErrorHandler == nil {
 		app.config.ErrorHandler = DefaultErrorHandler
 	} else {
-		app.config.ErrorHandlerConfigured = true
+		app.errorHandlerConfigured = true
 	}
 
 	if app.config.JSONEncoder == nil {
@@ -1004,7 +1003,7 @@ func (app *App) ErrorHandler(ctx *Ctx, err error) error {
 		if prefix != "" && strings.HasPrefix(ctx.path, prefix) {
 			parts := len(strings.Split(prefix, "/"))
 			if mountedPrefixParts <= parts {
-				if subApp.config.ErrorHandlerConfigured {
+				if subApp.errorHandlerConfigured {
 					mountedErrHandler = subApp.config.ErrorHandler
 				}
 

--- a/app.go
+++ b/app.go
@@ -110,8 +110,6 @@ type App struct {
 	latestRoute *Route
 	// TLS handler
 	tlsHandler *TLSHandler
-	// custom method check
-	customMethod bool
 	// Mount fields
 	mountFields *mountFields
 	// Indicates if the value was explicitly configured
@@ -562,8 +560,6 @@ func New(config ...Config) *App {
 	}
 	if len(app.config.RequestMethods) == 0 {
 		app.config.RequestMethods = DefaultMethods
-	} else {
-		app.customMethod = true
 	}
 
 	app.config.trustedProxiesMap = make(map[string]struct{}, len(app.config.TrustedProxies))

--- a/app.go
+++ b/app.go
@@ -114,8 +114,8 @@ type App struct {
 	customMethod bool
 	// Mount fields
 	mountFields *mountFields
-	// True if the ErrorHandler is explicitly configured
-	errorHandlerConfigured bool
+	// Indicates if the value was explicitly configured
+	configured Config
 }
 
 // Config is a struct holding the server settings.
@@ -515,6 +515,9 @@ func New(config ...Config) *App {
 		app.config = config[0]
 	}
 
+	// Initialize configured before defaults are set
+	app.configured = app.config
+
 	if app.config.ETag {
 		if !IsChild() {
 			fmt.Println("[Warning] Config.ETag is deprecated since v2.0.6, please use 'middleware/etag'.")
@@ -543,8 +546,6 @@ func New(config ...Config) *App {
 
 	if app.config.ErrorHandler == nil {
 		app.config.ErrorHandler = DefaultErrorHandler
-	} else {
-		app.errorHandlerConfigured = true
 	}
 
 	if app.config.JSONEncoder == nil {
@@ -1003,7 +1004,7 @@ func (app *App) ErrorHandler(ctx *Ctx, err error) error {
 		if prefix != "" && strings.HasPrefix(ctx.path, prefix) {
 			parts := len(strings.Split(prefix, "/"))
 			if mountedPrefixParts <= parts {
-				if subApp.errorHandlerConfigured {
+				if subApp.configured.ErrorHandler != nil {
 					mountedErrHandler = subApp.config.ErrorHandler
 				}
 

--- a/app.go
+++ b/app.go
@@ -248,6 +248,9 @@ type Config struct {
 	// Default: DefaultErrorHandler
 	ErrorHandler ErrorHandler `json:"-"`
 
+	// ErrorHandlerConfigured is true when the fiber.ErrorHandler is configured explicitly.
+	ErrorHandlerConfigured bool `json:"-"`
+
 	// When set to true, disables keep-alive connections.
 	// The server will close incoming connections after sending the first response to client.
 	//
@@ -541,6 +544,8 @@ func New(config ...Config) *App {
 
 	if app.config.ErrorHandler == nil {
 		app.config.ErrorHandler = DefaultErrorHandler
+	} else {
+		app.config.ErrorHandlerConfigured = true
 	}
 
 	if app.config.JSONEncoder == nil {
@@ -999,7 +1004,10 @@ func (app *App) ErrorHandler(ctx *Ctx, err error) error {
 		if prefix != "" && strings.HasPrefix(ctx.path, prefix) {
 			parts := len(strings.Split(prefix, "/"))
 			if mountedPrefixParts <= parts {
-				mountedErrHandler = subApp.config.ErrorHandler
+				if subApp.config.ErrorHandlerConfigured {
+					mountedErrHandler = subApp.config.ErrorHandler
+				}
+
 				mountedPrefixParts = parts
 			}
 		}

--- a/helpers.go
+++ b/helpers.go
@@ -334,7 +334,7 @@ var getBytesImmutable = func(s string) (b []byte) {
 // HTTP methods and their unique INTs
 func (app *App) methodInt(s string) int {
 	// For better performance
-	if !app.customMethod {
+	if len(app.configured.RequestMethods) == 0 {
 		switch s {
 		case MethodGet:
 			return 0

--- a/mount_test.go
+++ b/mount_test.go
@@ -139,6 +139,24 @@ func Test_App_Group_Mount(t *testing.T) {
 	utils.AssertEqual(t, uint32(2), app.handlersCount)
 }
 
+func Test_App_UseParentErrorHandler(t *testing.T) {
+	app := New(Config{
+		ErrorHandler: func(ctx *Ctx, err error) error {
+			return ctx.Status(500).SendString("hi, i'm a custom error")
+		},
+	})
+
+	fiber := New()
+	fiber.Get("/", func(c *Ctx) error {
+		return errors.New("something happened")
+	})
+
+	app.Mount("/api", fiber)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/api", nil))
+	testErrorResponse(t, err, resp, "hi, i'm a custom error")
+}
+
 func Test_App_UseMountedErrorHandler(t *testing.T) {
 	app := New()
 


### PR DESCRIPTION
## Description

Between version v2.23.0 and v2.24.0 the behavior of Mount changed with regard to how the child's ErrorHandler is used. Before v2.24.0 if the child's error handler was not set, then it used the parent's error handler. From v2.24.0 to v2.39.0 (most recent as of this PR) the behavior is to use the child's error handler (which, even when it isn't explicitly set, is set to the DefaultErrorHandler by `New()`).

This change fixes that issue and provides a way for others to fix similar issues as they arise by checking if the value was explicitly configured.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - https://github.com/gofiber/docs for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
