### PR TITLE
📚 Doc: Add additional information as to why GetReqHeaders returns a map where the values are slices of strings 

### DIFF
--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -618,7 +618,7 @@ app.Get("/", func(c *fiber.Ctx) error {
 
 ## GetRespHeaders
 
-Returns the HTTP response headers.
+Returns the HTTP response headers as a map. Since a header can be set multiple times in a single request, the values of the map are slices of strings containing all the different values of the header.
 
 ```go title="Signature"
 func (c *Ctx) GetRespHeaders() map[string][]string

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -583,7 +583,7 @@ app.Get("/", func(c *fiber.Ctx) error {
 
 ## GetReqHeaders
 
-Returns the HTTP request headers.
+Returns the HTTP request headers as a map. Since a header can be set multiple times in a single request, the values of the map are slices of strings containing all the different values of the header.
 
 ```go title="Signature"
 func (c *Ctx) GetReqHeaders() map[string][]string


### PR DESCRIPTION
Added additional information as to why GetReqHeaders returns a map where the values are slices of strings (instead of a single string as one might expect)

## Description

In a (more or less) recent breaking change, the signature of [GetReqHeaders](https://docs.gofiber.io/api/ctx#getreqheaders) was changed to return a map where the values are not single strings anymore but instead slices of strings. As someone who encountered this breaking change after upgrading fiber, it was not clear why this was changed and - more importantly - what exactly would be contained in these slices. Therefore I added a short and simple explanation what one can expect to be returned by this method.

Documents the intent of #2594

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

