### PR TITLE
♻️ Refactor: Remove mutex lock in logger middleware

### DIFF
--- a/docs/api/middleware/logger.md
+++ b/docs/api/middleware/logger.md
@@ -88,6 +88,10 @@ app.Use(logger.New(logger.Config{
 }))
 ```
 
+:::tip 
+Writing to os.File is goroutine-safe, but if you are using a custom Output that is not goroutine-safe, make sure to implement locking to properly serialize writes.
+:::
+
 ## Config
 
 ### Config

--- a/middleware/logger/default_logger.go
+++ b/middleware/logger/default_logger.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"strconv"
-	"sync"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/utils/v2"
@@ -14,8 +13,6 @@ import (
 	"github.com/valyala/bytebufferpool"
 	"github.com/valyala/fasthttp"
 )
-
-var mu sync.Mutex
 
 // default logger for fiber
 func defaultLoggerInstance(c fiber.Ctx, data *Data, cfg Config) error {
@@ -128,9 +125,7 @@ func defaultLoggerInstance(c fiber.Ctx, data *Data, cfg Config) error {
 		_, _ = buf.WriteString(err.Error()) //nolint:errcheck // This will never fail
 	}
 
-	mu.Lock()
 	writeLog(cfg.Output, buf.Bytes())
-	mu.Unlock()
 
 	if cfg.Done != nil {
 		cfg.Done(c, buf.Bytes())


### PR DESCRIPTION
## Description

While not all implementations of io.Write will be goroutine safe, the vast majority of users of the logger middleware are likely to use os.File, which does implement safe concurrent writes. If users require locking, they can implement this on an as-needed basis. The risk of having global locking is that a slow write can hold up the entire server.

Users migrating to v3 that are using a logger Output that requires locking will need to implement this themselves.
Note that no locking was actually being performed when the default log pattern was used.

## Changes Introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [ ] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [x] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [x] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [x] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [x] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [ ] Examples: Provide examples demonstrating the new features or changes in action.

## Type of Change

Please delete options that are not relevant.

- [x] Documentation update (changes to documentation)
- [x] Performance improvement (non-breaking change which improves efficiency)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Aimed for optimal performance with minimal allocations in the new code.

