### PR TITLE
♻️ Refactor: use slices.Contains instead of isInCharset()

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1430,7 +1431,7 @@ func (c *Ctx) getLocationFromRoute(route Route, params Map) (string, error) {
 
 		for key, val := range params {
 			isSame := key == segment.ParamName || (!c.app.config.CaseSensitive && utils.EqualFold(key, segment.ParamName))
-			isGreedy := segment.IsGreedy && len(key) == 1 && isInCharset(key[0], greedyParameters)
+			isGreedy := segment.IsGreedy && len(key) == 1 && slices.Contains(greedyParameters, key[0])
 			if isSame || isGreedy {
 				_, err := buf.WriteString(utils.ToString(val))
 				if err != nil {

--- a/path.go
+++ b/path.go
@@ -8,6 +8,7 @@ package fiber
 
 import (
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -302,7 +303,7 @@ func (routeParser *routeParser) analyseParameterPart(pattern string) (string, *r
 		parameterEndPosition = 0
 	case parameterEndPosition == -1:
 		parameterEndPosition = len(pattern) - 1
-	case !isInCharset(pattern[parameterEndPosition+1], parameterDelimiterChars):
+	case !slices.Contains(parameterDelimiterChars, pattern[parameterEndPosition+1]):
 		parameterEndPosition++
 	}
 
@@ -384,16 +385,6 @@ func (routeParser *routeParser) analyseParameterPart(pattern string) (string, *r
 	}
 
 	return processedPart, segment
-}
-
-// isInCharset check is the given character in the charset list
-func isInCharset(searchChar byte, charset []byte) bool {
-	for _, char := range charset {
-		if char == searchChar {
-			return true
-		}
-	}
-	return false
 }
 
 // findNextCharsetPosition search the next char position from the charset


### PR DESCRIPTION
## Description

Hello, the slices package is available in the go 1.21 version. 
Since fiber is using the go 1.21 version, how about using the slices package?
Please check the [link](https://tip.golang.org/doc/go1.21#slices) and check the code and thank you.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
