### PR TITLE
Revert revert requestid contextkey

### DIFF
--- a/docs/api/middleware/requestid.md
+++ b/docs/api/middleware/requestid.md
@@ -45,7 +45,7 @@ app.Use(requestid.New(requestid.Config{
 | Next       | `func(*fiber.Ctx) bool` | Next defines a function to skip this middleware when returned true.                               | `nil`          |
 | Header     | `string`                | Header is the header key where to get/set the unique request ID.                                  | "X-Request-ID" |
 | Generator  | `func() string`         | Generator defines a function to generate the unique identifier.                                   | utils.UUID     |
-| ContextKey | `string`                | ContextKey defines the key used when storing the request ID in the locals for a specific request. | "requestid"    |
+| ContextKey | `interface{}`           | ContextKey defines the key used when storing the request ID in the locals for a specific request. | "requestid"    |
 
 ## Default Config
 The default config uses a fast UUID generator which will expose the number of

--- a/middleware/requestid/config.go
+++ b/middleware/requestid/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	// the locals for a specific request.
 	//
 	// Optional. Default: requestid
-	ContextKey string
+	ContextKey interface{}
 }
 
 // ConfigDefault is the default config

--- a/middleware/requestid/config.go
+++ b/middleware/requestid/config.go
@@ -24,8 +24,10 @@ type Config struct {
 
 	// ContextKey defines the key used when storing the request ID in
 	// the locals for a specific request.
+	// Should be a private type instead of string, but too many apps probably
+	// rely on this exact value.
 	//
-	// Optional. Default: requestid
+	// Optional. Default: "requestid"
 	ContextKey interface{}
 }
 
@@ -57,7 +59,7 @@ func configDefault(config ...Config) Config {
 	if cfg.Generator == nil {
 		cfg.Generator = ConfigDefault.Generator
 	}
-	if cfg.ContextKey == "" {
+	if cfg.ContextKey == nil {
 		cfg.ContextKey = ConfigDefault.ContextKey
 	}
 	return cfg

--- a/middleware/requestid/requestid_test.go
+++ b/middleware/requestid/requestid_test.go
@@ -55,20 +55,21 @@ func Test_RequestID_Next(t *testing.T) {
 func Test_RequestID_Locals(t *testing.T) {
 	t.Parallel()
 	reqID := "ThisIsARequestId"
-	ctxKey := "ThisIsAContextKey"
+	type ContextKey int
+	const requestContextKey ContextKey = iota
 
 	app := fiber.New()
 	app.Use(New(Config{
 		Generator: func() string {
 			return reqID
 		},
-		ContextKey: ctxKey,
+		ContextKey: requestContextKey,
 	}))
 
 	var ctxVal string
 
 	app.Use(func(c *fiber.Ctx) error {
-		ctxVal = c.Locals(ctxKey).(string) //nolint:forcetypeassert,errcheck // We always store a string in here
+		ctxVal = c.Locals(requestContextKey).(string) //nolint:forcetypeassert,errcheck // We always store a string in here
 		return c.Next()
 	})
 

--- a/middleware/requestid/requestid_test.go
+++ b/middleware/requestid/requestid_test.go
@@ -77,3 +77,27 @@ func Test_RequestID_Locals(t *testing.T) {
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, reqID, ctxVal)
 }
+
+// go test -run Test_RequestID_DefaultKey
+func Test_RequestID_DefaultKey(t *testing.T) {
+	t.Parallel()
+	reqID := "ThisIsARequestId"
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Generator: func() string {
+			return reqID
+		},
+	}))
+
+	var ctxVal string
+
+	app.Use(func(c *fiber.Ctx) error {
+		ctxVal = c.Locals("requestid").(string) //nolint:forcetypeassert,errcheck // We always store a string in here
+		return c.Next()
+	})
+
+	_, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, reqID, ctxVal)
+}


### PR DESCRIPTION
## Description

Revert the revert of #2742, fix condition check, add a unit test that asserts that the condition is correct, and add a comment about why the default value is `string` instead of the recommended private-type-style.

See also the initial discussion and my latest [comment](https://github.com/gofiber/fiber/pull/2731#issuecomment-1837084401) in #2731 - there are several incorrect assumptions about how the context works or should work, which lead to the commit reversal.

Fixes #2356 

## Specific case example

* I am a developer of some app that uses fiber, and other libraries, which use `context.Context`.
* I follow the [standard go library documentation's recommendation](https://pkg.go.dev/context#Context) on context keys and use unexported types.
* I cannot use the `requestid` middleware because #2742 has constrained the key to be a `string`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

