### PR TITLE
Update cors.md documentation

### DIFF
--- a/docs/api/middleware/cors.md
+++ b/docs/api/middleware/cors.md
@@ -35,8 +35,8 @@ app.Use(cors.New())
 
 // Or extend your config for customization
 app.Use(cors.New(cors.Config{
-    AllowOrigins: "https://gofiber.io, https://gofiber.net",
-    AllowHeaders:  "Origin, Content-Type, Accept",
+    AllowOrigins: "https://gofiber.io,https://gofiber.net",
+    AllowHeaders:  "Origin,Content-Type,Accept",
 }))
 ```
 


### PR DESCRIPTION
## Description

Recent version of golang fiber now breaks if you provide allowOrigins configuration with a space after the comma. For example, if you give the input:

```
https://first-url.com, https://second-url.com

```

it breaks with the following error:

2024/02/26 15:01:16.338384 cors.go:124: [Warn] [CORS] Invalid origin format in configuration:  https://second-url.com
```

## Changes Introduced

- Update docs for `docs/api/middleware/cors.md`

- [x] Documentation update (changes to documentation)