### PR TITLE
🩹 Fix: Fixed Adapter Otelfiber c.BaseURL()  issue

### DIFF
--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -76,6 +76,7 @@ func HTTPMiddleware(mw func(http.Handler) http.Handler) fiber.Handler {
 			c.Request().Header.SetMethod(r.Method)
 			c.Request().SetRequestURI(r.RequestURI)
 			c.Request().SetHost(r.Host)
+			c.Request().Header.SetHostBytes([]byte(r.Host))
 			for key, val := range r.Header {
 				for _, v := range val {
 					c.Request().Header.Set(key, v)

--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -76,7 +76,7 @@ func HTTPMiddleware(mw func(http.Handler) http.Handler) fiber.Handler {
 			c.Request().Header.SetMethod(r.Method)
 			c.Request().SetRequestURI(r.RequestURI)
 			c.Request().SetHost(r.Host)
-			c.Request().Header.SetHostBytes([]byte(r.Host))
+			c.Request().Header.SetHost(r.Host)
 			for key, val := range r.Header {
 				for _, v := range val {
 					c.Request().Header.Set(key, v)


### PR DESCRIPTION
## Description

It solves Adaptator + otelfiber issue bug where combination of Adaptator + Otelfiber contrib Middleware, c.BaseURL() returns wrong value (http:// instead of http://localhost:3000)
[issue link](https://github.com/gofiber/fiber/issues/2641)
Detailed explanation of solution of this issue is mentioned in [here](https://github.com/gofiber/fiber/issues/2641#issuecomment-1741785618)


Fixes # (issue)

:warning: **For changes specific to v3, please switch to the [v3 Pull Request Template](?template=v3-changes.md).**

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I tried to make my code as fast as possible with as few allocations as possible

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
