### PR TITLE
chore: Fix remaining testifylint errors

### DIFF
--- a/bind_test.go
+++ b/bind_test.go
@@ -34,23 +34,23 @@ func Test_Bind_Query(t *testing.T) {
 	c.Request().Header.SetContentType("")
 	c.Request().URI().SetQueryString("id=1&name=tom&hobby=basketball&hobby=football")
 	q := new(Query)
-	require.Nil(t, c.Bind().Query(q))
-	require.Equal(t, 2, len(q.Hobby))
+	require.NoError(t, c.Bind().Query(q))
+	require.Len(t, q.Hobby, 2)
 
 	c.Request().URI().SetQueryString("id=1&name=tom&hobby=basketball,football")
 	q = new(Query)
-	require.Nil(t, c.Bind().Query(q))
-	require.Equal(t, 2, len(q.Hobby))
+	require.NoError(t, c.Bind().Query(q))
+	require.Len(t, q.Hobby, 2)
 
 	c.Request().URI().SetQueryString("id=1&name=tom&hobby=scoccer&hobby=basketball,football")
 	q = new(Query)
-	require.Nil(t, c.Bind().Query(q))
-	require.Equal(t, 3, len(q.Hobby))
+	require.NoError(t, c.Bind().Query(q))
+	require.Len(t, q.Hobby, 3)
 
 	empty := new(Query)
 	c.Request().URI().SetQueryString("")
-	require.Nil(t, c.Bind().Query(empty))
-	require.Equal(t, 0, len(empty.Hobby))
+	require.NoError(t, c.Bind().Query(empty))
+	require.Empty(t, empty.Hobby)
 
 	type Query2 struct {
 		Bool            bool
@@ -67,7 +67,7 @@ func Test_Bind_Query(t *testing.T) {
 	q2 := new(Query2)
 	q2.Bool = true
 	q2.Name = helloWorld
-	require.Nil(t, c.Bind().Query(q2))
+	require.NoError(t, c.Bind().Query(q2))
 	require.Equal(t, "basketball,football", q2.Hobby)
 	require.True(t, q2.Bool)
 	require.Equal(t, "tom", q2.Name) // check value get overwritten
@@ -89,8 +89,8 @@ func Test_Bind_Query(t *testing.T) {
 	}
 	aq := new(ArrayQuery)
 	c.Request().URI().SetQueryString("data[]=john&data[]=doe")
-	require.Nil(t, c.Bind().Query(aq))
-	require.Equal(t, 2, len(aq.Data))
+	require.NoError(t, c.Bind().Query(aq))
+	require.Len(t, aq.Data, 2)
 }
 
 // go test -run Test_Bind_Query_Map -v
@@ -104,32 +104,32 @@ func Test_Bind_Query_Map(t *testing.T) {
 	c.Request().Header.SetContentType("")
 	c.Request().URI().SetQueryString("id=1&name=tom&hobby=basketball&hobby=football")
 	q := make(map[string][]string)
-	require.Nil(t, c.Bind().Query(&q))
-	require.Equal(t, 2, len(q["hobby"]))
+	require.NoError(t, c.Bind().Query(&q))
+	require.Len(t, q["hobby"], 2)
 
 	c.Request().URI().SetQueryString("id=1&name=tom&hobby=basketball,football")
 	q = make(map[string][]string)
-	require.Nil(t, c.Bind().Query(&q))
-	require.Equal(t, 2, len(q["hobby"]))
+	require.NoError(t, c.Bind().Query(&q))
+	require.Len(t, q["hobby"], 2)
 
 	c.Request().URI().SetQueryString("id=1&name=tom&hobby=scoccer&hobby=basketball,football")
 	q = make(map[string][]string)
-	require.Nil(t, c.Bind().Query(&q))
-	require.Equal(t, 3, len(q["hobby"]))
+	require.NoError(t, c.Bind().Query(&q))
+	require.Len(t, q["hobby"], 3)
 
 	c.Request().URI().SetQueryString("id=1&name=tom&hobby=scoccer")
 	qq := make(map[string]string)
-	require.Nil(t, c.Bind().Query(&qq))
+	require.NoError(t, c.Bind().Query(&qq))
 	require.Equal(t, "1", qq["id"])
 
 	empty := make(map[string][]string)
 	c.Request().URI().SetQueryString("")
-	require.Nil(t, c.Bind().Query(&empty))
-	require.Equal(t, 0, len(empty["hobby"]))
+	require.NoError(t, c.Bind().Query(&empty))
+	require.Empty(t, empty["hobby"])
 
 	em := make(map[string][]int)
 	c.Request().URI().SetQueryString("")
-	require.Equal(t, binder.ErrMapNotConvertable, c.Bind().Query(&em))
+	require.ErrorIs(t, c.Bind().Query(&em), binder.ErrMapNotConvertable)
 }
 
 // go test -run Test_Bind_Query_WithSetParserDecoder -v
@@ -169,7 +169,7 @@ func Test_Bind_Query_WithSetParserDecoder(t *testing.T) {
 	q := new(NonRFCTimeInput)
 
 	c.Request().URI().SetQueryString("date=2021-04-10&title=CustomDateTest&Body=October")
-	require.Nil(t, c.Bind().Query(q))
+	require.NoError(t, c.Bind().Query(q))
 	require.Equal(t, "CustomDateTest", q.Title)
 	date := fmt.Sprintf("%v", q.Date)
 	require.Equal(t, "{0 63753609600 <nil>}", date)
@@ -180,7 +180,7 @@ func Test_Bind_Query_WithSetParserDecoder(t *testing.T) {
 		Title: "Existing title",
 		Body:  "Existing Body",
 	}
-	require.Nil(t, c.Bind().Query(q))
+	require.NoError(t, c.Bind().Query(q))
 	require.Equal(t, "", q.Title)
 }
 
@@ -200,7 +200,7 @@ func Test_Bind_Query_Schema(t *testing.T) {
 	c.Request().Header.SetContentType("")
 	c.Request().URI().SetQueryString("name=tom&nested.age=10")
 	q := new(Query1)
-	require.Nil(t, c.Bind().Query(q))
+	require.NoError(t, c.Bind().Query(q))
 
 	c.Request().URI().SetQueryString("namex=tom&nested.age=10")
 	q = new(Query1)
@@ -208,7 +208,7 @@ func Test_Bind_Query_Schema(t *testing.T) {
 
 	c.Request().URI().SetQueryString("name=tom&nested.agex=10")
 	q = new(Query1)
-	require.Nil(t, c.Bind().Query(q))
+	require.NoError(t, c.Bind().Query(q))
 
 	c.Request().URI().SetQueryString("name=tom&test.age=10")
 	q = new(Query1)
@@ -222,11 +222,11 @@ func Test_Bind_Query_Schema(t *testing.T) {
 	}
 	c.Request().URI().SetQueryString("name=tom&nested.age=10")
 	q2 := new(Query2)
-	require.Nil(t, c.Bind().Query(q2))
+	require.NoError(t, c.Bind().Query(q2))
 
 	c.Request().URI().SetQueryString("nested.age=10")
 	q2 = new(Query2)
-	require.Nil(t, c.Bind().Query(q2))
+	require.NoError(t, c.Bind().Query(q2))
 
 	c.Request().URI().SetQueryString("nested.agex=10")
 	q2 = new(Query2)
@@ -242,7 +242,7 @@ func Test_Bind_Query_Schema(t *testing.T) {
 	}
 	c.Request().URI().SetQueryString("val=1&next.val=3")
 	n := new(Node)
-	require.Nil(t, c.Bind().Query(n))
+	require.NoError(t, c.Bind().Query(n))
 	require.Equal(t, 1, n.Value)
 	require.Equal(t, 3, n.Next.Value)
 
@@ -253,7 +253,7 @@ func Test_Bind_Query_Schema(t *testing.T) {
 	c.Request().URI().SetQueryString("val=3&next.value=2")
 	n = new(Node)
 	n.Next = new(Node)
-	require.Nil(t, c.Bind().Query(n))
+	require.NoError(t, c.Bind().Query(n))
 	require.Equal(t, 3, n.Value)
 	require.Equal(t, 0, n.Next.Value)
 
@@ -268,8 +268,8 @@ func Test_Bind_Query_Schema(t *testing.T) {
 
 	c.Request().URI().SetQueryString("data[0][name]=john&data[0][age]=10&data[1][name]=doe&data[1][age]=12")
 	cq := new(CollectionQuery)
-	require.Nil(t, c.Bind().Query(cq))
-	require.Equal(t, 2, len(cq.Data))
+	require.NoError(t, c.Bind().Query(cq))
+	require.Len(t, cq.Data, 2)
 	require.Equal(t, "john", cq.Data[0].Name)
 	require.Equal(t, 10, cq.Data[0].Age)
 	require.Equal(t, "doe", cq.Data[1].Name)
@@ -277,8 +277,8 @@ func Test_Bind_Query_Schema(t *testing.T) {
 
 	c.Request().URI().SetQueryString("data.0.name=john&data.0.age=10&data.1.name=doe&data.1.age=12")
 	cq = new(CollectionQuery)
-	require.Nil(t, c.Bind().Query(cq))
-	require.Equal(t, 2, len(cq.Data))
+	require.NoError(t, c.Bind().Query(cq))
+	require.Len(t, cq.Data, 2)
 	require.Equal(t, "john", cq.Data[0].Name)
 	require.Equal(t, 10, cq.Data[0].Age)
 	require.Equal(t, "doe", cq.Data[1].Name)
@@ -303,19 +303,19 @@ func Test_Bind_Header(t *testing.T) {
 	c.Request().Header.Add("Name", "John Doe")
 	c.Request().Header.Add("Hobby", "golang,fiber")
 	q := new(Header)
-	require.Nil(t, c.Bind().Header(q))
-	require.Equal(t, 2, len(q.Hobby))
+	require.NoError(t, c.Bind().Header(q))
+	require.Len(t, q.Hobby, 2)
 
 	c.Request().Header.Del("hobby")
 	c.Request().Header.Add("Hobby", "golang,fiber,go")
 	q = new(Header)
-	require.Nil(t, c.Bind().Header(q))
-	require.Equal(t, 3, len(q.Hobby))
+	require.NoError(t, c.Bind().Header(q))
+	require.Len(t, q.Hobby, 3)
 
 	empty := new(Header)
 	c.Request().Header.Del("hobby")
-	require.Nil(t, c.Bind().Query(empty))
-	require.Equal(t, 0, len(empty.Hobby))
+	require.NoError(t, c.Bind().Query(empty))
+	require.Empty(t, empty.Hobby)
 
 	type Header2 struct {
 		Bool            bool
@@ -339,7 +339,7 @@ func Test_Bind_Header(t *testing.T) {
 	h2 := new(Header2)
 	h2.Bool = true
 	h2.Name = helloWorld
-	require.Nil(t, c.Bind().Header(h2))
+	require.NoError(t, c.Bind().Header(h2))
 	require.Equal(t, "go,fiber", h2.Hobby)
 	require.True(t, h2.Bool)
 	require.Equal(t, "Jane Doe", h2.Name) // check value get overwritten
@@ -371,19 +371,19 @@ func Test_Bind_Header_Map(t *testing.T) {
 	c.Request().Header.Add("Name", "John Doe")
 	c.Request().Header.Add("Hobby", "golang,fiber")
 	q := make(map[string][]string, 0)
-	require.Nil(t, c.Bind().Header(&q))
-	require.Equal(t, 2, len(q["Hobby"]))
+	require.NoError(t, c.Bind().Header(&q))
+	require.Len(t, q["Hobby"], 2)
 
 	c.Request().Header.Del("hobby")
 	c.Request().Header.Add("Hobby", "golang,fiber,go")
 	q = make(map[string][]string, 0)
-	require.Nil(t, c.Bind().Header(&q))
-	require.Equal(t, 3, len(q["Hobby"]))
+	require.NoError(t, c.Bind().Header(&q))
+	require.Len(t, q["Hobby"], 3)
 
 	empty := make(map[string][]string, 0)
 	c.Request().Header.Del("hobby")
-	require.Nil(t, c.Bind().Query(&empty))
-	require.Equal(t, 0, len(empty["Hobby"]))
+	require.NoError(t, c.Bind().Query(&empty))
+	require.Empty(t, empty["Hobby"])
 }
 
 // go test -run Test_Bind_Header_WithSetParserDecoder -v
@@ -426,7 +426,7 @@ func Test_Bind_Header_WithSetParserDecoder(t *testing.T) {
 	c.Request().Header.Add("Title", "CustomDateTest")
 	c.Request().Header.Add("Body", "October")
 
-	require.Nil(t, c.Bind().Header(r))
+	require.NoError(t, c.Bind().Header(r))
 	require.Equal(t, "CustomDateTest", r.Title)
 	date := fmt.Sprintf("%v", r.Date)
 	require.Equal(t, "{0 63753609600 <nil>}", date)
@@ -437,7 +437,7 @@ func Test_Bind_Header_WithSetParserDecoder(t *testing.T) {
 		Title: "Existing title",
 		Body:  "Existing Body",
 	}
-	require.Nil(t, c.Bind().Header(r))
+	require.NoError(t, c.Bind().Header(r))
 	require.Equal(t, "", r.Title)
 }
 
@@ -459,7 +459,7 @@ func Test_Bind_Header_Schema(t *testing.T) {
 	c.Request().Header.Add("Name", "tom")
 	c.Request().Header.Add("Nested.Age", "10")
 	q := new(Header1)
-	require.Nil(t, c.Bind().Header(q))
+	require.NoError(t, c.Bind().Header(q))
 
 	c.Request().Header.Del("Name")
 	q = new(Header1)
@@ -469,7 +469,7 @@ func Test_Bind_Header_Schema(t *testing.T) {
 	c.Request().Header.Del("Nested.Age")
 	c.Request().Header.Add("Nested.Agex", "10")
 	q = new(Header1)
-	require.Nil(t, c.Bind().Header(q))
+	require.NoError(t, c.Bind().Header(q))
 
 	c.Request().Header.Del("Nested.Agex")
 	q = new(Header1)
@@ -489,11 +489,11 @@ func Test_Bind_Header_Schema(t *testing.T) {
 	c.Request().Header.Add("Nested.Age", "10")
 
 	h2 := new(Header2)
-	require.Nil(t, c.Bind().Header(h2))
+	require.NoError(t, c.Bind().Header(h2))
 
 	c.Request().Header.Del("Name")
 	h2 = new(Header2)
-	require.Nil(t, c.Bind().Header(h2))
+	require.NoError(t, c.Bind().Header(h2))
 
 	c.Request().Header.Del("Name")
 	c.Request().Header.Del("Nested.Age")
@@ -508,7 +508,7 @@ func Test_Bind_Header_Schema(t *testing.T) {
 	c.Request().Header.Add("Val", "1")
 	c.Request().Header.Add("Next.Val", "3")
 	n := new(Node)
-	require.Nil(t, c.Bind().Header(n))
+	require.NoError(t, c.Bind().Header(n))
 	require.Equal(t, 1, n.Value)
 	require.Equal(t, 3, n.Next.Value)
 
@@ -521,7 +521,7 @@ func Test_Bind_Header_Schema(t *testing.T) {
 	c.Request().Header.Add("Next.Value", "2")
 	n = new(Node)
 	n.Next = new(Node)
-	require.Nil(t, c.Bind().Header(n))
+	require.NoError(t, c.Bind().Header(n))
 	require.Equal(t, 3, n.Value)
 	require.Equal(t, 0, n.Next.Value)
 }
@@ -544,19 +544,19 @@ func Test_Bind_RespHeader(t *testing.T) {
 	c.Response().Header.Add("Name", "John Doe")
 	c.Response().Header.Add("Hobby", "golang,fiber")
 	q := new(Header)
-	require.Nil(t, c.Bind().RespHeader(q))
-	require.Equal(t, 2, len(q.Hobby))
+	require.NoError(t, c.Bind().RespHeader(q))
+	require.Len(t, q.Hobby, 2)
 
 	c.Response().Header.Del("hobby")
 	c.Response().Header.Add("Hobby", "golang,fiber,go")
 	q = new(Header)
-	require.Nil(t, c.Bind().RespHeader(q))
-	require.Equal(t, 3, len(q.Hobby))
+	require.NoError(t, c.Bind().RespHeader(q))
+	require.Len(t, q.Hobby, 3)
 
 	empty := new(Header)
 	c.Response().Header.Del("hobby")
-	require.Nil(t, c.Bind().Query(empty))
-	require.Equal(t, 0, len(empty.Hobby))
+	require.NoError(t, c.Bind().Query(empty))
+	require.Empty(t, empty.Hobby)
 
 	type Header2 struct {
 		Bool            bool
@@ -580,7 +580,7 @@ func Test_Bind_RespHeader(t *testing.T) {
 	h2 := new(Header2)
 	h2.Bool = true
 	h2.Name = helloWorld
-	require.Nil(t, c.Bind().RespHeader(h2))
+	require.NoError(t, c.Bind().RespHeader(h2))
 	require.Equal(t, "go,fiber", h2.Hobby)
 	require.True(t, h2.Bool)
 	require.Equal(t, "Jane Doe", h2.Name) // check value get overwritten
@@ -612,19 +612,19 @@ func Test_Bind_RespHeader_Map(t *testing.T) {
 	c.Response().Header.Add("Name", "John Doe")
 	c.Response().Header.Add("Hobby", "golang,fiber")
 	q := make(map[string][]string, 0)
-	require.Nil(t, c.Bind().RespHeader(&q))
-	require.Equal(t, 2, len(q["Hobby"]))
+	require.NoError(t, c.Bind().RespHeader(&q))
+	require.Len(t, q["Hobby"], 2)
 
 	c.Response().Header.Del("hobby")
 	c.Response().Header.Add("Hobby", "golang,fiber,go")
 	q = make(map[string][]string, 0)
-	require.Nil(t, c.Bind().RespHeader(&q))
-	require.Equal(t, 3, len(q["Hobby"]))
+	require.NoError(t, c.Bind().RespHeader(&q))
+	require.Len(t, q["Hobby"], 3)
 
 	empty := make(map[string][]string, 0)
 	c.Response().Header.Del("hobby")
-	require.Nil(t, c.Bind().Query(&empty))
-	require.Equal(t, 0, len(empty["Hobby"]))
+	require.NoError(t, c.Bind().Query(&empty))
+	require.Empty(t, empty["Hobby"])
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Bind_Query -benchmem -count=4
@@ -648,7 +648,7 @@ func Benchmark_Bind_Query(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().Query(q)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Bind_Query_Map -benchmem -count=4
@@ -667,7 +667,7 @@ func Benchmark_Bind_Query_Map(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().Query(&q)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Bind_Query_WithParseParam -benchmem -count=4
@@ -697,7 +697,7 @@ func Benchmark_Bind_Query_WithParseParam(b *testing.B) {
 		err = c.Bind().Query(cq)
 	}
 
-	require.Nil(b, err)
+	require.NoError(b, err)
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Bind_Query_Comma -benchmem -count=4
@@ -722,7 +722,7 @@ func Benchmark_Bind_Query_Comma(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().Query(q)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Bind_Header -benchmem -count=4
@@ -750,7 +750,7 @@ func Benchmark_Bind_Header(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().Header(q)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Bind_Header_Map -benchmem -count=4
@@ -772,7 +772,7 @@ func Benchmark_Bind_Header_Map(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().Header(&q)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Bind_RespHeader -benchmem -count=4
@@ -800,7 +800,7 @@ func Benchmark_Bind_RespHeader(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().RespHeader(q)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Bind_RespHeader_Map -benchmem -count=4
@@ -822,7 +822,7 @@ func Benchmark_Bind_RespHeader_Map(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().RespHeader(&q)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 }
 
 // go test -run Test_Bind_Body
@@ -848,7 +848,7 @@ func Test_Bind_Body(t *testing.T) {
 		c.Request().SetBody(gzipJSON.Bytes())
 		c.Request().Header.SetContentLength(len(gzipJSON.Bytes()))
 		d := new(Demo)
-		require.Nil(t, c.Bind().Body(d))
+		require.NoError(t, c.Bind().Body(d))
 		require.Equal(t, "john", d.Name)
 		c.Request().Header.Del(HeaderContentEncoding)
 	}
@@ -858,7 +858,7 @@ func Test_Bind_Body(t *testing.T) {
 		c.Request().SetBody([]byte(body))
 		c.Request().Header.SetContentLength(len(body))
 		d := new(Demo)
-		require.Nil(t, c.Bind().Body(d))
+		require.NoError(t, c.Bind().Body(d))
 		require.Equal(t, "john", d.Name)
 	}
 
@@ -871,7 +871,7 @@ func Test_Bind_Body(t *testing.T) {
 		c.Request().Header.SetContentType(contentType)
 		c.Request().SetBody([]byte(body))
 		c.Request().Header.SetContentLength(len(body))
-		require.False(t, c.Bind().Body(nil) == nil)
+		require.Error(t, c.Bind().Body(nil))
 	}
 
 	testDecodeParserError("invalid-content-type", "")
@@ -886,8 +886,8 @@ func Test_Bind_Body(t *testing.T) {
 	c.Request().SetBody([]byte("data[0][name]=john&data[1][name]=doe"))
 	c.Request().Header.SetContentLength(len(c.Body()))
 	cq := new(CollectionQuery)
-	require.Nil(t, c.Bind().Body(cq))
-	require.Equal(t, 2, len(cq.Data))
+	require.NoError(t, c.Bind().Body(cq))
+	require.Len(t, cq.Data, 2)
 	require.Equal(t, "john", cq.Data[0].Name)
 	require.Equal(t, "doe", cq.Data[1].Name)
 
@@ -896,8 +896,8 @@ func Test_Bind_Body(t *testing.T) {
 	c.Request().SetBody([]byte("data.0.name=john&data.1.name=doe"))
 	c.Request().Header.SetContentLength(len(c.Body()))
 	cq = new(CollectionQuery)
-	require.Nil(t, c.Bind().Body(cq))
-	require.Equal(t, 2, len(cq.Data))
+	require.NoError(t, c.Bind().Body(cq))
+	require.Len(t, cq.Data, 2)
 	require.Equal(t, "john", cq.Data[0].Name)
 	require.Equal(t, "doe", cq.Data[1].Name)
 }
@@ -942,7 +942,7 @@ func Test_Bind_Body_WithSetParserDecoder(t *testing.T) {
 			Title: "Existing title",
 			Body:  "Existing Body",
 		}
-		require.Nil(t, c.Bind().Body(&d))
+		require.NoError(t, c.Bind().Body(&d))
 		date := fmt.Sprintf("%v", d.Date)
 		require.Equal(t, "{0 63743587200 <nil>}", date)
 		require.Equal(t, "", d.Title)
@@ -975,7 +975,7 @@ func Benchmark_Bind_Body_JSON(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().Body(d)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 	require.Equal(b, "john", d.Name)
 }
 
@@ -1001,7 +1001,7 @@ func Benchmark_Bind_Body_XML(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().Body(d)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 	require.Equal(b, "john", d.Name)
 }
 
@@ -1027,7 +1027,7 @@ func Benchmark_Bind_Body_Form(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().Body(d)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 	require.Equal(b, "john", d.Name)
 }
 
@@ -1054,7 +1054,7 @@ func Benchmark_Bind_Body_MultipartForm(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().Body(d)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 	require.Equal(b, "john", d.Name)
 }
 
@@ -1077,7 +1077,7 @@ func Benchmark_Bind_Body_Form_Map(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().Body(&d)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 	require.Equal(b, "john", d["name"])
 }
 
@@ -1214,19 +1214,19 @@ func Test_Bind_Cookie(t *testing.T) {
 	c.Request().Header.SetCookie("Name", "John Doe")
 	c.Request().Header.SetCookie("Hobby", "golang,fiber")
 	q := new(Cookie)
-	require.Nil(t, c.Bind().Cookie(q))
-	require.Equal(t, 2, len(q.Hobby))
+	require.NoError(t, c.Bind().Cookie(q))
+	require.Len(t, q.Hobby, 2)
 
 	c.Request().Header.DelCookie("hobby")
 	c.Request().Header.SetCookie("Hobby", "golang,fiber,go")
 	q = new(Cookie)
-	require.Nil(t, c.Bind().Cookie(q))
-	require.Equal(t, 3, len(q.Hobby))
+	require.NoError(t, c.Bind().Cookie(q))
+	require.Len(t, q.Hobby, 3)
 
 	empty := new(Cookie)
 	c.Request().Header.DelCookie("hobby")
-	require.Nil(t, c.Bind().Query(empty))
-	require.Equal(t, 0, len(empty.Hobby))
+	require.NoError(t, c.Bind().Query(empty))
+	require.Empty(t, empty.Hobby)
 
 	type Cookie2 struct {
 		Bool            bool
@@ -1250,7 +1250,7 @@ func Test_Bind_Cookie(t *testing.T) {
 	h2 := new(Cookie2)
 	h2.Bool = true
 	h2.Name = helloWorld
-	require.Nil(t, c.Bind().Cookie(h2))
+	require.NoError(t, c.Bind().Cookie(h2))
 	require.Equal(t, "go,fiber", h2.Hobby)
 	require.True(t, h2.Bool)
 	require.Equal(t, "Jane Doe", h2.Name) // check value get overwritten
@@ -1282,19 +1282,19 @@ func Test_Bind_Cookie_Map(t *testing.T) {
 	c.Request().Header.SetCookie("Name", "John Doe")
 	c.Request().Header.SetCookie("Hobby", "golang,fiber")
 	q := make(map[string][]string)
-	require.Nil(t, c.Bind().Cookie(&q))
-	require.Equal(t, 2, len(q["Hobby"]))
+	require.NoError(t, c.Bind().Cookie(&q))
+	require.Len(t, q["Hobby"], 2)
 
 	c.Request().Header.DelCookie("hobby")
 	c.Request().Header.SetCookie("Hobby", "golang,fiber,go")
 	q = make(map[string][]string)
-	require.Nil(t, c.Bind().Cookie(&q))
-	require.Equal(t, 3, len(q["Hobby"]))
+	require.NoError(t, c.Bind().Cookie(&q))
+	require.Len(t, q["Hobby"], 3)
 
 	empty := make(map[string][]string)
 	c.Request().Header.DelCookie("hobby")
-	require.Nil(t, c.Bind().Query(&empty))
-	require.Equal(t, 0, len(empty["Hobby"]))
+	require.NoError(t, c.Bind().Query(&empty))
+	require.Empty(t, empty["Hobby"])
 }
 
 // go test -run Test_Bind_Cookie_WithSetParserDecoder -v
@@ -1337,7 +1337,7 @@ func Test_Bind_Cookie_WithSetParserDecoder(t *testing.T) {
 	c.Request().Header.SetCookie("Title", "CustomDateTest")
 	c.Request().Header.SetCookie("Body", "October")
 
-	require.Nil(t, c.Bind().Cookie(r))
+	require.NoError(t, c.Bind().Cookie(r))
 	require.Equal(t, "CustomDateTest", r.Title)
 	date := fmt.Sprintf("%v", r.Date)
 	require.Equal(t, "{0 63753609600 <nil>}", date)
@@ -1348,7 +1348,7 @@ func Test_Bind_Cookie_WithSetParserDecoder(t *testing.T) {
 		Title: "Existing title",
 		Body:  "Existing Body",
 	}
-	require.Nil(t, c.Bind().Cookie(r))
+	require.NoError(t, c.Bind().Cookie(r))
 	require.Equal(t, "", r.Title)
 }
 
@@ -1371,7 +1371,7 @@ func Test_Bind_Cookie_Schema(t *testing.T) {
 	c.Request().Header.SetCookie("Name", "tom")
 	c.Request().Header.SetCookie("Nested.Age", "10")
 	q := new(Cookie1)
-	require.Nil(t, c.Bind().Cookie(q))
+	require.NoError(t, c.Bind().Cookie(q))
 
 	c.Request().Header.DelCookie("Name")
 	q = new(Cookie1)
@@ -1381,7 +1381,7 @@ func Test_Bind_Cookie_Schema(t *testing.T) {
 	c.Request().Header.DelCookie("Nested.Age")
 	c.Request().Header.SetCookie("Nested.Agex", "10")
 	q = new(Cookie1)
-	require.Nil(t, c.Bind().Cookie(q))
+	require.NoError(t, c.Bind().Cookie(q))
 
 	c.Request().Header.DelCookie("Nested.Agex")
 	q = new(Cookie1)
@@ -1401,11 +1401,11 @@ func Test_Bind_Cookie_Schema(t *testing.T) {
 	c.Request().Header.SetCookie("Nested.Age", "10")
 
 	h2 := new(Cookie2)
-	require.Nil(t, c.Bind().Cookie(h2))
+	require.NoError(t, c.Bind().Cookie(h2))
 
 	c.Request().Header.DelCookie("Name")
 	h2 = new(Cookie2)
-	require.Nil(t, c.Bind().Cookie(h2))
+	require.NoError(t, c.Bind().Cookie(h2))
 
 	c.Request().Header.DelCookie("Name")
 	c.Request().Header.DelCookie("Nested.Age")
@@ -1420,7 +1420,7 @@ func Test_Bind_Cookie_Schema(t *testing.T) {
 	c.Request().Header.SetCookie("Val", "1")
 	c.Request().Header.SetCookie("Next.Val", "3")
 	n := new(Node)
-	require.Nil(t, c.Bind().Cookie(n))
+	require.NoError(t, c.Bind().Cookie(n))
 	require.Equal(t, 1, n.Value)
 	require.Equal(t, 3, n.Next.Value)
 
@@ -1433,7 +1433,7 @@ func Test_Bind_Cookie_Schema(t *testing.T) {
 	c.Request().Header.SetCookie("Next.Value", "2")
 	n = new(Node)
 	n.Next = new(Node)
-	require.Nil(t, c.Bind().Cookie(n))
+	require.NoError(t, c.Bind().Cookie(n))
 	require.Equal(t, 3, n.Value)
 	require.Equal(t, 0, n.Next.Value)
 }
@@ -1464,7 +1464,7 @@ func Benchmark_Bind_Cookie(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().Cookie(q)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Bind_Cookie_Map -benchmem -count=4
@@ -1488,7 +1488,7 @@ func Benchmark_Bind_Cookie_Map(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		err = c.Bind().Cookie(&q)
 	}
-	require.Nil(b, err)
+	require.NoError(b, err)
 }
 
 // custom binder for testing
@@ -1524,8 +1524,8 @@ func Test_Bind_CustomBinder(t *testing.T) {
 	c.Request().Header.SetContentLength(len(body))
 	d := new(Demo)
 
-	require.Nil(t, c.Bind().Body(d))
-	require.Nil(t, c.Bind().Custom("custom", d))
+	require.NoError(t, c.Bind().Body(d))
+	require.NoError(t, c.Bind().Custom("custom", d))
 	require.Equal(t, ErrCustomBinderNotFound, c.Bind().Custom("not_custom", d))
 	require.Equal(t, "john", d.Name)
 }
@@ -1581,7 +1581,7 @@ func Test_Bind_StructValidator(t *testing.T) {
 
 	rq = new(simpleQuery)
 	c.Request().URI().SetQueryString("name=john")
-	require.Nil(t, c.Bind().Query(rq))
+	require.NoError(t, c.Bind().Query(rq))
 }
 
 // go test -run Test_Bind_RepeatParserWithSameStruct -v
@@ -1600,11 +1600,11 @@ func Test_Bind_RepeatParserWithSameStruct(t *testing.T) {
 	r := new(Request)
 
 	c.Request().URI().SetQueryString("query_param=query_param")
-	require.Equal(t, nil, c.Bind().Query(r))
+	require.NoError(t, c.Bind().Query(r))
 	require.Equal(t, "query_param", r.QueryParam)
 
 	c.Request().Header.Add("header_param", "header_param")
-	require.Equal(t, nil, c.Bind().Header(r))
+	require.NoError(t, c.Bind().Header(r))
 	require.Equal(t, "header_param", r.HeaderParam)
 
 	var gzipJSON bytes.Buffer
@@ -1617,7 +1617,7 @@ func Test_Bind_RepeatParserWithSameStruct(t *testing.T) {
 	c.Request().Header.Set(HeaderContentEncoding, "gzip")
 	c.Request().SetBody(gzipJSON.Bytes())
 	c.Request().Header.SetContentLength(len(gzipJSON.Bytes()))
-	require.Equal(t, nil, c.Bind().Body(r))
+	require.NoError(t, c.Bind().Body(r))
 	require.Equal(t, "body_param", r.BodyParam)
 	c.Request().Header.Del(HeaderContentEncoding)
 
@@ -1625,7 +1625,7 @@ func Test_Bind_RepeatParserWithSameStruct(t *testing.T) {
 		c.Request().Header.SetContentType(contentType)
 		c.Request().SetBody([]byte(body))
 		c.Request().Header.SetContentLength(len(body))
-		require.Equal(t, nil, c.Bind().Body(r))
+		require.NoError(t, c.Bind().Body(r))
 		require.Equal(t, "body_param", r.BodyParam)
 	}
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -240,7 +240,7 @@ func Test_Utils_ForEachParameter(t *testing.T) {
 	for _, tc := range testCases {
 		n := 0
 		forEachParameter(tc.paramStr, func(p, v string) bool {
-			require.Equal(t, true, n < len(tc.expectedParams), "Received more parameters than expected: "+p+"="+v)
+			require.Less(t, n, len(tc.expectedParams), "Received more parameters than expected: "+p+"="+v)
 			require.Equal(t, tc.expectedParams[n][0], p, tc.description)
 			require.Equal(t, tc.expectedParams[n][1], v, tc.description)
 			n++
@@ -248,7 +248,7 @@ func Test_Utils_ForEachParameter(t *testing.T) {
 			// Stop parsing at the first parameter called "end"
 			return p != "end"
 		})
-		require.Equal(t, len(tc.expectedParams), n, tc.description+": number of parameters differs")
+		require.Len(t, tc.expectedParams, n, tc.description+": number of parameters differs")
 	}
 	// Check that we exited on the second parameter (bar)
 }
@@ -323,7 +323,7 @@ func Benchmark_Utils_ParamsMatch(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		match = paramsMatch(`; appLe=orange; param="foo"`, `;param=foo; apple=orange`)
 	}
-	require.Equal(b, true, match)
+	require.True(b, match)
 }
 
 func Test_Utils_AcceptsOfferType(t *testing.T) {
@@ -451,7 +451,7 @@ func Test_Utils_SortAcceptedTypes(t *testing.T) {
 		{spec: "application/json", quality: 0.999, specificity: 3, params: ";a=1", order: 11},
 	}
 	sortAcceptedTypes(&acceptedTypes)
-	require.Equal(t, acceptedTypes, []acceptedType{
+	require.Equal(t, []acceptedType{
 		{spec: "text/html", quality: 1, specificity: 3, order: 0},
 		{spec: "application/xml", quality: 1, specificity: 3, order: 4},
 		{spec: "application/pdf", quality: 1, specificity: 3, order: 5},
@@ -464,7 +464,7 @@ func Test_Utils_SortAcceptedTypes(t *testing.T) {
 		{spec: "application/json", quality: 0.999, specificity: 3, order: 3},
 		{spec: "text/*", quality: 0.5, specificity: 2, order: 1},
 		{spec: "*/*", quality: 0.1, specificity: 1, order: 2},
-	})
+	}, acceptedTypes)
 }
 
 // go test -v -run=^$ -bench=Benchmark_Utils_SortAcceptedTypes_Sorted -benchmem -count=4
@@ -498,7 +498,7 @@ func Benchmark_Utils_SortAcceptedTypes_Unsorted(b *testing.B) {
 		acceptedTypes[10] = acceptedType{spec: "text/plain", quality: 1, specificity: 3, order: 10}
 		sortAcceptedTypes(&acceptedTypes)
 	}
-	require.Equal(b, acceptedTypes, []acceptedType{
+	require.Equal(b, []acceptedType{
 		{spec: "text/html", quality: 1, specificity: 3, order: 0},
 		{spec: "application/xml", quality: 1, specificity: 3, order: 4},
 		{spec: "application/pdf", quality: 1, specificity: 3, order: 5},
@@ -510,7 +510,7 @@ func Benchmark_Utils_SortAcceptedTypes_Unsorted(b *testing.B) {
 		{spec: "application/json", quality: 0.999, specificity: 3, order: 3},
 		{spec: "text/*", quality: 0.5, specificity: 2, order: 1},
 		{spec: "*/*", quality: 0.1, specificity: 1, order: 2},
-	})
+	}, acceptedTypes)
 }
 
 func Test_Utils_UniqueRouteStack(t *testing.T) {
@@ -609,9 +609,9 @@ func Test_Utils_Parse_Address(t *testing.T) {
 func Test_Utils_TestConn_Deadline(t *testing.T) {
 	t.Parallel()
 	conn := &testConn{}
-	require.Nil(t, conn.SetDeadline(time.Time{}))
-	require.Nil(t, conn.SetReadDeadline(time.Time{}))
-	require.Nil(t, conn.SetWriteDeadline(time.Time{}))
+	require.NoError(t, conn.SetDeadline(time.Time{}))
+	require.NoError(t, conn.SetReadDeadline(time.Time{}))
+	require.NoError(t, conn.SetWriteDeadline(time.Time{}))
 }
 
 func Test_Utils_IsNoCache(t *testing.T) {

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -63,7 +63,7 @@ func Test_Hook_OnName(t *testing.T) {
 
 	app.Hooks().OnName(func(r Route) error {
 		_, err := buf.WriteString(r.Name)
-		require.NoError(t, nil, err)
+		require.NoError(t, err)
 
 		return nil
 	})
@@ -104,7 +104,7 @@ func Test_Hook_OnGroup(t *testing.T) {
 
 	app.Hooks().OnGroup(func(g Group) error {
 		_, err := buf.WriteString(g.Prefix)
-		require.NoError(t, nil, err)
+		require.NoError(t, err)
 		return nil
 	})
 
@@ -143,7 +143,7 @@ func Test_Hook_OnGroupName(t *testing.T) {
 
 	app.Hooks().OnGroupName(func(g Group) error {
 		_, err := buf.WriteString(g.name)
-		require.NoError(t, nil, err)
+		require.NoError(t, err)
 
 		return nil
 	})
@@ -189,12 +189,12 @@ func Test_Hook_OnShutdown(t *testing.T) {
 
 	app.Hooks().OnShutdown(func() error {
 		_, err := buf.WriteString("shutdowning")
-		require.NoError(t, nil, err)
+		require.NoError(t, err)
 
 		return nil
 	})
 
-	require.Nil(t, app.Shutdown())
+	require.NoError(t, app.Shutdown())
 	require.Equal(t, "shutdowning", buf.String())
 }
 
@@ -215,9 +215,9 @@ func Test_Hook_OnListen(t *testing.T) {
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Equal(t, nil, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
-	require.Equal(t, nil, app.Listen(":9000"))
+	require.NoError(t, app.Listen(":9000"))
 
 	require.Equal(t, "ready", buf.String())
 }
@@ -231,17 +231,17 @@ func Test_Hook_OnListenPrefork(t *testing.T) {
 
 	app.Hooks().OnListen(func(listenData ListenData) error {
 		_, err := buf.WriteString("ready")
-		require.NoError(t, nil, err)
+		require.NoError(t, err)
 
 		return nil
 	})
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.Listen(":9000", ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
+	require.NoError(t, app.Listen(":9000", ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
 	require.Equal(t, "ready", buf.String())
 }
 
@@ -254,7 +254,7 @@ func Test_Hook_OnHook(t *testing.T) {
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
 	app.Hooks().OnFork(func(pid int) error {
@@ -262,7 +262,7 @@ func Test_Hook_OnHook(t *testing.T) {
 		return nil
 	})
 
-	require.Nil(t, app.prefork(":3000", nil, ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
+	require.NoError(t, app.prefork(":3000", nil, ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
 }
 
 func Test_Hook_OnMount(t *testing.T) {
@@ -274,7 +274,7 @@ func Test_Hook_OnMount(t *testing.T) {
 	subApp.Get("/test", testSimpleHandler)
 
 	subApp.Hooks().OnMount(func(parent *App) error {
-		require.Equal(t, parent.mountFields.mountPath, "")
+		require.Empty(t, parent.mountFields.mountPath)
 
 		return nil
 	})

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -69,7 +69,7 @@ func Test_Storage_Memory_Get_Expired(t *testing.T) {
 
 	result, err := testStore.Get(key)
 	require.NoError(t, err)
-	require.Equal(t, true, len(result) == 0)
+	require.Empty(t, result)
 }
 
 func Test_Storage_Memory_Get_NotExist(t *testing.T) {
@@ -77,7 +77,7 @@ func Test_Storage_Memory_Get_NotExist(t *testing.T) {
 
 	result, err := testStore.Get("notexist")
 	require.NoError(t, err)
-	require.Equal(t, true, len(result) == 0)
+	require.Empty(t, result)
 }
 
 func Test_Storage_Memory_Delete(t *testing.T) {
@@ -95,7 +95,7 @@ func Test_Storage_Memory_Delete(t *testing.T) {
 
 	result, err := testStore.Get(key)
 	require.NoError(t, err)
-	require.Equal(t, true, len(result) == 0)
+	require.Empty(t, result)
 }
 
 func Test_Storage_Memory_Reset(t *testing.T) {
@@ -113,11 +113,11 @@ func Test_Storage_Memory_Reset(t *testing.T) {
 
 	result, err := testStore.Get("john1")
 	require.NoError(t, err)
-	require.Equal(t, true, len(result) == 0)
+	require.Empty(t, result)
 
 	result, err = testStore.Get("john2")
 	require.NoError(t, err)
-	require.Equal(t, true, len(result) == 0)
+	require.Empty(t, result)
 }
 
 func Test_Storage_Memory_Close(t *testing.T) {
@@ -127,7 +127,7 @@ func Test_Storage_Memory_Close(t *testing.T) {
 
 func Test_Storage_Memory_Conn(t *testing.T) {
 	t.Parallel()
-	require.True(t, testStore.Conn() != nil)
+	require.NotNil(t, testStore.Conn())
 }
 
 // go test -v -run=^$ -bench=Benchmark_Storage_Memory -benchmem -count=4

--- a/listen_test.go
+++ b/listen_test.go
@@ -24,14 +24,14 @@ import (
 func Test_Listen(t *testing.T) {
 	app := New()
 
-	require.False(t, app.Listen(":99999") == nil)
+	require.Error(t, app.Listen(":99999"))
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.Listen(":4003", ListenConfig{DisableStartupMessage: true}))
+	require.NoError(t, app.Listen(":4003", ListenConfig{DisableStartupMessage: true}))
 }
 
 // go test -run Test_Listen_Graceful_Shutdown
@@ -83,7 +83,7 @@ func Test_Listen_Graceful_Shutdown(t *testing.T) {
 
 		require.Equal(t, tc.ExpectedStatusCode, code)
 		require.Equal(t, tc.ExpectedBody, body)
-		require.Equal(t, tc.ExceptedErrsLen, len(errs))
+		require.Len(t, errs, tc.ExceptedErrsLen)
 	}
 
 	mu.Lock()
@@ -97,7 +97,7 @@ func Test_Listen_Prefork(t *testing.T) {
 
 	app := New()
 
-	require.Nil(t, app.Listen(":99999", ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
+	require.NoError(t, app.Listen(":99999", ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
 }
 
 // go test -run Test_Listen_TLS
@@ -105,17 +105,17 @@ func Test_Listen_TLS(t *testing.T) {
 	app := New()
 
 	// invalid port
-	require.False(t, app.Listen(":99999", ListenConfig{
+	require.Error(t, app.Listen(":99999", ListenConfig{
 		CertFile:    "./.github/testdata/ssl.pem",
 		CertKeyFile: "./.github/testdata/ssl.key",
-	}) == nil)
+	}))
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.Listen(":0", ListenConfig{
+	require.NoError(t, app.Listen(":0", ListenConfig{
 		CertFile:    "./.github/testdata/ssl.pem",
 		CertKeyFile: "./.github/testdata/ssl.key",
 	}))
@@ -128,19 +128,19 @@ func Test_Listen_TLS_Prefork(t *testing.T) {
 	app := New()
 
 	// invalid key file content
-	require.False(t, app.Listen(":0", ListenConfig{
+	require.Error(t, app.Listen(":0", ListenConfig{
 		DisableStartupMessage: true,
 		EnablePrefork:         true,
 		CertFile:              "./.github/testdata/ssl.pem",
 		CertKeyFile:           "./.github/testdata/template.tmpl",
-	}) == nil)
+	}))
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.Listen(":99999", ListenConfig{
+	require.NoError(t, app.Listen(":99999", ListenConfig{
 		DisableStartupMessage: true,
 		EnablePrefork:         true,
 		CertFile:              "./.github/testdata/ssl.pem",
@@ -153,18 +153,18 @@ func Test_Listen_MutualTLS(t *testing.T) {
 	app := New()
 
 	// invalid port
-	require.False(t, app.Listen(":99999", ListenConfig{
+	require.Error(t, app.Listen(":99999", ListenConfig{
 		CertFile:       "./.github/testdata/ssl.pem",
 		CertKeyFile:    "./.github/testdata/ssl.key",
 		CertClientFile: "./.github/testdata/ca-chain.cert.pem",
-	}) == nil)
+	}))
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.Listen(":0", ListenConfig{
+	require.NoError(t, app.Listen(":0", ListenConfig{
 		CertFile:       "./.github/testdata/ssl.pem",
 		CertKeyFile:    "./.github/testdata/ssl.key",
 		CertClientFile: "./.github/testdata/ca-chain.cert.pem",
@@ -178,20 +178,20 @@ func Test_Listen_MutualTLS_Prefork(t *testing.T) {
 	app := New()
 
 	// invalid key file content
-	require.False(t, app.Listen(":0", ListenConfig{
+	require.Error(t, app.Listen(":0", ListenConfig{
 		DisableStartupMessage: true,
 		EnablePrefork:         true,
 		CertFile:              "./.github/testdata/ssl.pem",
 		CertKeyFile:           "./.github/testdata/template.html",
 		CertClientFile:        "./.github/testdata/ca-chain.cert.pem",
-	}) == nil)
+	}))
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.Listen(":99999", ListenConfig{
+	require.NoError(t, app.Listen(":99999", ListenConfig{
 		DisableStartupMessage: true,
 		EnablePrefork:         true,
 		CertFile:              "./.github/testdata/ssl.pem",
@@ -206,11 +206,11 @@ func Test_Listener(t *testing.T) {
 
 	go func() {
 		time.Sleep(500 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
 	ln := fasthttputil.NewInmemoryListener()
-	require.Nil(t, app.Listener(ln))
+	require.NoError(t, app.Listener(ln))
 }
 
 func Test_App_Listener_TLS_Listener(t *testing.T) {
@@ -231,10 +231,10 @@ func Test_App_Listener_TLS_Listener(t *testing.T) {
 
 	go func() {
 		time.Sleep(time.Millisecond * 500)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.Listener(ln))
+	require.NoError(t, app.Listener(ln))
 }
 
 // go test -run Test_Listen_TLSConfigFunc
@@ -244,10 +244,10 @@ func Test_Listen_TLSConfigFunc(t *testing.T) {
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.Listen(":0", ListenConfig{
+	require.NoError(t, app.Listen(":0", ListenConfig{
 		DisableStartupMessage: true,
 		TLSConfigFunc: func(tlsConfig *tls.Config) {
 			callTLSConfig = true
@@ -266,10 +266,10 @@ func Test_Listen_ListenerAddrFunc(t *testing.T) {
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.Listen(":0", ListenConfig{
+	require.NoError(t, app.Listen(":0", ListenConfig{
 		DisableStartupMessage: true,
 		ListenerAddrFunc: func(addr net.Addr) {
 			network = addr.Network()
@@ -288,19 +288,20 @@ func Test_Listen_BeforeServeFunc(t *testing.T) {
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Equal(t, errors.New("test"), app.Listen(":0", ListenConfig{
+	wantErr := errors.New("test")
+	require.ErrorIs(t, app.Listen(":0", ListenConfig{
 		DisableStartupMessage: true,
 		BeforeServeFunc: func(fiber *App) error {
 			handlers = fiber.HandlersCount()
 
-			return errors.New("test")
+			return wantErr
 		},
-	}))
+	}), wantErr)
 
-	require.Equal(t, uint32(0), handlers)
+	require.Zero(t, handlers)
 }
 
 // go test -run Test_Listen_ListenerNetwork
@@ -310,10 +311,10 @@ func Test_Listen_ListenerNetwork(t *testing.T) {
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.Listen(":0", ListenConfig{
+	require.NoError(t, app.Listen(":0", ListenConfig{
 		DisableStartupMessage: true,
 		ListenerNetwork:       NetworkTCP6,
 		ListenerAddrFunc: func(addr net.Addr) {
@@ -321,14 +322,14 @@ func Test_Listen_ListenerNetwork(t *testing.T) {
 		},
 	}))
 
-	require.True(t, strings.Contains(network, "[::]:"))
+	require.Contains(t, network, "[::]:")
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.Listen(":0", ListenConfig{
+	require.NoError(t, app.Listen(":0", ListenConfig{
 		DisableStartupMessage: true,
 		ListenerNetwork:       NetworkTCP4,
 		ListenerAddrFunc: func(addr net.Addr) {
@@ -336,7 +337,7 @@ func Test_Listen_ListenerNetwork(t *testing.T) {
 		},
 	}))
 
-	require.True(t, strings.Contains(network, "0.0.0.0:"))
+	require.Contains(t, network, "0.0.0.0:")
 }
 
 // go test -run Test_Listen_Master_Process_Show_Startup_Message
@@ -350,11 +351,11 @@ func Test_Listen_Master_Process_Show_Startup_Message(t *testing.T) {
 			startupMessage(":3000", true, strings.Repeat(",11111,22222,33333,44444,55555,60000", 10), cfg)
 	})
 	colors := Colors{}
-	require.True(t, strings.Contains(startupMessage, "https://127.0.0.1:3000"))
-	require.True(t, strings.Contains(startupMessage, "(bound on host 0.0.0.0 and port 3000)"))
-	require.True(t, strings.Contains(startupMessage, "Child PIDs"))
-	require.True(t, strings.Contains(startupMessage, "11111, 22222, 33333, 44444, 55555, 60000"))
-	require.True(t, strings.Contains(startupMessage, fmt.Sprintf("Prefork: %sEnabled%s", colors.Blue, colors.Reset)))
+	require.Contains(t, startupMessage, "https://127.0.0.1:3000")
+	require.Contains(t, startupMessage, "(bound on host 0.0.0.0 and port 3000)")
+	require.Contains(t, startupMessage, "Child PIDs")
+	require.Contains(t, startupMessage, "11111, 22222, 33333, 44444, 55555, 60000")
+	require.Contains(t, startupMessage, fmt.Sprintf("Prefork: %sEnabled%s", colors.Blue, colors.Reset))
 }
 
 // go test -run Test_Listen_Master_Process_Show_Startup_MessageWithAppName
@@ -368,7 +369,7 @@ func Test_Listen_Master_Process_Show_Startup_MessageWithAppName(t *testing.T) {
 		app.startupMessage(":3000", true, strings.Repeat(",11111,22222,33333,44444,55555,60000", 10), cfg)
 	})
 	require.Equal(t, "Test App v3.0.0", app.Config().AppName)
-	require.True(t, strings.Contains(startupMessage, app.Config().AppName))
+	require.Contains(t, startupMessage, app.Config().AppName)
 }
 
 // go test -run Test_Listen_Master_Process_Show_Startup_MessageWithAppNameNonAscii
@@ -383,7 +384,7 @@ func Test_Listen_Master_Process_Show_Startup_MessageWithAppNameNonAscii(t *testi
 	startupMessage := captureOutput(func() {
 		app.startupMessage(":3000", false, "", cfg)
 	})
-	require.True(t, strings.Contains(startupMessage, "Serveur de vérification des données"))
+	require.Contains(t, startupMessage, "Serveur de vérification des données")
 }
 
 // go test -run Test_Listen_Master_Process_Show_Startup_MessageWithDisabledPreforkAndCustomEndpoint
@@ -398,10 +399,10 @@ func Test_Listen_Master_Process_Show_Startup_MessageWithDisabledPreforkAndCustom
 		app.startupMessage("server.com:8081", true, strings.Repeat(",11111,22222,33333,44444,55555,60000", 5), cfg)
 	})
 	colors := Colors{}
-	require.True(t, strings.Contains(startupMessage, fmt.Sprintf("%sINFO%s", colors.Green, colors.Reset)))
-	require.True(t, strings.Contains(startupMessage, fmt.Sprintf("%s%s%s", colors.Blue, appName, colors.Reset)))
-	require.True(t, strings.Contains(startupMessage, fmt.Sprintf("%s%s%s", colors.Blue, "https://server.com:8081", colors.Reset)))
-	require.True(t, strings.Contains(startupMessage, fmt.Sprintf("Prefork: %sDisabled%s", colors.Red, colors.Reset)))
+	require.Contains(t, startupMessage, fmt.Sprintf("%sINFO%s", colors.Green, colors.Reset))
+	require.Contains(t, startupMessage, fmt.Sprintf("%s%s%s", colors.Blue, appName, colors.Reset))
+	require.Contains(t, startupMessage, fmt.Sprintf("%s%s%s", colors.Blue, "https://server.com:8081", colors.Reset))
+	require.Contains(t, startupMessage, fmt.Sprintf("Prefork: %sDisabled%s", colors.Red, colors.Reset))
 }
 
 // go test -run Test_Listen_Print_Route
@@ -411,10 +412,10 @@ func Test_Listen_Print_Route(t *testing.T) {
 	printRoutesMessage := captureOutput(func() {
 		app.printRoutesMessage()
 	})
-	require.True(t, strings.Contains(printRoutesMessage, MethodGet))
-	require.True(t, strings.Contains(printRoutesMessage, "/"))
-	require.True(t, strings.Contains(printRoutesMessage, "emptyHandler"))
-	require.True(t, strings.Contains(printRoutesMessage, "routeName"))
+	require.Contains(t, printRoutesMessage, MethodGet)
+	require.Contains(t, printRoutesMessage, "/")
+	require.Contains(t, printRoutesMessage, "emptyHandler")
+	require.Contains(t, printRoutesMessage, "routeName")
 }
 
 // go test -run Test_Listen_Print_Route_With_Group
@@ -431,14 +432,14 @@ func Test_Listen_Print_Route_With_Group(t *testing.T) {
 		app.printRoutesMessage()
 	})
 
-	require.True(t, strings.Contains(printRoutesMessage, MethodGet))
-	require.True(t, strings.Contains(printRoutesMessage, "/"))
-	require.True(t, strings.Contains(printRoutesMessage, "emptyHandler"))
-	require.True(t, strings.Contains(printRoutesMessage, "/v1/test"))
-	require.True(t, strings.Contains(printRoutesMessage, "POST"))
-	require.True(t, strings.Contains(printRoutesMessage, "/v1/test/fiber"))
-	require.True(t, strings.Contains(printRoutesMessage, "PUT"))
-	require.True(t, strings.Contains(printRoutesMessage, "/v1/test/fiber/*"))
+	require.Contains(t, printRoutesMessage, MethodGet)
+	require.Contains(t, printRoutesMessage, "/")
+	require.Contains(t, printRoutesMessage, "emptyHandler")
+	require.Contains(t, printRoutesMessage, "/v1/test")
+	require.Contains(t, printRoutesMessage, "POST")
+	require.Contains(t, printRoutesMessage, "/v1/test/fiber")
+	require.Contains(t, printRoutesMessage, "PUT")
+	require.Contains(t, printRoutesMessage, "/v1/test/fiber/*")
 }
 
 func captureOutput(f func()) string {

--- a/mount_test.go
+++ b/mount_test.go
@@ -26,7 +26,7 @@ func Test_App_Mount(t *testing.T) {
 	app := New()
 	app.Use("/john", micro)
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/john/doe", http.NoBody))
-	require.Equal(t, nil, err, "app.Test(req)")
+	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, 200, resp.StatusCode, "Status code")
 	require.Equal(t, uint32(1), app.handlersCount)
 }
@@ -76,15 +76,15 @@ func Test_App_Mount_Nested(t *testing.T) {
 	})
 
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/one/doe", http.NoBody))
-	require.Equal(t, nil, err, "app.Test(req)")
+	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, 200, resp.StatusCode, "Status code")
 
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/one/two/nested", http.NoBody))
-	require.Equal(t, nil, err, "app.Test(req)")
+	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, 200, resp.StatusCode, "Status code")
 
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/one/two/three/test", http.NoBody))
-	require.Equal(t, nil, err, "app.Test(req)")
+	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, 200, resp.StatusCode, "Status code")
 
 	require.Equal(t, uint32(3), app.handlersCount)
@@ -101,7 +101,7 @@ func Test_App_Mount_Express_Behavior(t *testing.T) {
 	}
 	testEndpoint := func(app *App, route, expectedBody string, expectedStatusCode int) {
 		resp, err := app.Test(httptest.NewRequest(MethodGet, route, http.NoBody))
-		require.Equal(t, nil, err, "app.Test(req)")
+		require.NoError(t, err, "app.Test(req)")
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		require.Equal(t, expectedStatusCode, resp.StatusCode, "Status code")
@@ -146,7 +146,7 @@ func Test_App_Mount_RoutePositions(t *testing.T) {
 	t.Parallel()
 	testEndpoint := func(app *App, route, expectedBody string) {
 		resp, err := app.Test(httptest.NewRequest(MethodGet, route, http.NoBody))
-		require.Equal(t, nil, err, "app.Test(req)")
+		require.NoError(t, err, "app.Test(req)")
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		require.Equal(t, StatusOK, resp.StatusCode, "Status code")
@@ -189,26 +189,26 @@ func Test_App_Mount_RoutePositions(t *testing.T) {
 	testEndpoint(app, "/subApp2/world", "hello")
 
 	routeStackGET := app.Stack()[0]
-	require.Equal(t, true, routeStackGET[0].use)
+	require.True(t, routeStackGET[0].use)
 	require.Equal(t, "/", routeStackGET[0].path)
 
-	require.Equal(t, true, routeStackGET[1].use)
+	require.True(t, routeStackGET[1].use)
 	require.Equal(t, "/", routeStackGET[1].path)
-	require.Equal(t, true, routeStackGET[0].pos < routeStackGET[1].pos, "wrong position of route 0")
+	require.Less(t, routeStackGET[0].pos, routeStackGET[1].pos, "wrong position of route 0")
 
-	require.Equal(t, false, routeStackGET[2].use)
+	require.False(t, routeStackGET[2].use)
 	require.Equal(t, "/bar", routeStackGET[2].path)
-	require.Equal(t, true, routeStackGET[1].pos < routeStackGET[2].pos, "wrong position of route 1")
+	require.Less(t, routeStackGET[1].pos, routeStackGET[2].pos, "wrong position of route 1")
 
-	require.Equal(t, true, routeStackGET[3].use)
+	require.True(t, routeStackGET[3].use)
 	require.Equal(t, "/", routeStackGET[3].path)
-	require.Equal(t, true, routeStackGET[2].pos < routeStackGET[3].pos, "wrong position of route 2")
+	require.Less(t, routeStackGET[2].pos, routeStackGET[3].pos, "wrong position of route 2")
 
-	require.Equal(t, false, routeStackGET[4].use)
+	require.False(t, routeStackGET[4].use)
 	require.Equal(t, "/subapp2/world", routeStackGET[4].path)
-	require.Equal(t, true, routeStackGET[3].pos < routeStackGET[4].pos, "wrong position of route 3")
+	require.Less(t, routeStackGET[3].pos, routeStackGET[4].pos, "wrong position of route 3")
 
-	require.Equal(t, 5, len(routeStackGET))
+	require.Len(t, routeStackGET, 5)
 }
 
 // go test -run Test_App_MountPath
@@ -282,7 +282,7 @@ func Test_App_Group_Mount(t *testing.T) {
 	v1.Use("/john", micro)
 
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/v1/john/doe", http.NoBody))
-	require.Equal(t, nil, err, "app.Test(req)")
+	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, 200, resp.StatusCode, "Status code")
 	require.Equal(t, uint32(1), app.handlersCount)
 }
@@ -383,19 +383,19 @@ func Test_App_UseMountedErrorHandlerForBestPrefixMatch(t *testing.T) {
 	app.Use("/api", fiber)
 
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/api/sub", http.NoBody))
-	require.Equal(t, nil, err, "/api/sub req")
+	require.NoError(t, err, "/api/sub req")
 	require.Equal(t, 200, resp.StatusCode, "Status code")
 
 	b, err := io.ReadAll(resp.Body)
-	require.Equal(t, nil, err, "iotuil.ReadAll()")
+	require.NoError(t, err, "iotuil.ReadAll()")
 	require.Equal(t, "hi, i'm a custom sub fiber error", string(b), "Response body")
 
 	resp2, err := app.Test(httptest.NewRequest(MethodGet, "/api/sub/third", http.NoBody))
-	require.Equal(t, nil, err, "/api/sub/third req")
+	require.NoError(t, err, "/api/sub/third req")
 	require.Equal(t, 200, resp.StatusCode, "Status code")
 
 	b, err = io.ReadAll(resp2.Body)
-	require.Equal(t, nil, err, "iotuil.ReadAll()")
+	require.NoError(t, err, "iotuil.ReadAll()")
 	require.Equal(t, "hi, i'm a custom sub sub fiber error", string(b), "Third fiber Response body")
 }
 
@@ -405,15 +405,15 @@ func Test_Mount_Route_Names(t *testing.T) {
 	subApp1 := New()
 	subApp1.Get("/users", func(c Ctx) error {
 		url, err := c.GetRouteURL("add-user", Map{})
-		require.Equal(t, err, nil)
-		require.Equal(t, url, "/app1/users", "handler: app1.add-user") // the prefix is /app1 because of the mount
+		require.NoError(t, err)
+		require.Equal(t, "/app1/users", url, "handler: app1.add-user") // the prefix is /app1 because of the mount
 		// if subApp1 is not mounted, expected url just /users
 		return nil
 	}).Name("get-users")
 	subApp1.Post("/users", func(c Ctx) error {
 		route := c.App().GetRoute("get-users")
-		require.Equal(t, route.Method, MethodGet, "handler: app1.get-users method")
-		require.Equal(t, route.Path, "/app1/users", "handler: app1.get-users path")
+		require.Equal(t, MethodGet, route.Method, "handler: app1.get-users method")
+		require.Equal(t, "/app1/users", route.Path, "handler: app1.get-users path")
 		return nil
 	}).Name("add-user")
 
@@ -432,30 +432,30 @@ func Test_Mount_Route_Names(t *testing.T) {
 
 	// take route directly from sub-app
 	route := subApp1.GetRoute("get-users")
-	require.Equal(t, route.Method, MethodGet)
-	require.Equal(t, route.Path, "/users")
+	require.Equal(t, MethodGet, route.Method)
+	require.Equal(t, "/users", route.Path)
 
 	route = subApp1.GetRoute("add-user")
-	require.Equal(t, route.Method, MethodPost)
-	require.Equal(t, route.Path, "/users")
+	require.Equal(t, MethodPost, route.Method)
+	require.Equal(t, "/users", route.Path)
 
 	// take route directly from sub-app with group
 	route = subApp2.GetRoute("users.get")
-	require.Equal(t, route.Method, MethodGet)
-	require.Equal(t, route.Path, "/users")
+	require.Equal(t, MethodGet, route.Method)
+	require.Equal(t, "/users", route.Path)
 
 	route = subApp2.GetRoute("users.add")
-	require.Equal(t, route.Method, MethodPost)
-	require.Equal(t, route.Path, "/users")
+	require.Equal(t, MethodPost, route.Method)
+	require.Equal(t, "/users", route.Path)
 
 	// take route from root app (using names of sub-apps)
 	route = rootApp.GetRoute("add-user")
-	require.Equal(t, route.Method, MethodPost)
-	require.Equal(t, route.Path, "/app1/users")
+	require.Equal(t, MethodPost, route.Method)
+	require.Equal(t, "/app1/users", route.Path)
 
 	route = rootApp.GetRoute("users.add")
-	require.Equal(t, route.Method, MethodPost)
-	require.Equal(t, route.Path, "/app2/users")
+	require.Equal(t, MethodPost, route.Method)
+	require.Equal(t, "/app2/users", route.Path)
 
 	// GetRouteURL inside handler
 	req := httptest.NewRequest(MethodGet, "/app1/users", nil)
@@ -495,7 +495,7 @@ func Test_Ctx_Render_Mount(t *testing.T) {
 
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/hello/a", http.NoBody))
 	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
-	require.Equal(t, nil, err, "app.Test(req)")
+	require.NoError(t, err, "app.Test(req)")
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -551,7 +551,7 @@ func Test_Ctx_Render_Mount_ParentOrSubHasViews(t *testing.T) {
 
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/hello/world/a", http.NoBody))
 	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
-	require.Equal(t, nil, err, "app.Test(req)")
+	require.NoError(t, err, "app.Test(req)")
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -559,7 +559,7 @@ func Test_Ctx_Render_Mount_ParentOrSubHasViews(t *testing.T) {
 
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test", http.NoBody))
 	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
-	require.Equal(t, nil, err, "app.Test(req)")
+	require.NoError(t, err, "app.Test(req)")
 
 	body, err = io.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -567,7 +567,7 @@ func Test_Ctx_Render_Mount_ParentOrSubHasViews(t *testing.T) {
 
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/hello/bruh/moment", http.NoBody))
 	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
-	require.Equal(t, nil, err, "app.Test(req)")
+	require.NoError(t, err, "app.Test(req)")
 
 	body, err = io.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -596,7 +596,7 @@ func Test_Ctx_Render_MountGroup(t *testing.T) {
 	v1.Use("/john", micro)
 
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/v1/john/doe", http.NoBody))
-	require.Equal(t, nil, err, "app.Test(req)")
+	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, 200, resp.StatusCode, "Status code")
 
 	body, err := io.ReadAll(resp.Body)

--- a/prefork_test.go
+++ b/prefork_test.go
@@ -24,14 +24,14 @@ func Test_App_Prefork_Child_Process(t *testing.T) {
 	app := New()
 
 	err := app.prefork("invalid", nil, listenConfigDefault())
-	require.False(t, err == nil)
+	require.Error(t, err)
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.prefork("[::1]:", nil, ListenConfig{ListenerNetwork: NetworkTCP6}))
+	require.NoError(t, app.prefork("[::1]:", nil, ListenConfig{ListenerNetwork: NetworkTCP6}))
 
 	// Create tls certificate
 	cer, err := tls.LoadX509KeyPair("./.github/testdata/ssl.pem", "./.github/testdata/ssl.key")
@@ -43,10 +43,10 @@ func Test_App_Prefork_Child_Process(t *testing.T) {
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.prefork("127.0.0.1:", config, listenConfigDefault()))
+	require.NoError(t, app.prefork("127.0.0.1:", config, listenConfigDefault()))
 }
 
 func Test_App_Prefork_Master_Process(t *testing.T) {
@@ -57,15 +57,15 @@ func Test_App_Prefork_Master_Process(t *testing.T) {
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		require.Nil(t, app.Shutdown())
+		require.NoError(t, app.Shutdown())
 	}()
 
-	require.Nil(t, app.prefork(":3000", nil, listenConfigDefault()))
+	require.NoError(t, app.prefork(":3000", nil, listenConfigDefault()))
 
 	dummyChildCmd.Store("invalid")
 
 	err := app.prefork("127.0.0.1:", nil, listenConfigDefault())
-	require.False(t, err == nil)
+	require.Error(t, err)
 
 	dummyChildCmd.Store("go")
 }
@@ -84,21 +84,21 @@ func Test_App_Prefork_Child_Process_Never_Show_Startup_Message(t *testing.T) {
 
 	New().startupProcess().startupMessage(":3000", false, "", listenConfigDefault())
 
-	require.Nil(t, w.Close())
+	require.NoError(t, w.Close())
 
 	out, err := io.ReadAll(r)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(out))
+	require.Empty(t, out)
 }
 
 func setupIsChild(t *testing.T) {
 	t.Helper()
 
-	require.Nil(t, os.Setenv(envPreforkChildKey, envPreforkChildVal))
+	require.NoError(t, os.Setenv(envPreforkChildKey, envPreforkChildVal))
 }
 
 func teardownIsChild(t *testing.T) {
 	t.Helper()
 
-	require.Nil(t, os.Setenv(envPreforkChildKey, ""))
+	require.NoError(t, os.Setenv(envPreforkChildKey, ""))
 }

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -325,7 +325,7 @@ func Test_Redirect_Request(t *testing.T) {
 
 		require.Equal(t, tc.ExpectedStatusCode, code)
 		require.Equal(t, tc.ExpectedBody, body)
-		require.Equal(t, tc.ExceptedErrsLen, len(errs))
+		require.Len(t, errs, tc.ExceptedErrsLen)
 	}
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net/http/httptest"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/gofiber/utils/v2"
@@ -353,7 +352,7 @@ func Test_Route_Static_Root(t *testing.T) {
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err, "app.Test(req)")
-	require.True(t, strings.Contains(app.getString(body), "color"))
+	require.Contains(t, app.getString(body), "color")
 
 	app = New()
 	app.Static("/", dir)
@@ -368,7 +367,7 @@ func Test_Route_Static_Root(t *testing.T) {
 
 	body, err = io.ReadAll(resp.Body)
 	require.NoError(t, err, "app.Test(req)")
-	require.True(t, strings.Contains(app.getString(body), "color"))
+	require.Contains(t, app.getString(body), "color")
 }
 
 func Test_Route_Static_HasPrefix(t *testing.T) {
@@ -394,7 +393,7 @@ func Test_Route_Static_HasPrefix(t *testing.T) {
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err, "app.Test(req)")
-	require.True(t, strings.Contains(app.getString(body), "color"))
+	require.Contains(t, app.getString(body), "color")
 
 	app = New()
 	app.Static("/static/", dir, Static{
@@ -415,7 +414,7 @@ func Test_Route_Static_HasPrefix(t *testing.T) {
 
 	body, err = io.ReadAll(resp.Body)
 	require.NoError(t, err, "app.Test(req)")
-	require.True(t, strings.Contains(app.getString(body), "color"))
+	require.Contains(t, app.getString(body), "color")
 
 	app = New()
 	app.Static("/static", dir)
@@ -434,7 +433,7 @@ func Test_Route_Static_HasPrefix(t *testing.T) {
 
 	body, err = io.ReadAll(resp.Body)
 	require.NoError(t, err, "app.Test(req)")
-	require.True(t, strings.Contains(app.getString(body), "color"))
+	require.Contains(t, app.getString(body), "color")
 
 	app = New()
 	app.Static("/static/", dir)
@@ -453,7 +452,7 @@ func Test_Route_Static_HasPrefix(t *testing.T) {
 
 	body, err = io.ReadAll(resp.Body)
 	require.NoError(t, err, "app.Test(req)")
-	require.True(t, strings.Contains(app.getString(body), "color"))
+	require.Contains(t, app.getString(body), "color")
 }
 
 func Test_Router_NotFound(t *testing.T) {


### PR DESCRIPTION
If this is too big, I can split this into multiple PRs.

## Description

In preparation for the upcoming linter update, fix testifylint errors.
Where possible, `require.ErrorContains` was avoided. Using `require.ErrorContains` [is planned to eventually be made a lint error](https://github.com/Antonboom/testifylint/blob/master/CONTRIBUTING.md#error-compare).

https://github.com/Antonboom/testifylint

## Type of Change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
