### PR TITLE
🐛 [Bug]: Naming of routes works wrong after mount #2688

### DIFF
--- a/router.go
+++ b/router.go
@@ -47,7 +47,7 @@ type Router interface {
 
 // Route is a struct that holds all metadata for each registered handler.
 type Route struct {
-	// always keep in sync with the copy method "app.copyRoute"
+	// ### important: always keep in sync with the copy method "app.copyRoute" ###
 	// Data for routing
 	pos         uint32      // Position in stack -> important for the sort of the matched routes
 	use         bool        // USE matches path prefixes
@@ -214,13 +214,14 @@ func (*App) copyRoute(route *Route) *Route {
 		// Path data
 		path:        route.path,
 		routeParser: route.routeParser,
-		Params:      route.Params,
 
 		// misc
 		pos: route.pos,
 
 		// Public data
 		Path:     route.Path,
+		Params:   route.Params,
+		Name:     route.Name,
 		Method:   route.Method,
 		Handlers: route.Handlers,
 	}


### PR DESCRIPTION
## Description

Fixes #2688

Enables the use of routes with names after apps have been mounted

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I tried to make my code as fast as possible with as few allocations as possible
