### PR TITLE
⚡ middleware/pprof: improve performance

### DIFF
--- a/middleware/pprof/pprof.go
+++ b/middleware/pprof/pprof.go
@@ -29,6 +29,9 @@ func New(config ...Config) fiber.Handler {
 		pprofThreadcreate = fasthttpadaptor.NewFastHTTPHandlerFunc(pprof.Handler("threadcreate").ServeHTTP)
 	)
 
+	// Construct actual prefix
+	prefix := cfg.Prefix + "/debug/pprof"
+
 	// Return new handler
 	return func(c *fiber.Ctx) error {
 		// Don't execute middleware if Next returns true
@@ -38,43 +41,53 @@ func New(config ...Config) fiber.Handler {
 
 		path := c.Path()
 		// We are only interested in /debug/pprof routes
-		if len(path) < 12 || !strings.HasPrefix(path, cfg.Prefix+"/debug/pprof") {
+		path, found := cutPrefix(path, prefix)
+		if !found {
 			return c.Next()
 		}
-		// Switch to original path without stripped slashes
+		// Switch on trimmed path against constant strings
 		switch path {
-		case cfg.Prefix + "/debug/pprof/":
+		case "/":
 			pprofIndex(c.Context())
-		case cfg.Prefix + "/debug/pprof/cmdline":
+		case "/cmdline":
 			pprofCmdline(c.Context())
-		case cfg.Prefix + "/debug/pprof/profile":
+		case "/profile":
 			pprofProfile(c.Context())
-		case cfg.Prefix + "/debug/pprof/symbol":
+		case "/symbol":
 			pprofSymbol(c.Context())
-		case cfg.Prefix + "/debug/pprof/trace":
+		case "/trace":
 			pprofTrace(c.Context())
-		case cfg.Prefix + "/debug/pprof/allocs":
+		case "/allocs":
 			pprofAllocs(c.Context())
-		case cfg.Prefix + "/debug/pprof/block":
+		case "/block":
 			pprofBlock(c.Context())
-		case cfg.Prefix + "/debug/pprof/goroutine":
+		case "/goroutine":
 			pprofGoroutine(c.Context())
-		case cfg.Prefix + "/debug/pprof/heap":
+		case "/heap":
 			pprofHeap(c.Context())
-		case cfg.Prefix + "/debug/pprof/mutex":
+		case "/mutex":
 			pprofMutex(c.Context())
-		case cfg.Prefix + "/debug/pprof/threadcreate":
+		case "/threadcreate":
 			pprofThreadcreate(c.Context())
 		default:
 			// pprof index only works with trailing slash
 			if strings.HasSuffix(path, "/") {
 				path = strings.TrimRight(path, "/")
 			} else {
-				path = cfg.Prefix + "/debug/pprof/"
+				path = prefix + "/"
 			}
 
 			return c.Redirect(path, fiber.StatusFound)
 		}
 		return nil
 	}
+}
+
+// cutPrefix is a copy of [strings.CutPrefix] added in Go 1.20.
+// Remove this function when we drop support for Go 1.19.
+func cutPrefix(s, prefix string) (after string, found bool) {
+	if !strings.HasPrefix(s, prefix) {
+		return s, false
+	}
+	return s[len(prefix):], true
 }

--- a/middleware/pprof/pprof.go
+++ b/middleware/pprof/pprof.go
@@ -85,6 +85,8 @@ func New(config ...Config) fiber.Handler {
 
 // cutPrefix is a copy of [strings.CutPrefix] added in Go 1.20.
 // Remove this function when we drop support for Go 1.19.
+//
+//nolint:nonamedreturns // Align with its original form in std.
 func cutPrefix(s, prefix string) (after string, found bool) {
 	if !strings.HasPrefix(s, prefix) {
 		return s, false


### PR DESCRIPTION
## Description

Concatenate the custom and fixed prefixes beforehand, so the trimmed path can be switched on against constant strings.

Here's a simple benchmark:

```go
package pprof

import (
	"crypto/rand"
	"errors"
	"strings"
	"testing"
	"unsafe"
)

var errBadPath = errors.New("bad path")

func doSlow(prefix, path string) error {
	if len(path) < 12 || !strings.HasPrefix(path, prefix+"/debug/pprof") {
		return errBadPath
	}
	// Switch to original path without stripped slashes
	switch path {
	case prefix + "/debug/pprof/":
		return errBadPath
	case prefix + "/debug/pprof/cmdline":
		return errBadPath
	case prefix + "/debug/pprof/profile":
		return errBadPath
	case prefix + "/debug/pprof/symbol":
		return errBadPath
	case prefix + "/debug/pprof/trace":
		return errBadPath
	case prefix + "/debug/pprof/allocs":
		return errBadPath
	case prefix + "/debug/pprof/block":
		return errBadPath
	case prefix + "/debug/pprof/goroutine":
		return errBadPath
	case prefix + "/debug/pprof/heap":
		return errBadPath
	case prefix + "/debug/pprof/mutex":
		return errBadPath
	case prefix + "/debug/pprof/threadcreate":
		return errBadPath
	default:
		return nil
	}
}

func newSlowBenchFunc(prefix, path string) func(b *testing.B) {
	return func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			if err := doSlow(prefix, path); err != nil {
				b.Error(err)
			}
		}
	}
}

func doFast(prefix, path string) error {
	path, found := strings.CutPrefix(path, prefix)
	if !found {
		return errBadPath
	}
	// Switch to original path without stripped slashes
	switch path {
	case "", "/":
		return errBadPath
	case "/cmdline":
		return errBadPath
	case "/profile":
		return errBadPath
	case "/symbol":
		return errBadPath
	case "/trace":
		return errBadPath
	case "/allocs":
		return errBadPath
	case "/block":
		return errBadPath
	case "/goroutine":
		return errBadPath
	case "/heap":
		return errBadPath
	case "/mutex":
		return errBadPath
	case "/threadcreate":
		return errBadPath
	default:
		return nil
	}

}

func newFastBenchFunc(prefix, path string) func(b *testing.B) {
	prefix += "/debug/pprof"
	return func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			if err := doFast(prefix, path); err != nil {
				b.Error(err)
			}
		}
	}
}

func BenchmarkPprof(b *testing.B) {
	buf := make([]byte, 16)
	if _, err := rand.Read(buf); err != nil {
		b.Fatal(err)
	}
	prefix := unsafe.String(unsafe.SliceData(buf), len(buf))
	path := prefix + "/debug/pprof/nonexistent"

	b.Run("Slow", newSlowBenchFunc(prefix, path))
	b.Run("Fast", newFastBenchFunc(prefix, path))
}
```

```
goos: linux
goarch: amd64
pkg: github.com/gofiber/fiber/v2/middleware/pprof
cpu: 13th Gen Intel(R) Core(TM) i9-13900K
BenchmarkPprof/Slow-32         	 4912642	       246.3 ns/op	     480 B/op	      10 allocs/op
BenchmarkPprof/Fast-32         	411908472	         2.913 ns/op	       0 B/op	       0 allocs/op
PASS
```

To the maintainers: These slow patterns introduced by #2194 were quite obvious, and it would've been nice if they were called out when the PR was being reviewed. Thanks!

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [x] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/
