### PR TITLE
🩹Fix incorrect log depth when use log.WithContext

### DIFF
--- a/log/default.go
+++ b/log/default.go
@@ -188,7 +188,11 @@ func (l *defaultLogger) Panicw(msg string, keysAndValues ...interface{}) {
 }
 
 func (l *defaultLogger) WithContext(_ context.Context) CommonLogger {
-	return l
+	return &defaultLogger{
+		stdlog: l.stdlog,
+		level:  l.level,
+		depth:  l.depth - 1,
+	}
 }
 
 func (l *defaultLogger) SetLevel(level Level) {

--- a/log/default_test.go
+++ b/log/default_test.go
@@ -156,6 +156,22 @@ func Test_LogfKeyAndValues(t *testing.T) {
 	}
 }
 
+func Test_WithContextCaller(t *testing.T) {
+	logger = &defaultLogger{
+		stdlog: log.New(os.Stderr, "", log.Lshortfile),
+		depth:  4,
+	}
+
+	var w byteSliceWriter
+	SetOutput(&w)
+	ctx := context.TODO()
+
+	WithContext(ctx).Info("")
+	Info("")
+
+	utils.AssertEqual(t, "default_test.go:169: [Info] \ndefault_test.go:170: [Info] \n", string(w.b))
+}
+
 func Test_SetLevel(t *testing.T) {
 	setLogger := &defaultLogger{
 		stdlog: log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),


### PR DESCRIPTION
## Description

Fix incorrect log depth when use log.WithContex

Fixes # (issue)
https://github.com/gofiber/fiber/issues/2646

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
