### PR TITLE
Run tests against Apple M1 platform

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.20.x, 1.21.x, 1.22.x]
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ubuntu-latest, windows-latest, macos-latest, macos-14]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Fetch Repository


### PR DESCRIPTION
Add support for running the tests against the newly released arm64 M1 runner. This is based on Apple M1 platform with MacOS.

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/?trk=feed_main-feed-card_feed-article-content