### PR TITLE
:lipstick: feat(middleware/logger): ip match gin-gonic/gin formatter

### DIFF
--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -231,6 +231,25 @@ func getLatencyTimeUnits() []struct {
 	}
 }
 
+// go test -run Test_Logger_LenTagIP
+func Test_Logger_LenTagIP(t *testing.T) {
+	t.Parallel()
+	buf := bytebufferpool.Get()
+	defer bytebufferpool.Put(buf)
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Format: "${ip}",
+		Output: buf,
+	}))
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, fiber.StatusNotFound, resp.StatusCode)
+
+	utils.AssertEqual(t, 15, len(buf.String()))
+}
+
 // go test -run Test_Logger_WithLatency
 func Test_Logger_WithLatency(t *testing.T) {
 	t.Parallel()

--- a/middleware/logger/tags.go
+++ b/middleware/logger/tags.go
@@ -64,7 +64,7 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			return output.WriteString(c.Port())
 		},
 		TagIP: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
-			return output.WriteString(c.IP())
+			return output.WriteString(fmt.Sprintf("%15s", c.IP()))
 		},
 		TagIPs: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
 			return output.WriteString(c.Get(fiber.HeaderXForwardedFor))


### PR DESCRIPTION
## Description

TagIP to match gin-gonic/gin defaultLogFormatter, specifically %15v instead of %v.

With %v:

```bash
| 127.0.0.1 |
| 192.168.1.10 |
| 105.103.142.227 |
```

With %15v, like gin https://github.com/gin-gonic/gin/blob/62b50cfbc0de877207ff74c160a23dff6394f563/logger.go#L143:

```bash
|       127.0.0.1 |
|    192.168.1.10 |
| 105.103.142.227 |
```

And, adds Test_Logger_LenTagIP.

## Type of change

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

