### PR TITLE
test(limiter): fix intermittent failures

### DIFF
--- a/middleware/limiter/limiter_test.go
+++ b/middleware/limiter/limiter_test.go
@@ -218,7 +218,7 @@ func Test_Limiter_Sliding_Window_No_Skip_Choices(t *testing.T) {
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, 429, resp.StatusCode)
 
-	time.Sleep(4 * time.Second)
+	time.Sleep(4*time.Second + 500*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	utils.AssertEqual(t, nil, err)
@@ -258,7 +258,7 @@ func Test_Limiter_Sliding_Window_Custom_Storage_No_Skip_Choices(t *testing.T) {
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, 429, resp.StatusCode)
 
-	time.Sleep(4 * time.Second)
+	time.Sleep(4*time.Second + 500*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	utils.AssertEqual(t, nil, err)
@@ -373,7 +373,7 @@ func Test_Limiter_Sliding_Window_Skip_Failed_Requests(t *testing.T) {
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, 429, resp.StatusCode)
 
-	time.Sleep(4 * time.Second)
+	time.Sleep(4*time.Second + 500*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	utils.AssertEqual(t, nil, err)
@@ -412,7 +412,7 @@ func Test_Limiter_Sliding_Window_Custom_Storage_Skip_Failed_Requests(t *testing.
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, 429, resp.StatusCode)
 
-	time.Sleep(4 * time.Second)
+	time.Sleep(4*time.Second + 500*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	utils.AssertEqual(t, nil, err)
@@ -533,7 +533,7 @@ func Test_Limiter_Sliding_Window_Skip_Successful_Requests(t *testing.T) {
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, 429, resp.StatusCode)
 
-	time.Sleep(4 * time.Second)
+	time.Sleep(4*time.Second + 500*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
 	utils.AssertEqual(t, nil, err)
@@ -574,7 +574,7 @@ func Test_Limiter_Sliding_Window_Custom_Storage_Skip_Successful_Requests(t *test
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, 429, resp.StatusCode)
 
-	time.Sleep(4 * time.Second)
+	time.Sleep(4*time.Second + 500*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
 	utils.AssertEqual(t, nil, err)


### PR DESCRIPTION
The limiter middleware unit tests are failing due to a race between the storage garbage collector and the unit test itself. The sliding window limiter tracks requests using memory storage. In several of the unit tests, this storage expiry ends up being 4 seconds. The test waits for 4 seconds, then sends a request, expecting it to succeed. However, the unit test occasionally wakes up before the storage GC kicks in. As an effect of the very coarse timer (using seconds as units), the middleware correctly rejects the request, causing the test to fail.

Update the sleep to 4.5 seconds. This will not slow down the execution of the test suite, as these tests run in parallel with a separate 9 second long test.

I'm not 100% sure this solves the issue, and ideally we'd be able to run tests without time.Sleep.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
Explain the *details* for making this change. What existing problem does the pull request solve?

## Type of change

Please delete options that are not relevant.

- [x] Unit Tests

## Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes