### PR TITLE
add go:generate line to install msgp if not present

### DIFF
--- a/middleware/idempotency/response.go
+++ b/middleware/idempotency/response.go
@@ -1,5 +1,6 @@
 package idempotency
 
+//go:generate go install -v github.com/tinylib/msgp/...@latest
 //go:generate msgp -o=response_msgp.go -io=false -unexported
 type response struct {
 	StatusCode int `msg:"sc"`


### PR DESCRIPTION
## Description

I've got an error while running `go generate ./...` that I have no msgp installed

I add one line to install it

## Type of change

minor change in `go:generate` tag

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
