### PR TITLE
:bug: bug: fix middleware naming and returned values of group methods

### DIFF
--- a/app.go
+++ b/app.go
@@ -611,15 +611,15 @@ func (app *App) Name(name string) Router {
 	app.mutex.Lock()
 	for _, routes := range app.stack {
 		for _, route := range routes {
-			latestGroup := app.latestRoute.group
-			if latestGroup != nil {
-				app.latestRoute.Name = latestGroup.name + name
-			} else {
-				if route.Path == app.latestRoute.path {
-					route.Name = name
-				}
+			if route.Path == app.latestRoute.path {
+				route.Name = name
 			}
 		}
+	}
+
+	latestGroup := app.latestRoute.group
+	if latestGroup != nil {
+		app.latestRoute.Name = latestGroup.name + name
 	}
 
 	if err := app.hooks.executeOnNameHooks(*app.latestRoute); err != nil {

--- a/app.go
+++ b/app.go
@@ -609,7 +609,8 @@ func (app *App) SetTLSHandler(tlsHandler *TLSHandler) {
 // Name Assign name to specific route.
 func (app *App) Name(name string) Router {
 	app.mutex.Lock()
-	fmt.Print(app.latestRoute)
+	defer app.mutex.Unlock()
+
 	for _, routes := range app.stack {
 		for _, route := range routes {
 			if route.Path == app.latestRoute.path {
@@ -625,7 +626,6 @@ func (app *App) Name(name string) Router {
 	if err := app.hooks.executeOnNameHooks(*app.latestRoute); err != nil {
 		panic(err)
 	}
-	app.mutex.Unlock()
 
 	return app
 }
@@ -759,12 +759,16 @@ func (app *App) Patch(path string, handlers ...Handler) Router {
 
 // Add allows you to specify a HTTP method to register a route
 func (app *App) Add(method, path string, handlers ...Handler) Router {
-	return app.register(method, path, nil, handlers...)
+	app.register(method, path, nil, handlers...)
+
+	return app
 }
 
 // Static will create a file server serving static files
 func (app *App) Static(prefix, root string, config ...Static) Router {
-	return app.registerStatic(prefix, root, config...)
+	app.registerStatic(prefix, root, config...)
+
+	return app
 }
 
 // All will register the handler on all HTTP methods

--- a/app.go
+++ b/app.go
@@ -609,12 +609,17 @@ func (app *App) SetTLSHandler(tlsHandler *TLSHandler) {
 // Name Assign name to specific route.
 func (app *App) Name(name string) Router {
 	app.mutex.Lock()
-
-	latestGroup := app.latestRoute.group
-	if latestGroup != nil {
-		app.latestRoute.Name = latestGroup.name + name
-	} else {
-		app.latestRoute.Name = name
+	for _, routes := range app.stack {
+		for _, route := range routes {
+			latestGroup := app.latestRoute.group
+			if latestGroup != nil {
+				app.latestRoute.Name = latestGroup.name + name
+			} else {
+				if route.Path == app.latestRoute.path {
+					route.Name = name
+				}
+			}
+		}
 	}
 
 	if err := app.hooks.executeOnNameHooks(*app.latestRoute); err != nil {

--- a/app.go
+++ b/app.go
@@ -609,17 +609,17 @@ func (app *App) SetTLSHandler(tlsHandler *TLSHandler) {
 // Name Assign name to specific route.
 func (app *App) Name(name string) Router {
 	app.mutex.Lock()
+	fmt.Print(app.latestRoute)
 	for _, routes := range app.stack {
 		for _, route := range routes {
 			if route.Path == app.latestRoute.path {
 				route.Name = name
+
+				if route.group != nil {
+					route.Name = route.group.name + route.Name
+				}
 			}
 		}
-	}
-
-	latestGroup := app.latestRoute.group
-	if latestGroup != nil {
-		app.latestRoute.Name = latestGroup.name + name
 	}
 
 	if err := app.hooks.executeOnNameHooks(*app.latestRoute); err != nil {

--- a/app_test.go
+++ b/app_test.go
@@ -1805,12 +1805,8 @@ func TestApp_GetRoutes(t *testing.T) {
 }
 
 func Test_Middleware_Route_Name(t *testing.T) {
-	home, named := "home", "named"
+	named := "named"
 	app := New()
-
-	app.Use(func(c *Ctx) error {
-		return c.Next()
-	}).Name(home)
 
 	app.Get("/unnamed", func(c *Ctx) error {
 		return c.Next()
@@ -1820,10 +1816,30 @@ func Test_Middleware_Route_Name(t *testing.T) {
 		return c.Next()
 	}).Name(named)
 
+	app.Use(func(c *Ctx) error {
+		return c.Next()
+	}) // no name - logging MW
+
+	app.Use(func(c *Ctx) error {
+		return c.Next()
+	}).Name("corsMW")
+
+	app.Use(func(c *Ctx) error {
+		return c.Next()
+	}).Name("compressMW")
+
+	app.Use(func(c *Ctx) error {
+		return c.Next()
+	}) // no name - cache MW
+
+	for _, route := range app.GetRoutes() {
+		fmt.Printf("Path: %s, Method: %s, Name: %s\n", route.Path, route.Method, route.Name)
+	}
+
 	for _, route := range app.GetRoutes() {
 		switch route.Path {
 		case "/":
-			utils.AssertEqual(t, route.Name, home)
+			utils.AssertEqual(t, route.Name, "compressMW")
 		case "/unnamed":
 			utils.AssertEqual(t, route.Name, "")
 		case "named":

--- a/app_test.go
+++ b/app_test.go
@@ -1803,3 +1803,31 @@ func TestApp_GetRoutes(t *testing.T) {
 		utils.AssertEqual(t, name, route.Name)
 	}
 }
+
+func TestRouteName(t *testing.T) {
+	home, named := "home", "named"
+	app := New()
+
+	app.Use(func(c *Ctx) error {
+		return c.Next()
+	}).Name(home)
+
+	app.Get("/unnamed", func(c *Ctx) error {
+		return c.Next()
+	})
+
+	app.Post("/named", func(c *Ctx) error {
+		return c.Next()
+	}).Name(named)
+
+	for _, route := range app.GetRoutes() {
+		switch route.Path {
+		case "/":
+			utils.AssertEqual(t, route.Name, home)
+		case "/unnamed":
+			utils.AssertEqual(t, route.Name, "")
+		case "named":
+			utils.AssertEqual(t, route.Name, named)
+		}
+	}
+}

--- a/app_test.go
+++ b/app_test.go
@@ -1804,7 +1804,7 @@ func TestApp_GetRoutes(t *testing.T) {
 	}
 }
 
-func TestRouteName(t *testing.T) {
+func Test_Middleware_Route_Name(t *testing.T) {
 	home, named := "home", "named"
 	app := New()
 

--- a/app_test.go
+++ b/app_test.go
@@ -1846,10 +1846,6 @@ func Test_Middleware_Route_Naming_With_Use(t *testing.T) {
 	})
 
 	for _, route := range app.GetRoutes() {
-		fmt.Printf("Path: %s, Method: %s, Name: %s\n", route.Path, route.Method, route.Name)
-	}
-
-	for _, route := range app.GetRoutes() {
 		switch route.Path {
 		case "/":
 			utils.AssertEqual(t, "compressMW", route.Name)

--- a/app_test.go
+++ b/app_test.go
@@ -1836,7 +1836,7 @@ func Test_Middleware_Route_Naming_With_Use(t *testing.T) {
 	grp.Use(func(c *Ctx) error {
 		return c.Next()
 	})
-	app.Name("csrfMW")
+	app.Name("csrfMW") // TODO: This should be done by using group's Name method. But it just working for group naming.
 
 	grp.Get("/home", func(c *Ctx) error {
 		return c.Next()

--- a/app_test.go
+++ b/app_test.go
@@ -1835,8 +1835,7 @@ func Test_Middleware_Route_Naming_With_Use(t *testing.T) {
 	grp := app.Group("/pages").Name("pages.")
 	grp.Use(func(c *Ctx) error {
 		return c.Next()
-	})
-	app.Name("csrfMW") // TODO: This should be done by using group's Name method. But it just working for group naming.
+	}).Name("csrfMW")
 
 	grp.Get("/home", func(c *Ctx) error {
 		return c.Next()

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -162,7 +162,6 @@ func Test_Hook_OnGroupName(t *testing.T) {
 
 	utils.AssertEqual(t, "x.", buf.String())
 	utils.AssertEqual(t, "x.test", buf2.String())
-
 }
 
 func Test_Hook_OnGroupName_Error(t *testing.T) {

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -139,6 +139,9 @@ func Test_Hook_OnGroupName(t *testing.T) {
 	buf := bytebufferpool.Get()
 	defer bytebufferpool.Put(buf)
 
+	buf2 := bytebufferpool.Get()
+	defer bytebufferpool.Put(buf2)
+
 	app.Hooks().OnGroupName(func(g Group) error {
 		_, err := buf.WriteString(g.name)
 		utils.AssertEqual(t, nil, err)
@@ -146,11 +149,20 @@ func Test_Hook_OnGroupName(t *testing.T) {
 		return nil
 	})
 
+	app.Hooks().OnName(func(r Route) error {
+		_, err := buf2.WriteString(r.Name)
+		utils.AssertEqual(t, nil, err)
+
+		return nil
+	})
+
 	grp := app.Group("/x").Name("x.")
-	grp.Get("/test", testSimpleHandler)
+	grp.Get("/test", testSimpleHandler).Name("test")
 	grp.Get("/test2", testSimpleHandler)
 
 	utils.AssertEqual(t, "x.", buf.String())
+	utils.AssertEqual(t, "x.test", buf2.String())
+
 }
 
 func Test_Hook_OnGroupName_Error(t *testing.T) {

--- a/router.go
+++ b/router.go
@@ -225,7 +225,7 @@ func (*App) copyRoute(route *Route) *Route {
 	}
 }
 
-func (app *App) register(method, pathRaw string, group *Group, handlers ...Handler) Router {
+func (app *App) register(method, pathRaw string, group *Group, handlers ...Handler) {
 	// Uppercase HTTP methods
 	method = utils.ToUpper(method)
 	// Check if the HTTP method is valid unless it's USE
@@ -302,10 +302,9 @@ func (app *App) register(method, pathRaw string, group *Group, handlers ...Handl
 		// Add route to stack
 		app.addRoute(method, &route, isMount)
 	}
-	return app
 }
 
-func (app *App) registerStatic(prefix, root string, config ...Static) Router {
+func (app *App) registerStatic(prefix, root string, config ...Static) {
 	// For security we want to restrict to the current work directory.
 	if root == "" {
 		root = "."
@@ -441,7 +440,6 @@ func (app *App) registerStatic(prefix, root string, config ...Static) Router {
 	app.addRoute(MethodGet, &route)
 	// Add HEAD route
 	app.addRoute(MethodHead, &route)
-	return app
 }
 
 func (app *App) addRoute(method string, route *Route, isMounted ...bool) {


### PR DESCRIPTION
## Description
Edited app.Name() method to add a name parameter to reach route unless already assigned. This required looping over app.stack which feels ineffecient but it was the only method of accessing all of the routes that I could find

Fixes # (issue)
Resolves #2467 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
