### PR TITLE
:bug: bug: fix mounting when mount prefix is `/`

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -44,8 +44,10 @@ func (app *App) Mount(prefix string, fiber *App) Router {
 
 	// Support for configs of mounted-apps and sub-mounted-apps
 	for mountedPrefixes, subApp := range fiber.mountFields.appList {
-		subApp.mountFields.mountPath = prefix + mountedPrefixes
-		app.mountFields.appList[prefix+mountedPrefixes] = subApp
+		path := getGroupPath(prefix, mountedPrefixes)
+
+		subApp.mountFields.mountPath = path
+		app.mountFields.appList[path] = subApp
 	}
 
 	// Execute onMount hooks
@@ -68,8 +70,10 @@ func (grp *Group) Mount(prefix string, fiber *App) Router {
 
 	// Support for configs of mounted-apps and sub-mounted-apps
 	for mountedPrefixes, subApp := range fiber.mountFields.appList {
-		subApp.mountFields.mountPath = groupPath + mountedPrefixes
-		grp.app.mountFields.appList[groupPath+mountedPrefixes] = subApp
+		path := getGroupPath(groupPath, mountedPrefixes)
+
+		subApp.mountFields.mountPath = path
+		grp.app.mountFields.appList[path] = subApp
 	}
 
 	// Execute onMount hooks
@@ -105,7 +109,7 @@ func (app *App) appendSubAppLists(appList map[string]*App, parent ...string) {
 		}
 
 		if len(parent) > 0 {
-			prefix = parent[0] + prefix
+			prefix = getGroupPath(parent[0], prefix)
 		}
 
 		if _, ok := app.mountFields.appList[prefix]; !ok {
@@ -129,7 +133,7 @@ func (app *App) addSubAppsRoutes(appList map[string]*App, parent ...string) {
 		}
 
 		if len(parent) > 0 {
-			prefix = parent[0] + prefix
+			prefix = getGroupPath(parent[0], prefix)
 		}
 
 		// add routes

--- a/mount_test.go
+++ b/mount_test.go
@@ -29,6 +29,25 @@ func Test_App_Mount(t *testing.T) {
 	utils.AssertEqual(t, uint32(2), app.handlersCount)
 }
 
+func Test_App_Mount_RootPath_Nested(t *testing.T) {
+	app := New()
+	dynamic := New()
+	apiserver := New()
+
+	apiroutes := apiserver.Group("/v1")
+	apiroutes.Get("/home", func(c *Ctx) error {
+		return c.SendString("home")
+	})
+
+	dynamic.Mount("/api", apiserver)
+	app.Mount("/", dynamic)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/api/v1/home", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, 200, resp.StatusCode, "Status code")
+	utils.AssertEqual(t, uint32(2), app.handlersCount)
+}
+
 // go test -run Test_App_Mount_Nested
 func Test_App_Mount_Nested(t *testing.T) {
 	app := New()


### PR DESCRIPTION
## Description
Fix mounting scenarios like 
```go
app := New()
dynamic := New()
apiserver := New()

apiroutes := apiserver.Group("/v1")
apiroutes.Get("/home", func(c *Ctx) error {
	return c.SendString("home")
})

dynamic.Mount("/api", apiserver)
app.Mount("/", dynamic)
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Commit formatting:
Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
