### PR TITLE
🐛fix: update getOffer to consider quality and specificity

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -45,7 +45,10 @@ func Test_Ctx_Accepts(t *testing.T) {
 	utils.AssertEqual(t, "", c.Accepts())
 	utils.AssertEqual(t, ".xml", c.Accepts(".xml"))
 	utils.AssertEqual(t, "", c.Accepts(".john"))
-	utils.AssertEqual(t, "application/xhtml+xml", c.Accepts("application/xml", "application/xml+rss", "application/yml", "application/xhtml+xml"))
+	utils.AssertEqual(t, "application/xhtml+xml", c.Accepts("application/xml", "application/xml+rss", "application/yml", "application/xhtml+xml"), "must use client-preferred mime type")
+
+	c.Request().Header.Set(HeaderAccept, "application/json, text/plain, */*;q=0")
+	utils.AssertEqual(t, "", c.Accepts("html"), "must treat */*;q=0 as not acceptable")
 
 	c.Request().Header.Set(HeaderAccept, "text/*, application/json")
 	utils.AssertEqual(t, "html", c.Accepts("html"))

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -45,7 +45,7 @@ func Test_Ctx_Accepts(t *testing.T) {
 	utils.AssertEqual(t, "", c.Accepts())
 	utils.AssertEqual(t, ".xml", c.Accepts(".xml"))
 	utils.AssertEqual(t, "", c.Accepts(".john"))
-	utils.AssertEqual(t, "application/xhtml+xml", c.Accepts("application/xml", "application/xml+rss", "application/yml", "application/xhtml+xml"), "must use client-preferred mime type")
+	utils.AssertEqual(t, "application/xhtml+xml", c.Accepts("application/xml", "application/xml+rss", "application/yaml", "application/xhtml+xml"), "must use client-preferred mime type")
 
 	c.Request().Header.Set(HeaderAccept, "application/json, text/plain, */*;q=0")
 	utils.AssertEqual(t, "", c.Accepts("html"), "must treat */*;q=0 as not acceptable")

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -45,6 +45,7 @@ func Test_Ctx_Accepts(t *testing.T) {
 	utils.AssertEqual(t, "", c.Accepts())
 	utils.AssertEqual(t, ".xml", c.Accepts(".xml"))
 	utils.AssertEqual(t, "", c.Accepts(".john"))
+	utils.AssertEqual(t, "application/xhtml+xml", c.Accepts("application/xml", "application/xml+rss", "application/yml", "application/xhtml+xml"))
 
 	c.Request().Header.Set(HeaderAccept, "text/*, application/json")
 	utils.AssertEqual(t, "html", c.Accepts("html"))

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -24,13 +24,16 @@ func (c *Ctx) AcceptsLanguages(offers ...string) string
 ```
 
 ```go title="Example"
-// Accept: text/*, application/json
+// Accept: text/html, application/json; q=0.8, text/plain; q=0.5; charset="utf-8"
 
 app.Get("/", func(c *fiber.Ctx) error {
   c.Accepts("html")             // "html"
   c.Accepts("text/html")        // "text/html"
   c.Accepts("json", "text")     // "json"
   c.Accepts("application/json") // "application/json"
+  c.Accepts("text/plain", "application/json") // "application/json", due to quality
+  c.Accepts("text/plain", "application/json") // "application/json", due to specificity
+  c.Accepts("text/html", "application/json") // "text/html", due to first match
   c.Accepts("image/png")        // ""
   c.Accepts("png")              // ""
   // ...

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -39,7 +39,7 @@ app.Get("/", func(c *fiber.Ctx) error {
 ```
 
 ```go title="Example 2"
-// Accept: text/html, text/*, application/json, */*; q=0"
+// Accept: text/html, text/*, application/json, */*; q=0
 
 app.Get("/", func(c *fiber.Ctx) error {
   c.Accepts("text/plain", "application/json") // "application/json", due to specificity

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -32,10 +32,19 @@ app.Get("/", func(c *fiber.Ctx) error {
   c.Accepts("json", "text")     // "json"
   c.Accepts("application/json") // "application/json"
   c.Accepts("text/plain", "application/json") // "application/json", due to quality
-  c.Accepts("text/plain", "application/json") // "application/json", due to specificity
-  c.Accepts("text/html", "application/json") // "text/html", due to first match
   c.Accepts("image/png")        // ""
   c.Accepts("png")              // ""
+  // ...
+})
+```
+
+```go title="Example 2"
+// Accept: text/html, text/*, application/json, */*; q=0"
+
+app.Get("/", func(c *fiber.Ctx) error {
+  c.Accepts("text/plain", "application/json") // "application/json", due to specificity
+  c.Accepts("application/json", "text/html") // "text/html", due to first match
+  c.Accepts("image/png")        // "", due to */* without q factor 0 is Not Acceptable
   // ...
 })
 ```

--- a/helpers.go
+++ b/helpers.go
@@ -295,7 +295,9 @@ func getOffer(header string, isAccepted func(spec, offer string) bool, offers ..
 		if factorSign := strings.IndexByte(spec, ';'); factorSign != -1 {
 			factor := utils.Trim(spec[factorSign+1:], ' ')
 			if strings.HasPrefix(factor, "q=") {
-				quality, _ = strconv.ParseFloat(factor[2:], 64)
+				if q, err := strconv.ParseFloat(factor[2:], 64); err != nil {
+					quality = q
+				}
 			}
 			spec = spec[:factorSign]
 		}

--- a/helpers.go
+++ b/helpers.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -336,7 +337,14 @@ func getOffer(header string, isAccepted func(spec, offer string) bool, offers ..
 	}
 
 	// Sort accepted types by quality and specificity
-	if len(acceptedTypes) > 1 {
+	if len(acceptedTypes) > 20 {
+		sort.SliceStable(acceptedTypes, func(i, j int) bool {
+			if acceptedTypes[i].quality == acceptedTypes[j].quality {
+				return acceptedTypes[i].specificity > acceptedTypes[j].specificity
+			}
+			return acceptedTypes[i].quality > acceptedTypes[j].quality
+		})
+	} else if len(acceptedTypes) > 1 {
 		// Insertion sort
 		changes := false
 		for i := 1; i < len(acceptedTypes); i++ {

--- a/helpers.go
+++ b/helpers.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -337,14 +336,7 @@ func getOffer(header string, isAccepted func(spec, offer string) bool, offers ..
 	}
 
 	// Sort accepted types by quality and specificity
-	if len(acceptedTypes) > 6 {
-		sort.SliceStable(acceptedTypes, func(i, j int) bool {
-			if acceptedTypes[i].quality == acceptedTypes[j].quality {
-				return acceptedTypes[i].specificity > acceptedTypes[j].specificity
-			}
-			return acceptedTypes[i].quality > acceptedTypes[j].quality
-		})
-	} else if len(acceptedTypes) > 1 {
+	if len(acceptedTypes) > 1 {
 		// Insertion sort
 		changes := false
 		for i := 1; i < len(acceptedTypes); i++ {

--- a/helpers.go
+++ b/helpers.go
@@ -337,16 +337,24 @@ func getOffer(header string, isAccepted func(spec, offer string) bool, offers ..
 
 	// Sort accepted types by quality and specificity
 	if len(acceptedTypes) > 1 {
-		// Insertion sort
 		for i := 1; i < len(acceptedTypes); i++ {
-			for j := i; j > 0; j-- {
-				if acceptedTypes[j-1].quality < acceptedTypes[j].quality {
-					acceptedTypes[j-1], acceptedTypes[j] = acceptedTypes[j], acceptedTypes[j-1]
-				} else if acceptedTypes[j-1].quality == acceptedTypes[j].quality && acceptedTypes[j-1].specificity < acceptedTypes[j].specificity {
-					acceptedTypes[j-1], acceptedTypes[j] = acceptedTypes[j], acceptedTypes[j-1]
+			swap := false
+			lo, hi := 0, i-1
+			for lo <= hi {
+				mid := (lo + hi) / 2
+				if acceptedTypes[i].quality > acceptedTypes[mid].quality ||
+					(acceptedTypes[i].quality == acceptedTypes[mid].quality && acceptedTypes[i].specificity > acceptedTypes[mid].specificity) {
+					lo = mid + 1
 				} else {
-					break
+					hi = mid - 1
 				}
+			}
+			for j := i; j > lo; j-- {
+				acceptedTypes[j-1], acceptedTypes[j] = acceptedTypes[j], acceptedTypes[j-1]
+				swap = true
+			}
+			if !swap {
+				break
 			}
 		}
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 	"unsafe"
@@ -298,7 +297,7 @@ func getOffer(header string, isAccepted func(spec, offer string) bool, offers ..
 		if factorSign := strings.IndexByte(spec, ';'); factorSign != -1 {
 			factor := utils.Trim(spec[factorSign+1:], ' ')
 			if strings.HasPrefix(factor, "q=") {
-				if q, err := strconv.ParseFloat(factor[2:], 64); err == nil {
+				if q, err := fasthttp.ParseUfloat([]byte(factor[2:])); err == nil {
 					quality = q
 				}
 			}

--- a/helpers.go
+++ b/helpers.go
@@ -300,7 +300,7 @@ func getOffer(header string, isAccepted func(spec, offer string) bool, offers ..
 			spec = spec[:factorSign]
 		}
 
-		if quality == 0 {
+		if quality == 0.0 {
 			// Skip this spec
 			if commaPos != -1 {
 				header = header[commaPos+1:]

--- a/helpers.go
+++ b/helpers.go
@@ -301,7 +301,7 @@ func getOffer(header string, isAccepted func(spec, offer string) bool, offers ..
 		if factorSign := strings.IndexByte(spec, ';'); factorSign != -1 {
 			factor := utils.Trim(spec[factorSign+1:], ' ')
 			if strings.HasPrefix(factor, "q=") {
-				if q, err := fasthttp.ParseUfloat([]byte(factor[2:])); err == nil {
+				if q, err := fasthttp.ParseUfloat(utils.UnsafeBytes(factor[2:])); err == nil {
 					quality = q
 				}
 			}

--- a/helpers.go
+++ b/helpers.go
@@ -275,7 +275,8 @@ func getOffer(header string, isAccepted func(spec, offer string) bool, offers ..
 		specificity int
 	}
 
-	// Parse header
+	// Parse header and get accepted types with their quality and specificity
+	// See: https://www.rfc-editor.org/rfc/rfc9110#name-content-negotiation-fields
 	spec, commaPos := "", 0
 	acceptedTypes := make([]acceptedType, 0)
 	for len(header) > 0 {
@@ -300,8 +301,9 @@ func getOffer(header string, isAccepted func(spec, offer string) bool, offers ..
 			spec = spec[:factorSign]
 		}
 
+		// Skip if quality is 0.0
+		// See: https://www.rfc-editor.org/rfc/rfc9110#quality.values
 		if quality == 0.0 {
-			// Skip this spec
 			if commaPos != -1 {
 				header = header[commaPos+1:]
 			} else {

--- a/helpers.go
+++ b/helpers.go
@@ -271,9 +271,6 @@ func acceptsOfferType(spec, offerType string) bool {
 
 // getOffer return valid offer for header negotiation
 func getOffer(header string, isAccepted func(spec, offer string) bool, offers ...string) string {
-	if isAccepted == nil {
-		return ""
-	}
 	if len(offers) == 0 {
 		return ""
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -300,6 +300,16 @@ func getOffer(header string, isAccepted func(spec, offer string) bool, offers ..
 			spec = spec[:factorSign]
 		}
 
+		if quality == 0 {
+			// Skip this spec
+			if commaPos != -1 {
+				header = header[commaPos+1:]
+			} else {
+				break
+			}
+			continue
+		}
+
 		// Get specificity
 		specificity := 0
 		// check for wildcard this could be a mime */* or a wildcard character *

--- a/helpers.go
+++ b/helpers.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -278,7 +277,7 @@ func getOffer(header string, isAccepted func(spec, offer string) bool, offers ..
 	// Parse header and get accepted types with their quality and specificity
 	// See: https://www.rfc-editor.org/rfc/rfc9110#name-content-negotiation-fields
 	spec, commaPos := "", 0
-	acceptedTypes := make([]acceptedType, 0)
+	acceptedTypes := make([]acceptedType, 0, 20)
 	for len(header) > 0 {
 		// Skip spaces
 		header = utils.TrimLeft(header, ' ')
@@ -337,27 +336,15 @@ func getOffer(header string, isAccepted func(spec, offer string) bool, offers ..
 	}
 
 	// Sort accepted types by quality and specificity
-	if len(acceptedTypes) > 20 {
-		sort.SliceStable(acceptedTypes, func(i, j int) bool {
-			if acceptedTypes[i].quality == acceptedTypes[j].quality {
-				return acceptedTypes[i].specificity > acceptedTypes[j].specificity
-			}
-			return acceptedTypes[i].quality > acceptedTypes[j].quality
-		})
-	} else if len(acceptedTypes) > 1 {
+	if len(acceptedTypes) > 1 {
 		// Insertion sort
-		changes := false
 		for i := 1; i < len(acceptedTypes); i++ {
 			for j := i; j > 0; j-- {
 				if acceptedTypes[j-1].quality < acceptedTypes[j].quality {
 					acceptedTypes[j-1], acceptedTypes[j] = acceptedTypes[j], acceptedTypes[j-1]
-					changes = true
 				} else if acceptedTypes[j-1].quality == acceptedTypes[j].quality && acceptedTypes[j-1].specificity < acceptedTypes[j].specificity {
 					acceptedTypes[j-1], acceptedTypes[j] = acceptedTypes[j], acceptedTypes[j-1]
-					changes = true
-				}
-
-				if !changes {
+				} else {
 					break
 				}
 			}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -221,7 +221,7 @@ func Test_Utils_Parse_Address(t *testing.T) {
 	}
 }
 
-func Test_GetOffer(t *testing.T) {
+func Test_Utils_GetOffer(t *testing.T) {
 	t.Parallel()
 	utils.AssertEqual(t, "", getOffer("hello", acceptsOffer))
 	utils.AssertEqual(t, "1", getOffer("", acceptsOffer, "1"))

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -88,11 +88,13 @@ func Test_Utils_GetOffer(t *testing.T) {
 func Benchmark_Utils_GetOffer(b *testing.B) {
 	headers := []string{
 		"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+		"application/json",
 		"utf-8, iso-8859-1;q=0.5",
 		"gzip, deflate",
 	}
 	offers := [][]string{
-		{"application/xml", "application/json"},
+		{"text/html", "application/xml", "application/xml+xhtml"},
+		{"application/json"},
 		{"utf-8"},
 		{"deflate"},
 	}
@@ -101,6 +103,37 @@ func Benchmark_Utils_GetOffer(b *testing.B) {
 			getOffer(header, acceptsOfferType, offers[i]...)
 		}
 	}
+}
+
+func Test_Utils_SortAcceptedTypes(t *testing.T) {
+	t.Parallel()
+	acceptedTypes := []acceptedType{
+		{spec: "text/html", quality: 1, specificity: 3, order: 0},
+		{spec: "text/*", quality: 0.5, specificity: 2, order: 1},
+		{spec: "*/*", quality: 0.1, specificity: 1, order: 2},
+		{spec: "application/json", quality: 0.999, specificity: 3, order: 3},
+		{spec: "application/xml", quality: 1, specificity: 3, order: 4},
+		{spec: "application/pdf", quality: 1, specificity: 3, order: 5},
+		{spec: "image/png", quality: 1, specificity: 3, order: 6},
+		{spec: "image/jpeg", quality: 1, specificity: 3, order: 7},
+		{spec: "image/*", quality: 1, specificity: 2, order: 8},
+		{spec: "image/gif", quality: 1, specificity: 3, order: 9},
+		{spec: "text/plain", quality: 1, specificity: 3, order: 10},
+	}
+	sortAcceptedTypes(&acceptedTypes)
+	utils.AssertEqual(t, acceptedTypes, []acceptedType{
+		{spec: "text/html", quality: 1, specificity: 3, order: 0},
+		{spec: "application/xml", quality: 1, specificity: 3, order: 4},
+		{spec: "application/pdf", quality: 1, specificity: 3, order: 5},
+		{spec: "image/png", quality: 1, specificity: 3, order: 6},
+		{spec: "image/jpeg", quality: 1, specificity: 3, order: 7},
+		{spec: "image/gif", quality: 1, specificity: 3, order: 9},
+		{spec: "text/plain", quality: 1, specificity: 3, order: 10},
+		{spec: "image/*", quality: 1, specificity: 2, order: 8},
+		{spec: "application/json", quality: 0.999, specificity: 3, order: 3},
+		{spec: "text/*", quality: 0.5, specificity: 2, order: 1},
+		{spec: "*/*", quality: 0.1, specificity: 1, order: 2},
+	})
 }
 
 // go test -v -run=^$ -bench=Benchmark_Utils_SortAcceptedTypes_Sorted -benchmem -count=4
@@ -124,7 +157,7 @@ func Benchmark_Utils_SortAcceptedTypes_Unsorted(b *testing.B) {
 		acceptedTypes[0] = acceptedType{spec: "text/html", quality: 1, specificity: 3, order: 0}
 		acceptedTypes[1] = acceptedType{spec: "text/*", quality: 0.5, specificity: 2, order: 1}
 		acceptedTypes[2] = acceptedType{spec: "*/*", quality: 0.1, specificity: 1, order: 2}
-		acceptedTypes[3] = acceptedType{spec: "application/json", quality: 1, specificity: 3, order: 3}
+		acceptedTypes[3] = acceptedType{spec: "application/json", quality: 0.999, specificity: 3, order: 3}
 		acceptedTypes[4] = acceptedType{spec: "application/xml", quality: 1, specificity: 3, order: 4}
 		acceptedTypes[5] = acceptedType{spec: "application/pdf", quality: 1, specificity: 3, order: 5}
 		acceptedTypes[6] = acceptedType{spec: "image/png", quality: 1, specificity: 3, order: 6}
@@ -134,17 +167,19 @@ func Benchmark_Utils_SortAcceptedTypes_Unsorted(b *testing.B) {
 		acceptedTypes[10] = acceptedType{spec: "text/plain", quality: 1, specificity: 3, order: 10}
 		sortAcceptedTypes(&acceptedTypes)
 	}
-	utils.AssertEqual(b, "text/html", acceptedTypes[0].spec)
-	utils.AssertEqual(b, "application/json", acceptedTypes[1].spec)
-	utils.AssertEqual(b, "application/xml", acceptedTypes[2].spec)
-	utils.AssertEqual(b, "application/pdf", acceptedTypes[3].spec)
-	utils.AssertEqual(b, "image/png", acceptedTypes[4].spec)
-	utils.AssertEqual(b, "image/jpeg", acceptedTypes[5].spec)
-	utils.AssertEqual(b, "image/gif", acceptedTypes[6].spec)
-	utils.AssertEqual(b, "text/plain", acceptedTypes[7].spec)
-	utils.AssertEqual(b, "image/*", acceptedTypes[8].spec)
-	utils.AssertEqual(b, "text/*", acceptedTypes[9].spec)
-	utils.AssertEqual(b, "*/*", acceptedTypes[10].spec)
+	utils.AssertEqual(b, acceptedTypes, []acceptedType{
+		{spec: "text/html", quality: 1, specificity: 3, order: 0},
+		{spec: "application/xml", quality: 1, specificity: 3, order: 4},
+		{spec: "application/pdf", quality: 1, specificity: 3, order: 5},
+		{spec: "image/png", quality: 1, specificity: 3, order: 6},
+		{spec: "image/jpeg", quality: 1, specificity: 3, order: 7},
+		{spec: "image/gif", quality: 1, specificity: 3, order: 9},
+		{spec: "text/plain", quality: 1, specificity: 3, order: 10},
+		{spec: "image/*", quality: 1, specificity: 2, order: 8},
+		{spec: "application/json", quality: 0.999, specificity: 3, order: 3},
+		{spec: "text/*", quality: 0.5, specificity: 2, order: 1},
+		{spec: "*/*", quality: 0.1, specificity: 1, order: 2},
+	})
 }
 
 // go test -v -run=^$ -bench=Benchmark_App_ETag -benchmem -count=4

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -221,7 +221,7 @@ func Test_Utils_Parse_Address(t *testing.T) {
 	}
 }
 
-func Test_Utils_GetOffset(t *testing.T) {
+func Test_Utils_GetOffer(t *testing.T) {
 	t.Parallel()
 	utils.AssertEqual(t, "", getOffer("hello", acceptsOffer))
 	utils.AssertEqual(t, "1", getOffer("", acceptsOffer, "1"))

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -62,6 +62,91 @@ func Test_Utils_ETag(t *testing.T) {
 	})
 }
 
+func Test_Utils_GetOffer(t *testing.T) {
+	t.Parallel()
+	utils.AssertEqual(t, "", getOffer("hello", acceptsOffer))
+	utils.AssertEqual(t, "1", getOffer("", acceptsOffer, "1"))
+	utils.AssertEqual(t, "", getOffer("2", acceptsOffer, "1"))
+
+	utils.AssertEqual(t, "", getOffer("", acceptsOfferType))
+	utils.AssertEqual(t, "", getOffer("text/html", acceptsOfferType))
+	utils.AssertEqual(t, "", getOffer("text/html", acceptsOfferType, "application/json"))
+	utils.AssertEqual(t, "", getOffer("text/html;q=0", acceptsOfferType, "text/html"))
+	utils.AssertEqual(t, "application/xml", getOffer("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", acceptsOfferType, "application/xml", "application/json"))
+	utils.AssertEqual(t, "text/html", getOffer("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", acceptsOfferType, "text/html"))
+	utils.AssertEqual(t, "application/pdf", getOffer("text/plain;q=0,application/pdf;q=0.9,*/*;q=0.000", acceptsOfferType, "application/pdf", "application/json"))
+
+	utils.AssertEqual(t, "", getOffer("utf-8, iso-8859-1;q=0.5", acceptsOffer))
+	utils.AssertEqual(t, "", getOffer("utf-8, iso-8859-1;q=0.5", acceptsOffer, "ascii"))
+	utils.AssertEqual(t, "utf-8", getOffer("utf-8, iso-8859-1;q=0.5", acceptsOffer, "utf-8"))
+	utils.AssertEqual(t, "iso-8859-1", getOffer("utf-8;q=0, iso-8859-1;q=0.5", acceptsOffer, "utf-8", "iso-8859-1"))
+
+	utils.AssertEqual(t, "deflate", getOffer("gzip, deflate", acceptsOffer, "deflate"))
+	utils.AssertEqual(t, "", getOffer("gzip, deflate;q=0", acceptsOffer, "deflate"))
+}
+
+func Benchmark_Utils_GetOffer(b *testing.B) {
+	headers := []string{
+		"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+		"utf-8, iso-8859-1;q=0.5",
+		"gzip, deflate",
+	}
+	offers := [][]string{
+		{"application/xml", "application/json"},
+		{"utf-8"},
+		{"deflate"},
+	}
+	for n := 0; n < b.N; n++ {
+		for i, header := range headers {
+			getOffer(header, acceptsOfferType, offers[i]...)
+		}
+	}
+}
+
+// go test -v -run=^$ -bench=Benchmark_Utils_SortAcceptedTypes_Sorted -benchmem -count=4
+func Benchmark_Utils_SortAcceptedTypes_Sorted(b *testing.B) {
+	acceptedTypes := make([]acceptedType, 3)
+	for n := 0; n < b.N; n++ {
+		acceptedTypes[0] = acceptedType{spec: "text/html", quality: 1, specificity: 1, order: 0}
+		acceptedTypes[1] = acceptedType{spec: "text/*", quality: 0.5, specificity: 1, order: 1}
+		acceptedTypes[2] = acceptedType{spec: "*/*", quality: 0.1, specificity: 1, order: 2}
+		sortAcceptedTypes(&acceptedTypes)
+	}
+	utils.AssertEqual(b, "text/html", acceptedTypes[0].spec)
+	utils.AssertEqual(b, "text/*", acceptedTypes[1].spec)
+	utils.AssertEqual(b, "*/*", acceptedTypes[2].spec)
+}
+
+// go test -v -run=^$ -bench=Benchmark_Utils_SortAcceptedTypes_Unsorted -benchmem -count=4
+func Benchmark_Utils_SortAcceptedTypes_Unsorted(b *testing.B) {
+	acceptedTypes := make([]acceptedType, 11)
+	for n := 0; n < b.N; n++ {
+		acceptedTypes[0] = acceptedType{spec: "text/html", quality: 1, specificity: 3, order: 0}
+		acceptedTypes[1] = acceptedType{spec: "text/*", quality: 0.5, specificity: 2, order: 1}
+		acceptedTypes[2] = acceptedType{spec: "*/*", quality: 0.1, specificity: 1, order: 2}
+		acceptedTypes[3] = acceptedType{spec: "application/json", quality: 1, specificity: 3, order: 3}
+		acceptedTypes[4] = acceptedType{spec: "application/xml", quality: 1, specificity: 3, order: 4}
+		acceptedTypes[5] = acceptedType{spec: "application/pdf", quality: 1, specificity: 3, order: 5}
+		acceptedTypes[6] = acceptedType{spec: "image/png", quality: 1, specificity: 3, order: 6}
+		acceptedTypes[7] = acceptedType{spec: "image/jpeg", quality: 1, specificity: 3, order: 7}
+		acceptedTypes[8] = acceptedType{spec: "image/*", quality: 1, specificity: 2, order: 8}
+		acceptedTypes[9] = acceptedType{spec: "image/gif", quality: 1, specificity: 3, order: 9}
+		acceptedTypes[10] = acceptedType{spec: "text/plain", quality: 1, specificity: 3, order: 10}
+		sortAcceptedTypes(&acceptedTypes)
+	}
+	utils.AssertEqual(b, "text/html", acceptedTypes[0].spec)
+	utils.AssertEqual(b, "application/json", acceptedTypes[1].spec)
+	utils.AssertEqual(b, "application/xml", acceptedTypes[2].spec)
+	utils.AssertEqual(b, "application/pdf", acceptedTypes[3].spec)
+	utils.AssertEqual(b, "image/png", acceptedTypes[4].spec)
+	utils.AssertEqual(b, "image/jpeg", acceptedTypes[5].spec)
+	utils.AssertEqual(b, "image/gif", acceptedTypes[6].spec)
+	utils.AssertEqual(b, "text/plain", acceptedTypes[7].spec)
+	utils.AssertEqual(b, "image/*", acceptedTypes[8].spec)
+	utils.AssertEqual(b, "text/*", acceptedTypes[9].spec)
+	utils.AssertEqual(b, "*/*", acceptedTypes[10].spec)
+}
+
 // go test -v -run=^$ -bench=Benchmark_App_ETag -benchmem -count=4
 func Benchmark_Utils_ETag(b *testing.B) {
 	app := New()
@@ -219,13 +304,6 @@ func Test_Utils_Parse_Address(t *testing.T) {
 		utils.AssertEqual(t, c.host, host, "addr host")
 		utils.AssertEqual(t, c.port, port, "addr port")
 	}
-}
-
-func Test_Utils_GetOffer(t *testing.T) {
-	t.Parallel()
-	utils.AssertEqual(t, "", getOffer("hello", acceptsOffer))
-	utils.AssertEqual(t, "1", getOffer("", acceptsOffer, "1"))
-	utils.AssertEqual(t, "", getOffer("2", acceptsOffer, "1"))
 }
 
 func Test_Utils_TestConn_Deadline(t *testing.T) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -221,7 +221,7 @@ func Test_Utils_Parse_Address(t *testing.T) {
 	}
 }
 
-func Test_Utils_GetOffer(t *testing.T) {
+func Test_GetOffer(t *testing.T) {
 	t.Parallel()
 	utils.AssertEqual(t, "", getOffer("hello", acceptsOffer))
 	utils.AssertEqual(t, "1", getOffer("", acceptsOffer, "1"))

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -72,8 +72,10 @@ func Test_Utils_GetOffer(t *testing.T) {
 	utils.AssertEqual(t, "", getOffer("text/html", acceptsOfferType))
 	utils.AssertEqual(t, "", getOffer("text/html", acceptsOfferType, "application/json"))
 	utils.AssertEqual(t, "", getOffer("text/html;q=0", acceptsOfferType, "text/html"))
+	utils.AssertEqual(t, "", getOffer("application/json, */*; q=0", acceptsOfferType, "image/png"))
 	utils.AssertEqual(t, "application/xml", getOffer("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", acceptsOfferType, "application/xml", "application/json"))
 	utils.AssertEqual(t, "text/html", getOffer("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", acceptsOfferType, "text/html"))
+	utils.AssertEqual(t, "application/pdf", getOffer("text/plain;q=0,application/pdf;q=0.9,*/*;q=0.000", acceptsOfferType, "application/pdf", "application/json"))
 	utils.AssertEqual(t, "application/pdf", getOffer("text/plain;q=0,application/pdf;q=0.9,*/*;q=0.000", acceptsOfferType, "application/pdf", "application/json"))
 
 	utils.AssertEqual(t, "", getOffer("utf-8, iso-8859-1;q=0.5", acceptsOffer))


### PR DESCRIPTION
## Description

Updates the getOffer helper function so that content negotiation follows https://www.rfc-editor.org/rfc/rfc9110#name-content-negotiation-fields, specifically that quality values are considered (also where q=0 type is not acceptable) and that specificity is also considered in a tie, as a final tie breaker client order is used.

Fixes #2387 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [x] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
