### PR TITLE
:rocket:  [Feature]: Add contentType ...string to JSON

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -789,14 +789,19 @@ func (c *Ctx) Is(extension string) bool {
 // Array and slice values encode as JSON arrays,
 // except that []byte encodes as a base64-encoded string,
 // and a nil slice encodes as the null JSON value.
-// This method also sets the content header to application/json.
-func (c *Ctx) JSON(data interface{}) error {
+// This method also sets the content header to application/json
+// Unless specified otherwise with contentType
+func (c *Ctx) JSON(data interface{}, contentType ...string) error {
 	raw, err := c.app.config.JSONEncoder(data)
 	if err != nil {
 		return err
 	}
 	c.fasthttp.Response.SetBodyRaw(raw)
-	c.fasthttp.Response.Header.SetContentType(MIMEApplicationJSON)
+	if len(contentType) > 0 {
+		c.fasthttp.Response.Header.SetContentType(contentType[0])
+	} else {
+		c.fasthttp.Response.Header.SetContentType(MIMEApplicationJSON)
+	}
 	return nil
 }
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2593,6 +2593,14 @@ func Test_Ctx_JSON(t *testing.T) {
 	utils.AssertEqual(t, `{"Age":20,"Name":"Grame"}`, string(c.Response().Body()))
 	utils.AssertEqual(t, "application/json", string(c.Response().Header.Peek("content-type")))
 
+	err = c.JSON(Map{ // map has no order
+		"Name": "Grame",
+		"Age":  20,
+	}, "application/problem+json; charset=utf-8")
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, `{"Age":20,"Name":"Grame"}`, string(c.Response().Body()))
+	utils.AssertEqual(t, "application/problem+json; charset=utf-8", string(c.Response().Header.Peek("content-type")))
+
 	testEmpty := func(v interface{}, r string) {
 		err := c.JSON(v)
 		utils.AssertEqual(t, nil, err)

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -683,14 +683,15 @@ app.Get("/", func(c *fiber.Ctx) error {
 
 ## JSON
 
-Converts any **interface** or **string** to JSON using the [goccy/go-json](https://github.com/goccy/go-json) package.
+Converts any **interface** or **string** to JSON.
 
 :::info
-JSON also sets the content header to **application/json**.
+JSON sets the content header to **application/json**
+Unless specified otherwise with contentType
 :::
 
 ```go title="Signature"
-func (c *Ctx) JSON(data interface{}) error
+func (c *Ctx) JSON(data interface{}, contentType ...string) error
 ```
 
 ```go title="Example"
@@ -715,6 +716,13 @@ app.Get("/json", func(c *fiber.Ctx) error {
     "age": 20,
   })
   // => Content-Type: application/json
+  // => "{"name": "Grame", "age": 20}"
+
+  return c.JSON(fiber.Map{
+    "name": "Grame",
+    "age": 20,
+  }, "application/problem+json; charset=utf-8")
+  // => Content-Type: application/problem+json; charset=utf-8
   // => "{"name": "Grame", "age": 20}"
 })
 ```


### PR DESCRIPTION
## Description
This commit adds an optional contentType parameter to JSON, which can be used to set the Content-Type like so
```go
c.JSON(Map{
	"Name": "Grame",
	"Age":  20,
}, "application/problem+json; charset=utf-8")
```

Also, remove old info from ctx.JSON which is incorrect
Converts any **interface** or **string** to `JSON using the [goccy/go-json](https://github.com/goccy/go-json) package.`

Fixes #2428

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
