### PR TITLE
:bug: bug: fix PassLocalsToView when bind parameter is nil

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1503,6 +1503,11 @@ func (c *Ctx) Render(name string, bind interface{}, layouts ...string) error {
 	buf := bytebufferpool.Get()
 	defer bytebufferpool.Put(buf)
 
+	// Initialize empty bind map if bind is nil
+	if bind == nil {
+		bind = make(Map)
+	}
+
 	// Pass-locals-to-views, bind, appListKeys
 	c.renderExtensions(bind)
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -3138,10 +3138,6 @@ func Test_Ctx_Render(t *testing.T) {
 	})
 	utils.AssertEqual(t, nil, err)
 
-	buf := bytebufferpool.Get()
-	_, _ = buf.WriteString("overwrite") //nolint:errcheck // This will never fail
-	defer bytebufferpool.Put(buf)
-
 	utils.AssertEqual(t, "<h1>Hello, World!</h1>", string(c.Response().Body()))
 
 	err = c.Render("./.github/testdata/template-non-exists.html", nil)
@@ -3157,16 +3153,12 @@ func Test_Ctx_RenderWithoutLocals(t *testing.T) {
 		PassLocalsToViews: false,
 	})
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
 
 	c.Locals("Title", "Hello, World!")
-	defer app.ReleaseCtx(c)
+
 	err := c.Render("./.github/testdata/index.tmpl", Map{})
 	utils.AssertEqual(t, nil, err)
-
-	buf := bytebufferpool.Get()
-	_, _ = buf.WriteString("overwrite") //nolint:errcheck // This will never fail
-	defer bytebufferpool.Put(buf)
-
 	utils.AssertEqual(t, "<h1><no value></h1>", string(c.Response().Body()))
 }
 
@@ -3175,18 +3167,29 @@ func Test_Ctx_RenderWithLocals(t *testing.T) {
 	app := New(Config{
 		PassLocalsToViews: true,
 	})
-	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 
-	c.Locals("Title", "Hello, World!")
-	defer app.ReleaseCtx(c)
-	err := c.Render("./.github/testdata/index.tmpl", Map{})
-	utils.AssertEqual(t, nil, err)
+	t.Run("EmptyBind", func(t *testing.T) {
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(c)
 
-	buf := bytebufferpool.Get()
-	_, _ = buf.WriteString("overwrite") //nolint:errcheck // This will never fail
-	defer bytebufferpool.Put(buf)
+		c.Locals("Title", "Hello, World!")
+		err := c.Render("./.github/testdata/index.tmpl", Map{})
 
-	utils.AssertEqual(t, "<h1>Hello, World!</h1>", string(c.Response().Body()))
+		utils.AssertEqual(t, nil, err)
+		utils.AssertEqual(t, "<h1>Hello, World!</h1>", string(c.Response().Body()))
+	})
+
+	t.Run("NilBind", func(t *testing.T) {
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(c)
+
+		c.Locals("Title", "Hello, World!")
+		err := c.Render("./.github/testdata/index.tmpl", nil)
+
+		utils.AssertEqual(t, nil, err)
+		utils.AssertEqual(t, "<h1>Hello, World!</h1>", string(c.Response().Body()))
+	})
+
 }
 
 func Test_Ctx_RenderWithBind(t *testing.T) {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -3189,7 +3189,6 @@ func Test_Ctx_RenderWithLocals(t *testing.T) {
 		utils.AssertEqual(t, nil, err)
 		utils.AssertEqual(t, "<h1>Hello, World!</h1>", string(c.Response().Body()))
 	})
-
 }
 
 func Test_Ctx_RenderWithBind(t *testing.T) {


### PR DESCRIPTION
## Description
Fixes https://github.com/gofiber/fiber/issues/2644

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
