### PR TITLE
Fix Sliding Window limiter when SkipSuccessfulRequests/SkipFailedRequests is used.

### DIFF
--- a/middleware/limiter/limiter_sliding.go
+++ b/middleware/limiter/limiter_sliding.go
@@ -117,9 +117,13 @@ func (SlidingWindow) New(cfg Config) fiber.Handler {
 		// Check for SkipFailedRequests and SkipSuccessfulRequests
 		if (cfg.SkipSuccessfulRequests && c.Response().StatusCode() < fiber.StatusBadRequest) ||
 			(cfg.SkipFailedRequests && c.Response().StatusCode() >= fiber.StatusBadRequest) {
+			// Lock entry
 			mux.Lock()
+			e = manager.get(key)
 			e.currHits--
 			remaining++
+			manager.set(key, e, cfg.Expiration)
+			// Unlock entry
 			mux.Unlock()
 		}
 

--- a/middleware/limiter/limiter_test.go
+++ b/middleware/limiter/limiter_test.go
@@ -161,7 +161,7 @@ func Test_Limiter_Fixed_Window_Custom_Storage_No_Skip_Choices(t *testing.T) {
 	}))
 
 	app.Get("/:status", func(c *fiber.Ctx) error {
-		if c.Params("status") == "fail" { //nolint:goconst // False positive
+		if c.Params("status") == "fail" {
 			return c.SendStatus(400)
 		}
 		return c.SendStatus(200)
@@ -200,7 +200,7 @@ func Test_Limiter_Sliding_Window_No_Skip_Choices(t *testing.T) {
 	}))
 
 	app.Get("/:status", func(c *fiber.Ctx) error {
-		if c.Params("status") == "fail" { //nolint:goconst // False positive
+		if c.Params("status") == "fail" {
 			return c.SendStatus(400)
 		}
 		return c.SendStatus(200)
@@ -240,7 +240,7 @@ func Test_Limiter_Sliding_Window_Custom_Storage_No_Skip_Choices(t *testing.T) {
 	}))
 
 	app.Get("/:status", func(c *fiber.Ctx) error {
-		if c.Params("status") == "fail" { //nolint:goconst // False positive
+		if c.Params("status") == "fail" {
 			return c.SendStatus(400)
 		}
 		return c.SendStatus(200)

--- a/middleware/limiter/limiter_test.go
+++ b/middleware/limiter/limiter_test.go
@@ -107,8 +107,8 @@ func Test_Limiter_Concurrency(t *testing.T) {
 	utils.AssertEqual(t, 200, resp.StatusCode)
 }
 
-// go test -run Test_Limiter_No_Skip_Choices -v
-func Test_Limiter_No_Skip_Choices(t *testing.T) {
+// go test -run Test_Limiter_Fixed_Window_No_Skip_Choices -v
+func Test_Limiter_Fixed_Window_No_Skip_Choices(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
 
@@ -117,6 +117,7 @@ func Test_Limiter_No_Skip_Choices(t *testing.T) {
 		Expiration:             2 * time.Second,
 		SkipFailedRequests:     false,
 		SkipSuccessfulRequests: false,
+		LimiterMiddleware:      FixedWindow{},
 	}))
 
 	app.Get("/:status", func(c *fiber.Ctx) error {
@@ -137,10 +138,135 @@ func Test_Limiter_No_Skip_Choices(t *testing.T) {
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, 429, resp.StatusCode)
+
+	time.Sleep(3 * time.Second)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
 }
 
-// go test -run Test_Limiter_Skip_Failed_Requests -v
-func Test_Limiter_Skip_Failed_Requests(t *testing.T) {
+// go test -run Test_Limiter_Fixed_Window_Custom_Storage_No_Skip_Choices -v
+func Test_Limiter_Fixed_Window_Custom_Storage_No_Skip_Choices(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Max:                    2,
+		Expiration:             2 * time.Second,
+		SkipFailedRequests:     false,
+		SkipSuccessfulRequests: false,
+		Storage:                memory.New(),
+		LimiterMiddleware:      FixedWindow{},
+	}))
+
+	app.Get("/:status", func(c *fiber.Ctx) error {
+		if c.Params("status") == "fail" { //nolint:goconst // False positive
+			return c.SendStatus(400)
+		}
+		return c.SendStatus(200)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 400, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 429, resp.StatusCode)
+
+	time.Sleep(3 * time.Second)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+}
+
+// go test -run Test_Limiter_Sliding_Window_No_Skip_Choices -v
+func Test_Limiter_Sliding_Window_No_Skip_Choices(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Max:                    2,
+		Expiration:             2 * time.Second,
+		SkipFailedRequests:     false,
+		SkipSuccessfulRequests: false,
+		LimiterMiddleware:      SlidingWindow{},
+	}))
+
+	app.Get("/:status", func(c *fiber.Ctx) error {
+		if c.Params("status") == "fail" { //nolint:goconst // False positive
+			return c.SendStatus(400)
+		}
+		return c.SendStatus(200)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 400, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 429, resp.StatusCode)
+
+	time.Sleep(4 * time.Second)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+}
+
+// go test -run Test_Limiter_Sliding_Window_Custom_Storage_No_Skip_Choices -v
+func Test_Limiter_Sliding_Window_Custom_Storage_No_Skip_Choices(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Max:                    2,
+		Expiration:             2 * time.Second,
+		SkipFailedRequests:     false,
+		SkipSuccessfulRequests: false,
+		Storage:                memory.New(),
+		LimiterMiddleware:      SlidingWindow{},
+	}))
+
+	app.Get("/:status", func(c *fiber.Ctx) error {
+		if c.Params("status") == "fail" { //nolint:goconst // False positive
+			return c.SendStatus(400)
+		}
+		return c.SendStatus(200)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 400, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 429, resp.StatusCode)
+
+	time.Sleep(4 * time.Second)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+}
+
+// go test -run Test_Limiter_Fixed_Window_Skip_Failed_Requests -v
+func Test_Limiter_Fixed_Window_Skip_Failed_Requests(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
 
@@ -148,6 +274,7 @@ func Test_Limiter_Skip_Failed_Requests(t *testing.T) {
 		Max:                1,
 		Expiration:         2 * time.Second,
 		SkipFailedRequests: true,
+		LimiterMiddleware:  FixedWindow{},
 	}))
 
 	app.Get("/:status", func(c *fiber.Ctx) error {
@@ -176,8 +303,124 @@ func Test_Limiter_Skip_Failed_Requests(t *testing.T) {
 	utils.AssertEqual(t, 200, resp.StatusCode)
 }
 
-// go test -run Test_Limiter_Skip_Successful_Requests -v
-func Test_Limiter_Skip_Successful_Requests(t *testing.T) {
+// go test -run Test_Limiter_Fixed_Window_Custom_Storage_Skip_Failed_Requests -v
+func Test_Limiter_Fixed_Window_Custom_Storage_Skip_Failed_Requests(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Max:                1,
+		Expiration:         2 * time.Second,
+		Storage:            memory.New(),
+		SkipFailedRequests: true,
+		LimiterMiddleware:  FixedWindow{},
+	}))
+
+	app.Get("/:status", func(c *fiber.Ctx) error {
+		if c.Params("status") == "fail" {
+			return c.SendStatus(400)
+		}
+		return c.SendStatus(200)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 400, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 429, resp.StatusCode)
+
+	time.Sleep(3 * time.Second)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+}
+
+// go test -run Test_Limiter_Sliding_Window_Skip_Failed_Requests -v
+func Test_Limiter_Sliding_Window_Skip_Failed_Requests(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Max:                1,
+		Expiration:         2 * time.Second,
+		SkipFailedRequests: true,
+		LimiterMiddleware:  SlidingWindow{},
+	}))
+
+	app.Get("/:status", func(c *fiber.Ctx) error {
+		if c.Params("status") == "fail" {
+			return c.SendStatus(400)
+		}
+		return c.SendStatus(200)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 400, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 429, resp.StatusCode)
+
+	time.Sleep(4 * time.Second)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+}
+
+// go test -run Test_Limiter_Sliding_Window_Custom_Storage_Skip_Failed_Requests -v
+func Test_Limiter_Sliding_Window_Custom_Storage_Skip_Failed_Requests(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Max:                1,
+		Expiration:         2 * time.Second,
+		Storage:            memory.New(),
+		SkipFailedRequests: true,
+		LimiterMiddleware:  SlidingWindow{},
+	}))
+
+	app.Get("/:status", func(c *fiber.Ctx) error {
+		if c.Params("status") == "fail" {
+			return c.SendStatus(400)
+		}
+		return c.SendStatus(200)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 400, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 429, resp.StatusCode)
+
+	time.Sleep(4 * time.Second)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+}
+
+// go test -run Test_Limiter_Fixed_Window_Skip_Successful_Requests -v
+func Test_Limiter_Fixed_Window_Skip_Successful_Requests(t *testing.T) {
 	t.Parallel()
 	// Test concurrency using a default store
 
@@ -187,6 +430,7 @@ func Test_Limiter_Skip_Successful_Requests(t *testing.T) {
 		Max:                    1,
 		Expiration:             2 * time.Second,
 		SkipSuccessfulRequests: true,
+		LimiterMiddleware:      FixedWindow{},
 	}))
 
 	app.Get("/:status", func(c *fiber.Ctx) error {
@@ -209,6 +453,128 @@ func Test_Limiter_Skip_Successful_Requests(t *testing.T) {
 	utils.AssertEqual(t, 429, resp.StatusCode)
 
 	time.Sleep(3 * time.Second)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 400, resp.StatusCode)
+}
+
+// go test -run Test_Limiter_Fixed_Window_Custom_Storage_Skip_Successful_Requests -v
+func Test_Limiter_Fixed_Window_Custom_Storage_Skip_Successful_Requests(t *testing.T) {
+	t.Parallel()
+	// Test concurrency using a default store
+
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Max:                    1,
+		Expiration:             2 * time.Second,
+		Storage:                memory.New(),
+		SkipSuccessfulRequests: true,
+		LimiterMiddleware:      FixedWindow{},
+	}))
+
+	app.Get("/:status", func(c *fiber.Ctx) error {
+		if c.Params("status") == "fail" {
+			return c.SendStatus(400)
+		}
+		return c.SendStatus(200)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 400, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 429, resp.StatusCode)
+
+	time.Sleep(3 * time.Second)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 400, resp.StatusCode)
+}
+
+// go test -run Test_Limiter_Sliding_Window_Skip_Successful_Requests -v
+func Test_Limiter_Sliding_Window_Skip_Successful_Requests(t *testing.T) {
+	t.Parallel()
+	// Test concurrency using a default store
+
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Max:                    1,
+		Expiration:             2 * time.Second,
+		SkipSuccessfulRequests: true,
+		LimiterMiddleware:      SlidingWindow{},
+	}))
+
+	app.Get("/:status", func(c *fiber.Ctx) error {
+		if c.Params("status") == "fail" {
+			return c.SendStatus(400)
+		}
+		return c.SendStatus(200)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 400, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 429, resp.StatusCode)
+
+	time.Sleep(4 * time.Second)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 400, resp.StatusCode)
+}
+
+// go test -run Test_Limiter_Sliding_Window_Custom_Storage_Skip_Successful_Requests -v
+func Test_Limiter_Sliding_Window_Custom_Storage_Skip_Successful_Requests(t *testing.T) {
+	t.Parallel()
+	// Test concurrency using a default store
+
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Max:                    1,
+		Expiration:             2 * time.Second,
+		Storage:                memory.New(),
+		SkipSuccessfulRequests: true,
+		LimiterMiddleware:      SlidingWindow{},
+	}))
+
+	app.Get("/:status", func(c *fiber.Ctx) error {
+		if c.Params("status") == "fail" {
+			return c.SendStatus(400)
+		}
+		return c.SendStatus(200)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 200, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 400, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, 429, resp.StatusCode)
+
+	time.Sleep(4 * time.Second)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
 	utils.AssertEqual(t, nil, err)


### PR DESCRIPTION
Fix Sliding Window limiter when SkipSuccessfulRequests/SkipFailedRequests is used.
Issue [(#2483)](https://github.com/gofiber/fiber/issues/2483)