### PR TITLE
🐛 fix(cors): Changed condition for 'AllowOriginsFunc'

### DIFF
--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -97,7 +97,7 @@ func New(config ...Config) fiber.Handler {
 	}
 
 	// Warning logs if both AllowOrigins and AllowOriginsFunc are set
-	if cfg.AllowOrigins != "" && cfg.AllowOriginsFunc != nil {
+	if cfg.AllowOrigins != ConfigDefault.AllowOrigins && cfg.AllowOriginsFunc != nil {
 		log.Printf("[CORS] - [Warning] Both 'AllowOrigins' and 'AllowOriginsFunc' have been defined.\n")
 	}
 
@@ -142,7 +142,7 @@ func New(config ...Config) fiber.Handler {
 		// Run AllowOriginsFunc if the logic for
 		// handling the value in 'AllowOrigins' does
 		// not result in allowOrigin being set.
-		if allowOrigin == "" && cfg.AllowOriginsFunc != nil {
+		if (allowOrigin == "" || allowOrigin == ConfigDefault.AllowOrigins) && cfg.AllowOriginsFunc != nil {
 			if cfg.AllowOriginsFunc(origin) {
 				allowOrigin = origin
 			}

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -244,7 +244,7 @@ func Test_CORS_Next(t *testing.T) {
 	utils.AssertEqual(t, fiber.StatusNotFound, resp.StatusCode)
 }
 
-func Test_CORS_AllowOriginsFunc(t *testing.T) {
+func Test_CORS_AllowOriginsAndAllowOriginsFunc(t *testing.T) {
 	t.Parallel()
 	// New fiber instance
 	app := fiber.New()
@@ -267,7 +267,7 @@ func Test_CORS_AllowOriginsFunc(t *testing.T) {
 	// Perform request
 	handler(ctx)
 
-	// Allow-Origin header should be "" because http://google.com does not satisfy http://*.example.com
+	// Allow-Origin header should be "" because http://google.com does not satisfy http://example-1.com or 'strings.Contains(origin, "example-2")'
 	utils.AssertEqual(t, "", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
 
 	ctx.Request.Reset()
@@ -292,5 +292,45 @@ func Test_CORS_AllowOriginsFunc(t *testing.T) {
 
 	handler(ctx)
 
+	utils.AssertEqual(t, "http://example-2.com", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
+}
+
+func Test_CORS_AllowOriginsFunc(t *testing.T) {
+	t.Parallel()
+	// New fiber instance
+	app := fiber.New()
+	app.Use("/", New(Config{
+		AllowOriginsFunc: func(origin string) bool {
+			return strings.Contains(origin, "example-2")
+		},
+	}))
+
+	// Get handler pointer
+	handler := app.Handler()
+
+	// Make request with disallowed origin
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI("/")
+	ctx.Request.Header.SetMethod(fiber.MethodOptions)
+	ctx.Request.Header.Set(fiber.HeaderOrigin, "http://google.com")
+
+	// Perform request
+	handler(ctx)
+
+	// Allow-Origin header should be "*" because http://google.com does not satisfy 'strings.Contains(origin, "example-2")'
+	// and AllowOrigins has not been set so the default "*" is used
+	utils.AssertEqual(t, "*", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
+
+	ctx.Request.Reset()
+	ctx.Response.Reset()
+
+	// Make request with allowed origin
+	ctx.Request.SetRequestURI("/")
+	ctx.Request.Header.SetMethod(fiber.MethodOptions)
+	ctx.Request.Header.Set(fiber.HeaderOrigin, "http://example-2.com")
+
+	handler(ctx)
+
+	// Allow-Origin header should be "http://example-2.com"
 	utils.AssertEqual(t, "http://example-2.com", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
 }


### PR DESCRIPTION
## Description

The issue was that the condition to run `AllowOriginsFunc` was checking `if allowOrigin == ""`, however, `allowOrigin` is, by default if left empty, set to `*` and thus this condition was never being met.

Added a test to cover this case.
Also updated comments on tests around this feature to be more accurate.

Fixes #2422

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I tried to make my code as fast as possible with as few allocations as possible

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
