### PR TITLE
:recycle: Refactor: Use EnableColors instead of DisableColors

### DIFF
--- a/docs/api/middleware/logger.md
+++ b/docs/api/middleware/logger.md
@@ -83,7 +83,7 @@ app.Use(logger.New(logger.Config{
 
 // Disable colors when outputting to default format
 app.Use(logger.New(logger.Config{
-    DisableColors: true,
+    EnableColors: false,
 }))
 ```
 
@@ -132,12 +132,10 @@ type Config struct {
     // Default: os.Stdout
     Output io.Writer
     
-    // DisableColors defines if the logs output should be colorized
+    // EnableColors defines if the logs output should be colorized
     //
-    // Default: false
-    DisableColors bool
-    
-    enableColors     bool
+    // Default: true
+    EnableColors     bool
     enableLatency    bool
     timeZoneLocation *time.Location
 }
@@ -153,7 +151,7 @@ var ConfigDefault = Config{
 	TimeZone:     "Local",
 	TimeInterval: 500 * time.Millisecond,
 	Output:       os.Stdout,
-    DisableColors: true,
+    EnableColors: true,
 }
 ```
 

--- a/middleware/logger/config.go
+++ b/middleware/logger/config.go
@@ -51,12 +51,10 @@ type Config struct {
 	// Default: os.Stdout
 	Output io.Writer
 
-	// DisableColors defines if the logs output should be colorized
+	// EnableColors defines if the logs output should be colorized
 	//
-	// Default: false
-	DisableColors bool
-
-	enableColors     bool
+	// Default: true
+	EnableColors     bool
 	enableLatency    bool
 	timeZoneLocation *time.Location
 }
@@ -91,7 +89,7 @@ var ConfigDefault = Config{
 	TimeZone:     "Local",
 	TimeInterval: 500 * time.Millisecond,
 	Output:       os.Stdout,
-	enableColors: false,
+	EnableColors: true,
 }
 
 // Helper function to set default values
@@ -127,8 +125,8 @@ func configDefault(config ...Config) Config {
 		cfg.Output = ConfigDefault.Output
 	}
 
-	if !cfg.DisableColors && cfg.Output == ConfigDefault.Output {
-		cfg.enableColors = true
+	if cfg.Output == ConfigDefault.Output {
+		cfg.EnableColors = true
 	}
 
 	return cfg

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -61,7 +61,7 @@ func New(config ...Config) fiber.Handler {
 	)
 
 	// If colors are enabled, check terminal compatibility
-	if cfg.enableColors {
+	if cfg.EnableColors {
 		cfg.Output = colorable.NewColorableStdout()
 		if os.Getenv("TERM") == "dumb" || os.Getenv("NO_COLOR") == "1" || (!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd())) {
 			cfg.Output = colorable.NewNonColorable(os.Stdout)
@@ -141,7 +141,7 @@ func New(config ...Config) fiber.Handler {
 		if cfg.Format == ConfigDefault.Format {
 			// Format error if exist
 			formatErr := ""
-			if cfg.enableColors {
+			if cfg.EnableColors {
 				if chainErr != nil {
 					formatErr = colors.Red + " | " + chainErr.Error() + colors.Reset
 				}

--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -155,8 +155,8 @@ func Test_Logger_ErrorOutput_WithoutColor(t *testing.T) {
 	o := new(fakeOutput)
 	app := fiber.New()
 	app.Use(New(Config{
-		Output:        o,
-		DisableColors: true,
+		Output:       o,
+		EnableColors: false,
 	}))
 
 	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))

--- a/middleware/logger/tags.go
+++ b/middleware/logger/tags.go
@@ -174,14 +174,14 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			}
 		},
 		TagStatus: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
-			if cfg.enableColors {
+			if cfg.EnableColors {
 				colors := c.App().Config().ColorScheme
 				return output.WriteString(fmt.Sprintf("%s %3d %s", statusColor(c.Response().StatusCode(), colors), c.Response().StatusCode(), colors.Reset))
 			}
 			return appendInt(output, c.Response().StatusCode())
 		},
 		TagMethod: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
-			if cfg.enableColors {
+			if cfg.EnableColors {
 				colors := c.App().Config().ColorScheme
 				return output.WriteString(fmt.Sprintf("%s %-7s %s", methodColor(c.Method(), colors), c.Method(), colors.Reset))
 			}


### PR DESCRIPTION
## Description

In [this](#2493) pull request, initially, EnableColors was exported and used, [but then a new a bool variable was added](https://github.com/gofiber/fiber/pull/2493/commits/d30953786b9ce8bdf3083326606e50be805ce8fb), which I feel like is redundant, since EnableColors already exists, and works just like the added DisableColors bool

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [X] New and existing unit tests pass locally with my changes

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
