### PR TITLE
:sparkles: Feature: Add Protobuf method to ctx

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -838,7 +838,6 @@ func (c *Ctx) Protobuf(message proto.Message) error {
 		c.fasthttp.Response.Header.SetContentType(MIMEApplicationJSON)
 
 	case MIMEApplicationProtobuf:
-	default:
 		buf, err := proto.Marshal(message)
 		if err != nil {
 			return err
@@ -846,6 +845,9 @@ func (c *Ctx) Protobuf(message proto.Message) error {
 
 		c.fasthttp.Response.SetBodyRaw(buf)
 		c.fasthttp.Response.Header.SetContentType(MIMEApplicationProtobuf)
+
+	default:
+		return ErrUnsupportedMediaType
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -16,4 +16,5 @@ require (
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQanqjSY=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -30,3 +32,7 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/helpers.go
+++ b/helpers.go
@@ -385,12 +385,13 @@ const (
 
 // MIME types that are commonly used
 const (
-	MIMETextXML         = "text/xml"
-	MIMETextHTML        = "text/html"
-	MIMETextPlain       = "text/plain"
-	MIMETextJavaScript  = "text/javascript"
-	MIMEApplicationXML  = "application/xml"
-	MIMEApplicationJSON = "application/json"
+	MIMETextXML             = "text/xml"
+	MIMETextHTML            = "text/html"
+	MIMETextPlain           = "text/plain"
+	MIMETextJavaScript      = "text/javascript"
+	MIMEApplicationXML      = "application/xml"
+	MIMEApplicationJSON     = "application/json"
+	MIMEApplicationProtobuf = "application/x-protobuf"
 	// Deprecated: use MIMETextJavaScript instead
 	MIMEApplicationJavaScript = "application/javascript"
 	MIMEApplicationForm       = "application/x-www-form-urlencoded"


### PR DESCRIPTION
## Description

I was working on a Fiber fork for my server, and I've added a method to `Ctx` to allow sending Protobuf messages. I thought it was nice to include in the next release for any who want to support Protobuf encoding.  

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [X] I tried to make my code as fast as possible with as few allocations as possible
