### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gofiber/maintainers


### PR DESCRIPTION
This will allow github to auto assign the `gofiber/maintainers` team as reviewers of each new Pull Request. Currently this is a manual process.

This was suggested by @efectn the other day on discord.