### PR TITLE
fix go test error loop variable sub captured by func literal

### DIFF
--- a/middleware/compress/compress_test.go
+++ b/middleware/compress/compress_test.go
@@ -53,6 +53,7 @@ func Test_Compress_Different_Level(t *testing.T) {
 	t.Parallel()
 	levels := []Level{LevelBestSpeed, LevelBestCompression}
 	for _, level := range levels {
+		level := level
 		t.Run(fmt.Sprintf("level %d", level), func(t *testing.T) {
 			t.Parallel()
 			app := fiber.New()

--- a/middleware/filesystem/filesystem_test.go
+++ b/middleware/filesystem/filesystem_test.go
@@ -119,6 +119,7 @@ func Test_FileSystem(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, tt.url, nil))

--- a/middleware/pprof/pprof_test.go
+++ b/middleware/pprof/pprof_test.go
@@ -89,7 +89,6 @@ func Test_Pprof_Index_WithPrefix(t *testing.T) {
 }
 
 func Test_Pprof_Subs(t *testing.T) {
-	t.Parallel()
 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 
 	app.Use(New())
@@ -104,6 +103,7 @@ func Test_Pprof_Subs(t *testing.T) {
 	}
 
 	for _, sub := range subs {
+		sub := sub
 		t.Run(sub, func(t *testing.T) {
 			t.Parallel()
 			target := "/debug/pprof/" + sub
@@ -133,6 +133,7 @@ func Test_Pprof_Subs_WithPrefix(t *testing.T) {
 	}
 
 	for _, sub := range subs {
+		sub := sub
 		t.Run(sub, func(t *testing.T) {
 			t.Parallel()
 			target := "/federated-fiber/debug/pprof/" + sub


### PR DESCRIPTION
## Description
```
go vet ./... 
```
```
# github.com/gofiber/fiber/v2/middleware/filesystem
middleware/filesystem/filesystem_test.go:124:63: loop variable tt captured by func literal
middleware/filesystem/filesystem_test.go:126:25: loop variable tt captured by func literal
middleware/filesystem/filesystem_test.go:128:7: loop variable tt captured by func literal
middleware/filesystem/filesystem_test.go:130:26: loop variable tt captured by func literal
# github.com/gofiber/fiber/v2/middleware/pprof
middleware/pprof/pprof_test.go:109:32: loop variable sub captured by func literal
middleware/pprof/pprof_test.go:110:7: loop variable sub captured by func literal
middleware/pprof/pprof_test.go:138:48: loop variable sub captured by func literal
middleware/pprof/pprof_test.go:139:7: loop variable sub captured by func literal
```

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

