### PR TITLE
[Bug]: Logger Middleware: Enabling color changes padding for some fields #2604 

### DIFF
--- a/middleware/logger/tags.go
+++ b/middleware/logger/tags.go
@@ -176,14 +176,14 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 		TagStatus: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
 			if cfg.enableColors {
 				colors := c.App().Config().ColorScheme
-				return output.WriteString(fmt.Sprintf("%s %3d %s", statusColor(c.Response().StatusCode(), colors), c.Response().StatusCode(), colors.Reset))
+				return output.WriteString(fmt.Sprintf("%s%3d%s", statusColor(c.Response().StatusCode(), colors), c.Response().StatusCode(), colors.Reset))
 			}
 			return appendInt(output, c.Response().StatusCode())
 		},
 		TagMethod: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
 			if cfg.enableColors {
 				colors := c.App().Config().ColorScheme
-				return output.WriteString(fmt.Sprintf("%s %-7s %s", methodColor(c.Method(), colors), c.Method(), colors.Reset))
+				return output.WriteString(fmt.Sprintf("%s%s%s", methodColor(c.Method(), colors), c.Method(), colors.Reset))
 			}
 			return output.WriteString(c.Method())
 		},


### PR DESCRIPTION
## Description
Extra spacing when printing response code has been removed when printing with colors.
Fixes #2604 

## Type of change
- [ ] Bug fix (removes extra padding for printing response code)

