### PR TITLE
📚 Doc: Undocumented function in session.md

### DIFF
--- a/docs/api/middleware/session.md
+++ b/docs/api/middleware/session.md
@@ -29,6 +29,7 @@ func (s *Session) Save() error
 func (s *Session) Fresh() bool
 func (s *Session) ID() string
 func (s *Session) Keys() []string
+func (s *Session) SetExpiry(exp time.Duration)
 ```
 
 :::caution


### PR DESCRIPTION
SetExpiry was not listed in the Session functions.