### PR TITLE
🐛 [Bug-Fix]: add lock to avoid data race #2360

### DIFF
--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -139,5 +139,7 @@ func (s *Storage) gc() {
 
 // Return database client
 func (s *Storage) Conn() map[string]entry {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
 	return s.db
 }


### PR DESCRIPTION
The fix is to protect the access to s.db and save the result to a local variable.

Description
Fixed inconsistency and also potential data race in proto/table_unmarshal.go:
u.reqFields is read/written 4 times in proto/table_unmarshal.go; 3 out of 4 times it is protected by u.lock.Lock(); 1 out of 4 times it is read without a Lock, which is in func unmarshal() on L260.
A data race may happen when unmarshal() and other func like computeUnmarshalInfo() are called in parallel.

In order to avoid potential data race here, I use u.lock.RLock(); defer u.lock.RUnlock() to make sure that all usages of items is in critical section.

Fixes #2360

Type of change
[ ] Bug fix (non-breaking change which fixes an issue)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Checklist:
 For new functionalities I follow the inspiration of the express js framework and built them similar in usage
[ ] I have performed a self-review of my own code
[ ] I have commented my code, particularly in hard-to-understand areas
[ ] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
[ ] I have added tests that prove my fix is effective or that my feature works
[ ] New and existing unit tests pass locally with my changes
[ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
[ ] I tried to make my code as fast as possible with as few allocations as possible
[ ] For new code I have written benchmarks so that they can be analyzed and improved
