### PR TITLE
:bug: bug: handle url encoded space/values in middleware/filesystem

### DIFF
--- a/.github/testdata/fs/css/style with space.css
+++ b/.github/testdata/fs/css/style with space.css
@@ -1,0 +1,4 @@
+h1 {
+    color: red;
+    text-align: center;
+}

--- a/middleware/filesystem/filesystem.go
+++ b/middleware/filesystem/filesystem.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -135,6 +136,12 @@ func New(config ...Config) fiber.Handler {
 		if len(path) > 1 {
 			path = utils.TrimRight(path, '/')
 		}
+
+		path, err = url.PathUnescape(path)
+		if err != nil {
+			return
+		}
+
 		file, err = cfg.Root.Open(path)
 		if err != nil && os.IsNotExist(err) && cfg.NotFoundFile != "" {
 			file, err = cfg.Root.Open(cfg.NotFoundFile)

--- a/middleware/filesystem/filesystem_test.go
+++ b/middleware/filesystem/filesystem_test.go
@@ -113,6 +113,11 @@ func Test_FileSystem(t *testing.T) {
 			statusCode:  200,
 			contentType: "image/png",
 		},
+		{
+			name:       "Should handle url encoded space",
+			url:        "/test/css/style%20with%20space.css",
+			statusCode: 200,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Make the filesystem middleware handle url encoded values in the url path. 
Main purpose of the change is to handle url encoded space.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - https://github.com/gofiber/docs for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`go test -run Test_FileSystem ./middleware/filesystem`, normal `go test ./...` failed before and after my change)
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
