### PR TITLE
🩹 Fix: Unintended overwritten bind variables

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1437,7 +1437,9 @@ func (c *Ctx) renderExtensions(bind interface{}) {
 		// Bind view map
 		if c.viewBindMap != nil {
 			for _, v := range c.viewBindMap.D {
-				bindMap[v.Key] = v.Value
+				if _, ok := bindMap[v.Key]; !ok {
+					bindMap[v.Key] = v.Value
+				}
 			}
 		}
 

--- a/ctx.go
+++ b/ctx.go
@@ -1437,6 +1437,7 @@ func (c *Ctx) renderExtensions(bind interface{}) {
 		// Bind view map
 		if c.viewBindMap != nil {
 			for _, v := range c.viewBindMap.D {
+				// make sure key does not exist already
 				if _, ok := bindMap[v.Key]; !ok {
 					bindMap[v.Key] = v.Value
 				}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2851,6 +2851,29 @@ func Test_Ctx_RenderWithBind(t *testing.T) {
 
 }
 
+func Test_Ctx_RenderWithOverwrittenBind(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	err := c.Bind(Map{
+		"Title": "Hello, World!",
+	})
+	utils.AssertEqual(t, nil, err)
+	defer app.ReleaseCtx(c)
+	err = c.Render("./.github/testdata/index.tmpl", Map{
+		"Title": "Hello from Fiber!",
+	})
+
+	buf := bytebufferpool.Get()
+	_, _ = buf.WriteString("overwrite")
+	defer bytebufferpool.Put(buf)
+
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "<h1>Hello from Fiber!</h1>", string(c.Response().Body()))
+}
+
 func Test_Ctx_RenderWithBindLocals(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Presently, if a bind value passed when calling `c.Render` has the same key as a default value passed in middleware using `c.Bind`, the default value overwrites the value set with `c.Render`. Here is a [small demonstration](https://github.com/cwinters8/fiber-overwritten-bind) of the behavior. If you run that program, you will see that instead of the expected "Home" value being rendered in the h1 tag, the "default" value that was set with `c.Bind` is rendered.

This PR addresses the described issue of overwritten bind variables.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

I indicated "Bug fix" here as I have made a change that *seems* to be non-breaking on the surface, because it changes an unintended behavior to the intended behavior. However, I have seen cases in the past where changes like this actually end up breaking someone's project because they are depending on the existing (incorrect) behavior. Not sure if this is a concern here or not?

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I tried to make my code as fast as possible with as few allocations as possible
