### PR TITLE
chore: change interface{} to any

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1288,10 +1288,10 @@ func (c *DefaultCtx) Render(name string, bind Map, layouts ...string) error {
 	return nil
 }
 
-func (c *DefaultCtx) renderExtensions(bind interface{}) {
+func (c *DefaultCtx) renderExtensions(bind any) {
 	if bindMap, ok := bind.(Map); ok {
 		// Bind view map
-		c.viewBindMap.Range(func(key, value interface{}) bool {
+		c.viewBindMap.Range(func(key, value any) bool {
 			keyValue, ok := key.(string)
 			if !ok {
 				return true
@@ -1305,7 +1305,7 @@ func (c *DefaultCtx) renderExtensions(bind interface{}) {
 		// Check if the PassLocalsToViews option is enabled (by default it is disabled)
 		if c.app.config.PassLocalsToViews {
 			// Loop through each local and set it in the map
-			c.fasthttp.VisitUserValues(func(key []byte, val interface{}) {
+			c.fasthttp.VisitUserValues(func(key []byte, val any) {
 				// check if bindMap doesn't contain the key
 				if _, ok := bindMap[c.app.getString(key)]; !ok {
 					// Set the key and value in the bindMap

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2698,7 +2698,7 @@ func Test_Ctx_JSON(t *testing.T) {
 	require.Equal(t, `{"Age":20,"Name":"Grame"}`, string(c.Response().Body()))
 	require.Equal(t, "application/problem+json", string(c.Response().Header.Peek("content-type")))
 
-	testEmpty := func(v interface{}, r string) {
+	testEmpty := func(v any, r string) {
 		err := c.JSON(v)
 		require.NoError(t, err)
 		require.Equal(t, r, string(c.Response().Body()))
@@ -2713,7 +2713,7 @@ func Test_Ctx_JSON(t *testing.T) {
 		t.Parallel()
 
 		app := New(Config{
-			JSONEncoder: func(v interface{}) ([]byte, error) {
+			JSONEncoder: func(v any) ([]byte, error) {
 				return []byte(`["custom","json"]`), nil
 			},
 		})
@@ -2804,7 +2804,7 @@ func Test_Ctx_JSONP(t *testing.T) {
 		t.Parallel()
 
 		app := New(Config{
-			JSONEncoder: func(v interface{}) ([]byte, error) {
+			JSONEncoder: func(v any) ([]byte, error) {
 				return []byte(`["custom","json"]`), nil
 			},
 		})
@@ -2881,7 +2881,7 @@ func Test_Ctx_XML(t *testing.T) {
 		t.Parallel()
 
 		app := New(Config{
-			XMLEncoder: func(v interface{}) ([]byte, error) {
+			XMLEncoder: func(v any) ([]byte, error) {
 				return []byte(`<custom>xml</custom>`), nil
 			},
 		})

--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -271,7 +271,7 @@ agent.BodyStream(strings.NewReader("body=stream"), -1)
 JSON sends a JSON request by setting the Content-Type header to the `ctype` parameter. If no `ctype` is passed in, the header is set to `application/json`.
 
 ```go title="Signature"
-func (a *Agent) JSON(v interface{}, ctype ...string) *Agent
+func (a *Agent) JSON(v any, ctype ...string) *Agent
 ```
 
 ```go title="Example"
@@ -284,7 +284,7 @@ agent.JSON(fiber.Map{"success": true})
 XML sends an XML request by setting the Content-Type header to `application/xml`.
 
 ```go title="Signature"
-func (a *Agent) XML(v interface{}) *Agent
+func (a *Agent) XML(v any) *Agent
 ```
 
 ```go title="Example"
@@ -636,7 +636,7 @@ code, body, errs := agent.String()
 Struct returns the status code, bytes body and errors of url. And bytes body will be unmarshalled to given v.
 
 ```go title="Signature"
-func (a *Agent) Struct(v interface{}) (code int, body []byte, errs []error)
+func (a *Agent) Struct(v any) (code int, body []byte, errs []error)
 ```
 
 ```go title="Example"

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -318,7 +318,7 @@ It is important to specify the correct struct tag based on the content type to b
 | `text/xml`                          | xml        |
 
 ```go title="Signature"
-func (c *Ctx) BodyParser(out interface{}) error
+func (c *Ctx) BodyParser(out any) error
 ```
 
 ```go title="Example"
@@ -481,7 +481,7 @@ This method is similar to [BodyParser](ctx.md#bodyparser), but for cookie parame
 It is important to use the struct tag "cookie". For example, if you want to parse a cookie with a field called Age, you would use a struct field of `cookie:"age"`.
 
 ```go title="Signature"
-func (c *Ctx) CookieParser(out interface{}) error
+func (c *Ctx) CookieParser(out any) error
 ```
 
 ```go title="Example"
@@ -866,7 +866,7 @@ JSON also sets the content header to the `ctype` parameter. If no `ctype` is pas
 :::
 
 ```go title="Signature"
-func (c *Ctx) JSON(data interface{}, ctype ...string) error
+func (c *Ctx) JSON(data any, ctype ...string) error
 ```
 
 ```go title="Example"
@@ -918,7 +918,7 @@ Sends a JSON response with JSONP support. This method is identical to [JSON](ctx
 Override this by passing a **named string** in the method.
 
 ```go title="Signature"
-func (c *Ctx) JSONP(data interface{}, callback ...string) error
+func (c *Ctx) JSONP(data any, callback ...string) error
 ```
 
 ```go title="Example"
@@ -972,7 +972,7 @@ This is useful if you want to pass some **specific** data to the next middleware
 :::
 
 ```go title="Signature"
-func (c *Ctx) Locals(key interface{}, value ...interface{}) interface{}
+func (c *Ctx) Locals(key any, value ...any) any
 ```
 
 ```go title="Example"
@@ -1204,7 +1204,7 @@ This method is equivalent of using `atoi` with ctx.Params
 This method is similar to BodyParser, but for path parameters. It is important to use the struct tag "params". For example, if you want to parse a path parameter with a field called Pass, you would use a struct field of params:"pass"
 
 ```go title="Signature"
-func (c *Ctx) ParamsParser(out interface{}) error
+func (c *Ctx) ParamsParser(out any) error
 ```
 
 ```go title="Example"
@@ -1444,7 +1444,7 @@ This method is similar to [BodyParser](ctx.md#bodyparser), but for query paramet
 It is important to use the struct tag "query". For example, if you want to parse a query parameter with a field called Pass, you would use a struct field of `query:"pass"`.
 
 ```go title="Signature"
-func (c *Ctx) QueryParser(out interface{}) error
+func (c *Ctx) QueryParser(out any) error
 ```
 
 ```go title="Example"
@@ -1593,7 +1593,7 @@ app.Get("/back", func(c fiber.Ctx) error {
 Renders a view with data and sends a `text/html` response. By default `Render` uses the default [**Go Template engine**](https://pkg.go.dev/html/template/). If you want to use another View engine, please take a look at our [**Template middleware**](https://docs.gofiber.io/template).
 
 ```go title="Signature"
-func (c *Ctx) Render(name string, bind interface{}, layouts ...string) error
+func (c *Ctx) Render(name string, bind any, layouts ...string) error
 ```
 
 ## Request
@@ -1617,7 +1617,7 @@ This method is similar to [BodyParser](ctx.md#bodyparser), but for request heade
 It is important to use the struct tag "reqHeader". For example, if you want to parse a request header with a field called Pass, you would use a struct field of `reqHeader:"pass"`.
 
 ```go title="Signature"
-func (c *Ctx) ReqHeaderParser(out interface{}) error
+func (c *Ctx) ReqHeaderParser(out any) error
 ```
 
 ```go title="Example"
@@ -1916,7 +1916,7 @@ Allow you to config BodyParser/QueryParser decoder, base on schema's options, pr
 func SetParserDecoder(parserConfig fiber.ParserConfig{
   IgnoreUnknownKeys bool,
   ParserType        []fiber.ParserType{
-      Customtype interface{},
+      Customtype any,
       Converter  func(string) reflect.Value,
   },
   ZeroEmpty         bool,
@@ -2142,7 +2142,7 @@ app.Get("/", func(c fiber.Ctx) error {
 Writef adopts the string with variables
 
 ```go title="Signature"
-func (c *Ctx) Writef(f string, a ...interface{}) (n int, err error)
+func (c *Ctx) Writef(f string, a ...any) (n int, err error)
 ```
 
 ```go title="Example"
@@ -2197,7 +2197,7 @@ XML also sets the content header to **application/xml**.
 :::
 
 ```go title="Signature"
-func (c *Ctx) XML(data interface{}) error
+func (c *Ctx) XML(data any) error
 ```
 
 ```go title="Example"

--- a/docs/api/middleware/adaptor.md
+++ b/docs/api/middleware/adaptor.md
@@ -16,7 +16,7 @@ Converter for net/http handlers to/from Fiber request handlers, special thanks t
 | FiberHandlerFunc | `FiberHandlerFunc(h fiber.Handler) http.HandlerFunc` | fiber.Handler -> http.HandlerFunc
 | FiberApp | `FiberApp(app *fiber.App) http.HandlerFunc` | Fiber app -> http.HandlerFunc
 | ConvertRequest | `ConvertRequest(c fiber.Ctx, forServer bool) (*http.Request, error)` | fiber.Ctx -> http.Request
-| CopyContextToFiberContext | `CopyContextToFiberContext(context interface{}, requestContext *fasthttp.RequestCtx)` | context.Context -> fasthttp.RequestCtx
+| CopyContextToFiberContext | `CopyContextToFiberContext(context any, requestContext *fasthttp.RequestCtx)` | context.Context -> fasthttp.RequestCtx
 
 ## Examples
 

--- a/docs/api/middleware/recover.md
+++ b/docs/api/middleware/recover.md
@@ -41,7 +41,7 @@ app.Get("/", func(c fiber.Ctx) error {
 |:------------------|:--------------------------------|:--------------------------------------------------------------------|:-------------------------|
 | Next              | `func(fiber.Ctx) bool`         | Next defines a function to skip this middleware when returned true. | `nil`                    |
 | EnableStackTrace  | `bool`                          | EnableStackTrace enables handling stack trace.                      | `false`                  |
-| StackTraceHandler | `func(fiber.Ctx, interface{})` | StackTraceHandler defines a function to handle stack trace.         | defaultStackTraceHandler |
+| StackTraceHandler | `func(fiber.Ctx, any)` | StackTraceHandler defines a function to handle stack trace.         | defaultStackTraceHandler |
 
 ## Default Config
 

--- a/docs/api/middleware/session.md
+++ b/docs/api/middleware/session.md
@@ -14,13 +14,13 @@ This middleware uses our [Storage](https://github.com/gofiber/storage) package t
 
 ```go
 func New(config ...Config) *Store
-func (s *Store) RegisterType(i interface{})
+func (s *Store) RegisterType(i any)
 func (s *Store) Get(c fiber.Ctx) (*Session, error)
 func (s *Store) Delete(id string) error
 func (s *Store) Reset() error
 
-func (s *Session) Get(key string) interface{}
-func (s *Session) Set(key string, val interface{})
+func (s *Session) Get(key string) any
+func (s *Session) Set(key string, val any)
 func (s *Session) Delete(key string)
 func (s *Session) Destroy() error
 func (s *Session) Reset() error
@@ -33,7 +33,7 @@ func (s *Session) SetExpiry(exp time.Duration)
 ```
 
 :::caution
-Storing `interface{}` values are limited to built-ins Go types.
+Storing `any` values are limited to built-ins Go types.
 :::
 
 ## Examples

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -18,7 +18,7 @@ Fiber provides a Views interface to provide your own template engine:
 ```go
 type Views interface {
     Load() error
-    Render(io.Writer, string, interface{}, ...string) error
+    Render(io.Writer, string, any, ...string) error
 }
 ```
 </TabItem>

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -36,7 +36,7 @@ type (
 		Error       bool
 		FailedField string
 		Tag         string
-		Value       interface{}
+		Value       any
 	}
 
 	XValidator struct {
@@ -53,7 +53,7 @@ type (
 // for more information see: https://github.com/go-playground/validator
 var validate = validator.New()
 
-func (v XValidator) Validate(data interface{}) []ErrorResponse {
+func (v XValidator) Validate(data any) []ErrorResponse {
 	validationErrors := []ErrorResponse{}
 
 	errs := validate.Struct(data)

--- a/docs/partials/routing/handler.md
+++ b/docs/partials/routing/handler.md
@@ -40,7 +40,7 @@ app.Post("/api/register", func(c fiber.Ctx) error {
 **Use** can be used for middleware packages and prefix catchers. These routes will only match the beginning of each path i.e. `/john` will match `/john/doe`, `/johnnnnn` etc
 
 ```go title="Signature"
-func (app *App) Use(args ...interface{}) Router
+func (app *App) Use(args ...any) Router
 ```
 
 ```go title="Examples"

--- a/log/default.go
+++ b/log/default.go
@@ -21,7 +21,7 @@ type defaultLogger struct {
 
 // privateLog logs a message at a given level log the default logger.
 // when the level is fatal, it will exit the program.
-func (l *defaultLogger) privateLog(lv Level, fmtArgs []interface{}) {
+func (l *defaultLogger) privateLog(lv Level, fmtArgs []any) {
 	if l.level > lv {
 		return
 	}
@@ -40,7 +40,7 @@ func (l *defaultLogger) privateLog(lv Level, fmtArgs []interface{}) {
 
 // privateLog logs a message at a given level log the default logger.
 // when the level is fatal, it will exit the program.
-func (l *defaultLogger) privateLogf(lv Level, format string, fmtArgs []interface{}) {
+func (l *defaultLogger) privateLogf(lv Level, format string, fmtArgs []any) {
 	if l.level > lv {
 		return
 	}
@@ -63,7 +63,7 @@ func (l *defaultLogger) privateLogf(lv Level, format string, fmtArgs []interface
 
 // privateLogw logs a message at a given level log the default logger.
 // when the level is fatal, it will exit the program.
-func (l *defaultLogger) privateLogw(lv Level, format string, keysAndValues []interface{}) {
+func (l *defaultLogger) privateLogw(lv Level, format string, keysAndValues []any) {
 	if l.level > lv {
 		return
 	}
@@ -103,87 +103,87 @@ func (l *defaultLogger) privateLogw(lv Level, format string, keysAndValues []int
 	}
 }
 
-func (l *defaultLogger) Trace(v ...interface{}) {
+func (l *defaultLogger) Trace(v ...any) {
 	l.privateLog(LevelTrace, v)
 }
 
-func (l *defaultLogger) Debug(v ...interface{}) {
+func (l *defaultLogger) Debug(v ...any) {
 	l.privateLog(LevelDebug, v)
 }
 
-func (l *defaultLogger) Info(v ...interface{}) {
+func (l *defaultLogger) Info(v ...any) {
 	l.privateLog(LevelInfo, v)
 }
 
-func (l *defaultLogger) Warn(v ...interface{}) {
+func (l *defaultLogger) Warn(v ...any) {
 	l.privateLog(LevelWarn, v)
 }
 
-func (l *defaultLogger) Error(v ...interface{}) {
+func (l *defaultLogger) Error(v ...any) {
 	l.privateLog(LevelError, v)
 }
 
-func (l *defaultLogger) Fatal(v ...interface{}) {
+func (l *defaultLogger) Fatal(v ...any) {
 	l.privateLog(LevelFatal, v)
 }
 
-func (l *defaultLogger) Panic(v ...interface{}) {
+func (l *defaultLogger) Panic(v ...any) {
 	l.privateLog(LevelPanic, v)
 }
 
-func (l *defaultLogger) Tracef(format string, v ...interface{}) {
+func (l *defaultLogger) Tracef(format string, v ...any) {
 	l.privateLogf(LevelTrace, format, v)
 }
 
-func (l *defaultLogger) Debugf(format string, v ...interface{}) {
+func (l *defaultLogger) Debugf(format string, v ...any) {
 	l.privateLogf(LevelDebug, format, v)
 }
 
-func (l *defaultLogger) Infof(format string, v ...interface{}) {
+func (l *defaultLogger) Infof(format string, v ...any) {
 	l.privateLogf(LevelInfo, format, v)
 }
 
-func (l *defaultLogger) Warnf(format string, v ...interface{}) {
+func (l *defaultLogger) Warnf(format string, v ...any) {
 	l.privateLogf(LevelWarn, format, v)
 }
 
-func (l *defaultLogger) Errorf(format string, v ...interface{}) {
+func (l *defaultLogger) Errorf(format string, v ...any) {
 	l.privateLogf(LevelError, format, v)
 }
 
-func (l *defaultLogger) Fatalf(format string, v ...interface{}) {
+func (l *defaultLogger) Fatalf(format string, v ...any) {
 	l.privateLogf(LevelFatal, format, v)
 }
 
-func (l *defaultLogger) Panicf(format string, v ...interface{}) {
+func (l *defaultLogger) Panicf(format string, v ...any) {
 	l.privateLogf(LevelPanic, format, v)
 }
 
-func (l *defaultLogger) Tracew(msg string, keysAndValues ...interface{}) {
+func (l *defaultLogger) Tracew(msg string, keysAndValues ...any) {
 	l.privateLogw(LevelTrace, msg, keysAndValues)
 }
 
-func (l *defaultLogger) Debugw(msg string, keysAndValues ...interface{}) {
+func (l *defaultLogger) Debugw(msg string, keysAndValues ...any) {
 	l.privateLogw(LevelDebug, msg, keysAndValues)
 }
 
-func (l *defaultLogger) Infow(msg string, keysAndValues ...interface{}) {
+func (l *defaultLogger) Infow(msg string, keysAndValues ...any) {
 	l.privateLogw(LevelInfo, msg, keysAndValues)
 }
 
-func (l *defaultLogger) Warnw(msg string, keysAndValues ...interface{}) {
+func (l *defaultLogger) Warnw(msg string, keysAndValues ...any) {
 	l.privateLogw(LevelWarn, msg, keysAndValues)
 }
 
-func (l *defaultLogger) Errorw(msg string, keysAndValues ...interface{}) {
+func (l *defaultLogger) Errorw(msg string, keysAndValues ...any) {
 	l.privateLogw(LevelError, msg, keysAndValues)
 }
 
-func (l *defaultLogger) Fatalw(msg string, keysAndValues ...interface{}) {
+func (l *defaultLogger) Fatalw(msg string, keysAndValues ...any) {
 	l.privateLogw(LevelFatal, msg, keysAndValues)
 }
 
-func (l *defaultLogger) Panicw(msg string, keysAndValues ...interface{}) {
+func (l *defaultLogger) Panicw(msg string, keysAndValues ...any) {
 	l.privateLogw(LevelPanic, msg, keysAndValues)
 }
 

--- a/log/default_test.go
+++ b/log/default_test.go
@@ -97,8 +97,8 @@ func Test_LogfKeyAndValues(t *testing.T) {
 		name          string
 		level         Level
 		format        string
-		fmtArgs       []interface{}
-		keysAndValues []interface{}
+		fmtArgs       []any
+		keysAndValues []any
 		wantOutput    string
 	}{
 		{
@@ -106,7 +106,7 @@ func Test_LogfKeyAndValues(t *testing.T) {
 			level:         LevelDebug,
 			format:        "",
 			fmtArgs:       nil,
-			keysAndValues: []interface{}{"name", "Bob", "age", 30},
+			keysAndValues: []any{"name", "Bob", "age", 30},
 			wantOutput:    "[Debug] name=Bob age=30\n",
 		},
 		{
@@ -114,7 +114,7 @@ func Test_LogfKeyAndValues(t *testing.T) {
 			level:         LevelInfo,
 			format:        "",
 			fmtArgs:       nil,
-			keysAndValues: []interface{}{"status", "ok", "code", 200},
+			keysAndValues: []any{"status", "ok", "code", 200},
 			wantOutput:    "[Info] status=ok code=200\n",
 		},
 		{
@@ -122,7 +122,7 @@ func Test_LogfKeyAndValues(t *testing.T) {
 			level:         LevelWarn,
 			format:        "",
 			fmtArgs:       nil,
-			keysAndValues: []interface{}{"error", "not found", "id", 123},
+			keysAndValues: []any{"error", "not found", "id", 123},
 			wantOutput:    "[Warn] error=not found id=123\n",
 		},
 		{
@@ -130,7 +130,7 @@ func Test_LogfKeyAndValues(t *testing.T) {
 			level:         LevelWarn,
 			format:        "test",
 			fmtArgs:       nil,
-			keysAndValues: []interface{}{"error", "not found", "id", 123},
+			keysAndValues: []any{"error", "not found", "id", 123},
 			wantOutput:    "[Warn] test error=not found id=123\n",
 		},
 		{
@@ -138,7 +138,7 @@ func Test_LogfKeyAndValues(t *testing.T) {
 			level:         LevelWarn,
 			format:        "",
 			fmtArgs:       nil,
-			keysAndValues: []interface{}{"error"},
+			keysAndValues: []any{"error"},
 			wantOutput:    "[Warn] error=KEYVALS UNPAIRED\n",
 		},
 	}

--- a/log/fiberlog.go
+++ b/log/fiberlog.go
@@ -6,114 +6,114 @@ import (
 )
 
 // Fatal calls the default logger's Fatal method and then os.Exit(1).
-func Fatal(v ...interface{}) {
+func Fatal(v ...any) {
 	logger.Fatal(v...)
 }
 
 // Error calls the default logger's Error method.
-func Error(v ...interface{}) {
+func Error(v ...any) {
 	logger.Error(v...)
 }
 
 // Warn calls the default logger's Warn method.
-func Warn(v ...interface{}) {
+func Warn(v ...any) {
 	logger.Warn(v...)
 }
 
 // Info calls the default logger's Info method.
-func Info(v ...interface{}) {
+func Info(v ...any) {
 	logger.Info(v...)
 }
 
 // Debug calls the default logger's Debug method.
-func Debug(v ...interface{}) {
+func Debug(v ...any) {
 	logger.Debug(v...)
 }
 
 // Trace calls the default logger's Trace method.
-func Trace(v ...interface{}) {
+func Trace(v ...any) {
 	logger.Trace(v...)
 }
 
 // Panic calls the default logger's Panic method.
-func Panic(v ...interface{}) {
+func Panic(v ...any) {
 	logger.Panic(v...)
 }
 
 // Fatalf calls the default logger's Fatalf method and then os.Exit(1).
-func Fatalf(format string, v ...interface{}) {
+func Fatalf(format string, v ...any) {
 	logger.Fatalf(format, v...)
 }
 
 // Errorf calls the default logger's Errorf method.
-func Errorf(format string, v ...interface{}) {
+func Errorf(format string, v ...any) {
 	logger.Errorf(format, v...)
 }
 
 // Warnf calls the default logger's Warnf method.
-func Warnf(format string, v ...interface{}) {
+func Warnf(format string, v ...any) {
 	logger.Warnf(format, v...)
 }
 
 // Infof calls the default logger's Infof method.
-func Infof(format string, v ...interface{}) {
+func Infof(format string, v ...any) {
 	logger.Infof(format, v...)
 }
 
 // Debugf calls the default logger's Debugf method.
-func Debugf(format string, v ...interface{}) {
+func Debugf(format string, v ...any) {
 	logger.Debugf(format, v...)
 }
 
 // Tracef calls the default logger's Tracef method.
-func Tracef(format string, v ...interface{}) {
+func Tracef(format string, v ...any) {
 	logger.Tracef(format, v...)
 }
 
 // Panicf calls the default logger's Tracef method.
-func Panicf(format string, v ...interface{}) {
+func Panicf(format string, v ...any) {
 	logger.Panicf(format, v...)
 }
 
 // Tracew logs a message with some additional context. The variadic key-value
 // pairs are treated as they are privateLog With.
-func Tracew(msg string, keysAndValues ...interface{}) {
+func Tracew(msg string, keysAndValues ...any) {
 	logger.Tracew(msg, keysAndValues...)
 }
 
 // Debugw logs a message with some additional context. The variadic key-value
 // pairs are treated as they are privateLog With.
-func Debugw(msg string, keysAndValues ...interface{}) {
+func Debugw(msg string, keysAndValues ...any) {
 	logger.Debugw(msg, keysAndValues...)
 }
 
 // Infow logs a message with some additional context. The variadic key-value
 // pairs are treated as they are privateLog With.
-func Infow(msg string, keysAndValues ...interface{}) {
+func Infow(msg string, keysAndValues ...any) {
 	logger.Infow(msg, keysAndValues...)
 }
 
 // Warnw logs a message with some additional context. The variadic key-value
 // pairs are treated as they are privateLog With.
-func Warnw(msg string, keysAndValues ...interface{}) {
+func Warnw(msg string, keysAndValues ...any) {
 	logger.Warnw(msg, keysAndValues...)
 }
 
 // Errorw logs a message with some additional context. The variadic key-value
 // pairs are treated as they are privateLog With.
-func Errorw(msg string, keysAndValues ...interface{}) {
+func Errorw(msg string, keysAndValues ...any) {
 	logger.Errorw(msg, keysAndValues...)
 }
 
 // Fatalw logs a message with some additional context. The variadic key-value
 // pairs are treated as they are privateLog With.
-func Fatalw(msg string, keysAndValues ...interface{}) {
+func Fatalw(msg string, keysAndValues ...any) {
 	logger.Fatalw(msg, keysAndValues...)
 }
 
 // Panicw logs a message with some additional context. The variadic key-value
 // pairs are treated as they are privateLog With.
-func Panicw(msg string, keysAndValues ...interface{}) {
+func Panicw(msg string, keysAndValues ...any) {
 	logger.Panicw(msg, keysAndValues...)
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -15,35 +15,35 @@ var logger AllLogger = &defaultLogger{
 
 // Logger is a logger interface that provides logging function with levels.
 type Logger interface {
-	Trace(v ...interface{})
-	Debug(v ...interface{})
-	Info(v ...interface{})
-	Warn(v ...interface{})
-	Error(v ...interface{})
-	Fatal(v ...interface{})
-	Panic(v ...interface{})
+	Trace(v ...any)
+	Debug(v ...any)
+	Info(v ...any)
+	Warn(v ...any)
+	Error(v ...any)
+	Fatal(v ...any)
+	Panic(v ...any)
 }
 
 // FormatLogger is a logger interface that output logs with a format.
 type FormatLogger interface {
-	Tracef(format string, v ...interface{})
-	Debugf(format string, v ...interface{})
-	Infof(format string, v ...interface{})
-	Warnf(format string, v ...interface{})
-	Errorf(format string, v ...interface{})
-	Fatalf(format string, v ...interface{})
-	Panicf(format string, v ...interface{})
+	Tracef(format string, v ...any)
+	Debugf(format string, v ...any)
+	Infof(format string, v ...any)
+	Warnf(format string, v ...any)
+	Errorf(format string, v ...any)
+	Fatalf(format string, v ...any)
+	Panicf(format string, v ...any)
 }
 
 // WithLogger is a logger interface that output logs with a message and key-value pairs.
 type WithLogger interface {
-	Tracew(msg string, keysAndValues ...interface{})
-	Debugw(msg string, keysAndValues ...interface{})
-	Infow(msg string, keysAndValues ...interface{})
-	Warnw(msg string, keysAndValues ...interface{})
-	Errorw(msg string, keysAndValues ...interface{})
-	Fatalw(msg string, keysAndValues ...interface{})
-	Panicw(msg string, keysAndValues ...interface{})
+	Tracew(msg string, keysAndValues ...any)
+	Debugw(msg string, keysAndValues ...any)
+	Infow(msg string, keysAndValues ...any)
+	Warnw(msg string, keysAndValues ...any)
+	Errorw(msg string, keysAndValues ...any)
+	Fatalw(msg string, keysAndValues ...any)
+	Panicw(msg string, keysAndValues ...any)
 }
 
 type CommonLogger interface {

--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -38,11 +38,11 @@ func ConvertRequest(c fiber.Ctx, forServer bool) (*http.Request, error) {
 }
 
 // CopyContextToFiberContext copies the values of context.Context to a fasthttp.RequestCtx
-func CopyContextToFiberContext(context interface{}, requestContext *fasthttp.RequestCtx) {
+func CopyContextToFiberContext(context any, requestContext *fasthttp.RequestCtx) {
 	contextValues := reflect.ValueOf(context).Elem()
 	contextKeys := reflect.TypeOf(context).Elem()
 	if contextKeys.Kind() == reflect.Struct {
-		var lastKey interface{}
+		var lastKey any
 		for i := 0; i < contextValues.NumField(); i++ {
 			reflectValue := contextValues.Field(i)
 			/* #nosec */

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -292,7 +292,7 @@ func testFiberToHandlerFunc(t *testing.T, checkDefaultPort bool, app ...*fiber.A
 	require.Equal(t, expectedResponseBody, string(w.body), "Body")
 }
 
-func setFiberContextValueMiddleware(next fiber.Handler, key string, value interface{}) fiber.Handler {
+func setFiberContextValueMiddleware(next fiber.Handler, key string, value any) fiber.Handler {
 	return func(c fiber.Ctx) error {
 		c.Locals(key, value)
 		return next(c)

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -238,7 +238,7 @@ func (handler *CSRFHandler) DeleteToken(c fiber.Ctx) error {
 }
 
 // isCsrfFromCookie checks if the extractor is set to ExtractFromCookie
-func isCsrfFromCookie(extractor interface{}) bool {
+func isCsrfFromCookie(extractor any) bool {
 	return reflect.ValueOf(extractor).Pointer() == reflect.ValueOf(CsrfFromCookie).Pointer()
 }
 

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -49,7 +49,7 @@ func New(config ...Config) fiber.Handler {
 		once       sync.Once
 		errHandler fiber.ErrorHandler
 
-		dataPool = sync.Pool{New: func() interface{} { return new(Data) }}
+		dataPool = sync.Pool{New: func() any { return new(Data) }}
 	)
 
 	// Err padding

--- a/middleware/recover/recover.go
+++ b/middleware/recover/recover.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
-func defaultStackTraceHandler(_ fiber.Ctx, e interface{}) {
+func defaultStackTraceHandler(_ fiber.Ctx, e any) {
 	_, _ = os.Stderr.WriteString(fmt.Sprintf("panic: %v\n%s\n", e, debug.Stack())) //nolint:errcheck // This will never fail
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -306,7 +306,7 @@ func Test_Router_Register_Missing_Handler(t *testing.T) {
 func Test_Ensure_Router_Interface_Implementation(t *testing.T) {
 	t.Parallel()
 
-	var app interface{} = (*App)(nil)
+	var app any = (*App)(nil)
 	_, ok := app.(Router)
 	require.True(t, ok)
 


### PR DESCRIPTION
## Description

Fix all occurrences of the `use-any` lint issue from `revive` and update the documentation accordingly.

## Changes Introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.  There is no functional change as `any` is an alias of `interface{}`.

- [x] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [x] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.

## Type of Change

Please delete options that are not relevant.

- [x] Enhancement (improvement to existing features and functionality)
- [x] Documentation update (changes to documentation)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Ensured that new and existing unit tests pass locally with the changes.
