### PR TITLE
✨ feat: add Delete method to Store struct in session middleware

### DIFF
--- a/docs/api/middleware/session.md
+++ b/docs/api/middleware/session.md
@@ -16,6 +16,7 @@ This middleware uses our [Storage](https://github.com/gofiber/storage) package t
 func New(config ...Config) *Store
 func (s *Store) RegisterType(i interface{})
 func (s *Store) Get(c *fiber.Ctx) (*Session, error)
+func (s *Store) Delete(id string) error
 func (s *Store) Reset() error
 
 func (s *Session) Get(key string) interface{}

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -140,3 +140,11 @@ func (s *Store) responseCookies(c *fiber.Ctx) (string, error) {
 func (s *Store) Reset() error {
 	return s.Storage.Reset()
 }
+
+// Delete deletes a session by its id
+func (s *Store) Delete(id string) error {
+	if len(id) == 0 {
+		return fmt.Errorf("session id cannot be empty")
+	}
+	return s.Storage.Delete(id)
+}

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"encoding/gob"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -11,6 +12,9 @@ import (
 
 	"github.com/valyala/fasthttp"
 )
+
+// ErrEmptySessionID is an error that occurs when the session ID is empty.
+var ErrEmptySessionID = errors.New("session id cannot be empty")
 
 type Store struct {
 	Config
@@ -141,10 +145,10 @@ func (s *Store) Reset() error {
 	return s.Storage.Reset()
 }
 
-// Delete deletes a session by its id
+// Delete deletes a session by its id.
 func (s *Store) Delete(id string) error {
-	if len(id) == 0 {
-		return fmt.Errorf("session id cannot be empty")
+	if id == "" {
+		return ErrEmptySessionID
 	}
 	return s.Storage.Delete(id)
 }

--- a/middleware/session/store_test.go
+++ b/middleware/session/store_test.go
@@ -100,26 +100,19 @@ func TestStore_DeleteSession(t *testing.T) {
 
 	// Create a new session
 	session, err := store.Get(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	utils.AssertEqual(t, err, nil)
 
 	// Save the session ID
 	sessionID := session.ID()
 
 	// Delete the session
-	if err := store.Delete(sessionID); err != nil {
-		t.Fatal(err)
-	}
+	err = store.Delete(sessionID)
+	utils.AssertEqual(t, err, nil)
 
 	// Try to get the session again
 	session, err = store.Get(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	utils.AssertEqual(t, err, nil)
 
 	// The session ID should be different now, because the old session was deleted
-	if session.ID() == sessionID {
-		t.Errorf("The session was not deleted, the session ID is still the same")
-	}
+	utils.AssertEqual(t, session.ID() == sessionID, false)
 }

--- a/middleware/session/store_test.go
+++ b/middleware/session/store_test.go
@@ -85,3 +85,41 @@ func TestStore_Get(t *testing.T) {
 		utils.AssertEqual(t, unexpectedID, acquiredSession.ID())
 	})
 }
+
+// go test -run TestStore_DeleteSession
+func TestStore_DeleteSession(t *testing.T) {
+	t.Parallel()
+	// fiber instance
+	app := fiber.New()
+	// session store
+	store := New()
+
+	// fiber context
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+
+	// Create a new session
+	session, err := store.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Save the session ID
+	sessionID := session.ID()
+
+	// Delete the session
+	if err := store.Delete(sessionID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to get the session again
+	session, err = store.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The session ID should be different now, because the old session was deleted
+	if session.ID() == sessionID {
+		t.Errorf("The session was not deleted, the session ID is still the same")
+	}
+}


### PR DESCRIPTION
## Description

This pull request introduces a new `Delete` method to the `Store` struct in the Fiber's session middleware. The `Delete` method is designed to delete a specific session id from the storage.

The motivation behind this change is to provide more control over individual session management, especially in scenarios like administrator-enforced user logout or user-initiated logout from a specific device session. With the `Delete` method, we can easily delete a specific session, providing a more efficient and flexible way to manage individual user sessions.

This pull request also includes relevant test code to ensure the correct functionality of the `Delete` method. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [x] For new code I have written benchmarks so that they can be analyzed and improved

## Usage
```go
app.Post("/admin/session/:id/logout", func(c *fiber.Ctx) error {
    // Get session id from request
    sessionID := c.Params("id")

    // Delete the session
    if err := store.Delete(sessionID); err != nil {
        return c.Status(500).SendString(err.Error())
    }

    return c.SendString("Logout successful")
})
```