### PR TITLE
🚨 Test: race in session middleware tests

### DIFF
--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -503,6 +503,7 @@ func Test_Session_Reset(t *testing.T) {
 		utils.AssertEqual(t, nil, err)
 
 		utils.AssertEqual(t, false, acquiredSession.ID() == originalSessionUUIDString)
+		utils.AssertEqual(t, false, acquiredSession.ID() == "")
 
 		// acquiredSession.fresh should be true after resetting
 		utils.AssertEqual(t, true, acquiredSession.Fresh())
@@ -523,10 +524,6 @@ func Test_Session_Reset(t *testing.T) {
 		// Check that the session id is not in the header or cookie anymore
 		utils.AssertEqual(t, "", string(ctx.Response().Header.Peek(store.sessionName)))
 		utils.AssertEqual(t, "", string(ctx.Request().Header.Peek(store.sessionName)))
-
-		// But the new session id should be in the header or cookie
-		utils.AssertEqual(t, acquiredSession.ID(), string(ctx.Response().Header.Peek(store.sessionName)))
-		utils.AssertEqual(t, acquiredSession.ID(), string(ctx.Request().Header.Peek(store.sessionName)))
 	})
 }
 


### PR DESCRIPTION
## Description

A Session must not be accessed after Save() is called, but a unit test calls Session.ID() after Session.Save(), sometimes causing the test to fail when -race is enabled. The assertions that ID() was being used in were redundant with the previous two assertions (checking that the session name header is empty), so we can just remove the offending code.

## Type of change

- [x] Unit Test

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I tried to make my code as fast as possible with as few allocations as possible
