### PR TITLE
🎨 Style: Add inamedparam linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -191,7 +191,7 @@ linters:
     # - gosmopolitan # TODO https://github.com/gofiber/fiber/issues/2816
     - govet
     - grouper
-    # - inamedparam # TODO https://github.com/gofiber/fiber/issues/2816
+    - inamedparam
     - loggercheck
     # - mirror # TODO https://github.com/gofiber/fiber/issues/2816
     - misspell

--- a/bind.go
+++ b/bind.go
@@ -9,13 +9,13 @@ import (
 type CustomBinder interface {
 	Name() string
 	MIMETypes() []string
-	Parse(Ctx, any) error
+	Parse(c Ctx, out any) error
 }
 
 // An interface to register custom struct validator for binding.
 type StructValidator interface {
 	Engine() any
-	ValidateStruct(any) error
+	ValidateStruct(out any) error
 }
 
 // Bind struct

--- a/ctx.go
+++ b/ctx.go
@@ -105,7 +105,7 @@ type Cookie struct {
 // Views is the interface that wraps the Render function.
 type Views interface {
 	Load() error
-	Render(io.Writer, string, any, ...string) error
+	Render(out io.Writer, name string, binding any, layout ...string) error
 }
 
 // ResFmt associates a Content Type to a fiber.Handler for c.Format

--- a/log/log.go
+++ b/log/log.go
@@ -54,8 +54,8 @@ type CommonLogger interface {
 
 // ControlLogger provides methods to config a logger.
 type ControlLogger interface {
-	SetLevel(Level)
-	SetOutput(io.Writer)
+	SetLevel(level Level)
+	SetOutput(w io.Writer)
 }
 
 // AllLogger is the combination of Logger, FormatLogger, CtxLogger and ControlLogger.


### PR DESCRIPTION
## Description

inamedparam enforces that parameters in interface definitions be named. This is important for clarity so that users and implementers can easily understand the purpose of each parameter.

Related to #2817 

## Type of Change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Ensured that new and existing unit tests pass locally with the changes.

