### PR TITLE
Revert ":bug: requestid.Config.ContextKey is interface{} (#2369)"

### DIFF
--- a/docs/api/middleware/requestid.md
+++ b/docs/api/middleware/requestid.md
@@ -45,7 +45,7 @@ app.Use(requestid.New(requestid.Config{
 | Next       | `func(*fiber.Ctx) bool` | Next defines a function to skip this middleware when returned true.                               | `nil`          |
 | Header     | `string`                | Header is the header key where to get/set the unique request ID.                                  | "X-Request-ID" |
 | Generator  | `func() string`         | Generator defines a function to generate the unique identifier.                                   | utils.UUID     |
-| ContextKey | `interface{}`           | ContextKey defines the key used when storing the request ID in the locals for a specific request. | "requestid"    |
+| ContextKey | `string`                | ContextKey defines the key used when storing the request ID in the locals for a specific request. | "requestid"    |
 
 ## Default Config
 The default config uses a fast UUID generator which will expose the number of

--- a/middleware/requestid/config.go
+++ b/middleware/requestid/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	// the locals for a specific request.
 	//
 	// Optional. Default: requestid
-	ContextKey interface{}
+	ContextKey string
 }
 
 // ConfigDefault is the default config

--- a/middleware/requestid/requestid_test.go
+++ b/middleware/requestid/requestid_test.go
@@ -55,21 +55,20 @@ func Test_RequestID_Next(t *testing.T) {
 func Test_RequestID_Locals(t *testing.T) {
 	t.Parallel()
 	reqID := "ThisIsARequestId"
-	type ContextKey int
-	const requestContextKey ContextKey = iota
+	ctxKey := "ThisIsAContextKey"
 
 	app := fiber.New()
 	app.Use(New(Config{
 		Generator: func() string {
 			return reqID
 		},
-		ContextKey: requestContextKey,
+		ContextKey: ctxKey,
 	}))
 
 	var ctxVal string
 
 	app.Use(func(c *fiber.Ctx) error {
-		ctxVal = c.Locals(requestContextKey).(string) //nolint:forcetypeassert,errcheck // We always store a string in here
+		ctxVal = c.Locals(ctxKey).(string) //nolint:forcetypeassert,errcheck // We always store a string in here
 		return c.Next()
 	})
 


### PR DESCRIPTION
we have decided to reverse this change from #2369

https://github.com/gofiber/fiber/pull/2731

Fixes #2732
