### PR TITLE
:recycle: Refactor: use c.app.getString instead of string(...)

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -597,7 +597,7 @@ func (c *Ctx) GetRespHeader(key string, defaultValue ...string) string {
 func (c *Ctx) GetReqHeaders() map[string]string {
 	headers := make(map[string]string)
 	c.Request().Header.VisitAll(func(k, v []byte) {
-		headers[string(k)] = c.app.getString(v)
+		headers[c.app.getString(k)] = c.app.getString(v)
 	})
 
 	return headers
@@ -609,7 +609,7 @@ func (c *Ctx) GetReqHeaders() map[string]string {
 func (c *Ctx) GetRespHeaders() map[string]string {
 	headers := make(map[string]string)
 	c.Response().Header.VisitAll(func(k, v []byte) {
-		headers[string(k)] = c.app.getString(v)
+		headers[c.app.getString(k)] = c.app.getString(v)
 	})
 
 	return headers


### PR DESCRIPTION
## Description

I noticed 2 functions (those being `GetReqHeaders` and `GetRespHeaders`) use `string(...)` instead of `c.app.getString` to convert a byte array to a string

```go
c.Request().Header.VisitAll(func(k, v []byte) {
	headers[string(k)] = c.app.getString(v)
})

c.Response().Header.VisitAll(func(k, v []byte) {
	headers[string(k)] = c.app.getString(v)
})
```

Using `c.app.getString` is around 16-19% faster, and allocates less. (See benchmark spreadsheets below. Both `c.app.getString`, and `string(...)` was tested on both functions, 100 times.)

Benchmark result for using `string(...)` on `GetReqHeaders`: [GetReqHeaders.xlsx](https://github.com/gofiber/fiber/files/11622573/GetReqHeaders.xlsx)
_(Average 1,756,668 Iterations, 700 ns/op, 357 B/op, 5 allocs/op)_

Benchmark result for using `c.app.getString` on `GetReqHeaders`: [GetReqHeadersNew.xlsx](https://github.com/gofiber/fiber/files/11622581/GetReqHeadersNew.xlsx)
_(Average 2,164,354 Iterations, 567 ns/op, 336 B/op, 2 allocs/op)_

Benchmark result for using `string(...)` on `GetRespHeaders`: [GetRespHeaders.xlsx](https://github.com/gofiber/fiber/files/11622626/GetRespHeaders.xlsx)
_(Average 1,823,697 Iterations, 678 ns/op, 357 B/op, 5 allocs/op)_

Benchmark result for using `c.app.getString` on `GetRespHeaders`: [GetRespHeadersNew.xlsx](https://github.com/gofiber/fiber/files/11622629/GetRespHeadersNew.xlsx)
_(Average 2,176,443 Iterations, 564 ns/op, 336 B/op, 2 allocs/op)_

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
- [X] I tried to make my code as fast as possible with as few allocations as possible

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
