### PR TITLE
🩹 Fix: CORS middleware should use the defined AllowedOriginsFunc config when AllowedOrigins is empty

### DIFF
--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -94,13 +94,14 @@ func New(config ...Config) fiber.Handler {
 		if cfg.AllowMethods == "" {
 			cfg.AllowMethods = ConfigDefault.AllowMethods
 		}
-		if cfg.AllowOrigins == "" {
+		// When none of the AllowOrigins or AllowOriginsFunc config was defined, set the default AllowOrigins value with "*"
+		if cfg.AllowOrigins == "" && cfg.AllowOriginsFunc == nil {
 			cfg.AllowOrigins = ConfigDefault.AllowOrigins
 		}
 	}
 
 	// Warning logs if both AllowOrigins and AllowOriginsFunc are set
-	if cfg.AllowOrigins != ConfigDefault.AllowOrigins && cfg.AllowOriginsFunc != nil {
+	if cfg.AllowOrigins != "" && cfg.AllowOriginsFunc != nil {
 		log.Warn("[CORS] Both 'AllowOrigins' and 'AllowOriginsFunc' have been defined.")
 	}
 
@@ -145,7 +146,7 @@ func New(config ...Config) fiber.Handler {
 		// Run AllowOriginsFunc if the logic for
 		// handling the value in 'AllowOrigins' does
 		// not result in allowOrigin being set.
-		if (allowOrigin == "" || allowOrigin == ConfigDefault.AllowOrigins) && cfg.AllowOriginsFunc != nil {
+		if allowOrigin == "" && cfg.AllowOriginsFunc != nil {
 			if cfg.AllowOriginsFunc(origin) {
 				allowOrigin = origin
 			}


### PR DESCRIPTION
## Description

Current CORS middleware always returns the header `Access-Control-Allow-Origin` with the value of `*` when `AllowOriginsFunc` is defined and the function does not return `true`. It was due to the middleware always setting the default origin value with `*` whenever the `AllowOrigins` config is empty. So whenever the request origin is not allowed by the function (returns false), the middleware will return `*` in the `Access-Control-Allow-Origin` header which makes the function useless.

This PR sets the default origin value of `*` only when both `AllowOrigins` and `AllowOriginsFunc` configs are not defined so that it will not return the `Access-Control-Allow-Origin` header with the value of `*` when the function does not return `true`. Instead, it will return an empty origin when the function returns false, which means the request is rejected by CORS.

Current use cases
| AllowedOrigins | AllowedOriginsFunc | Request Origin | Response Origin |  | 
| --- | --- | --- | --- | --- |
| http://aaa.com |  nil | http://aaa.com | http://aaa.com | ✅ |
| http://aaa.com |  nil | http://bbb.com | empty | ✅ |
| http://aaa.com | return **true** | http://aaa.com | http://aaa.com | ✅ |
| http://aaa.com | return **true** | http://bbb.com | http://bbb.com | ✅ |
| http://aaa.com | return **false** | http://aaa.com | http://aaa.com | ✅ |
| http://aaa.com | return **false** | http://bbb.com | empty | ✅ |
| empty | nil | http://aaa.com | `*` | ✅ |
| empty | return **true** | http://aaa.com | http://aaa.com | ✅ |
| empty | return **false** | http://bbb.com | `*` | ❌ |

New use cases
| AllowedOrigins | AllowedOriginsFunc | Request Origin | Response Origin |  |
| --- | --- | --- | --- | --- |
| http://aaa.com |  nil | http://aaa.com | http://aaa.com | ✅ |
| http://aaa.com |  nil | http://bbb.com | empty | ✅ |
| http://aaa.com | return **true** | http://aaa.com | http://aaa.com | ✅ |
| http://aaa.com | return **true** | http://bbb.com | http://bbb.com | ✅ |
| http://aaa.com | return **false** | http://aaa.com | http://aaa.com | ✅ |
| http://aaa.com | return **false** | http://bbb.com | empty | ✅ |
| empty | nil | http://aaa.com | `*` | ✅ |
| empty | return **true** | http://aaa.com | http://aaa.com | ✅ |
| empty | return **false** | http://bbb.com | empty | ✅ |

Fixes #2770

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
