### PR TITLE
optimize : Using bytes operations to convert ascii slices

### DIFF
--- a/utils/bytes.go
+++ b/utils/bytes.go
@@ -5,17 +5,23 @@
 package utils
 
 // ToLowerBytes converts ascii slice to lower-case in-place.
+// Explanation : if string(77) = M, then string(77+32) = m
 func ToLowerBytes(b []byte) []byte {
 	for i := 0; i < len(b); i++ {
-		b[i] = toLowerTable[b[i]]
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] = b[i] + 32
+		}
 	}
 	return b
 }
 
 // ToUpperBytes converts ascii slice to upper-case in-place.
+// Explanation : if string(97) = a, then string(97-32) = A
 func ToUpperBytes(b []byte) []byte {
 	for i := 0; i < len(b); i++ {
-		b[i] = toUpperTable[b[i]]
+		if b[i] >= 'a' && b[i] <= 'z' {
+			b[i] = b[i] - 32
+		}
 	}
 	return b
 }
@@ -61,7 +67,8 @@ func EqualFoldBytes(b, s []byte) bool {
 		return false
 	}
 	for i := len(b) - 1; i >= 0; i-- {
-		if toUpperTable[b[i]] != toUpperTable[s[i]] {
+        // Check only for lowe case bytes
+		if b[i] >= 'a' && b[i] <= 'z' && b[i]+32 != s[i]+32 {
 			return false
 		}
 	}


### PR DESCRIPTION
## Description

I found that instead of using toLowerTable and toUpperTable to convert ascci slices, we can make some operation on thus bytes, So to convert to lower case we can add 32 to that byte and subtracting 32 to do the reverse operation.
For example  : ` 'M' + 32 = 'm'  `

## Type of change

Please delete options that are not relevant.

- [x] New optimize (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I tried to make my code as fast as possible with as few allocations as possible

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
