### PR TITLE
🚀 v3 Feature: Make app.Test accept a time.Duration timeout

### DIFF
--- a/app.go
+++ b/app.go
@@ -865,11 +865,11 @@ func (app *App) Hooks() *Hooks {
 
 // Test is used for internal debugging by passing a *http.Request.
 // Timeout is optional and defaults to 1s, -1 will disable it completely.
-func (app *App) Test(req *http.Request, msTimeout ...int) (resp *http.Response, err error) {
+func (app *App) Test(req *http.Request, timeout ...time.Duration) (resp *http.Response, err error) {
 	// Set timeout
-	timeout := 1000
-	if len(msTimeout) > 0 {
-		timeout = msTimeout[0]
+	to := 1 * time.Second
+	if len(timeout) > 0 {
+		to = timeout[0]
 	}
 
 	// Add Content-Length if not provided with body
@@ -908,12 +908,12 @@ func (app *App) Test(req *http.Request, msTimeout ...int) (resp *http.Response, 
 	}()
 
 	// Wait for callback
-	if timeout >= 0 {
+	if to >= 0 {
 		// With timeout
 		select {
 		case err = <-channel:
-		case <-time.After(time.Duration(timeout) * time.Millisecond):
-			return nil, fmt.Errorf("test: timeout error %vms", timeout)
+		case <-time.After(to):
+			return nil, fmt.Errorf("test: timeout error after %s", to)
 		}
 	} else {
 		// Without timeout

--- a/app_test.go
+++ b/app_test.go
@@ -1230,7 +1230,7 @@ func Test_Test_Timeout(t *testing.T) {
 		return nil
 	})
 
-	_, err = app.Test(httptest.NewRequest(MethodGet, "/timeout", nil), 20)
+	_, err = app.Test(httptest.NewRequest(MethodGet, "/timeout", nil), 20*time.Millisecond)
 	require.True(t, err != nil, "app.Test(req)")
 }
 

--- a/middleware/compress/compress_test.go
+++ b/middleware/compress/compress_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/require"
@@ -112,7 +113,7 @@ func Test_Compress_Brotli(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Accept-Encoding", "br")
 
-	resp, err := app.Test(req, 10000)
+	resp, err := app.Test(req, 10*time.Second)
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, 200, resp.StatusCode, "Status code")
 	require.Equal(t, "br", resp.Header.Get(fiber.HeaderContentEncoding))

--- a/middleware/pprof/pprof_test.go
+++ b/middleware/pprof/pprof_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/require"
@@ -104,7 +105,7 @@ func Test_Pprof_Subs(t *testing.T) {
 			if sub == "profile" {
 				target += "?seconds=1"
 			}
-			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, target, nil), 5000)
+			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, target, nil), 5*time.Second)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.StatusCode)
 		})
@@ -131,7 +132,7 @@ func Test_Pprof_Subs_WithPrefix(t *testing.T) {
 			if sub == "profile" {
 				target += "?seconds=1"
 			}
-			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, target, nil), 5000)
+			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, target, nil), 5*time.Second)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.StatusCode)
 		})

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -77,7 +77,7 @@ func Test_Proxy(t *testing.T) {
 		func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusTeapot) }, t,
 	)
 
-	resp, err := target.Test(httptest.NewRequest("GET", "/", nil), 2000)
+	resp, err := target.Test(httptest.NewRequest("GET", "/", nil), 2*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusTeapot, resp.StatusCode)
 
@@ -297,7 +297,7 @@ func Test_Proxy_Timeout_Slow_Server(t *testing.T) {
 		Timeout: 3 * time.Second,
 	}))
 
-	resp, err := app.Test(httptest.NewRequest("GET", "/", nil), 5000)
+	resp, err := app.Test(httptest.NewRequest("GET", "/", nil), 5*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusOK, resp.StatusCode)
 
@@ -321,7 +321,7 @@ func Test_Proxy_With_Timeout(t *testing.T) {
 		Timeout: 100 * time.Millisecond,
 	}))
 
-	resp, err := app.Test(httptest.NewRequest("GET", "/", nil), 2000)
+	resp, err := app.Test(httptest.NewRequest("GET", "/", nil), 2*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
 
@@ -475,7 +475,7 @@ func Test_ProxyBalancer_Custom_Client(t *testing.T) {
 		func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusTeapot) }, t,
 	)
 
-	resp, err := target.Test(httptest.NewRequest("GET", "/", nil), 2000)
+	resp, err := target.Test(httptest.NewRequest("GET", "/", nil), 2*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusTeapot, resp.StatusCode)
 


### PR DESCRIPTION
Cases found by running semgrep with an empty .semgrepignore file

    semgrep --lang=go -e '$O.Test($X, $Y)'

## Description

Make `app.Test` accept a `time.Duration` timeout instead of an timeout specified in milliseconds.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - https://github.com/gofiber/docs for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [x] For new code I have written benchmarks so that they can be analyzed and improved