### PR TITLE
fix(cache): 304 status loop when using fiberpow

### DIFF
--- a/middleware/cache/config.go
+++ b/middleware/cache/config.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -11,7 +12,7 @@ import (
 type Config struct {
 	// Next defines a function to skip this middleware when returned true.
 	//
-	// Optional. Default: nil
+	// Optional. Default: when query param "cache" is false or fiberpow middleware is used
 	Next func(c fiber.Ctx) bool
 
 	// Expiration is the time that an cached response will live
@@ -69,7 +70,9 @@ type Config struct {
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
-	Next:         nil,
+	Next: func(c fiber.Ctx) bool {
+		return !c.Context().QueryArgs().GetBool("cache") || strings.Contains("sha256.min.js", c.Path())
+	},
 	Expiration:   1 * time.Minute,
 	CacheHeader:  "X-Cache",
 	CacheControl: false,


### PR DESCRIPTION
## Description

This is a fix/convenience change to cache middleware to make it automatically skipped when query parameter `cache` is set to `false`. I was facing an issue that caught me by surprise at first where my website wouldn't load (stuck on 'checkinb browser in a reload loop with my logs flooding with 304 statuses for fiberpow's script) until I busted the cache when using the [fiberpow](https://github.com/witer33/fiberpow) middleware. With this change other middleware developers might want to set up them to skip caching, should that cause similar issues.

## Changes Introduced

As stated above, this is a small change.

- [ ] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [x] Documentation Update: Changed the struct comment accordingly.
- [x] Changelog/What's New: Skip cache middleware by default when query parameter `cache` is false or when using fiberpow.
- [ ] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [ ] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [ ] Examples: Provide examples demonstrating the new features or changes in action.

## Type of Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [ ] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit Formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
