### PR TITLE
Fix loop variable captured by func literal

### DIFF
--- a/middleware/compress/compress_test.go
+++ b/middleware/compress/compress_test.go
@@ -53,6 +53,7 @@ func Test_Compress_Different_Level(t *testing.T) {
 	t.Parallel()
 	levels := []Level{LevelBestSpeed, LevelBestCompression}
 	for _, level := range levels {
+		level := level
 		t.Run(fmt.Sprintf("level %d", level), func(t *testing.T) {
 			t.Parallel()
 			app := fiber.New()

--- a/middleware/filesystem/filesystem_test.go
+++ b/middleware/filesystem/filesystem_test.go
@@ -119,6 +119,7 @@ func Test_FileSystem(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, tt.url, nil))

--- a/middleware/pprof/pprof_test.go
+++ b/middleware/pprof/pprof_test.go
@@ -104,6 +104,7 @@ func Test_Pprof_Subs(t *testing.T) {
 	}
 
 	for _, sub := range subs {
+		sub := sub
 		t.Run(sub, func(t *testing.T) {
 			t.Parallel()
 			target := "/debug/pprof/" + sub
@@ -133,6 +134,7 @@ func Test_Pprof_Subs_WithPrefix(t *testing.T) {
 	}
 
 	for _, sub := range subs {
+		sub := sub
 		t.Run(sub, func(t *testing.T) {
 			t.Parallel()
 			target := "/federated-fiber/debug/pprof/" + sub

--- a/middleware/pprof/pprof_test.go
+++ b/middleware/pprof/pprof_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func Test_Non_Pprof_Path(t *testing.T) {
-	t.Parallel()
 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 
 	app.Use(New())
@@ -30,7 +29,6 @@ func Test_Non_Pprof_Path(t *testing.T) {
 }
 
 func Test_Non_Pprof_Path_WithPrefix(t *testing.T) {
-	t.Parallel()
 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 
 	app.Use(New(Config{Prefix: "/federated-fiber"}))
@@ -49,7 +47,6 @@ func Test_Non_Pprof_Path_WithPrefix(t *testing.T) {
 }
 
 func Test_Pprof_Index(t *testing.T) {
-	t.Parallel()
 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 
 	app.Use(New())
@@ -69,7 +66,6 @@ func Test_Pprof_Index(t *testing.T) {
 }
 
 func Test_Pprof_Index_WithPrefix(t *testing.T) {
-	t.Parallel()
 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 
 	app.Use(New(Config{Prefix: "/federated-fiber"}))
@@ -89,7 +85,6 @@ func Test_Pprof_Index_WithPrefix(t *testing.T) {
 }
 
 func Test_Pprof_Subs(t *testing.T) {
-	t.Parallel()
 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 
 	app.Use(New())
@@ -106,7 +101,6 @@ func Test_Pprof_Subs(t *testing.T) {
 	for _, sub := range subs {
 		sub := sub
 		t.Run(sub, func(t *testing.T) {
-			t.Parallel()
 			target := "/debug/pprof/" + sub
 			if sub == "profile" {
 				target += "?seconds=1"
@@ -119,7 +113,6 @@ func Test_Pprof_Subs(t *testing.T) {
 }
 
 func Test_Pprof_Subs_WithPrefix(t *testing.T) {
-	t.Parallel()
 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 
 	app.Use(New(Config{Prefix: "/federated-fiber"}))
@@ -136,7 +129,6 @@ func Test_Pprof_Subs_WithPrefix(t *testing.T) {
 	for _, sub := range subs {
 		sub := sub
 		t.Run(sub, func(t *testing.T) {
-			t.Parallel()
 			target := "/federated-fiber/debug/pprof/" + sub
 			if sub == "profile" {
 				target += "?seconds=1"
@@ -149,7 +141,6 @@ func Test_Pprof_Subs_WithPrefix(t *testing.T) {
 }
 
 func Test_Pprof_Other(t *testing.T) {
-	t.Parallel()
 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 
 	app.Use(New())
@@ -164,7 +155,6 @@ func Test_Pprof_Other(t *testing.T) {
 }
 
 func Test_Pprof_Other_WithPrefix(t *testing.T) {
-	t.Parallel()
 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 
 	app.Use(New(Config{Prefix: "/federated-fiber"}))
@@ -180,7 +170,6 @@ func Test_Pprof_Other_WithPrefix(t *testing.T) {
 
 // go test -run Test_Pprof_Next
 func Test_Pprof_Next(t *testing.T) {
-	t.Parallel()
 	app := fiber.New()
 
 	app.Use(New(Config{
@@ -196,7 +185,6 @@ func Test_Pprof_Next(t *testing.T) {
 
 // go test -run Test_Pprof_Next_WithPrefix
 func Test_Pprof_Next_WithPrefix(t *testing.T) {
-	t.Parallel()
 	app := fiber.New()
 
 	app.Use(New(Config{


### PR DESCRIPTION
## Description

by running `go vet ./...` with go latest version there are some warning about loop variable captured by func literal

this is linked to

https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable

and

https://github.com/golang/go/wiki/LoopvarExperiment

```shell
$ go version
go version go1.21.1 linux/amd64

$ go vet ./...
# github.com/gofiber/fiber/v2/internal/go-ole
internal/go-ole/variant.go:15:21: possible misuse of unsafe.Pointer
internal/go-ole/variant.go:23:22: possible misuse of unsafe.Pointer
internal/go-ole/variant.go:33:42: possible misuse of unsafe.Pointer
# github.com/gofiber/fiber/v2/middleware/compress
middleware/compress/compress_test.go:60:30: loop variable level captured by func literal
# github.com/gofiber/fiber/v2/middleware/filesystem
middleware/filesystem/filesystem_test.go:124:63: loop variable tt captured by func literal
middleware/filesystem/filesystem_test.go:126:25: loop variable tt captured by func literal
middleware/filesystem/filesystem_test.go:128:7: loop variable tt captured by func literal
middleware/filesystem/filesystem_test.go:130:26: loop variable tt captured by func literal
# github.com/gofiber/fiber/v2/middleware/pprof
middleware/pprof/pprof_test.go:109:32: loop variable sub captured by func literal
middleware/pprof/pprof_test.go:110:7: loop variable sub captured by func literal
middleware/pprof/pprof_test.go:138:48: loop variable sub captured by func literal
middleware/pprof/pprof_test.go:139:7: loop variable sub captured by func literal
```

I have no idea how to fix the `possible misuse of unsafe.Pointer` (this can be a false positive, someone with experience in windows and go unsafe must check) but the loop variable is _easier_

However this trigger some random 500 errors in the middleware/pprof because some handlers are not supposed to be called more than once at same time.

We can see outputs like

`Could not enable tracing: runtime error: tracing is already enabled`

or

`Could not enable CPU profiling: cpu profiling already in use`

I remove the `t.Parallel()` of such tests

## Type of change

minor change in tests

## Checklist:

- [ x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ x] I tried to make my code as fast as possible with as few allocations as possible
- [ x] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
