### PR TITLE
🐛 fix(middleware/adaptor): Reduce memory usage by replacing io.ReadAll() with io.Copy()

### DIFF
--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -116,14 +116,9 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 		defer fasthttp.ReleaseRequest(req)
 		// Convert net/http -> fasthttp request
 		if r.Body != nil {
-			body, err := io.ReadAll(r.Body)
-			if err != nil {
-				http.Error(w, utils.StatusMessage(fiber.StatusInternalServerError), fiber.StatusInternalServerError)
-				return
-			}
+			n, err := io.Copy(req.BodyWriter(), r.Body)
+			req.Header.SetContentLength(int(n))
 
-			req.Header.SetContentLength(len(body))
-			_, err = req.BodyWriter().Write(body)
 			if err != nil {
 				http.Error(w, utils.StatusMessage(fiber.StatusInternalServerError), fiber.StatusInternalServerError)
 				return

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -2,6 +2,7 @@
 package adaptor
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -484,4 +485,89 @@ func Test_ConvertRequest(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, "Request URL: /test?hello=world&another=test", string(body))
+}
+
+// Benchmark for FiberHandlerFunc
+func Benchmark_FiberHandlerFunc_1MB(b *testing.B) {
+	fiberH := func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	}
+	handlerFunc := FiberHandlerFunc(fiberH)
+
+	// Create body content
+	bodyContent := make([]byte, 1*1024*1024)
+	bodyBuffer := bytes.NewBuffer(bodyContent)
+
+	r := http.Request{
+		Method: http.MethodPost,
+		Body:   http.NoBody,
+	}
+
+	// Replace the empty Body with our buffer
+	r.Body = io.NopCloser(bodyBuffer)
+	defer r.Body.Close()
+
+	// Create recorder
+	w := httptest.NewRecorder()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handlerFunc.ServeHTTP(w, &r)
+	}
+}
+
+func Benchmark_FiberHandlerFunc_10MB(b *testing.B) {
+	fiberH := func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	}
+	handlerFunc := FiberHandlerFunc(fiberH)
+
+	// Create body content
+	bodyContent := make([]byte, 10*1024*1024)
+	bodyBuffer := bytes.NewBuffer(bodyContent)
+
+	r := http.Request{
+		Method: http.MethodPost,
+		Body:   http.NoBody,
+	}
+
+	// Replace the empty Body with our buffer
+	r.Body = io.NopCloser(bodyBuffer)
+	defer r.Body.Close()
+
+	// Create recorder
+	w := httptest.NewRecorder()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handlerFunc.ServeHTTP(w, &r)
+	}
+}
+
+func Benchmark_FiberHandlerFunc_50MB(b *testing.B) {
+	fiberH := func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	}
+	handlerFunc := FiberHandlerFunc(fiberH)
+
+	// Create body content
+	bodyContent := make([]byte, 50*1024*1024)
+	bodyBuffer := bytes.NewBuffer(bodyContent)
+
+	r := http.Request{
+		Method: http.MethodPost,
+		Body:   http.NoBody,
+	}
+
+	// Replace the empty Body with our buffer
+	r.Body = io.NopCloser(bodyBuffer)
+	defer r.Body.Close()
+
+	// Create recorder
+	w := httptest.NewRecorder()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handlerFunc.ServeHTTP(w, &r)
+	}
 }

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -505,7 +505,7 @@ func Benchmark_FiberHandlerFunc_1MB(b *testing.B) {
 
 	// Replace the empty Body with our buffer
 	r.Body = io.NopCloser(bodyBuffer)
-	defer r.Body.Close()
+	defer r.Body.Close() //nolint:errcheck // not needed
 
 	// Create recorder
 	w := httptest.NewRecorder()
@@ -533,7 +533,7 @@ func Benchmark_FiberHandlerFunc_10MB(b *testing.B) {
 
 	// Replace the empty Body with our buffer
 	r.Body = io.NopCloser(bodyBuffer)
-	defer r.Body.Close()
+	defer r.Body.Close() //nolint:errcheck // not needed
 
 	// Create recorder
 	w := httptest.NewRecorder()
@@ -561,7 +561,7 @@ func Benchmark_FiberHandlerFunc_50MB(b *testing.B) {
 
 	// Replace the empty Body with our buffer
 	r.Body = io.NopCloser(bodyBuffer)
-	defer r.Body.Close()
+	defer r.Body.Close() //nolint:errcheck // not needed
 
 	// Create recorder
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Description

The main purpose of this PR is to replace `io.ReadAll()` with `io.Copy()` in the Adaptor middleware. The io.ReadAll() although common practice in `net/http` examples will load the whole `body` into memory. This can cause Fiber to use more memory than required and/or affect performance of applications depending on this middleware.

Also added some benchmarks to compare keep track of performance from small to medium size content.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [x] For new code I have written benchmarks so that they can be analyzed and improved
