### PR TITLE
refactor: use utils.AssertEqual instead of t.Fatal on some tests

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -755,9 +755,7 @@ func Test_App_Shutdown(t *testing.T) {
 		t.Parallel()
 		app := &App{}
 		if err := app.Shutdown(); err != nil {
-			if err.Error() != "shutdown: server is not running" {
-				t.Fatal()
-			}
+			utils.AssertEqual(t, "shutdown: server is not running", err.Error())
 		}
 	})
 }

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -386,16 +386,15 @@ func Test_Ctx_Body_With_Compression(t *testing.T) {
 			if strings.Contains(tCase.contentEncoding, "gzip") {
 				var b bytes.Buffer
 				gz := gzip.NewWriter(&b)
+
 				_, err := gz.Write(tCase.body)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if err = gz.Flush(); err != nil {
-					t.Fatal(err)
-				}
-				if err = gz.Close(); err != nil {
-					t.Fatal(err)
-				}
+				utils.AssertEqual(t, nil, err)
+
+				err = gz.Flush()
+				utils.AssertEqual(t, nil, err)
+
+				err = gz.Close()
+				utils.AssertEqual(t, nil, err)
 				tCase.body = b.Bytes()
 			}
 
@@ -619,9 +618,8 @@ func Test_Ctx_ParamParser(t *testing.T) {
 			RoleID uint `params:"roleId"`
 		}
 		d := new(Demo)
-		if err := ctx.ParamsParser(d); err != nil {
-			t.Fatal(err)
-		}
+
+		utils.AssertEqual(t, nil, ctx.ParamsParser(d))
 		utils.AssertEqual(t, uint(111), d.UserID)
 		utils.AssertEqual(t, uint(222), d.RoleID)
 		return nil
@@ -4946,21 +4944,17 @@ func Test_Ctx_BodyStreamWriter(t *testing.T) {
 		}
 		fmt.Fprintf(w, "body writer line 2\n")
 	})
-	if !ctx.IsBodyStream() {
-		t.Fatal("IsBodyStream must return true")
-	}
+
+	utils.AssertEqual(t, true, ctx.IsBodyStream())
 
 	s := ctx.Response.String()
 	br := bufio.NewReader(bytes.NewBufferString(s))
 	var resp fasthttp.Response
-	if err := resp.Read(br); err != nil {
-		t.Fatalf("Error when reading response: %s", err)
-	}
+	utils.AssertEqual(t, nil, resp.Read(br))
+
 	body := string(resp.Body())
 	expectedBody := "body writer line 1\nbody writer line 2\n"
-	if body != expectedBody {
-		t.Fatalf("unexpected body: %q. Expecting %q", body, expectedBody)
-	}
+	utils.AssertEqual(t, expectedBody, body)
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Ctx_BodyStreamWriter -benchmem -count=4
@@ -5010,14 +5004,10 @@ func TestCtx_ParamsInt(t *testing.T) {
 		num, err := c.ParamsInt("user")
 
 		// Check the number matches
-		if num != 1111 {
-			t.Fatalf("Expected number 1111 from the path, got %d", num)
-		}
+		utils.AssertEqual(t, 1111, num)
 
 		// Check no errors are returned, because we want NO errors in this one
-		if err != nil {
-			t.Fatalf("Expected nil error for 1111 test, got " + err.Error())
-		}
+		utils.AssertEqual(t, nil, err)
 
 		return nil
 	})
@@ -5030,14 +5020,10 @@ func TestCtx_ParamsInt(t *testing.T) {
 		num, err := c.ParamsInt("user")
 
 		// Check the number matches
-		if num != 0 {
-			t.Fatalf("Expected number 0 from the path, got %d", num)
-		}
+		utils.AssertEqual(t, 0, num)
 
 		// Check an error is returned, because we want NO errors in this one
-		if err == nil {
-			t.Fatal("Expected non nil error for bad req test, got nil")
-		}
+		utils.AssertEqual(t, true, err != nil)
 
 		return nil
 	})
@@ -5050,14 +5036,10 @@ func TestCtx_ParamsInt(t *testing.T) {
 		num, err := c.ParamsInt("user", 1111)
 
 		// Check the number matches
-		if num != 2222 {
-			t.Fatalf("Expected number 2222 from the path, got %d", num)
-		}
+		utils.AssertEqual(t, 2222, num)
 
 		// Check no errors are returned, because we want NO errors in this one
-		if err != nil {
-			t.Fatalf("Expected nil error for 2222 test, got " + err.Error())
-		}
+		utils.AssertEqual(t, nil, err)
 
 		return nil
 	})
@@ -5070,14 +5052,10 @@ func TestCtx_ParamsInt(t *testing.T) {
 		num, err := c.ParamsInt("user", 1111)
 
 		// Check the number matches
-		if num != 1111 {
-			t.Fatalf("Expected number 1111 from the path, got %d", num)
-		}
+		utils.AssertEqual(t, 1111, num)
 
 		// Check an error is returned, because we want NO errors in this one
-		if err != nil {
-			t.Fatalf("Expected nil error for 1111 test, got " + err.Error())
-		}
+		utils.AssertEqual(t, nil, err)
 
 		return nil
 	})

--- a/middleware/favicon/favicon_test.go
+++ b/middleware/favicon/favicon_test.go
@@ -102,9 +102,7 @@ func Test_Custom_Favicon_Url(t *testing.T) {
 // go test -run Test_Custom_Favicon_Data
 func Test_Custom_Favicon_Data(t *testing.T) {
 	data, err := os.ReadFile("../../.github/testdata/favicon.ico")
-	if err != nil {
-		t.Fatal(err)
-	}
+	utils.AssertEqual(t, nil, err)
 
 	app := fiber.New()
 

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -496,9 +496,8 @@ func Test_Session_Regenerate(t *testing.T) {
 		err = acquiredSession.Regenerate()
 		utils.AssertEqual(t, nil, err)
 
-		if acquiredSession.ID() == originalSessionUUIDString {
-			t.Fatal("regenerate should generate another different id")
-		}
+		utils.AssertEqual(t, false, acquiredSession.ID() == originalSessionUUIDString)
+
 		// acquiredSession.fresh should be true after regenerating
 		utils.AssertEqual(t, true, acquiredSession.Fresh())
 	})

--- a/middleware/session/store_test.go
+++ b/middleware/session/store_test.go
@@ -82,8 +82,6 @@ func TestStore_Get(t *testing.T) {
 		acquiredSession, err := store.Get(ctx)
 		utils.AssertEqual(t, err, nil)
 
-		if acquiredSession.ID() != unexpectedID {
-			t.Fatal("server should not accept the unexpectedID which is not in the store")
-		}
+		utils.AssertEqual(t, unexpectedID, acquiredSession.ID())
 	})
 }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
Explain the *details* for making this change. What existing problem does the pull request solve?

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
