### PR TITLE
📚 [Doc] fix incorrect status code source

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -625,7 +625,7 @@ const (
 	MIMEApplicationJavaScriptCharsetUTF8 = "application/javascript; charset=utf-8"
 )
 
-// HTTP status codes were copied from https://github.com/nginx/nginx/blob/67d2a9541826ecd5db97d604f23460210fd3e517/conf/mime.types with the following updates:
+// HTTP status codes were copied from were copied from net/http with the following updates:
 // - Rename StatusNonAuthoritativeInfo to StatusNonAuthoritativeInformation
 // - Add StatusSwitchProxy (306)
 // NOTE: Keep this list in sync with statusMessage

--- a/helpers.go
+++ b/helpers.go
@@ -625,7 +625,7 @@ const (
 	MIMEApplicationJavaScriptCharsetUTF8 = "application/javascript; charset=utf-8"
 )
 
-// HTTP status codes were copied from were copied from net/http with the following updates:
+// HTTP status codes were copied from net/http with the following updates:
 // - Rename StatusNonAuthoritativeInfo to StatusNonAuthoritativeInformation
 // - Add StatusSwitchProxy (306)
 // NOTE: Keep this list in sync with statusMessage


### PR DESCRIPTION
## Description

Documentation for status codes (e.g. `fiber.StatusOK`) mentions that status codes in `helpers.go` were copied from [https://github.com/nginx/nginx/blob/67d2a9541826ecd5db97d604f23460210fd3e517/conf/mime.types](https://github.com/nginx/nginx/blob/67d2a9541826ecd5db97d604f23460210fd3e517/conf/mime.types). However, this source contains nothing about HTTP status codes.

This is most likely a typo, as the status codes appear to be copied from net/http, with two small updates. This PR updates the comment to reflect an accurate source for HTTP status codes.

## Type of change

- [x] Bug fix - documentation

