### PR TITLE
optimize: use **.header.ContentLength instead of  len(**.Body()) in logger middleware

### DIFF
--- a/middleware/logger/tags.go
+++ b/middleware/logger/tags.go
@@ -86,10 +86,10 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			return output.Write(c.Body())
 		},
 		TagBytesReceived: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
-			return appendInt(output, len(c.Request().Body()))
+			return appendInt(output, c.Request().Header.ContentLength())
 		},
 		TagBytesSent: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
-			return appendInt(output, len(c.Response().Body()))
+			return appendInt(output, c.Response().Header.ContentLength())
 		},
 		TagRoute: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
 			return output.WriteString(c.Route().Path)


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
Explain the *details* for making this change. What existing problem does the pull request solve?

Fixes https://github.com/gofiber/fiber/issues/2232

## Type of change

Please delete options that are not relevant.

- [x] New Optimize

## Checklist:

- [x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
