### PR TITLE
utils: add Go 1.20+ way of converting byte slice to string

### DIFF
--- a/utils/convert.go
+++ b/utils/convert.go
@@ -10,15 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unsafe"
 )
-
-// UnsafeString returns a string pointer without allocation
-//
-//nolint:gosec // unsafe is used for better performance here
-func UnsafeString(b []byte) string {
-	return *(*string)(unsafe.Pointer(&b))
-}
 
 // CopyString copies a string to make it immutable
 func CopyString(s string) string {

--- a/utils/convert_b2s_new.go
+++ b/utils/convert_b2s_new.go
@@ -1,0 +1,13 @@
+//go:build go1.20
+// +build go1.20
+
+package utils
+
+import (
+	"unsafe"
+)
+
+// UnsafeString returns a string pointer without allocation
+func UnsafeString(b []byte) string {
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}

--- a/utils/convert_b2s_old.go
+++ b/utils/convert_b2s_old.go
@@ -1,0 +1,15 @@
+//go:build !go1.20
+// +build !go1.20
+
+package utils
+
+import (
+	"unsafe"
+)
+
+// UnsafeString returns a string pointer without allocation
+//
+//nolint:gosec // unsafe is used for better performance here
+func UnsafeString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}


### PR DESCRIPTION
Ref. https://github.com/valyala/fasthttp/blob/d2f97fc426ed451e64dc8e35e7f87a1d4a2d7bde/b2s_old.go.
Ref. https://github.com/valyala/fasthttp/blob/d2f97fc426ed451e64dc8e35e7f87a1d4a2d7bde/b2s_new.go.
