### PR TITLE
:adhesive_bandage: Fix: default logger color behaviour

### DIFF
--- a/docs/api/middleware/logger.md
+++ b/docs/api/middleware/logger.md
@@ -153,7 +153,7 @@ var ConfigDefault = Config{
 	TimeZone:     "Local",
 	TimeInterval: 500 * time.Millisecond,
 	Output:       os.Stdout,
-    DisableColors: true,
+    DisableColors: false,
 }
 ```
 

--- a/middleware/logger/config.go
+++ b/middleware/logger/config.go
@@ -92,6 +92,7 @@ var ConfigDefault = Config{
 	TimeInterval:  500 * time.Millisecond,
 	Output:        os.Stdout,
 	DisableColors: false,
+	enableColors:  true,
 }
 
 // Helper function to set default values

--- a/middleware/logger/config.go
+++ b/middleware/logger/config.go
@@ -84,14 +84,14 @@ type LogFunc func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (i
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
-	Next:         nil,
-	Done:         nil,
-	Format:       "[${time}] ${status} - ${latency} ${method} ${path}\n",
-	TimeFormat:   "15:04:05",
-	TimeZone:     "Local",
-	TimeInterval: 500 * time.Millisecond,
-	Output:       os.Stdout,
-	enableColors: false,
+	Next:          nil,
+	Done:          nil,
+	Format:        "[${time}] ${status} - ${latency} ${method} ${path}\n",
+	TimeFormat:    "15:04:05",
+	TimeZone:      "Local",
+	TimeInterval:  500 * time.Millisecond,
+	Output:        os.Stdout,
+	DisableColors: false,
 }
 
 // Helper function to set default values

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -61,7 +61,7 @@ func New(config ...Config) fiber.Handler {
 	)
 
 	// If colors are enabled, check terminal compatibility
-	if cfg.enableColors {
+	if !cfg.DisableColors {
 		cfg.Output = colorable.NewColorableStdout()
 		if os.Getenv("TERM") == "dumb" || os.Getenv("NO_COLOR") == "1" || (!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd())) {
 			cfg.Output = colorable.NewNonColorable(os.Stdout)
@@ -141,7 +141,7 @@ func New(config ...Config) fiber.Handler {
 		if cfg.Format == ConfigDefault.Format {
 			// Format error if exist
 			formatErr := ""
-			if cfg.enableColors {
+			if !cfg.DisableColors {
 				if chainErr != nil {
 					formatErr = colors.Red + " | " + chainErr.Error() + colors.Reset
 				}

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -61,7 +61,7 @@ func New(config ...Config) fiber.Handler {
 	)
 
 	// If colors are enabled, check terminal compatibility
-	if !cfg.DisableColors {
+	if cfg.enableColors {
 		cfg.Output = colorable.NewColorableStdout()
 		if os.Getenv("TERM") == "dumb" || os.Getenv("NO_COLOR") == "1" || (!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd())) {
 			cfg.Output = colorable.NewNonColorable(os.Stdout)
@@ -141,7 +141,7 @@ func New(config ...Config) fiber.Handler {
 		if cfg.Format == ConfigDefault.Format {
 			// Format error if exist
 			formatErr := ""
-			if !cfg.DisableColors {
+			if cfg.enableColors {
 				if chainErr != nil {
 					formatErr = colors.Red + " | " + chainErr.Error() + colors.Reset
 				}


### PR DESCRIPTION
## Description

#2493  introduces DisableColors, but it's default value is set to true, which contradicts the documentation:

https://docs.gofiber.io/api/middleware/logger#config
```go
// DisableColors defines if the logs output should be colorized
//
// Default: false
DisableColors bool
```

https://docs.gofiber.io/api/middleware/logger#default-config, as well as https://github.com/gofiber/fiber/blob/master/middleware/logger/config.go#L94
```go
var ConfigDefault = Config{
	Next:         nil,
	Done:         nil,
	Format:       "[${time}] ${status} - ${latency} ${method} ${path}\n",
	TimeFormat:   "15:04:05",
	TimeZone:     "Local",
	TimeInterval: 500 * time.Millisecond,
	Output:       os.Stdout,
    	DisableColors: true,
}
```

and therefore, coloring is disabled by default, and can only be enabled by explicitly setting DisableColors to false
```go
app.Use(logger.New(logger.Config{DisableColors: false}))
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [X] New and existing unit tests pass locally with my changes

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
