### PR TITLE
:sparkles: Add custom data property to favicon middleware config

### DIFF
--- a/docs/api/middleware/favicon.md
+++ b/docs/api/middleware/favicon.md
@@ -45,6 +45,7 @@ app.Use(favicon.New(favicon.Config{
 | Property     | Type                    | Description                                                                      | Default                    |
 |:-------------|:------------------------|:---------------------------------------------------------------------------------|:---------------------------|
 | Next         | `func(*fiber.Ctx) bool` | Next defines a function to skip this middleware when returned true.              | `nil`                      |
+| Data         | `[]byte`                | Raw data of the favicon file. This can be used instead of `File`.                | `nil`                      |
 | File         | `string`                | File holds the path to an actual favicon that will be cached.                    | ""                         |
 | URL          | `string`                | URL for favicon handler.                                                         | "/favicon.ico"             |
 | FileSystem   | `http.FileSystem`       | FileSystem is an optional alternate filesystem to search for the favicon in.     | `nil`                      |

--- a/middleware/favicon/favicon.go
+++ b/middleware/favicon/favicon.go
@@ -16,6 +16,11 @@ type Config struct {
 	// Optional. Default: nil
 	Next func(c *fiber.Ctx) bool
 
+	// Raw data of the favicon file
+	//
+	// Optional. Default: nil
+	Data []byte `json:"-"`
+
 	// File holds the path to an actual favicon that will be cached
 	//
 	// Optional. Default: ""
@@ -83,7 +88,11 @@ func New(config ...Config) fiber.Handler {
 		icon    []byte
 		iconLen string
 	)
-	if cfg.File != "" {
+	if cfg.Data != nil {
+		// use the provided favicon data
+		icon = cfg.Data
+		iconLen = strconv.Itoa(len(cfg.Data))
+	} else if cfg.File != "" {
 		// read from configured filesystem if present
 		if cfg.FileSystem != nil {
 			f, err := cfg.FileSystem.Open(cfg.File)

--- a/middleware/favicon/favicon_test.go
+++ b/middleware/favicon/favicon_test.go
@@ -99,6 +99,31 @@ func Test_Custom_Favicon_Url(t *testing.T) {
 	utils.AssertEqual(t, "image/x-icon", resp.Header.Get(fiber.HeaderContentType))
 }
 
+// go test -run Test_Custom_Favicon_Data
+func Test_Custom_Favicon_Data(t *testing.T) {
+	data, err := os.ReadFile("../../.github/testdata/favicon.ico")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Data: data,
+	}))
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return nil
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/favicon.ico", nil))
+	utils.AssertEqual(t, nil, err, "app.Test(req)")
+	utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode, "Status code")
+	utils.AssertEqual(t, "image/x-icon", resp.Header.Get(fiber.HeaderContentType))
+	utils.AssertEqual(t, "public, max-age=31536000", resp.Header.Get(fiber.HeaderCacheControl), "CacheControl Control")
+}
+
 // mockFS wraps local filesystem for the purposes of
 // Test_Middleware_Favicon_FileSystem located below
 // TODO use os.Dir if fiber upgrades to 1.16


### PR DESCRIPTION
## Description

This pull request adds the `Data` property to the configuration of the `favicon` middleware, allowing the user to supply raw favicon data to the middleware instead of providing a file path. This allows the user to use `//go:embed` flags to load favicon data during build-time, and supply it to the middleware instead of reading the file every time the application starts.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [x] For new code I have written benchmarks so that they can be analyzed and improved