### PR TITLE
🔥 Feature: add queryBool parser

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1142,10 +1142,8 @@ func (c *Ctx) QueryBool(key string, defaultValue ...bool) bool {
 		if len(defaultValue) > 0 {
 			return defaultValue[0]
 		}
-
 		return true
 	}
-
 	return value
 }
 
@@ -1165,10 +1163,8 @@ func (c *Ctx) QueryFloat(key string, defaultValue ...float64) float64 {
 		if len(defaultValue) > 0 {
 			return defaultValue[0]
 		}
-
 		return 0
 	}
-
 	return value
 }
 

--- a/ctx.go
+++ b/ctx.go
@@ -1126,6 +1126,29 @@ func (c *Ctx) QueryInt(key string, defaultValue ...int) int {
 	return value
 }
 
+// QueryBool returns bool value of key string parameter in the url.
+// Default to empty or invalid key is true.
+//
+//	Get /?name=alex&want_pizza=false&id=
+//	QueryBool("want_pizza") == false
+//	QueryBool("want_pizza", true) == false
+//	QueryBool("alex") == true
+//	QueryBool("alex", false) == false
+//	QueryBool("id") == true
+//	QueryBool("id", false) == false
+func (c *Ctx) QueryBool(key string, defaultValue ...bool) bool {
+	value, err := strconv.ParseBool(c.app.getString(c.fasthttp.QueryArgs().Peek(key)))
+	if err != nil {
+		if len(defaultValue) > 0 {
+			return defaultValue[0]
+		}
+
+		return true
+	}
+
+	return value
+}
+
 // QueryParser binds the query string to a struct.
 func (c *Ctx) QueryParser(out interface{}) error {
 	data := make(map[string][]string)

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2149,6 +2149,21 @@ func Test_Ctx_QueryInt(t *testing.T) {
 	utils.AssertEqual(t, 2, c.QueryInt("id", 2))
 }
 
+func Test_Ctx_QueryBool(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+	c.Request().URI().SetQueryString("name=alex&want_pizza=false&id=")
+
+	utils.AssertEqual(t, false, c.QueryBool("want_pizza"))
+	utils.AssertEqual(t, false, c.QueryBool("want_pizza", true))
+	utils.AssertEqual(t, true, c.QueryBool("name"))
+	utils.AssertEqual(t, false, c.QueryBool("name", false))
+	utils.AssertEqual(t, true, c.QueryBool("id"))
+	utils.AssertEqual(t, false, c.QueryBool("id", false))
+}
+
 // go test -run Test_Ctx_Range
 func Test_Ctx_Range(t *testing.T) {
 	t.Parallel()

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2150,7 +2150,6 @@ func Test_Ctx_QueryInt(t *testing.T) {
 }
 
 func Test_Ctx_QueryBool(t *testing.T) {
-
 	t.Parallel()
 	app := New()
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
@@ -2164,8 +2163,8 @@ func Test_Ctx_QueryBool(t *testing.T) {
 	utils.AssertEqual(t, true, c.QueryBool("id"))
 	utils.AssertEqual(t, false, c.QueryBool("id", false))
 }
-func Test_Ctx_QueryFloat(t *testing.T) {
 
+func Test_Ctx_QueryFloat(t *testing.T) {
 	t.Parallel()
 	app := New()
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})


### PR DESCRIPTION
Hi!
Before this PR, I wrote this feature for integer variables https://github.com/gofiber/fiber/pull/2306 And float variables #2328.
Now I wrote this feature for boolean variables,
With this parser, you can easily extract bool values from URL queries. You can pass the desired key and the URL string to the parser, which will return the boolean value associated with that key. This eliminates manual string parsing and makes retrieving the values you need easier.