### PR TITLE
🔥 v3: update Ctx.Format to match Express's res.format

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -428,6 +428,8 @@ func (c *DefaultCtx) Format(handlers ...ResFmt) error {
 
 // AutoFormat performs content-negotiation on the Accept HTTP header.
 // It uses Accepts to select a proper format.
+// The supported content types are text/html, text/plain, application/json, and application/xml.
+// For more flexible content negotiation, use Format.
 // If the header is not specified or there is no proper format, text/plain is used.
 func (c *DefaultCtx) AutoFormat(body any) error {
 	// Get accepted content type

--- a/ctx_interface.go
+++ b/ctx_interface.go
@@ -99,6 +99,8 @@ type Ctx interface {
 
 	// AutoFormat performs content-negotiation on the Accept HTTP header.
 	// It uses Accepts to select a proper format.
+	// The supported content types are text/html, text/plain, application/json, and application/xml.
+	// For more flexible content negotiation, use Format.
 	// If the header is not specified or there is no proper format, text/plain is used.
 	AutoFormat(body any) error
 

--- a/ctx_interface.go
+++ b/ctx_interface.go
@@ -95,7 +95,7 @@ type Ctx interface {
 	// If no accepted format is found, and a format with MediaType "default" is given,
 	// that default handler is called. If no format is found and no default is given,
 	// StatusNotAcceptable is sent.
-	Format(handlers ...Fmt) error
+	Format(handlers ...ResFmt) error
 
 	// AutoFormat performs content-negotiation on the Accept HTTP header.
 	// It uses Accepts to select a proper format.

--- a/ctx_interface.go
+++ b/ctx_interface.go
@@ -90,9 +90,17 @@ type Ctx interface {
 	Response() *fasthttp.Response
 
 	// Format performs content-negotiation on the Accept HTTP header.
+	// It uses Accepts to select a proper format and calls the matching
+	// user-provided handler function.
+	// If no accepted format is found, and a format with MediaType "default" is given,
+	// that default handler is called. If no format is found and no default is given,
+	// StatusNotAcceptable is sent.
+	Format(handlers ...Fmt) error
+
+	// AutoFormat performs content-negotiation on the Accept HTTP header.
 	// It uses Accepts to select a proper format.
 	// If the header is not specified or there is no proper format, text/plain is used.
-	Format(body any) error
+	AutoFormat(body any) error
 
 	// FormFile returns the first file by key from a MultipartForm.
 	FormFile(key string) (*multipart.FileHeader, error)

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -717,49 +717,166 @@ func Test_Ctx_Format(t *testing.T) {
 	app := New()
 	c := app.NewCtx(&fasthttp.RequestCtx{})
 
+	// set `accepted` to whatever media type was chosen by Format
+	var accepted string
+	formatHandlers := func(types ...string) []Fmt {
+		fmts := []Fmt{}
+		for _, t := range types {
+			t := utils.CopyString(t)
+			fmts = append(fmts, Fmt{t, func(c Ctx) error {
+				accepted = t
+				return nil
+			}})
+		}
+		return fmts
+	}
+
+	c.Request().Header.Set(HeaderAccept, `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7`)
+	err := c.Format(formatHandlers("application/xhtml+xml", "application/xml", "foo/bar")...)
+	require.Equal(t, "application/xhtml+xml", accepted)
+	require.Equal(t, "application/xhtml+xml", c.GetRespHeader(HeaderContentType))
+	require.NoError(t, err)
+	require.NotEqual(t, StatusNotAcceptable, c.Response().StatusCode())
+
+	err = c.Format(formatHandlers("foo/bar;a=b")...)
+	require.Equal(t, "foo/bar;a=b", accepted)
+	require.Equal(t, "foo/bar;a=b", c.GetRespHeader(HeaderContentType))
+	require.NoError(t, err)
+	require.NotEqual(t, StatusNotAcceptable, c.Response().StatusCode())
+
+	myError := errors.New("this is an error")
+	err = c.Format(Fmt{"text/html", func(c Ctx) error { return myError }})
+	require.ErrorIs(t, err, myError)
+
+	c.Request().Header.Set(HeaderAccept, "application/json")
+	err = c.Format(Fmt{"text/html", func(c Ctx) error { return c.SendStatus(StatusOK) }})
+	require.Equal(t, StatusNotAcceptable, c.Response().StatusCode())
+	require.NoError(t, err)
+
+	err = c.Format(formatHandlers("text/html", "default")...)
+	require.Equal(t, "default", accepted)
+	require.Equal(t, "text/html", c.GetRespHeader(HeaderContentType))
+	require.NoError(t, err)
+
+	require.Panics(t, func() {
+		err = c.Format()
+	})
+}
+
+func Benchmark_Ctx_Format(b *testing.B) {
+	app := New()
+	c := app.NewCtx(&fasthttp.RequestCtx{})
+	c.Request().Header.Set(HeaderAccept, "application/json,text/plain; format=flowed; q=0.9")
+
+	fail := func(_ Ctx) error {
+		require.FailNow(b, "Wrong type chosen")
+		return errors.New("Wrong type chosen")
+	}
+	ok := func(_ Ctx) error {
+		return nil
+	}
+
+	var err error
+	b.Run("with arg allocation", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			err = c.Format(
+				Fmt{"application/xml", fail},
+				Fmt{"text/html", fail},
+				Fmt{"text/plain;format=fixed", fail},
+				Fmt{"text/plain;format=flowed", ok},
+			)
+		}
+		require.NoError(b, err)
+	})
+
+	b.Run("pre-allocated args", func(b *testing.B) {
+		offers := []Fmt{
+			{"application/xml", fail},
+			{"text/html", fail},
+			{"text/plain;format=fixed", fail},
+			{"text/plain;format=flowed", ok},
+		}
+		for n := 0; n < b.N; n++ {
+			err = c.Format(offers...)
+		}
+		require.NoError(b, err)
+	})
+
+	c.Request().Header.Set("Accept", "text/plain")
+	b.Run("text/plain", func(b *testing.B) {
+		offers := []Fmt{
+			{"application/xml", fail},
+			{"text/plain", ok},
+		}
+		for n := 0; n < b.N; n++ {
+			err = c.Format(offers...)
+		}
+		require.NoError(b, err)
+	})
+
+	c.Request().Header.Set("Accept", "json")
+	b.Run("json", func(b *testing.B) {
+		offers := []Fmt{
+			{"xml", fail},
+			{"html", fail},
+			{"json", ok},
+		}
+		for n := 0; n < b.N; n++ {
+			err = c.Format(offers...)
+		}
+		require.NoError(b, err)
+	})
+}
+
+// go test -run Test_Ctx_AutoFormat
+func Test_Ctx_AutoFormat(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.NewCtx(&fasthttp.RequestCtx{})
+
 	c.Request().Header.Set(HeaderAccept, MIMETextPlain)
-	err := c.Format([]byte("Hello, World!"))
+	err := c.AutoFormat([]byte("Hello, World!"))
 	require.NoError(t, err)
 	require.Equal(t, "Hello, World!", string(c.Response().Body()))
 
 	c.Request().Header.Set(HeaderAccept, MIMETextHTML)
-	err = c.Format("Hello, World!")
+	err = c.AutoFormat("Hello, World!")
 	require.NoError(t, err)
 	require.Equal(t, "<p>Hello, World!</p>", string(c.Response().Body()))
 
 	c.Request().Header.Set(HeaderAccept, MIMEApplicationJSON)
-	err = c.Format("Hello, World!")
+	err = c.AutoFormat("Hello, World!")
 	require.NoError(t, err)
 	require.Equal(t, `"Hello, World!"`, string(c.Response().Body()))
 
 	c.Request().Header.Set(HeaderAccept, MIMETextPlain)
-	err = c.Format(complex(1, 1))
+	err = c.AutoFormat(complex(1, 1))
 	require.NoError(t, err)
 	require.Equal(t, "(1+1i)", string(c.Response().Body()))
 
 	c.Request().Header.Set(HeaderAccept, MIMEApplicationXML)
-	err = c.Format("Hello, World!")
+	err = c.AutoFormat("Hello, World!")
 	require.NoError(t, err)
 	require.Equal(t, `<string>Hello, World!</string>`, string(c.Response().Body()))
 
-	err = c.Format(complex(1, 1))
+	err = c.AutoFormat(complex(1, 1))
 	require.Error(t, err)
 
 	c.Request().Header.Set(HeaderAccept, MIMETextPlain)
-	err = c.Format(Map{})
+	err = c.AutoFormat(Map{})
 	require.NoError(t, err)
 	require.Equal(t, "map[]", string(c.Response().Body()))
 
 	type broken string
 	c.Request().Header.Set(HeaderAccept, "broken/accept")
 	require.NoError(t, err)
-	err = c.Format(broken("Hello, World!"))
+	err = c.AutoFormat(broken("Hello, World!"))
 	require.NoError(t, err)
 	require.Equal(t, `Hello, World!`, string(c.Response().Body()))
 }
 
-// go test -v -run=^$ -bench=Benchmark_Ctx_Format -benchmem -count=4
-func Benchmark_Ctx_Format(b *testing.B) {
+// go test -v -run=^$ -bench=Benchmark_Ctx_AutoFormat -benchmem -count=4
+func Benchmark_Ctx_AutoFormat(b *testing.B) {
 	app := New()
 	c := app.NewCtx(&fasthttp.RequestCtx{})
 
@@ -769,14 +886,14 @@ func Benchmark_Ctx_Format(b *testing.B) {
 
 	var err error
 	for n := 0; n < b.N; n++ {
-		err = c.Format("Hello, World!")
+		err = c.AutoFormat("Hello, World!")
 	}
 	require.NoError(b, err)
 	require.Equal(b, `Hello, World!`, string(c.Response().Body()))
 }
 
-// go test -v -run=^$ -bench=Benchmark_Ctx_Format_HTML -benchmem -count=4
-func Benchmark_Ctx_Format_HTML(b *testing.B) {
+// go test -v -run=^$ -bench=Benchmark_Ctx_AutoFormat_HTML -benchmem -count=4
+func Benchmark_Ctx_AutoFormat_HTML(b *testing.B) {
 	app := New()
 	c := app.NewCtx(&fasthttp.RequestCtx{})
 
@@ -786,14 +903,14 @@ func Benchmark_Ctx_Format_HTML(b *testing.B) {
 
 	var err error
 	for n := 0; n < b.N; n++ {
-		err = c.Format("Hello, World!")
+		err = c.AutoFormat("Hello, World!")
 	}
 	require.NoError(b, err)
 	require.Equal(b, "<p>Hello, World!</p>", string(c.Response().Body()))
 }
 
-// go test -v -run=^$ -bench=Benchmark_Ctx_Format_JSON -benchmem -count=4
-func Benchmark_Ctx_Format_JSON(b *testing.B) {
+// go test -v -run=^$ -bench=Benchmark_Ctx_AutoFormat_JSON -benchmem -count=4
+func Benchmark_Ctx_AutoFormat_JSON(b *testing.B) {
 	app := New()
 	c := app.NewCtx(&fasthttp.RequestCtx{})
 
@@ -803,14 +920,14 @@ func Benchmark_Ctx_Format_JSON(b *testing.B) {
 
 	var err error
 	for n := 0; n < b.N; n++ {
-		err = c.Format("Hello, World!")
+		err = c.AutoFormat("Hello, World!")
 	}
 	require.NoError(b, err)
 	require.Equal(b, `"Hello, World!"`, string(c.Response().Body()))
 }
 
-// go test -v -run=^$ -bench=Benchmark_Ctx_Format_XML -benchmem -count=4
-func Benchmark_Ctx_Format_XML(b *testing.B) {
+// go test -v -run=^$ -bench=Benchmark_Ctx_AutoFormat_XML -benchmem -count=4
+func Benchmark_Ctx_AutoFormat_XML(b *testing.B) {
 	app := New()
 	c := app.NewCtx(&fasthttp.RequestCtx{})
 
@@ -820,7 +937,7 @@ func Benchmark_Ctx_Format_XML(b *testing.B) {
 
 	var err error
 	for n := 0; n < b.N; n++ {
-		err = c.Format("Hello, World!")
+		err = c.AutoFormat("Hello, World!")
 	}
 	require.NoError(b, err)
 	require.Equal(b, `<string>Hello, World!</string>`, string(c.Response().Body()))

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -187,17 +187,20 @@ app.Get("/", func(c *fiber.Ctx) error {
 ## AutoFormat
 
 Performs content-negotiation on the [Accept](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) HTTP header. It uses [Accepts](ctx.md#accepts) to select a proper format.
+The supported content types are `text/html`, `text/plain`, `application/json`, and `application/xml`.
+For more flexible content negotiation, use [Format](ctx.md#format).
+
 
 :::info
 If the header is **not** specified or there is **no** proper format, **text/plain** is used.
 :::
 
 ```go title="Signature"
-func (c *Ctx) AutoFormat(body interface{}) error
+func (c *Ctx) AutoFormat(body any) error
 ```
 
 ```go title="Example"
-app.Get("/", func(c *fiber.Ctx) error {
+app.Get("/", func(c fiber.Ctx) error {
   // Accept: text/plain
   c.AutoFormat("Hello, World!")
   // => Hello, World!
@@ -206,9 +209,18 @@ app.Get("/", func(c *fiber.Ctx) error {
   c.AutoFormat("Hello, World!")
   // => <p>Hello, World!</p>
 
+  type User struct {
+    Name string
+  }
+  user := User{"John Doe"}
+
   // Accept: application/json
-  c.AutoFormat("Hello, World!")
-  // => "Hello, World!"
+  c.AutoFormat(user)
+  // => {"Name":"John Doe"}
+
+  // Accept: application/xml
+  c.AutoFormat(user)
+  // => <User><Name>John Doe</Name></User>
   // ..
 })
 ```

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -546,7 +546,7 @@ If the Accept header is **not** specified, the first handler will be used.
 :::
 
 ```go title="Signature"
-func (c *Ctx) Format(handlers ...Fmt) error
+func (c *Ctx) Format(handlers ...ResFmt) error
 ```
 
 ```go title="Example"
@@ -555,13 +555,13 @@ func (c *Ctx) Format(handlers ...Fmt) error
 // Accept: application/xml => Not Acceptable
 app.Get("/no-default", func(c fiber.Ctx) error {
   return c.Format(
-    fiber.Fmt{"application/json", func(c fiber.Ctx) error {
+    fiber.ResFmt{"application/json", func(c fiber.Ctx) error {
       return c.JSON(fiber.Map{
         "command": "eat",
         "subject": "fruit",
       })
     }},
-    fiber.Fmt{"text/plain", func(c fiber.Ctx) error {
+    fiber.ResFmt{"text/plain", func(c fiber.Ctx) error {
       return c.SendString("Eat Fruit!")
     }},
   )
@@ -575,7 +575,7 @@ app.Get("/default", func(c fiber.Ctx) error {
     return c.SendString("Eat Fruit!")
   }
 
-  handlers := []fiber.Fmt{
+  handlers := []fiber.ResFmt{
     {"application/json", func(c fiber.Ctx) error {
       return c.JSON(fiber.Map{
         "command": "eat",

--- a/error.go
+++ b/error.go
@@ -7,6 +7,10 @@ import (
 	"github.com/gofiber/fiber/v3/internal/schema"
 )
 
+// Wrap and return this for unreachable code if panicking is undesirable (i.e., in a handler).
+// Unexported because users will hopefully never need to see it.
+var errUnreachable = stdErrors.New("fiber: unreachable code, please create an issue at github.com/gofiber/fiber")
+
 // Graceful shutdown errors
 var (
 	ErrGracefulTimeout = stdErrors.New("shutdown: graceful timeout has been reached, exiting")
@@ -25,6 +29,12 @@ var (
 
 // Binder errors
 var ErrCustomBinderNotFound = stdErrors.New("binder: custom binder not found, please be sure to enter the right name")
+
+// Format errors
+var (
+	// ErrNoHandlers is returned when c.Format is called with no arguments.
+	ErrNoHandlers = stdErrors.New("format: at least one handler is required, but none were set")
+)
 
 // gorilla/schema errors
 type (


### PR DESCRIPTION
## Description

While the existing Ctx.Format provides a concise convenience method for basic content negotiation on simple structures, res.format allows developers to set their own custom handlers for each content type.

Docs: moved the existing Ctx.Format docs to a section called AutoFormat and added docs for the new Ctx.Format.

I'm taking suggestions for better names than `Fmt` for the mediaType-handler struct...was just worried about making it overly long since people will need to type it over and over.

<details>
<summary>Benchmarks</summary>

Performs ever so slightly better than AutoFormat (formerly known as Format)

```
Benchmark_Ctx_Format/with_arg_allocation-8               2578868               464.5 ns/op            96 B/op          1 allocs/op
Benchmark_Ctx_Format/with_arg_allocation-8               2577880               466.9 ns/op            96 B/op          1 allocs/op
Benchmark_Ctx_Format/with_arg_allocation-8               2596575               462.0 ns/op            96 B/op          1 allocs/op
Benchmark_Ctx_Format/with_arg_allocation-8               2564602               460.6 ns/op            96 B/op          1 allocs/op
Benchmark_Ctx_Format/pre-allocated_args-8                2983128               407.3 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_Format/pre-allocated_args-8                3031767               400.3 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_Format/pre-allocated_args-8                3045684               397.7 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_Format/pre-allocated_args-8                2986521               407.1 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_Format/text/plain-8                       12827778                92.41 ns/op            0 B/op          0 allocs/op
Benchmark_Ctx_Format/text/plain-8                       13453144                93.66 ns/op            0 B/op          0 allocs/op
Benchmark_Ctx_Format/text/plain-8                       13534003                86.67 ns/op            0 B/op          0 allocs/op
Benchmark_Ctx_Format/text/plain-8                       13168622                88.81 ns/op            0 B/op          0 allocs/op
Benchmark_Ctx_Format/json-8                              9903925               128.8 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_Format/json-8                              9780688               124.1 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_Format/json-8                              9499648               128.1 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_Format/json-8                              9510656               122.2 ns/op             0 B/op          0 allocs/op
```

</details>

Related to #2745

## Migration

To make their code compatible with Fiber v3, users need only replace their uses of `c.Format` to `c.AutoFormat`.
To make full use of the new `c.Format`, users should note where in their application they are performing manual content negotiation and consider if `c.Format` will simplify their code.

## Changes Introduced

- [x] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [x] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [x] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [x] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [x] API Alignment with Express: Explain how the changes align with the Express API.
- [x] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [x] Examples: Provide examples demonstrating the new features or changes in action.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (changes to documentation)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.
