### PR TITLE
Doc: Remove the redundant space beside a comma

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -156,7 +156,7 @@ We **listen** to our users in [issues](https://github.com/gofiber/fiber/issues),
 
 ## 👀 Examples
 
-Listed below are some of the common examples. If you want to see more code examples , please visit our [Recipes repository](https://github.com/gofiber/recipes) or visit our hosted [API documentation](https://docs.gofiber.io).
+Listed below are some of the common examples. If you want to see more code examples, please visit our [Recipes repository](https://github.com/gofiber/recipes) or visit our hosted [API documentation](https://docs.gofiber.io).
 
 #### 📖 [**Basic Routing**](https://docs.gofiber.io/#basic-routing)
 


### PR DESCRIPTION
## Description

There is a redundant space between the sentence component and the punctuation in the documentation. This PR removes it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation - https://github.com/gofiber/docs for https://docs.gofiber.io/
