### PR TITLE
💄 feat(middleware/logger): latency match gin-gonic/gin formatter

### DIFF
--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -247,8 +247,6 @@ func Test_Logger_WithLatency(t *testing.T) {
 		utils.AssertEqual(t, nil, err)
 		utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
 
-		fmt.Println("|", buff.String(), "|")
-
 		// Assert that the log output contains the expected latency value in the current time unit
 		bb := buff.Bytes()
 		unit := bb[len(bb)-len(tu.unit):]

--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -248,9 +248,7 @@ func Test_Logger_WithLatency(t *testing.T) {
 		utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
 
 		// Assert that the log output contains the expected latency value in the current time unit
-		bb := buff.Bytes()
-		unit := bb[len(bb)-len(tu.unit):]
-		utils.AssertEqual(t, string(unit), tu.unit)
+		utils.AssertEqual(t, bytes.HasSuffix(buff.Bytes(), []byte(tu.unit)), true, "Expected latency to be in %s, got %s", tu.unit, buff.String())
 
 		// Reset the buffer
 		buff.Reset()

--- a/middleware/logger/tags.go
+++ b/middleware/logger/tags.go
@@ -192,7 +192,7 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 		},
 		TagLatency: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
 			latency := data.Stop.Sub(data.Start)
-			return output.WriteString(fmt.Sprintf("%7v", latency))
+			return output.WriteString(fmt.Sprintf("%13v", latency))
 		},
 		TagTime: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
 			return output.WriteString(data.Timestamp.Load().(string)) //nolint:forcetypeassert // We always store a string in here


### PR DESCRIPTION
## Description

TagLatency to match gin-gonic/gin defaultLogFormatter, specifically %13v instead of %7v.


With %7v:
```console
| 4.834µs |
| 1.136834ms |
| 1.000066333s |
```

With %13v, like gin https://github.com/gin-gonic/gin/blob/62b50cfbc0de877207ff74c160a23dff6394f563/logger.go#L143:
```console
|       4.333µs |
|    1.133916ms |
|  1.000057458s |
```

And, adds Test_Logger_WithLatency, which proves that the logger would show he smallest unit that makes sense. (except for ns, which is probably too fast for most systems to test).

Fixes #2561

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I tried to make my code as fast as possible with as few allocations as possible

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
