### PR TITLE
📚 Docs: fix bad documentation on queries function

### DIFF
--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -1076,7 +1076,7 @@ app.Get("/", func(c *fiber.Ctx) error {
 Queries is a function that returns an object containing a property for each query string parameter in the route.
 
 ```go title="Signature"
-func (c *Ctx) Queries() (map[string]string, error)
+func (c *Ctx) Queries() map[string]string
 ```
 
 ```go title="Example"


### PR DESCRIPTION
In the documentation, we have a wrong output of the queries function.
In docs, it said the `Queries` function returns `map[string]string, error`, but it just returns `map[string]string`. 