### PR TITLE
🚀 [Feature]: middleware/requestid: don't call "Generator" func on existing request ID header

### DIFF
--- a/middleware/requestid/requestid.go
+++ b/middleware/requestid/requestid.go
@@ -16,7 +16,10 @@ func New(config ...Config) fiber.Handler {
 			return c.Next()
 		}
 		// Get id from request, else we generate one
-		rid := c.Get(cfg.Header, cfg.Generator())
+		rid := c.Get(cfg.Header)
+		if rid == "" {
+			rid = cfg.Generator()
+		}
 
 		// Set new id to response header
 		c.Set(cfg.Header, rid)


### PR DESCRIPTION
origin issue: https://github.com/gofiber/fiber/issues/2350