### PR TITLE
corrected coding typos in MountPath docs section

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -145,7 +145,7 @@ func (app *App) MountPath() string
 
 ```go title="Examples"
 func main() {
-	app := fiber.New(h
+	app := fiber.New()
 	one := fiber.New()
 	two := fiber.New()
 	three := fiber.New()

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -145,10 +145,10 @@ func (app *App) MountPath() string
 
 ```go title="Examples"
 func main() {
-	app := New()
-	one := New()
-	two := New()
-	three := New()
+	app := fiber.New(h
+	one := fiber.New()
+	two := fiber.New()
+	three := fiber.New()
 
 	two.Mount("/three", three)
 	one.Mount("/two", two)


### PR DESCRIPTION
## Description

The MountPath coding example showed examples of code such as 
```go
two := New()
...
```
I changed them to make it 
```go
two := fiber.New()
...
```
