### PR TITLE
📒  Correcting a syntax error in the README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -587,11 +587,11 @@ import (
 )
 
 func main() {
-    app := fiber.New(fiber.Config{
-        EnableTrustedProxyCheck: true,
-        TrustedProxies: []string{"0.0.0.0", "1.1.1.1/30"}, // IP address or IP address range
-        ProxyHeader: fiber.HeaderXForwardedFor},
-    })
+	  app := fiber.New(fiber.Config{
+		  EnableTrustedProxyCheck: true,
+		  TrustedProxies: []string{"0.0.0.0", "1.1.1.1/30"}, // IP address or IP address range
+		  ProxyHeader: fiber.HeaderXForwardedFor,
+	  })
 
     // ...
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -587,11 +587,11 @@ import (
 )
 
 func main() {
-	  app := fiber.New(fiber.Config{
-		  EnableTrustedProxyCheck: true,
-		  TrustedProxies: []string{"0.0.0.0", "1.1.1.1/30"}, // IP address or IP address range
-		  ProxyHeader: fiber.HeaderXForwardedFor,
-	  })
+    app := fiber.New(fiber.Config{
+        EnableTrustedProxyCheck: true,
+        TrustedProxies: []string{"0.0.0.0", "1.1.1.1/30"}, // IP address or IP address range
+        ProxyHeader: fiber.HeaderXForwardedFor,
+    })
 
     // ...
 

--- a/.github/README_az.md
+++ b/.github/README_az.md
@@ -589,7 +589,7 @@ func main() {
     app := fiber.New(fiber.Config{
         EnableTrustedProxyCheck: true,
         TrustedProxies: []string{"0.0.0.0", "1.1.1.1/30"}, // IP address or IP address range
-        ProxyHeader: fiber.HeaderXForwardedFor},
+        ProxyHeader: fiber.HeaderXForwardedFor,
     })
 
     // ...

--- a/.github/README_ckb.md
+++ b/.github/README_ckb.md
@@ -589,7 +589,7 @@ func main() {
     app := fiber.New(fiber.Config{
         EnableTrustedProxyCheck: true,
         TrustedProxies: []string{"0.0.0.0", "1.1.1.1/30"}, // IP address or IP address range
-        ProxyHeader: fiber.HeaderXForwardedFor},
+        ProxyHeader: fiber.HeaderXForwardedFor,
     })
 
     // ...

--- a/.github/README_it.md
+++ b/.github/README_it.md
@@ -585,7 +585,7 @@ func main() {
     app := fiber.New(fiber.Config{
         EnableTrustedProxyCheck: true,
         TrustedProxies: []string{"0.0.0.0", "1.1.1.1/30"}, // IP address or IP address range
-        ProxyHeader: fiber.HeaderXForwardedFor},
+        ProxyHeader: fiber.HeaderXForwardedFor,
     })
 
     // ...

--- a/.github/README_uk.md
+++ b/.github/README_uk.md
@@ -594,7 +594,7 @@ func main() {
     app := fiber.New(fiber.Config{
         EnableTrustedProxyCheck: true,
         TrustedProxies: []string{"0.0.0.0", "1.1.1.1/30"}, // IP address or IP address range
-        ProxyHeader: fiber.HeaderXForwardedFor},
+        ProxyHeader: fiber.HeaderXForwardedFor,
     })
 
     // ...

--- a/.github/README_zh-TW.md
+++ b/.github/README_zh-TW.md
@@ -598,7 +598,7 @@ func main() {
     app := fiber.New(fiber.Config{
         EnableTrustedProxyCheck: true,
         TrustedProxies: []string{"0.0.0.0", "1.1.1.1/30"}, // IP 地址或 IP 地址區間
-        ProxyHeader: fiber.HeaderXForwardedFor},
+        ProxyHeader: fiber.HeaderXForwardedFor,
     })
 
     // ...


### PR DESCRIPTION
## Description

Corrected typo with double '}' in README, README_az, README_ckb, README_it, README_uk, README_zh-TW
