### PR TITLE
allow preloaded certs with prefork

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -525,6 +525,27 @@ Using `ListenTLS` defaults to the following config \( use `Listener` to provide 
 }
 ```
 
+## ListenTLSWithCertificate
+
+```go title="Signature"
+func (app *App) ListenTLS(addr string, cert tls.Certificate) error
+```
+
+```go title="Examples"
+app.ListenTLSWithCertificate(":443", cert);
+```
+
+Using `ListenTLSWithCertificate` defaults to the following config \( use `Listener` to provide your own config \)
+
+```go title="Default \*tls.Config"
+&tls.Config{
+    MinVersion:               tls.VersionTLS12,
+    Certificates: []tls.Certificate{
+        cert,
+    },
+}
+```
+
 ## ListenMutualTLS
 
 ListenMutualTLS serves HTTPs requests from the given address using certFile, keyFile and clientCertFile are the paths to TLS certificate and key file
@@ -538,6 +559,31 @@ app.ListenMutualTLS(":443", "./cert.pem", "./cert.key", "./ca-chain-cert.pem");
 ```
 
 Using `ListenMutualTLS` defaults to the following config \( use `Listener` to provide your own config \)
+
+```go title="Default \*tls.Config"
+&tls.Config{
+	MinVersion: tls.VersionTLS12,
+	ClientAuth: tls.RequireAndVerifyClientCert,
+	ClientCAs:  clientCertPool,
+	Certificates: []tls.Certificate{
+		cert,
+	},
+}
+```
+
+## ListenMutualTLSWithCertificate
+
+ListenMutualTLSWithCertificate serves HTTPs requests from the given address using certFile, keyFile and clientCertFile are the paths to TLS certificate and key file
+
+```go title="Signature"
+func (app *App) ListenMutualTLSWithCertificate(addr string, cert tls.Certificate, clientCertPool *x509.CertPool) error
+```
+
+```go title="Examples"
+app.ListenMutualTLSWithCertificate(":443", cert, clientCertPool);
+```
+
+Using `ListenMutualTLSWithCertificate` defaults to the following config \( use `Listener` to provide your own config \)
 
 ```go title="Default \*tls.Config"
 &tls.Config{

--- a/listen.go
+++ b/listen.go
@@ -98,6 +98,14 @@ func (app *App) ListenTLS(addr, certFile, keyFile string) error {
 		return fmt.Errorf("tls: cannot load TLS key pair from certFile=%q and keyFile=%q: %w", certFile, keyFile, err)
 	}
 
+	return app.ListenTLSWithCertificate(addr, cert)
+}
+
+// ListenTLS serves HTTPS requests from the given addr.
+// cert is a tls.Certificate
+//
+//	app.ListenTLSWithCertificate(":8080", cert)
+func (app *App) ListenTLSWithCertificate(addr string, cert tls.Certificate) error {
 	tlsHandler := &TLSHandler{}
 	config := &tls.Config{
 		MinVersion: tls.VersionTLS12,
@@ -161,6 +169,10 @@ func (app *App) ListenMutualTLS(addr, certFile, keyFile, clientCertFile string) 
 	clientCertPool := x509.NewCertPool()
 	clientCertPool.AppendCertsFromPEM(clientCACert)
 
+	return app.ListenMutualTLSWithCertificate(addr, cert, clientCertPool)
+}
+
+func (app *App) ListenMutualTLSWithCertificate(addr string, cert tls.Certificate, clientCertPool *x509.CertPool) error {
 	tlsHandler := &TLSHandler{}
 	config := &tls.Config{
 		MinVersion: tls.VersionTLS12,


### PR DESCRIPTION
## Description

Currently I have a function that generates or loads these keys according to different conditions.
Now I would have to save them temporarily as a file to be able to use the full functions of fiber.
The added functions allow me to specify the already loaded keys.
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Oh! Its too late :c should i recreate my pull request?
