### PR TITLE
[Bug]: utils.IsIPv4 and net.ParseIP have inconsistent results #2735

### DIFF
--- a/utils/ips.go
+++ b/utils/ips.go
@@ -23,7 +23,7 @@ func IsIPv4(s string) bool {
 
 		for ci = 0; ci < len(s) && '0' <= s[ci] && s[ci] <= '9'; ci++ {
 			n = n*10 + int(s[ci]-'0')
-			if n >= 0xFF {
+			if n > 0xFF {
 				return false
 			}
 		}

--- a/utils/ips_test.go
+++ b/utils/ips_test.go
@@ -14,6 +14,7 @@ func Test_IsIPv4(t *testing.T) {
 
 	AssertEqual(t, true, IsIPv4("174.23.33.100"))
 	AssertEqual(t, true, IsIPv4("127.0.0.1"))
+	AssertEqual(t, true, IsIPv4("127.255.255.255"))
 	AssertEqual(t, true, IsIPv4("0.0.0.0"))
 
 	AssertEqual(t, false, IsIPv4(".0.0.0"))


### PR DESCRIPTION
## Description

Fix utils.IsIPv4 to include 255.
