### PR TITLE
:zap:  set raw to nil in JSON to avoid memory leak

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -797,6 +797,7 @@ func (c *Ctx) JSON(data interface{}) error {
 	}
 	c.fasthttp.Response.SetBodyRaw(raw)
 	c.fasthttp.Response.Header.SetContentType(MIMEApplicationJSON)
+	raw = nil
 	return nil
 }
 

--- a/ctx.go
+++ b/ctx.go
@@ -797,7 +797,7 @@ func (c *Ctx) JSON(data interface{}) error {
 	}
 	c.fasthttp.Response.SetBodyRaw(raw)
 	c.fasthttp.Response.Header.SetContentType(MIMEApplicationJSON)
-	raw = nil
+	raw = nil  //nolint:ineffassign
 	return nil
 }
 


### PR DESCRIPTION
## Description

1 line change to set raw to nil in c.JSON() to avoid memory leak

Fixes #2470 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] New and existing unit tests pass locally with my changes

