### PR TITLE
Migrate to Golang official govulncheck action

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -17,7 +17,7 @@ jobs:
   Security:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x, 1.20.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x]
     runs-on: ubuntu-latest
     steps:
     - name: Run govulncheck

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -15,20 +15,13 @@ on:
 name: Vulnerability Check
 jobs:
   Security:
+    strategy:
+      matrix:
+        go-version: [1.17.x, 1.18.x, 1.19.x, 1.20.x]
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v4
+    - name: Run govulncheck
+      uses: golang/govulncheck-action@v0.1.0
       with:
-        go-version: 1.20.x
-        check-latest: true
-    - name: Fetch Repository
-      uses: actions/checkout@v3
-    - name: Install Govulncheck
-      run: |
-          export GO111MODULE=on
-          export PATH=${PATH}:`go env GOPATH`/bin
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-    - name: Run Govulncheck
-      run: "`go env GOPATH`/bin/govulncheck ./..."
-
+        go-version-input: ${{ matrix.go-version }}
+        go-package: ./...

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -15,13 +15,7 @@ on:
 name: Vulnerability Check
 jobs:
   Security:
-    strategy:
-      matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x]
     runs-on: ubuntu-latest
     steps:
     - name: Run govulncheck
       uses: golang/govulncheck-action@v0.1.0
-      with:
-        go-version-input: ${{ matrix.go-version }}
-        go-package: ./...


### PR DESCRIPTION
The go team now have an official `govulncheck` action. This heavily simplifies our CI file.