### PR TITLE
utils: add Go 1.20+ way of converting string to byte slice

### DIFF
--- a/utils/convert.go
+++ b/utils/convert.go
@@ -13,27 +13,11 @@ import (
 	"unsafe"
 )
 
-const MaxStringLen = 0x7fff0000 // Maximum string length for UnsafeBytes. (decimal: 2147418112)
-
 // UnsafeString returns a string pointer without allocation
 //
 //nolint:gosec // unsafe is used for better performance here
 func UnsafeString(b []byte) string {
 	return *(*string)(unsafe.Pointer(&b))
-}
-
-// UnsafeBytes returns a byte pointer without allocation.
-// String length shouldn't be more than 2147418112.
-//
-//nolint:gosec // unsafe is used for better performance here
-func UnsafeBytes(s string) []byte {
-	if s == "" {
-		return nil
-	}
-
-	return (*[MaxStringLen]byte)(unsafe.Pointer(
-		(*reflect.StringHeader)(unsafe.Pointer(&s)).Data),
-	)[:len(s):len(s)]
 }
 
 // CopyString copies a string to make it immutable

--- a/utils/convert_s2b_new.go
+++ b/utils/convert_s2b_new.go
@@ -8,8 +8,6 @@ import (
 )
 
 // UnsafeBytes returns a byte pointer without allocation.
-//
-//nolint:gosec // unsafe is used for better performance here
 func UnsafeBytes(s string) []byte {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }

--- a/utils/convert_s2b_new.go
+++ b/utils/convert_s2b_new.go
@@ -1,0 +1,15 @@
+//go:build go1.20
+// +build go1.20
+
+package utils
+
+import (
+	"unsafe"
+)
+
+// UnsafeBytes returns a byte pointer without allocation.
+//
+//nolint:gosec // unsafe is used for better performance here
+func UnsafeBytes(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}

--- a/utils/convert_s2b_old.go
+++ b/utils/convert_s2b_old.go
@@ -1,0 +1,25 @@
+//go:build !go1.20
+// +build !go1.20
+
+package utils
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+const MaxStringLen = 0x7fff0000 // Maximum string length for UnsafeBytes. (decimal: 2147418112)
+
+// UnsafeBytes returns a byte pointer without allocation.
+// String length shouldn't be more than 2147418112.
+//
+//nolint:gosec // unsafe is used for better performance here
+func UnsafeBytes(s string) []byte {
+	if s == "" {
+		return nil
+	}
+
+	return (*[MaxStringLen]byte)(unsafe.Pointer(
+		(*reflect.StringHeader)(unsafe.Pointer(&s)).Data),
+	)[:len(s):len(s)]
+}


### PR DESCRIPTION
Ref. https://github.com/valyala/fasthttp/blob/d2f97fc426ed451e64dc8e35e7f87a1d4a2d7bde/s2b_old.go.
Ref. https://github.com/valyala/fasthttp/blob/d2f97fc426ed451e64dc8e35e7f87a1d4a2d7bde/s2b_new.go.
