### PR TITLE
🚨 Test: Speed up addon/retry tests

### DIFF
--- a/addon/retry/exponential_backoff_test.go
+++ b/addon/retry/exponential_backoff_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestExponentialBackoff_Retry(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		expBackoff *ExponentialBackoff
@@ -21,14 +22,6 @@ func TestExponentialBackoff_Retry(t *testing.T) {
 			f: func() error {
 				return nil
 			},
-		},
-		{
-			name:       "With default values - unsuccessful",
-			expBackoff: NewExponentialBackoff(),
-			f: func() error {
-				return fmt.Errorf("failed function")
-			},
-			expErr: fmt.Errorf("failed function"),
 		},
 		{
 			name: "Successful function",
@@ -66,6 +59,7 @@ func TestExponentialBackoff_Retry(t *testing.T) {
 }
 
 func TestExponentialBackoff_Next(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                 string
 		expBackoff           *ExponentialBackoff


### PR DESCRIPTION

## Description

There was a test that used the default exponential backoff configuration, causing the test to run for over 3 minutes. This test does not increase coverage in a way that warrants the slowdown of CI, and the default backoff time values are already verified by a separate test.

Alternatively, the test could be added to a separate file, disabled by default using build tags.

## Type of Change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Aimed for optimal performance with minimal allocations in the new code.
