### PR TITLE
return raw header map

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -659,6 +659,20 @@ func (c *Ctx) GetReqHeaders() map[string]string {
 
 	return headers
 }
+// The issue with GetReqHeaders is it formats keys with the first letter
+// capitalized. This function returns the raw headers as a string map.
+// The keys are not formatted by default
+func (c *Ctx) GetRawReqHeaderMap() map[string]string {
+	headerStr := string(c.Request().Header.RawHeaders())
+	headers := make(map[string]string)
+	for _, header := range strings.Split(headerStr, "\r\n") {
+		if header != "" {
+			headerSplit := strings.Split(header, ": ")
+			headers[headerSplit[0]] = headerSplit[1]
+		}
+	}
+	return headers
+}
 
 // GetRespHeaders returns the HTTP response headers.
 // Returned value is only valid within the handler. Do not store any references.


### PR DESCRIPTION
## Description
Currently the GetHeaders method built into gofiber returns a map of headers which are formatted. There is no function which returns a map of unformatted raw headers.

Explain the *details* for making this change. What existing problem does the pull request solve?

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
