### PR TITLE
:bug: requestid.Config.ContextKey is interface{}

### DIFF
--- a/docs/api/middleware/requestid.md
+++ b/docs/api/middleware/requestid.md
@@ -61,7 +61,7 @@ type Config struct {
     // the locals for a specific request.
     //
     // Optional. Default: requestid
-    ContextKey string
+    ContextKey interface{}
 }
 ```
 

--- a/middleware/requestid/config.go
+++ b/middleware/requestid/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	// the locals for a specific request.
 	//
 	// Optional. Default: requestid
-	ContextKey string
+	ContextKey interface{}
 }
 
 // ConfigDefault is the default config

--- a/middleware/requestid/requestid_test.go
+++ b/middleware/requestid/requestid_test.go
@@ -55,20 +55,21 @@ func Test_RequestID_Next(t *testing.T) {
 func Test_RequestID_Locals(t *testing.T) {
 	t.Parallel()
 	reqID := "ThisIsARequestId"
-	ctxKey := "ThisIsAContextKey"
+	type ContextKey int
+	const requestContextKey ContextKey = iota
 
 	app := fiber.New()
 	app.Use(New(Config{
 		Generator: func() string {
 			return reqID
 		},
-		ContextKey: ctxKey,
+		ContextKey: requestContextKey,
 	}))
 
 	var ctxVal string
 
 	app.Use(func(c *fiber.Ctx) error {
-		ctxVal = c.Locals(ctxKey).(string) //nolint:forcetypeassert,errcheck // We always store a string in here
+		ctxVal = c.Locals(requestContextKey).(string) //nolint:forcetypeassert,errcheck // We always store a string in here
 		return c.Next()
 	})
 


### PR DESCRIPTION
## Description

https://github.com/gofiber/fiber/issues/2143 allows to use any as key for c.Locals(key, v). The RequestID middleware should be consistent with that.
This allows to use a custom type for context keys, like for other keys. The RequestID is likely read back somewhere else along other context keys.

Fixes #2356

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
