### PR TITLE
ci: re-enable tparallel linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -195,7 +195,7 @@ linters:
     - tagliatelle
     # - testpackage # TODO: Enable once https://github.com/gofiber/fiber/issues/2252 is implemented
     - thelper
-    # - tparallel # TODO: Enable once https://github.com/gofiber/fiber/issues/2254 is implemented
+    - tparallel
     - typecheck
     - unconvert
     - unparam

--- a/addon/retry/exponential_backoff_test.go
+++ b/addon/retry/exponential_backoff_test.go
@@ -51,7 +51,9 @@ func TestExponentialBackoff_Retry(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := tt.expBackoff.Retry(tt.f)
 			require.Equal(t, tt.expErr, err)
 		})
@@ -104,7 +106,9 @@ func TestExponentialBackoff_Next(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			for i := 0; i < tt.expBackoff.MaxRetryCount; i++ {
 				next := tt.expBackoff.next()
 				if next < tt.expNextTimeIntervals[i] || next > tt.expNextTimeIntervals[i]+1*time.Second {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -405,6 +405,7 @@ func Test_Ctx_Body_With_Compression(t *testing.T) {
 	for _, testObject := range tests {
 		tCase := testObject // Duplicate object to ensure it will be unique across all runs
 		t.Run(tCase.name, func(t *testing.T) {
+			t.Parallel()
 			app := New()
 			c := app.NewCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
 			c.Request().Header.Set("Content-Encoding", tCase.contentEncoding)
@@ -567,14 +568,17 @@ func Test_Ctx_Context(t *testing.T) {
 
 // go test -run Test_Ctx_UserContext
 func Test_Ctx_UserContext(t *testing.T) {
+	t.Parallel()
 	app := New()
 	c := app.NewCtx(&fasthttp.RequestCtx{})
 
 	t.Run("Nil_Context", func(t *testing.T) {
+		t.Parallel()
 		ctx := c.UserContext()
 		require.Equal(t, ctx, context.Background())
 	})
 	t.Run("ValueContext", func(t *testing.T) {
+		t.Parallel()
 		testKey := struct{}{}
 		testValue := "Test Value"
 		ctx := context.WithValue(context.Background(), testKey, testValue)
@@ -618,7 +622,9 @@ func Test_Ctx_UserContext_Multiple_Requests(t *testing.T) {
 
 	// Consecutive Requests
 	for i := 1; i <= 10; i++ {
+		i := i
 		t.Run(fmt.Sprintf("request_%d", i), func(t *testing.T) {
+			t.Parallel()
 			resp, err := app.Test(httptest.NewRequest(MethodGet, fmt.Sprintf("/?input=%d", i), nil))
 
 			require.NoError(t, err, "Unexpected error from response")
@@ -2640,7 +2646,9 @@ func Test_Ctx_SendFile_Immutable(t *testing.T) {
 	}
 
 	for _, endpoint := range endpointsForTest {
+		endpoint := endpoint
 		t.Run(endpoint, func(t *testing.T) {
+			t.Parallel()
 			// 1st try
 			resp, err := app.Test(httptest.NewRequest(MethodGet, endpoint, nil))
 			require.NoError(t, err)
@@ -3041,6 +3049,7 @@ func Test_Ctx_RenderWithLocals(t *testing.T) {
 	})
 
 	t.Run("EmptyBind", func(t *testing.T) {
+		t.Parallel()
 		c := app.NewCtx(&fasthttp.RequestCtx{})
 
 		c.Locals("Title", "Hello, World!")
@@ -3051,6 +3060,7 @@ func Test_Ctx_RenderWithLocals(t *testing.T) {
 	})
 
 	t.Run("NilBind", func(t *testing.T) {
+		t.Parallel()
 		c := app.NewCtx(&fasthttp.RequestCtx{})
 
 		c.Locals("Title", "Hello, World!")

--- a/middleware/filesystem/filesystem_test.go
+++ b/middleware/filesystem/filesystem_test.go
@@ -122,6 +122,7 @@ func Test_FileSystem(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, tt.url, nil))
 			require.NoError(t, err)
 			require.Equal(t, tt.statusCode, resp.StatusCode)

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -235,6 +235,7 @@ func Test_Session_Save(t *testing.T) {
 	t.Parallel()
 
 	t.Run("save to cookie", func(t *testing.T) {
+		t.Parallel()
 		// session store
 		store := New()
 		// fiber instance
@@ -254,6 +255,7 @@ func Test_Session_Save(t *testing.T) {
 	})
 
 	t.Run("save to header", func(t *testing.T) {
+		t.Parallel()
 		// session store
 		store := New(Config{
 			KeyLookup: "header:session_id",
@@ -466,6 +468,7 @@ func Test_Session_Reset(t *testing.T) {
 	ctx := app.NewCtx(&fasthttp.RequestCtx{})
 
 	t.Run("reset session data and id, and set fresh to be true", func(t *testing.T) {
+		t.Parallel()
 		// a random session uuid
 		originalSessionUUIDString := ""
 
@@ -524,6 +527,7 @@ func Test_Session_Regenerate(t *testing.T) {
 	// fiber instance
 	app := fiber.New()
 	t.Run("set fresh to be true when regenerating a session", func(t *testing.T) {
+		t.Parallel()
 		// session store
 		store := New()
 		// a random session uuid


### PR DESCRIPTION
## Description

In some cases, loop variables had to be reassigned to a local variable to avoid concurrent access. This will no longer be needed when fiber's minimum go version is bumped to 1.22 or later, where each loop iteration gets its own variable.

## Type of Change

Please delete options that are not relevant.

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
