### PR TITLE
🚀 [Feature]: middleware/recover: ignore error from panics

### DIFF
--- a/docs/api/middleware/recover.md
+++ b/docs/api/middleware/recover.md
@@ -49,6 +49,11 @@ type Config struct {
     // Optional. Default: false
     EnableStackTrace bool
 
+	// SkipResponseError disable showing panics in response body
+	//
+	// Optional. Default: false
+	SkipResponseError bool
+
     // StackTraceHandler defines a function to handle stack trace
     //
     // Optional. Default: defaultStackTraceHandler
@@ -62,6 +67,7 @@ type Config struct {
 var ConfigDefault = Config{
     Next:              nil,
     EnableStackTrace:  false,
+	SkipResponseError: false,
     StackTraceHandler: defaultStackTraceHandler,
 }
 ```

--- a/docs/api/middleware/recover.md
+++ b/docs/api/middleware/recover.md
@@ -49,10 +49,10 @@ type Config struct {
     // Optional. Default: false
     EnableStackTrace bool
 
-	// SkipResponseError disable showing panics in response body
-	//
-	// Optional. Default: false
-	SkipResponseError bool
+    // SkipResponseError disable showing panics in response body
+    //
+    // Optional. Default: false
+    SkipResponseError bool
 
     // StackTraceHandler defines a function to handle stack trace
     //
@@ -67,7 +67,7 @@ type Config struct {
 var ConfigDefault = Config{
     Next:              nil,
     EnableStackTrace:  false,
-	SkipResponseError: false,
+    SkipResponseError: false,
     StackTraceHandler: defaultStackTraceHandler,
 }
 ```

--- a/middleware/recover/config.go
+++ b/middleware/recover/config.go
@@ -16,6 +16,11 @@ type Config struct {
 	// Optional. Default: false
 	EnableStackTrace bool
 
+	// SkipResponseError disable showing panics in response body
+	//
+	// Optional. Default: false
+	SkipResponseError bool
+
 	// StackTraceHandler defines a function to handle stack trace
 	//
 	// Optional. Default: defaultStackTraceHandler
@@ -26,6 +31,7 @@ type Config struct {
 var ConfigDefault = Config{
 	Next:              nil,
 	EnableStackTrace:  false,
+	SkipResponseError: false,
 	StackTraceHandler: defaultStackTraceHandler,
 }
 

--- a/middleware/recover/recover.go
+++ b/middleware/recover/recover.go
@@ -31,6 +31,10 @@ func New(config ...Config) fiber.Handler {
 					cfg.StackTraceHandler(c, r)
 				}
 
+				if cfg.SkipResponseError {
+					return
+				}
+
 				var ok bool
 				if err, ok = r.(error); !ok {
 					// Set error that will call the global error handler


### PR DESCRIPTION
## Description

Once panic occur there is possibility to recover and continue serving request. Current `recover` middleware also transform panic message into error and pass into response body with status code 500. This can confuse users or disclose secure information.

With skipping error message response become good (code 200) and body is empty. Extended with custom `StackTraceHandler` allow to write any response and status code.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [x] For new code I have written benchmarks so that they can be analyzed and improved

