### PR TITLE
:bug: bug: fix onListen hooks when they are used with prefork mode

### DIFF
--- a/app.go
+++ b/app.go
@@ -1092,12 +1092,6 @@ func (app *App) serverErrorHandler(fctx *fasthttp.RequestCtx, err error) {
 
 // startupProcess Is the method which executes all the necessary processes just before the start of the server.
 func (app *App) startupProcess() *App {
-	if !app.config.Prefork {
-		if err := app.hooks.executeOnListenHooks(); err != nil {
-			panic(err)
-		}
-	}
-
 	app.mutex.Lock()
 	defer app.mutex.Unlock()
 
@@ -1107,4 +1101,11 @@ func (app *App) startupProcess() *App {
 	app.buildTree()
 
 	return app
+}
+
+// Run onListen hooks. If they return an error, panic.
+func (app *App) runOnListenHooks() {
+	if err := app.hooks.executeOnListenHooks(); err != nil {
+		panic(err)
+	}
 }

--- a/app.go
+++ b/app.go
@@ -1092,8 +1092,10 @@ func (app *App) serverErrorHandler(fctx *fasthttp.RequestCtx, err error) {
 
 // startupProcess Is the method which executes all the necessary processes just before the start of the server.
 func (app *App) startupProcess() *App {
-	if err := app.hooks.executeOnListenHooks(); err != nil {
-		panic(err)
+	if !app.config.Prefork {
+		if err := app.hooks.executeOnListenHooks(); err != nil {
+			panic(err)
+		}
 	}
 
 	app.mutex.Lock()

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -224,6 +224,32 @@ func Test_Hook_OnListen(t *testing.T) {
 	utils.AssertEqual(t, "ready", buf.String())
 }
 
+func Test_Hook_OnListenPrefork(t *testing.T) {
+	t.Parallel()
+	app := New(Config{
+		DisableStartupMessage: true,
+		Prefork:               true,
+	})
+
+	buf := bytebufferpool.Get()
+	defer bytebufferpool.Put(buf)
+
+	app.Hooks().OnListen(func() error {
+		_, err := buf.WriteString("ready")
+		utils.AssertEqual(t, nil, err)
+
+		return nil
+	})
+
+	go func() {
+		time.Sleep(1000 * time.Millisecond)
+		utils.AssertEqual(t, nil, app.Shutdown())
+	}()
+	utils.AssertEqual(t, nil, app.Listen(":9000"))
+
+	utils.AssertEqual(t, "ready", buf.String())
+}
+
 func Test_Hook_OnHook(t *testing.T) {
 	app := New()
 

--- a/listen.go
+++ b/listen.go
@@ -30,6 +30,9 @@ func (app *App) Listener(ln net.Listener) error {
 	// prepare the server for the start
 	app.startupProcess()
 
+	// run hooks
+	app.runOnListenHooks()
+
 	// Print startup message
 	if !app.config.DisableStartupMessage {
 		app.startupMessage(ln.Addr().String(), getTLSConfig(ln) != nil, "")
@@ -67,6 +70,9 @@ func (app *App) Listen(addr string) error {
 
 	// prepare the server for the start
 	app.startupProcess()
+
+	// run hooks
+	app.runOnListenHooks()
 
 	// Print startup message
 	if !app.config.DisableStartupMessage {
@@ -129,6 +135,9 @@ func (app *App) ListenTLSWithCertificate(addr string, cert tls.Certificate) erro
 
 	// prepare the server for the start
 	app.startupProcess()
+
+	// run hooks
+	app.runOnListenHooks()
 
 	// Print startup message
 	if !app.config.DisableStartupMessage {
@@ -201,6 +210,9 @@ func (app *App) ListenMutualTLSWithCertificate(addr string, cert tls.Certificate
 
 	// prepare the server for the start
 	app.startupProcess()
+
+	// run hooks
+	app.runOnListenHooks()
 
 	// Print startup message
 	if !app.config.DisableStartupMessage {

--- a/prefork.go
+++ b/prefork.go
@@ -128,9 +128,7 @@ func (app *App) prefork(network, addr string, tlsConfig *tls.Config) error {
 
 	// Run onListen hooks
 	// Hooks have to be run here as different as non-prefork mode due to they should run as child or master
-	if err := app.hooks.executeOnListenHooks(); err != nil {
-		panic(err)
-	}
+	app.runOnListenHooks()
 
 	// Print startup message
 	if !app.config.DisableStartupMessage {

--- a/prefork.go
+++ b/prefork.go
@@ -126,6 +126,12 @@ func (app *App) prefork(network, addr string, tlsConfig *tls.Config) error {
 		}()
 	}
 
+	// Run onListen hooks
+	// Hooks have to be run here as different as non-prefork mode due to they should run as child or master
+	if err := app.hooks.executeOnListenHooks(); err != nil {
+		panic(err)
+	}
+
 	// Print startup message
 	if !app.config.DisableStartupMessage {
 		app.startupMessage(addr, tlsConfig != nil, ","+strings.Join(pids, ","))


### PR DESCRIPTION
## Description
Hooks doesn't work properly in prefork mode because of we run them all in child processes. This PR allows them to be used on child or master processes. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Commit formatting:
Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
