### PR TITLE
🩹 middleware/logger/: log client IP address by default

### DIFF
--- a/docs/api/middleware/logger.md
+++ b/docs/api/middleware/logger.md
@@ -97,7 +97,7 @@ app.Use(logger.New(logger.Config{
 | Next             | `func(*fiber.Ctx) bool`    | Next defines a function to skip this middleware when returned true.                                                              | `nil`                                                  |
 | Done             | `func(*fiber.Ctx, []byte)` | Done is a function that is called after the log string for a request is written to Output, and pass the log string as parameter. | `nil`                                                  |
 | CustomTags       | `map[string]LogFunc`       | tagFunctions defines the custom tag action.                                                                                      | `map[string]LogFunc`                                   |
-| Format           | `string`                   | Format defines the logging tags.                                                                                                 | `[${time}] ${status} - ${latency} ${method} ${path}\n` |
+| Format           | `string`                   | Format defines the logging tags.                                                                                                 | `[${time}] ${ip} ${status} - ${latency} ${method} ${path}\n` |
 | TimeFormat       | `string`                   | TimeFormat defines the time format for log timestamps.                                                                           | `15:04:05`                                             |
 | TimeZone         | `string`                   | TimeZone can be specified, such as "UTC" and "America/New_York" and "Asia/Chongqing", etc                                        | `"Local"`                                              |
 | TimeInterval     | `time.Duration`            | TimeInterval is the delay before the timestamp is updated.                                                                       | `500 * time.Millisecond`                               |
@@ -112,7 +112,7 @@ app.Use(logger.New(logger.Config{
 var ConfigDefault = Config{
     Next:          nil,
     Done:          nil,
-    Format:        "[${time}] ${status} - ${latency} ${method} ${path}\n",
+    Format:        "[${time}] ${ip} ${status} - ${latency} ${method} ${path}\n",
     TimeFormat:    "15:04:05",
     TimeZone:      "Local",
     TimeInterval:  500 * time.Millisecond,

--- a/middleware/logger/config.go
+++ b/middleware/logger/config.go
@@ -28,7 +28,7 @@ type Config struct {
 
 	// Format defines the logging tags
 	//
-	// Optional. Default: [${time}] ${status} - ${latency} ${method} ${path}\n
+	// Optional. Default: [${time}] ${ip} ${status} - ${latency} ${method} ${path}\n
 	Format string
 
 	// TimeFormat https://programming.guide/go/format-parse-string-time-date-example.html
@@ -86,7 +86,7 @@ type LogFunc func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (i
 var ConfigDefault = Config{
 	Next:          nil,
 	Done:          nil,
-	Format:        "[${time}] ${status} - ${latency} ${method} ${path}\n",
+	Format:        "[${time}] ${ip} ${status} - ${latency} ${method} ${path}\n",
 	TimeFormat:    "15:04:05",
 	TimeZone:      "Local",
 	TimeInterval:  500 * time.Millisecond,


### PR DESCRIPTION
## Description

middleware/logger/ doesn't log client IP address by default, this PR fixes it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] For new functionalities I follow the inspiration of the express js framework and built them similar in usage
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - /docs/ directory for https://docs.gofiber.io/
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved
