### PR TITLE
:memo: middleware/filesystem does not handle url encoded values on it's own

### DIFF
--- a/middleware/filesystem/README.md
+++ b/middleware/filesystem/README.md
@@ -3,6 +3,7 @@
 Filesystem middleware for [Fiber](https://github.com/gofiber/fiber) that enables you to serve files from a directory.
 
 ⚠️ **`:params` & `:optionals?` within the prefix path are not supported!**
+⚠️ **To handle paths with spaces (or other url encoded values) make sure to set `fiber.Config{ UnescapePath: true}`**
 
 ## Table of Contents
 

--- a/middleware/filesystem/README.md
+++ b/middleware/filesystem/README.md
@@ -2,7 +2,7 @@
 
 Filesystem middleware for [Fiber](https://github.com/gofiber/fiber) that enables you to serve files from a directory.
 
-⚠️ **`:params` & `:optionals?` within the prefix path are not supported!**
+⚠️ **`:params` & `:optionals?` within the prefix path are not supported!**  
 ⚠️ **To handle paths with spaces (or other url encoded values) make sure to set `fiber.Config{ UnescapePath: true}`**
 
 ## Table of Contents

--- a/middleware/filesystem/filesystem.go
+++ b/middleware/filesystem/filesystem.go
@@ -64,7 +64,11 @@ var ConfigDefault = Config{
 	MaxAge:     0,
 }
 
-// New creates a new middleware handler
+// New creates a new middleware handler.
+//
+// filesystem does not handle url encoded values (for example spaces)
+// on it's own. If you need that functionality, set "UnescapePath"
+// in fiber.Config
 func New(config ...Config) fiber.Handler {
 	// Set default config
 	cfg := ConfigDefault


### PR DESCRIPTION
## Description

In #2246 middleware/filesystem was changed to handle url encoded values on it's own. This change is not necessary. A documentation update is enough.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - https://github.com/gofiber/docs for https://docs.gofiber.io/ (https://github.com/gofiber/docs/pull/305)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
