### PR TITLE
[filesystem middleware] improve status for SendFile

### DIFF
--- a/middleware/filesystem/filesystem.go
+++ b/middleware/filesystem/filesystem.go
@@ -254,6 +254,8 @@ func SendFile(c *fiber.Ctx, filesystem http.FileSystem, path string) error {
 		return fiber.ErrForbidden
 	}
 
+	c.Status(fiber.StatusOK)
+
 	modTime := stat.ModTime()
 	contentLength := int(stat.Size())
 


### PR DESCRIPTION
Set the status to 200 OK for the filesystem middleware `SendFile` func, just before the file is sent.
