### PR TITLE
feat(ci): do not retry flaky tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,4 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Run Test
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 3
-          timeout_minutes: 15
-          command: go test ./... -v -race -count=1
+      - run: go test ./... -v -race -count=1


### PR DESCRIPTION
Reporting flaky tests is important so they can be fixed. Also this allows to discover data races which else might go completely unnoticed.