### PR TITLE
🐛 fix(middleware/logger): default latency output format

### DIFF
--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -146,10 +146,10 @@ func New(config ...Config) fiber.Handler {
 					formatErr = colors.Red + " | " + chainErr.Error() + colors.Reset
 				}
 				_, _ = buf.WriteString( //nolint:errcheck // This will never fail
-					fmt.Sprintf("%s |%s %3d %s| %7v | %15s |%s %-7s %s| %-"+errPaddingStr+"s %s\n",
+					fmt.Sprintf("%s |%s %3d %s| %13v | %15s |%s %-7s %s| %-"+errPaddingStr+"s %s\n",
 						timestamp.Load().(string),
 						statusColor(c.Response().StatusCode(), colors), c.Response().StatusCode(), colors.Reset,
-						data.Stop.Sub(data.Start).Round(time.Millisecond),
+						data.Stop.Sub(data.Start),
 						c.IP(),
 						methodColor(c.Method(), colors), c.Method(), colors.Reset,
 						c.Path(),
@@ -161,10 +161,10 @@ func New(config ...Config) fiber.Handler {
 					formatErr = " | " + chainErr.Error()
 				}
 				_, _ = buf.WriteString( //nolint:errcheck // This will never fail
-					fmt.Sprintf("%s | %3d | %7v | %15s | %-7s | %-"+errPaddingStr+"s %s\n",
+					fmt.Sprintf("%s | %3d | %13v | %15s | %-7s | %-"+errPaddingStr+"s %s\n",
 						timestamp.Load().(string),
 						c.Response().StatusCode(),
-						data.Stop.Sub(data.Start).Round(time.Millisecond),
+						data.Stop.Sub(data.Start),
 						c.IP(),
 						c.Method(),
 						c.Path(),

--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -248,7 +248,59 @@ func Test_Logger_WithLatency(t *testing.T) {
 		utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
 
 		// Assert that the log output contains the expected latency value in the current time unit
-		utils.AssertEqual(t, bytes.HasSuffix(buff.Bytes(), []byte(tu.unit)), true, "Expected latency to be in %s, got %s", tu.unit, buff.String())
+		utils.AssertEqual(t, bytes.HasSuffix(buff.Bytes(), []byte(tu.unit)), true, fmt.Sprintf("Expected latency to be in %s, got %s", tu.unit, buff.String()))
+
+		// Reset the buffer
+		buff.Reset()
+	}
+}
+
+// go test -run Test_Logger_WithLatency_DefaultFormat
+func Test_Logger_WithLatency_DefaultFormat(t *testing.T) {
+	t.Parallel()
+	buff := bytebufferpool.Get()
+	defer bytebufferpool.Put(buff)
+	app := fiber.New()
+	logger := New(Config{
+		Output: buff,
+	})
+	app.Use(logger)
+
+	// Define a list of time units to test
+	timeUnits := []struct {
+		unit string
+		div  time.Duration
+	}{
+		// {"ns", time.Nanosecond}, // TODO: Nano seconds are too fast to test
+		{"µs", time.Microsecond},
+		{"ms", time.Millisecond},
+		{"s", time.Second},
+	}
+
+	// Initialize a new time unit
+	sleepDuration := 1 * time.Nanosecond
+
+	// Define a test route that sleeps
+	app.Get("/test", func(c *fiber.Ctx) error {
+		time.Sleep(sleepDuration)
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	// Loop through each time unit and assert that the log output contains the expected latency value
+	for _, tu := range timeUnits {
+		// Update the sleep duration for the next iteration
+		sleepDuration = 1 * tu.div
+
+		// Create a new HTTP request to the test route
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/test", nil), int(2*time.Second))
+		utils.AssertEqual(t, nil, err)
+		utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
+
+		// Assert that the log output contains the expected latency value in the current time unit
+		// parse out the latency value from the log output
+		latency := bytes.Split(buff.Bytes(), []byte(" | "))[2]
+		// Assert that the latency value is in the current time unit
+		utils.AssertEqual(t, bytes.HasSuffix(latency, []byte(tu.unit)), true, fmt.Sprintf("Expected latency to be in %s, got %s", tu.unit, latency))
 
 		// Reset the buffer
 		buff.Reset()

--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -207,7 +207,6 @@ func Test_Logger_All(t *testing.T) {
 
 // go test -run Test_Logger_WithLatency
 func Test_Logger_WithLatency(t *testing.T) {
-	t.Parallel()
 	buff := bytebufferpool.Get()
 	defer bytebufferpool.Put(buff)
 	app := fiber.New()
@@ -257,7 +256,6 @@ func Test_Logger_WithLatency(t *testing.T) {
 
 // go test -run Test_Logger_WithLatency_DefaultFormat
 func Test_Logger_WithLatency_DefaultFormat(t *testing.T) {
-	t.Parallel()
 	buff := bytebufferpool.Get()
 	defer bytebufferpool.Put(buff)
 	app := fiber.New()


### PR DESCRIPTION
## Description

fixes middleware/logger default latency output format to match TagLatency

Fixes #2561 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I tried to make my code as fast as possible with as few allocations as possible

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
