### PR TITLE
fix: Decompress request body when multi Content-Encoding sent on request headers

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -278,8 +278,10 @@ func (c *Ctx) Body() (body []byte) {
 		originalBody  []byte
 		encodingOrder = []string{"", "", ""}
 	)
-	encodingOrder = getSplicedStrList(c.Get(HeaderContentEncoding), encodingOrder)
 
+	// Split and get the encodings list, in order to attend the
+	// rule defined at: https://www.rfc-editor.org/rfc/rfc9110#section-8.4-5
+	encodingOrder = getSplicedStrList(c.Get(HeaderContentEncoding), encodingOrder)
 	if len(encodingOrder) == 0 {
 		return c.fasthttp.Request.Body()
 	}

--- a/ctx.go
+++ b/ctx.go
@@ -295,13 +295,18 @@ func (c *Ctx) Body() []byte {
 		case StrDeflate:
 			body, err = c.fasthttp.Request.BodyInflate()
 		default:
-			return body
+			if len(encodingOrder) == 1 {
+				return c.fasthttp.Request.Body()
+			}
+			break
 		}
 
 		if err != nil {
-			return []byte(err.Error())
+			body = []byte(err.Error())
+			break
 		}
 
+		// Only execute body raw update if it has a next iteration to try to decode
 		if index < len(encodingOrder)-1 {
 			if originalBody == nil {
 				tempBody := c.fasthttp.Request.Body()

--- a/ctx.go
+++ b/ctx.go
@@ -272,11 +272,11 @@ func (c *Ctx) BodyRaw() []byte {
 // It returns the original (or decompressed) body data which is valid only within the handler.
 // Don't store direct references to the returned data.
 // If you need to keep the body's data later, make a copy or use the Immutable option.
-func (c *Ctx) Body() (body []byte) {
+func (c *Ctx) Body() []byte {
 	var (
-		err           error
-		originalBody  []byte
-		encodingOrder = []string{"", "", ""}
+		err                error
+		body, originalBody []byte
+		encodingOrder      = []string{"", "", ""}
 	)
 
 	// Split and get the encodings list, in order to attend the
@@ -295,7 +295,7 @@ func (c *Ctx) Body() (body []byte) {
 		case StrDeflate:
 			body, err = c.fasthttp.Request.BodyInflate()
 		default:
-			return
+			return body
 		}
 
 		if err != nil {

--- a/ctx.go
+++ b/ctx.go
@@ -274,12 +274,11 @@ func (c *Ctx) BodyRaw() []byte {
 // If you need to keep the body's data later, make a copy or use the Immutable option.
 func (c *Ctx) Body() (body []byte) {
 	var (
-		err          error
-		originalBody []byte
+		err           error
+		originalBody  []byte
+		encodingOrder = []string{"", "", ""}
 	)
-	encodingOrder := getEncodingList(
-		c.Get(HeaderContentEncoding), StrGzip, StrBr, StrBrotli, StrDeflate,
-	)
+	encodingOrder = getSplicedStrList(c.Get(HeaderContentEncoding), encodingOrder)
 
 	if len(encodingOrder) == 0 {
 		return c.fasthttp.Request.Body()

--- a/ctx.go
+++ b/ctx.go
@@ -321,12 +321,20 @@ func (c *Ctx) Body() []byte {
 	var (
 		err                error
 		body, originalBody []byte
+		headerEncoding     string
 		encodingOrder      = []string{"", "", ""}
 	)
 
+	// faster than peek
+	c.Request().Header.VisitAll(func(key, value []byte) {
+		if c.app.getString(key) == HeaderContentEncoding {
+			headerEncoding = c.app.getString(value)
+		}
+	})
+
 	// Split and get the encodings list, in order to attend the
 	// rule defined at: https://www.rfc-editor.org/rfc/rfc9110#section-8.4-5
-	encodingOrder = getSplicedStrList(c.Get(HeaderContentEncoding), encodingOrder)
+	encodingOrder = getSplicedStrList(headerEncoding, encodingOrder)
 	if len(encodingOrder) == 0 {
 		return c.fasthttp.Request.Body()
 	}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -324,6 +324,21 @@ func Test_Ctx_Body(t *testing.T) {
 	utils.AssertEqual(t, []byte("john=doe"), c.Body())
 }
 
+func Benchmark_Ctx_Body(b *testing.B) {
+	const input = "john=doe"
+
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+
+	c.Request().SetBody([]byte(input))
+	for i := 0; i < b.N; i++ {
+		_ = c.Body()
+	}
+
+	utils.AssertEqual(b, []byte(input), c.Body())
+}
+
 // go test -run Test_Ctx_Body_With_Compression
 func Test_Ctx_Body_With_Compression(t *testing.T) {
 	t.Parallel()

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -365,18 +365,21 @@ func Benchmark_Ctx_Body_With_Compression(b *testing.B) {
 		compressWriter  func([]byte) ([]byte, error)
 	}
 
+	encodingErr := errors.New("failed to encoding data")
 	compressionTests := []compressionTest{
 		{
 			contentEncoding: "gzip",
 			compressWriter: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				writer := gzip.NewWriter(&buf)
-				_, err := writer.Write(data)
-				if err != nil {
-					return nil, err
+				if _, err := writer.Write(data); err != nil {
+					return nil, encodingErr
 				}
-				if err = errors.Join(writer.Flush(), writer.Close()); err != nil {
-					return nil, err
+				if err := writer.Flush(); err != nil {
+					return nil, encodingErr
+				}
+				if err := writer.Close(); err != nil {
+					return nil, encodingErr
 				}
 				return buf.Bytes(), nil
 			},
@@ -387,12 +390,14 @@ func Benchmark_Ctx_Body_With_Compression(b *testing.B) {
 				var buf bytes.Buffer
 				writer := zlib.NewWriter(&buf)
 				if _, err := writer.Write(data); err != nil {
-					return nil, err
+					return nil, encodingErr
 				}
-				if err := errors.Join(writer.Flush(), writer.Close()); err != nil {
-					return nil, err
+				if err := writer.Flush(); err != nil {
+					return nil, encodingErr
 				}
-
+				if err := writer.Close(); err != nil {
+					return nil, encodingErr
+				}
 				return buf.Bytes(), nil
 			},
 		},
@@ -412,10 +417,13 @@ func Benchmark_Ctx_Body_With_Compression(b *testing.B) {
 				{
 					writer = zlib.NewWriter(&buf)
 					if _, err = writer.Write(data); err != nil {
-						return nil, err
+						return nil, encodingErr
 					}
-					if err = errors.Join(writer.Flush(), writer.Close()); err != nil {
-						return nil, err
+					if err = writer.Flush(); err != nil {
+						return nil, encodingErr
+					}
+					if err = writer.Close(); err != nil {
+						return nil, encodingErr
 					}
 				}
 
@@ -427,10 +435,13 @@ func Benchmark_Ctx_Body_With_Compression(b *testing.B) {
 				{
 					writer = gzip.NewWriter(&buf)
 					if _, err = writer.Write(data); err != nil {
-						return nil, err
+						return nil, encodingErr
 					}
-					if err = errors.Join(writer.Flush(), writer.Close()); err != nil {
-						return nil, err
+					if err = writer.Flush(); err != nil {
+						return nil, encodingErr
+					}
+					if err = writer.Close(); err != nil {
+						return nil, encodingErr
 					}
 				}
 

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -57,13 +57,13 @@ Fiber provides similar functions for the other accept headers.
 // Accept-Language: en;q=0.8, nl, ru
 
 app.Get("/", func(c *fiber.Ctx) error {
-  c.AcceptsCharsets("utf-16", "iso-8859-1") 
+  c.AcceptsCharsets("utf-16", "iso-8859-1")
   // "iso-8859-1"
 
-  c.AcceptsEncodings("compress", "br") 
+  c.AcceptsEncodings("compress", "br")
   // "compress"
 
-  c.AcceptsLanguages("pt", "nl", "ru") 
+  c.AcceptsLanguages("pt", "nl", "ru")
   // "nl"
   // ...
 })
@@ -171,6 +171,7 @@ app.Get("/", func(c *fiber.Ctx) error {
 ```
 
 ## Bind
+
 Add vars to default view var map binding to template engine.
 Variables are read by the Render method and may be overwritten.
 
@@ -190,12 +191,12 @@ app.Get("/", func(c *fiber.Ctx) error {
 })
 ```
 
-## Body
+## BodyRaw
 
 Returns the raw request **body**.
 
 ```go title="Signature"
-func (c *Ctx) Body() []byte
+func (c *Ctx) BodyRaw() []byte
 ```
 
 ```go title="Example"
@@ -203,6 +204,26 @@ func (c *Ctx) Body() []byte
 
 app.Post("/", func(c *fiber.Ctx) error {
   // Get raw body from POST request:
+  return c.Send(c.BodyRaw()) // []byte("user=john")
+})
+```
+
+> _Returned value is only valid within the handler. Do not store any references.  
+> Make copies or use the_ [_**`Immutable`**_](ctx.md) _setting instead._ [_Read more..._](../#zero-allocation)
+
+## Body
+
+As per the header `Content-Encoding`, this method will try to perform a file decompression from the **body** bytes. In case no `Content-Encoding` header is sent, it will perform as [BodyRaw](#bodyraw).
+
+```go title="Signature"
+func (c *Ctx) Body() []byte
+```
+
+```go title="Example"
+// echo 'user=john' | gzip | curl -v -i --data-binary @- -H "Content-Encoding: gzip" http://localhost:8080
+
+app.Post("/", func(c *fiber.Ctx) error {
+  // Decompress body from POST request based on the Content-Encoding and return the raw content:
   return c.Send(c.Body()) // []byte("user=john")
 })
 ```
@@ -216,13 +237,13 @@ Binds the request body to a struct.
 
 It is important to specify the correct struct tag based on the content type to be parsed. For example, if you want to parse a JSON body with a field called Pass, you would use a struct field of `json:"pass"`.
 
-| content-type | struct tag |
-|---|---|
-| `application/x-www-form-urlencoded` | form |
-| `multipart/form-data` | form |
-| `application/json` | json |
-| `application/xml` | xml |
-| `text/xml` | xml |
+| content-type                        | struct tag |
+| ----------------------------------- | ---------- |
+| `application/x-www-form-urlencoded` | form       |
+| `multipart/form-data`               | form       |
+| `application/json`                  | json       |
+| `application/xml`                   | xml        |
+| `text/xml`                          | xml        |
 
 ```go title="Signature"
 func (c *Ctx) BodyParser(out interface{}) error
@@ -693,6 +714,7 @@ app.Get("/", func(c *fiber.Ctx) error {
 ## IsFromLocal
 
 Returns true if request came from localhost
+
 ```go title="Signature"
 func (c *Ctx) IsFromLocal() bool {
 ```
@@ -837,7 +859,7 @@ app.Post("/", func(c *fiber.Ctx) error {
   c.Location("http://example.com")
 
   c.Location("/foo/bar")
-  
+
   return nil
 })
 ```
@@ -1024,6 +1046,7 @@ app.Get("/user/:id", func(c *fiber.Ctx) error {
 This method is equivalent of using `atoi` with ctx.Params
 
 ## ParamsParser
+
 This method is similar to BodyParser, but for path parameters. It is important to use the struct tag "params". For example, if you want to parse a path parameter with a field called Pass, you would use a struct field of params:"pass"
 
 ```go title="Signature"
@@ -1034,7 +1057,7 @@ func (c *Ctx) ParamsParser(out interface{}) error
 // GET http://example.com/user/111
 app.Get("/user/:id", func(c *fiber.Ctx) error {
   param := struct {ID uint `params:"id"`}{}
-       
+
   c.ParamsParser(&param) // "{"id": 111}"
 
   // ...
@@ -1176,7 +1199,6 @@ app.Get("/", func(c *fiber.Ctx) error {
 
 This property is an object containing a property for each query boolean parameter in the route, you could pass an optional default value that will be returned if the query key does not exist.
 
-
 :::caution
 Please note if that parameter is not in the request, false will be returned.
 If the parameter is not a boolean, it is still tried to be converted and usually returned as false.
@@ -1232,11 +1254,9 @@ app.Get("/", func(c *fiber.Ctx) error {
 })
 ```
 
-
 ## QueryInt
 
 This property is an object containing a property for each query integer parameter in the route, you could pass an optional default value that will be returned if the query key does not exist.
-
 
 :::caution
 Please note if that parameter is not in the request, zero will be returned.
@@ -1522,7 +1542,7 @@ func (c *Ctx) Route() *Route
 app.Get("/hello/:name", func(c *fiber.Ctx) error {
   r := c.Route()
   fmt.Println(r.Method, r.Path, r.Params, r.Handlers)
-  // GET /hello/:name handler [name] 
+  // GET /hello/:name handler [name]
 
   // ...
 })
@@ -1768,7 +1788,7 @@ var timeConverter = func(value string) reflect.Value {
 customTime := fiber.ParserType{
   Customtype: CustomTime{},
   Converter:  timeConverter,
-} 
+}
 
 // Add setting to the Decoder
 fiber.SetParserDecoder(fiber.ParserConfig{
@@ -1803,7 +1823,6 @@ app.Get("/query", func(c *fiber.Ctx) error {
 // curl -X GET "http://localhost:3000/query?title=title&body=body&date=2021-10-20"
 
 ```
-
 
 ## SetUserContext
 
@@ -2020,7 +2039,7 @@ XML also sets the content header to **application/xml**.
 :::
 
 ```go title="Signature"
-func (c *Ctx) XML(data interface{}) error 
+func (c *Ctx) XML(data interface{}) error
 ```
 
 ```go title="Example"

--- a/helpers.go
+++ b/helpers.go
@@ -282,7 +282,7 @@ func getSplicedStrList(headerValue string, dst []string) []string {
 	var (
 		index             int
 		character         rune
-		lastElementEndsAt uint8 = 0
+		lastElementEndsAt uint8
 		insertIndex       int
 	)
 	for index, character = range headerValue + "$" {
@@ -294,7 +294,7 @@ func getSplicedStrList(headerValue string, dst []string) []string {
 			}
 			dst[insertIndex] = utils.TrimLeft(headerValue[lastElementEndsAt:index], ' ')
 			lastElementEndsAt = uint8(index + 1)
-			insertIndex += 1
+			insertIndex++
 		}
 	}
 

--- a/helpers.go
+++ b/helpers.go
@@ -269,6 +269,11 @@ func acceptsOfferType(spec, offerType string) bool {
 	return false
 }
 
+// getSplicedStrList function takes a string and a string slice as an argument, divides the string into different
+// elements divided by ',' and stores these elements in the string slice.
+// It returns the populated string slice as an output.
+//
+// If the given slice hasn't enough space, it will allocate more and return.
 func getSplicedStrList(headerValue string, dst []string) []string {
 	if headerValue == "" {
 		return nil
@@ -287,7 +292,7 @@ func getSplicedStrList(headerValue string, dst []string) []string {
 				dst = make([]string, len(dst)+(len(dst)>>1)+2)
 				copy(dst, oldSlice)
 			}
-			dst[insertIndex] = strings.TrimLeft(headerValue[lastElementEndsAt:index], " ")
+			dst[insertIndex] = utils.TrimLeft(headerValue[lastElementEndsAt:index], ' ')
 			lastElementEndsAt = uint8(index + 1)
 			insertIndex += 1
 		}

--- a/helpers.go
+++ b/helpers.go
@@ -269,6 +269,50 @@ func acceptsOfferType(spec, offerType string) bool {
 	return false
 }
 
+func getEncodingList(headerValue string, encodings ...string) (orderedEncoding []string) {
+	if len(encodings) == 0 || headerValue == "" {
+		return nil
+	}
+	orderedEncoding = make([]string, 0, len(encodings))
+
+	var (
+		index             int
+		character         rune
+		lastElementEndsAt uint8 = 0
+		foundEncodings          = make([]string, 0, len(encodings))
+	)
+	for index, character = range headerValue {
+		if character == ',' {
+			foundEncodings = append(
+				foundEncodings,
+				strings.TrimLeft(headerValue[lastElementEndsAt:index], " "),
+			)
+			lastElementEndsAt = uint8(index + 1)
+		}
+	}
+
+	if lastElementEndsAt < uint8(index) {
+		foundEncodings = append(
+			foundEncodings,
+			strings.TrimLeft(headerValue[lastElementEndsAt:], " "),
+		)
+	}
+
+	if len(foundEncodings) == 0 {
+		orderedEncoding = []string{headerValue}
+	}
+
+	orderedEncoding = make([]string, 0, len(encodings))
+	for _, foundEnc := range foundEncodings {
+		for _, toCheck := range encodings {
+			if foundEnc == toCheck {
+				orderedEncoding = append(orderedEncoding, foundEnc)
+			}
+		}
+	}
+	return
+}
+
 // getOffer return valid offer for header negotiation
 func getOffer(header string, isAccepted func(spec, offer string) bool, offers ...string) string {
 	if len(offers) == 0 {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -107,6 +107,48 @@ func Benchmark_Utils_GetOffer(b *testing.B) {
 	}
 }
 
+func Test_Utils_GetSplicedStrList(t *testing.T) {
+	testCases := []struct {
+		description  string
+		headerValue  string
+		expectedList []string
+	}{
+		{
+			description:  "normal case",
+			headerValue:  "gzip, deflate,br",
+			expectedList: []string{"gzip", "deflate", "br"},
+		},
+		{
+			description:  "no matter the value",
+			headerValue:  "   gzip,deflate, br, zip",
+			expectedList: []string{"gzip", "deflate", "br", "zip"},
+		},
+		{
+			description:  "headerValue is empty",
+			headerValue:  "",
+			expectedList: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			dst := make([]string, 10)
+			result := getSplicedStrList(tc.headerValue, dst)
+			utils.AssertEqual(t, tc.expectedList, result)
+		})
+	}
+}
+
+func Benchmark_Utils_GetSplicedStrList(b *testing.B) {
+	destination := make([]string, 5)
+	result := destination
+	const input = "deflate, gzip,br,brotli"
+	for n := 0; n < b.N; n++ {
+		result = getSplicedStrList(input, destination)
+	}
+	utils.AssertEqual(b, []string{"deflate", "gzip", "br", "brotli"}, result)
+}
+
 func Test_Utils_SortAcceptedTypes(t *testing.T) {
 	t.Parallel()
 	acceptedTypes := []acceptedType{

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -128,6 +128,11 @@ func Test_Utils_GetSplicedStrList(t *testing.T) {
 			headerValue:  "",
 			expectedList: nil,
 		},
+		{
+			description:  "has a comma without element",
+			headerValue:  "gzip,",
+			expectedList: []string{"gzip", ""},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -287,6 +287,7 @@ func Test_Session_Save_Expiration(t *testing.T) {
 	t.Parallel()
 
 	t.Run("save to cookie", func(t *testing.T) {
+		const sessionDuration = 5 * time.Second
 		t.Parallel()
 		// session store
 		store := New()
@@ -302,7 +303,7 @@ func Test_Session_Save_Expiration(t *testing.T) {
 		sess.Set("name", "john")
 
 		// expire this session in 5 seconds
-		sess.SetExpiry(time.Second * 5)
+		sess.SetExpiry(sessionDuration)
 
 		// save session
 		err = sess.Save()
@@ -314,7 +315,7 @@ func Test_Session_Save_Expiration(t *testing.T) {
 		utils.AssertEqual(t, "john", sess.Get("name"))
 
 		// just to make sure the session has been expired
-		time.Sleep(time.Second * 5)
+		time.Sleep(sessionDuration + (10 * time.Millisecond))
 
 		// here you should get a new session
 		sess, err = store.Get(ctx)


### PR DESCRIPTION
## Description

Currently the Ctx.Body() implementation doesn't parse multi content-encoding body, so in order to attend [RFC9110](https://www.rfc-editor.org/rfc/rfc9110#section-8.4-5), the Body method was changed, and a new wrapper method to body raw was made.

Fixes #2085 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [x] For new code I have written benchmarks so that they can be analyzed and improved

