### PR TITLE
Basic auth alloc

### DIFF
--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -24,7 +24,7 @@ func New(config Config) fiber.Handler {
 		auth := c.Get(fiber.HeaderAuthorization)
 
 		// Check if the header contains content besides "basic".
-		if len(auth) <= 6 || strings.ToLower(auth[:5]) != "basic" {
+		if len(auth) <= 6 || !strings.EqualFold(auth[:6], "basic ") {
 			return cfg.Unauthorized(c)
 		}
 

--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -24,7 +24,7 @@ func New(config Config) fiber.Handler {
 		auth := c.Get(fiber.HeaderAuthorization)
 
 		// Check if the header contains content besides "basic".
-		if len(auth) <= 6 || !strings.EqualFold(auth[:6], "basic ") {
+		if len(auth) <= 6 || !utils.EqualFold(auth[:6], "basic ") {
 			return cfg.Unauthorized(c)
 		}
 

--- a/middleware/basicauth/basicauth_test.go
+++ b/middleware/basicauth/basicauth_test.go
@@ -122,3 +122,33 @@ func Benchmark_Middleware_BasicAuth(b *testing.B) {
 
 	utils.AssertEqual(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
 }
+
+// go test -v -run=^$ -bench=Benchmark_Middleware_BasicAuth -benchmem -count=4
+func Benchmark_Middleware_BasicAuth_Upper(b *testing.B) {
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Users: map[string]string{
+			"john": "doe",
+		},
+	}))
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusTeapot)
+	})
+
+	h := app.Handler()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.SetMethod(fiber.MethodGet)
+	fctx.Request.SetRequestURI("/")
+	fctx.Request.Header.Set(fiber.HeaderAuthorization, "Basic am9objpkb2U=") // john:doe
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		h(fctx)
+	}
+
+	utils.AssertEqual(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+}


### PR DESCRIPTION
## Description

Fix for test basic header as described in RFC 7617, like

Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==

Also avoid string buffer alloc in `strings.ToLower` if  string not in lower case, like `Basic`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
