### PR TITLE
Disable caching when running govulncheck

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: 1.20.x
+          go-version: '1.20.x'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,11 +14,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: '1.20.x'
-      - uses: actions/checkout@v3
+          go-version: 1.20.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -17,7 +17,7 @@ jobs:
   Security:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x, 1.20.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x]
     runs-on: ubuntu-latest
     steps:
     - name: Run govulncheck

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -19,3 +19,5 @@ jobs:
     steps:
     - name: Run govulncheck
       uses: golang/govulncheck-action@v0.1.0
+      with:
+        go-version-input: 1.20.x

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -1,3 +1,5 @@
+name: Run govulncheck
+
 on:
     push:
         branches:
@@ -12,12 +14,22 @@ on:
           - '**'
           - '!docs/**'
           - '!**.md'
-name: Vulnerability Check
+
 jobs:
-  Security:
+  govulncheck-check:
     runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
     steps:
-    - name: Run govulncheck
-      uses: golang/govulncheck-action@v0.1.0
+    - name: Fetch Repository
+      uses: actions/checkout@v3
+    - name: Install Go
+      uses: actions/setup-go@v4
       with:
-        go-version-input: 1.20.x
+        go-version: 'stable'
+        check-latest: true
+        cache: false
+    - name: Install Govulncheck
+      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+    - name: Run Govulncheck
+      run: govulncheck ./...

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -15,20 +15,13 @@ on:
 name: Vulnerability Check
 jobs:
   Security:
+    strategy:
+      matrix:
+        go-version: [1.17.x, 1.18.x, 1.19.x, 1.20.x]
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v4
+    - name: Run govulncheck
+      uses: golang/govulncheck-action@v0.1.0
       with:
-        go-version: 1.20.x
-        check-latest: true
-    - name: Fetch Repository
-      uses: actions/checkout@v3
-    - name: Install Govulncheck
-      run: |
-          export GO111MODULE=on
-          export PATH=${PATH}:`go env GOPATH`/bin
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-    - name: Run Govulncheck
-      run: "`go env GOPATH`/bin/govulncheck ./..."
-
+        go-version-input: ${{ matrix.go-version }}
+        go-package: ./...

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -15,13 +15,7 @@ on:
 name: Vulnerability Check
 jobs:
   Security:
-    strategy:
-      matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x]
     runs-on: ubuntu-latest
     steps:
     - name: Run govulncheck
       uses: golang/govulncheck-action@v0.1.0
-      with:
-        go-version-input: ${{ matrix.go-version }}
-        go-package: ./...


### PR DESCRIPTION
Disabling caching and using "check-latest" allows setup-go to work properly when being used with `govulncheck`.

I was waiting for the golang team to fix the official action, but it's been over 1 week to add one config option.