### PR TITLE
🚨 Test: fix race condition in parallel tests

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -636,7 +636,6 @@ func Test_Ctx_ParamParser(t *testing.T) {
 
 // go test -run Test_Ctx_BodyParser_WithSetParserDecoder
 func Test_Ctx_BodyParser_WithSetParserDecoder(t *testing.T) {
-	t.Parallel()
 	type CustomTime time.Time
 
 	timeConverter := func(value string) reflect.Value {
@@ -4555,7 +4554,6 @@ func Test_Ctx_QueryParser_WithoutSplitting(t *testing.T) {
 
 // go test -run Test_Ctx_QueryParser_WithSetParserDecoder -v
 func Test_Ctx_QueryParser_WithSetParserDecoder(t *testing.T) {
-	t.Parallel()
 	type NonRFCTime time.Time
 
 	nonRFCConverter := func(value string) reflect.Value {
@@ -4885,7 +4883,6 @@ func Test_Ctx_ReqHeaderParser_WithoutSplitting(t *testing.T) {
 
 // go test -run Test_Ctx_ReqHeaderParser_WithSetParserDecoder -v
 func Test_Ctx_ReqHeaderParser_WithSetParserDecoder(t *testing.T) {
-	t.Parallel()
 	type NonRFCTime time.Time
 
 	nonRFCConverter := func(value string) reflect.Value {


### PR DESCRIPTION
## Description

Tests that call SetParserDecoder were causing a race condition with other tests that read from decoderPoolMap. Fix by making the offending tests not run in parallel.
This often manifested as CI failures.

To reproduce, run ` go test -race -v . -count=1 -run=Test_Ctx_QueryParser`. It will fail virtually every time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I tried to make my code as fast as possible with as few allocations as possible
