### PR TITLE
🩹 Fix: race condition in memory storage

### DIFF
--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -137,9 +137,9 @@ func (s *Storage) gc() {
 	}
 }
 
-// Return database client
-func (s *Storage) Conn() map[string]entry {
-	s.mux.RLock()
-	defer s.mux.RUnlock()
-	return s.db
+// ConnLocked can be used to access the underlying db in a thread-safe manner.
+func (s *Storage) ConnLocked(f func(map[string]entry)) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	f(s.db)
 }


### PR DESCRIPTION
## Description

This commit updates `Conn` method of memory storage to fix race conditions.

The `Conn` method returned the reference to underlying map which could be used
for read/write and had a risk of race condition.

This commit fixes it by updating the method to take in a function to access
underlying map, which is wrapped in lock to make it thread safe.

Fixes: #2400

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
