### PR TITLE
:pencil2: Fix: typo in ctx.md

### DIFF
--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -1718,7 +1718,7 @@ app.Get("/", func(c *fiber.Ctx) error {
 
 ## SetParserDecoder
 
-Allow you to config BodyParser/QueryParser decoder, base on schema's options, providing possibility to add custom type for pausing.
+Allow you to config BodyParser/QueryParser decoder, base on schema's options, providing possibility to add custom type for parsing.
 
 ```go title="Signature"
 func SetParserDecoder(parserConfig fiber.ParserConfig{


### PR DESCRIPTION
## Description

Typo in ctx.md where parsing is misspelled as pausing. Just a minor issue, no existing issues

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
