### PR TITLE
🎨 Style!: Update CSRF and Limiter to remove repetitive names

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -109,8 +109,6 @@ linters-settings:
         disabled: true
       - name: exported
         disabled: true
-        arguments:
-          - disableStutteringCheck # TODO https://github.com/gofiber/fiber/issues/2816
       - name: file-header
         disabled: true
       - name: function-result-limit

--- a/docs/api/middleware/csrf.md
+++ b/docs/api/middleware/csrf.md
@@ -31,7 +31,7 @@ By default, the middleware generates and stores tokens using the `fiber.Storage`
 When the authorization status changes, the previously issued token MUST be deleted, and a new one generated. See [Token Lifecycle](#token-lifecycle) [Deleting Tokens](#deleting-tokens) for more information.
 
 :::caution
-When using this pattern, it's important to set the `CookieSameSite` option to `Lax` or `Strict` and ensure that the Extractor is not `CsrfFromCookie`, and KeyLookup is not `cookie:<name>`.
+When using this pattern, it's important to set the `CookieSameSite` option to `Lax` or `Strict` and ensure that the Extractor is not `FromCookie`, and KeyLookup is not `cookie:<name>`.
 :::
 
 :::note
@@ -206,7 +206,7 @@ var ConfigDefault = Config{
 	Expiration:        1 * time.Hour,
 	KeyGenerator:      utils.UUIDv4,
 	ErrorHandler:      defaultErrorHandler,
-	Extractor:         CsrfFromHeader(HeaderName),
+	Extractor:         FromHeader(HeaderName),
 	SessionKey:        "csrfToken",
 }
 ```
@@ -226,7 +226,7 @@ var ConfigDefault = Config{
 	Expiration:        1 * time.Hour,
 	KeyGenerator:      utils.UUIDv4,
 	ErrorHandler:      defaultErrorHandler,
-	Extractor:         CsrfFromHeader(HeaderName),
+	Extractor:         FromHeader(HeaderName),
 	Session:           session.Store,
 	SessionKey:        "csrfToken",
 }

--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -117,7 +117,7 @@ var ConfigDefault = Config{
 	Expiration:     1 * time.Hour,
 	KeyGenerator:   utils.UUIDv4,
 	ErrorHandler:   defaultErrorHandler,
-	Extractor:      CsrfFromHeader(HeaderName),
+	Extractor:      FromHeader(HeaderName),
 	SessionKey:     "csrfToken",
 }
 
@@ -169,15 +169,15 @@ func configDefault(config ...Config) Config {
 
 	if cfg.Extractor == nil {
 		// By default we extract from a header
-		cfg.Extractor = CsrfFromHeader(textproto.CanonicalMIMEHeaderKey(selectors[1]))
+		cfg.Extractor = FromHeader(textproto.CanonicalMIMEHeaderKey(selectors[1]))
 
 		switch selectors[0] {
 		case "form":
-			cfg.Extractor = CsrfFromForm(selectors[1])
+			cfg.Extractor = FromForm(selectors[1])
 		case "query":
-			cfg.Extractor = CsrfFromQuery(selectors[1])
+			cfg.Extractor = FromQuery(selectors[1])
 		case "param":
-			cfg.Extractor = CsrfFromParam(selectors[1])
+			cfg.Extractor = FromParam(selectors[1])
 		case "cookie":
 			if cfg.Session == nil {
 				log.Warn("[CSRF] Cookie extractor is not recommended without a session store")
@@ -185,7 +185,7 @@ func configDefault(config ...Config) Config {
 			if cfg.CookieSameSite == "None" || cfg.CookieSameSite != "Lax" && cfg.CookieSameSite != "Strict" {
 				log.Warn("[CSRF] Cookie extractor is only recommended for use with SameSite=Lax or SameSite=Strict")
 			}
-			cfg.Extractor = CsrfFromCookie(selectors[1])
+			cfg.Extractor = FromCookie(selectors[1])
 			cfg.CookieName = selectors[1] // Cookie name is the same as the key
 		}
 	}

--- a/middleware/csrf/extractors.go
+++ b/middleware/csrf/extractors.go
@@ -14,8 +14,8 @@ var (
 	ErrMissingCookie = errors.New("missing csrf token in cookie")
 )
 
-// csrfFromParam returns a function that extracts token from the url param string.
-func CsrfFromParam(param string) func(c fiber.Ctx) (string, error) {
+// FromParam returns a function that extracts token from the url param string.
+func FromParam(param string) func(c fiber.Ctx) (string, error) {
 	return func(c fiber.Ctx) (string, error) {
 		token := c.Params(param)
 		if token == "" {
@@ -25,8 +25,8 @@ func CsrfFromParam(param string) func(c fiber.Ctx) (string, error) {
 	}
 }
 
-// csrfFromForm returns a function that extracts a token from a multipart-form.
-func CsrfFromForm(param string) func(c fiber.Ctx) (string, error) {
+// FromForm returns a function that extracts a token from a multipart-form.
+func FromForm(param string) func(c fiber.Ctx) (string, error) {
 	return func(c fiber.Ctx) (string, error) {
 		token := c.FormValue(param)
 		if token == "" {
@@ -36,8 +36,8 @@ func CsrfFromForm(param string) func(c fiber.Ctx) (string, error) {
 	}
 }
 
-// csrfFromCookie returns a function that extracts token from the cookie header.
-func CsrfFromCookie(param string) func(c fiber.Ctx) (string, error) {
+// FromCookie returns a function that extracts token from the cookie header.
+func FromCookie(param string) func(c fiber.Ctx) (string, error) {
 	return func(c fiber.Ctx) (string, error) {
 		token := c.Cookies(param)
 		if token == "" {
@@ -47,8 +47,8 @@ func CsrfFromCookie(param string) func(c fiber.Ctx) (string, error) {
 	}
 }
 
-// csrfFromHeader returns a function that extracts token from the request header.
-func CsrfFromHeader(param string) func(c fiber.Ctx) (string, error) {
+// FromHeader returns a function that extracts token from the request header.
+func FromHeader(param string) func(c fiber.Ctx) (string, error) {
 	return func(c fiber.Ctx) (string, error) {
 		token := c.Get(param)
 		if token == "" {
@@ -58,8 +58,8 @@ func CsrfFromHeader(param string) func(c fiber.Ctx) (string, error) {
 	}
 }
 
-// csrfFromQuery returns a function that extracts token from the query string.
-func CsrfFromQuery(param string) func(c fiber.Ctx) (string, error) {
+// FromQuery returns a function that extracts token from the query string.
+func FromQuery(param string) func(c fiber.Ctx) (string, error) {
 	return func(c fiber.Ctx) (string, error) {
 		token := fiber.Query[string](c, param)
 		if token == "" {

--- a/middleware/limiter/config.go
+++ b/middleware/limiter/config.go
@@ -55,7 +55,7 @@ type Config struct {
 	// LimiterMiddleware is the struct that implements a limiter middleware.
 	//
 	// Default: a new Fixed Window Rate Limiter
-	LimiterMiddleware LimiterHandler
+	LimiterMiddleware Handler
 }
 
 // ConfigDefault is the default config

--- a/middleware/limiter/limiter.go
+++ b/middleware/limiter/limiter.go
@@ -11,7 +11,7 @@ const (
 	xRateLimitReset     = "X-RateLimit-Reset"
 )
 
-type LimiterHandler interface {
+type Handler interface {
 	New(config Config) fiber.Handler
 }
 


### PR DESCRIPTION
## Description

The `exported` rule of revive warns to not repeat the package name in method names. For example, prefer `csrf.FromCookie` over `csrf.CsrfFromCookie`.

It appears that these issues will not be caught by the linter until the `exported` rule is reenabled. This requires comments on all exported symbols, which is a much broader effort.

BREAKING CHANGE: This is a breaking change for v3.

Related to #2817

## Changes Introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [x] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [x] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [x] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [x] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.

Users will be required to change to the new function and type names when upgrading to v3.  This change is beneficial to API longevity by being more in line with Go style standards.

## Type of Change

Please delete options that are not relevant.

- [x] Documentation update (changes to documentation)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Ensured that new and existing unit tests pass locally with the changes.
