### PR TITLE
filesystem: refactor: use `errors.Is` instead of `os.IsNotExist`

### DIFF
--- a/internal/gopsutil/net/net_linux.go
+++ b/internal/gopsutil/net/net_linux.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"os"
 	"strconv"
@@ -673,7 +674,7 @@ func getProcInodesAll(root string, max int) (map[string][]inodeMap, error) {
 		t, err := getProcInodes(root, pid, max)
 		if err != nil {
 			// skip if permission error or no longer exists
-			if os.IsPermission(err) || os.IsNotExist(err) || err == io.EOF {
+			if os.IsPermission(err) || errors.Is(err, fs.ErrNotExist) || err == io.EOF {
 				continue
 			}
 			return ret, err

--- a/internal/gopsutil/process/process_posix.go
+++ b/internal/gopsutil/process/process_posix.go
@@ -5,7 +5,9 @@ package process
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -86,7 +88,7 @@ func PidExistsWithContext(ctx context.Context, pid int32) (bool, error) {
 		// This covers the case when running inside container with a different process namespace (by default)
 
 		_, err := os.Stat(common.HostProc(strconv.Itoa(int(pid))))
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return false, nil
 		}
 		return err == nil, err


### PR DESCRIPTION
## Description

Suggested way by https://pkg.go.dev/os#IsNotExist
Explain the *details* for making this change. What existing problem does the pull request solve?

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
