### PR TITLE
🐛 [Bug]: Adaptator + otelfiber issue #2641

### DIFF
--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -76,6 +76,7 @@ func HTTPMiddleware(mw func(http.Handler) http.Handler) fiber.Handler {
 			c.Request().Header.SetMethod(r.Method)
 			c.Request().SetRequestURI(r.RequestURI)
 			c.Request().SetHost(r.Host)
+			c.Request().Header.SetHost(r.Host)
 			for key, val := range r.Header {
 				for _, v := range val {
 					c.Request().Header.Set(key, v)
@@ -128,6 +129,7 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 		req.Header.SetMethod(r.Method)
 		req.SetRequestURI(r.RequestURI)
 		req.SetHost(r.Host)
+		req.Header.SetHost(r.Host)
 		for key, val := range r.Header {
 			for _, v := range val {
 				req.Header.Set(key, v)

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -116,6 +116,7 @@ var (
 )
 
 func Test_HTTPMiddleware(t *testing.T) {
+	const expectedHost = "foobar.com"
 	tests := []struct {
 		name       string
 		url        string
@@ -148,6 +149,7 @@ func Test_HTTPMiddleware(t *testing.T) {
 				w.WriteHeader(http.StatusMethodNotAllowed)
 				return
 			}
+
 			r = r.WithContext(context.WithValue(r.Context(), TestContextKey, "okay"))
 			r = r.WithContext(context.WithValue(r.Context(), TestContextSecondKey, "not_okay"))
 			r = r.WithContext(context.WithValue(r.Context(), TestContextSecondKey, "okay"))
@@ -180,6 +182,7 @@ func Test_HTTPMiddleware(t *testing.T) {
 
 	for _, tt := range tests {
 		req, err := http.NewRequestWithContext(context.Background(), tt.method, tt.url, nil)
+		req.Host = expectedHost
 		utils.AssertEqual(t, nil, err)
 
 		resp, err := app.Test(req)
@@ -188,6 +191,7 @@ func Test_HTTPMiddleware(t *testing.T) {
 	}
 
 	req, err := http.NewRequestWithContext(context.Background(), fiber.MethodPost, "/", nil)
+	req.Host = expectedHost
 	utils.AssertEqual(t, nil, err)
 
 	resp, err := app.Test(req)
@@ -239,6 +243,8 @@ func testFiberToHandlerFunc(t *testing.T, checkDefaultPort bool, app ...*fiber.A
 		utils.AssertEqual(t, expectedRequestURI, string(c.Context().RequestURI()), "RequestURI")
 		utils.AssertEqual(t, expectedContentLength, c.Context().Request.Header.ContentLength(), "ContentLength")
 		utils.AssertEqual(t, expectedHost, c.Hostname(), "Host")
+		utils.AssertEqual(t, expectedHost, string(c.Request().Header.Host()), "Host")
+		utils.AssertEqual(t, "http://"+expectedHost, c.BaseURL(), "BaseURL")
 		utils.AssertEqual(t, expectedRemoteAddr, c.Context().RemoteAddr().String(), "RemoteAddr")
 
 		body := string(c.Body())


### PR DESCRIPTION
## Description

It solves Adaptator + otelfiber issue bug where combination of Adaptator + Otelfiber contrib Middleware, c.BaseURL() returns wrong value (http:// instead of http://localhost:3000)
[issue link](https://github.com/gofiber/fiber/issues/2641)
Detailed explanation of solution of this issue is mentioned in [here](https://github.com/gofiber/fiber/issues/2641#issuecomment-1741785618)


Fixes #2641 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I tried to make my code as fast as possible with as few allocations as possible

