### PR TITLE
⚡️ perf(ctx.Range): reduce allocations

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2565,8 +2565,8 @@ func Benchmark_Ctx_Range(b *testing.B) {
 		{"bytes=500-1000", 500, 999},
 		{"bytes=0-700,800-1000", 0, 700},
 	}
-	for _, tc := range testCases {
 
+	for _, tc := range testCases {
 		b.Run(tc.str, func(b *testing.B) {
 			c.Request().Header.Set(HeaderRange, tc.str)
 			var (

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2521,39 +2521,67 @@ func Test_Ctx_Range(t *testing.T) {
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 	defer app.ReleaseCtx(c)
 
-	var (
-		result Range
-		err    error
-	)
-
-	_, err = c.Range(1000)
-	utils.AssertEqual(t, true, err != nil)
-
-	c.Request().Header.Set(HeaderRange, "bytes=500")
-	_, err = c.Range(1000)
-	utils.AssertEqual(t, true, err != nil)
-
-	c.Request().Header.Set(HeaderRange, "bytes=500=")
-	_, err = c.Range(1000)
-	utils.AssertEqual(t, true, err != nil)
-
-	c.Request().Header.Set(HeaderRange, "bytes=500-300")
-	_, err = c.Range(1000)
-	utils.AssertEqual(t, true, err != nil)
-
-	testRange := func(header string, start, end int) {
+	testRange := func(header string, ranges ...RangeSet) {
 		c.Request().Header.Set(HeaderRange, header)
-		result, err = c.Range(1000)
-		utils.AssertEqual(t, nil, err)
-		utils.AssertEqual(t, "bytes", result.Type)
-		utils.AssertEqual(t, start, result.Ranges[0].Start)
-		utils.AssertEqual(t, end, result.Ranges[0].End)
+		result, err := c.Range(1000)
+		if len(ranges) == 0 {
+			utils.AssertEqual(t, true, err != nil)
+		} else {
+			utils.AssertEqual(t, "bytes", result.Type)
+			utils.AssertEqual(t, true, err == nil)
+		}
+		utils.AssertEqual(t, len(ranges), len(result.Ranges))
+		for i := range ranges {
+			utils.AssertEqual(t, ranges[i], result.Ranges[i])
+		}
 	}
 
-	testRange("bytes=a-700", 300, 999)
-	testRange("bytes=500-b", 500, 999)
-	testRange("bytes=500-1000", 500, 999)
-	testRange("bytes=500-700", 500, 700)
+	testRange("bytes=500")
+	testRange("bytes=")
+	testRange("bytes=500=")
+	testRange("bytes=500-300")
+	testRange("bytes=a-700", RangeSet{300, 999})
+	testRange("bytes=500-b", RangeSet{500, 999})
+	testRange("bytes=500-1000", RangeSet{500, 999})
+	testRange("bytes=500-700", RangeSet{500, 700})
+	testRange("bytes=0-0,2-1000", RangeSet{0, 0}, RangeSet{2, 999})
+	testRange("bytes=0-99,450-549,-100", RangeSet{0, 99}, RangeSet{450, 549}, RangeSet{900, 999})
+	testRange("bytes=500-700,601-999", RangeSet{500, 700}, RangeSet{601, 999})
+}
+
+// go test -v -run=^$ -bench=Benchmark_Ctx_Range -benchmem -count=4
+func Benchmark_Ctx_Range(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(c)
+
+	testCases := []struct {
+		str   string
+		start int
+		end   int
+	}{
+		{"bytes=-700", 300, 999},
+		{"bytes=500-", 500, 999},
+		{"bytes=500-1000", 500, 999},
+		{"bytes=0-700,800-1000", 0, 700},
+	}
+	for _, tc := range testCases {
+
+		b.Run(tc.str, func(b *testing.B) {
+			c.Request().Header.Set(HeaderRange, tc.str)
+			var (
+				result Range
+				err    error
+			)
+			for n := 0; n < b.N; n++ {
+				result, err = c.Range(1000)
+			}
+			utils.AssertEqual(b, nil, err)
+			utils.AssertEqual(b, "bytes", result.Type)
+			utils.AssertEqual(b, tc.start, result.Ranges[0].Start)
+			utils.AssertEqual(b, tc.end, result.Ranges[0].End)
+		})
+	}
 }
 
 // go test -run Test_Ctx_Route


### PR DESCRIPTION

## Description

`strings.Split` was causing extra allocations where `strings.Cut` can suffice. Also switch from `strconv.Atoi` because it causes an allocation when parsing a non-integer, which is common for Ranges.

The remaining allocation (see benchmarks) comes from the returned slice.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [x] For new code I have written benchmarks so that they can be analyzed and improved

## Bench:
```
                            │  master.txt  │             branch.txt              │
                            │    sec/op    │   sec/op     vs base                │
_Ctx_Range/bytes=-700-8       197.80n ± 0%   65.06n ± 0%  -67.11% (p=0.000 n=20)
_Ctx_Range/bytes=500--8       198.10n ± 0%   63.70n ± 0%  -67.84% (p=0.000 n=20)
_Ctx_Range/bytes=500-1000-8   162.30n ± 0%   64.76n ± 0%  -60.10% (p=0.000 n=20)
_Ctx_Range/bytes=500-700-8    161.75n ± 0%   64.48n ± 0%  -60.14% (p=0.000 n=20)
geomean                        179.1n        64.50n       -63.98%

                            │ master.txt  │             branch.txt             │
                            │    B/op     │    B/op     vs base                │
_Ctx_Range/bytes=-700-8       144.00 ± 0%   16.00 ± 0%  -88.89% (p=0.000 n=20)
_Ctx_Range/bytes=500--8       144.00 ± 0%   16.00 ± 0%  -88.89% (p=0.000 n=20)
_Ctx_Range/bytes=500-1000-8    96.00 ± 0%   16.00 ± 0%  -83.33% (p=0.000 n=20)
_Ctx_Range/bytes=500-700-8     96.00 ± 0%   16.00 ± 0%  -83.33% (p=0.000 n=20)
geomean                        117.6        16.00       -86.39%

                            │ master.txt │             branch.txt             │
                            │ allocs/op  │ allocs/op   vs base                │
_Ctx_Range/bytes=-700-8       5.000 ± 0%   1.000 ± 0%  -80.00% (p=0.000 n=20)
_Ctx_Range/bytes=500--8       5.000 ± 0%   1.000 ± 0%  -80.00% (p=0.000 n=20)
_Ctx_Range/bytes=500-1000-8   4.000 ± 0%   1.000 ± 0%  -75.00% (p=0.000 n=20)
_Ctx_Range/bytes=500-700-8    4.000 ± 0%   1.000 ± 0%  -75.00% (p=0.000 n=20)
geomean                       4.472        1.000       -77.64%
```