### PR TITLE
fix(middleware/cors): Validation of multiple Origins

### DIFF
--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -114,24 +114,28 @@ func New(config ...Config) fiber.Handler {
 	}
 
 	// allowOrigins is a slice of strings that contains the allowed origins
-	// that are defined in the 'AllowOrigins' configuration.
+	// defined in the 'AllowOrigins' configuration.
 	var allowOrigins []string
 
 	// Validate and normalize static AllowOrigins
 	if cfg.AllowOrigins != "" && cfg.AllowOrigins != "*" {
-		for _, origin := range strings.Split(cfg.AllowOrigins, ",") {
-			origin = strings.TrimSpace(origin)
-			isValid, normalizedOrigin := normalizeOrigin(origin)
+		origins := strings.Split(cfg.AllowOrigins, ",")
+		allowOrigins = make([]string, len(origins))
+
+		for i, origin := range origins {
+			trimmedOrigin := strings.TrimSpace(origin)
+			isValid, normalizedOrigin := normalizeOrigin(trimmedOrigin)
+
 			if isValid {
-				allowOrigins = append(allowOrigins, normalizedOrigin)
+				allowOrigins[i] = normalizedOrigin
 			} else {
-				log.Warnf("[CORS] Invalid origin format in configuration: %s", origin)
+				log.Warnf("[CORS] Invalid origin format in configuration: %s", trimmedOrigin)
 				panic("[CORS] Invalid origin provided in configuration")
 			}
 		}
 	} else {
 		// If AllowOrigins is set to a wildcard or not set,
-		// set the allowOrigins to a slice with a single element
+		// set allowOrigins to a slice with a single element
 		allowOrigins = []string{cfg.AllowOrigins}
 	}
 

--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -113,23 +113,27 @@ func New(config ...Config) fiber.Handler {
 		panic("[CORS] Insecure setup, 'AllowCredentials' is set to true, and 'AllowOrigins' is set to a wildcard.")
 	}
 
-	// Validate and normalize static AllowOrigins if not using AllowOriginsFunc
-	if cfg.AllowOriginsFunc == nil && cfg.AllowOrigins != "" && cfg.AllowOrigins != "*" {
-		validatedOrigins := []string{}
+	// allowOrigins is a slice of strings that contains the allowed origins
+	// that are defined in the 'AllowOrigins' configuration.
+	var allowOrigins []string
+
+	// Validate and normalize static AllowOrigins
+	if cfg.AllowOrigins != "" && cfg.AllowOrigins != "*" {
 		for _, origin := range strings.Split(cfg.AllowOrigins, ",") {
+			origin = strings.TrimSpace(origin)
 			isValid, normalizedOrigin := normalizeOrigin(origin)
 			if isValid {
-				validatedOrigins = append(validatedOrigins, normalizedOrigin)
+				allowOrigins = append(allowOrigins, normalizedOrigin)
 			} else {
 				log.Warnf("[CORS] Invalid origin format in configuration: %s", origin)
 				panic("[CORS] Invalid origin provided in configuration")
 			}
 		}
-		cfg.AllowOrigins = strings.Join(validatedOrigins, ",")
+	} else {
+		// If AllowOrigins is set to a wildcard or not set,
+		// set the allowOrigins to a slice with a single element
+		allowOrigins = []string{cfg.AllowOrigins}
 	}
-
-	// Convert string to slice
-	allowOrigins := strings.Split(strings.ReplaceAll(cfg.AllowOrigins, " ", ""), ",")
 
 	// Strip white spaces
 	allowMethods := strings.ReplaceAll(cfg.AllowMethods, " ", "")
@@ -165,10 +169,8 @@ func New(config ...Config) fiber.Handler {
 		// Run AllowOriginsFunc if the logic for
 		// handling the value in 'AllowOrigins' does
 		// not result in allowOrigin being set.
-		if allowOrigin == "" && cfg.AllowOriginsFunc != nil {
-			if cfg.AllowOriginsFunc(originHeader) {
-				allowOrigin = originHeader
-			}
+		if allowOrigin == "" && cfg.AllowOriginsFunc != nil && cfg.AllowOriginsFunc(originHeader) {
+			allowOrigin = originHeader
 		}
 
 		// Simple request

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -726,6 +726,195 @@ func Benchmark_CORS_NewHandler(b *testing.B) {
 	}
 }
 
+// go test -v -run=^$ -bench=Benchmark_CORS_NewHandlerParallel -benchmem -count=4
+func Benchmark_CORS_NewHandlerParallel(b *testing.B) {
+	app := fiber.New()
+	c := New(Config{
+		AllowOrigins:     "http://localhost,http://example.com",
+		AllowMethods:     "GET,POST,PUT,DELETE",
+		AllowHeaders:     "Origin,Content-Type,Accept",
+		AllowCredentials: true,
+		MaxAge:           600,
+	})
+
+	app.Use(c)
+	app.Use(func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	h := app.Handler()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		ctx := &fasthttp.RequestCtx{}
+
+		req := &fasthttp.Request{}
+		req.Header.SetMethod(fiber.MethodGet)
+		req.SetRequestURI("/")
+		req.Header.Set(fiber.HeaderOrigin, "http://localhost")
+		req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
+		req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
+
+		ctx.Init(req, nil, nil)
+
+		for pb.Next() {
+			h(ctx)
+		}
+	})
+}
+
+// go test -v -run=^$ -bench=Benchmark_CORS_NewHandlerSingleOrigin -benchmem -count=4
+func Benchmark_CORS_NewHandlerSingleOrigin(b *testing.B) {
+	app := fiber.New()
+	c := New(Config{
+		AllowOrigins:     "http://example.com",
+		AllowMethods:     "GET,POST,PUT,DELETE",
+		AllowHeaders:     "Origin,Content-Type,Accept",
+		AllowCredentials: true,
+		MaxAge:           600,
+	})
+
+	app.Use(c)
+	app.Use(func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	h := app.Handler()
+	ctx := &fasthttp.RequestCtx{}
+
+	req := &fasthttp.Request{}
+	req.Header.SetMethod(fiber.MethodGet)
+	req.SetRequestURI("/")
+	req.Header.Set(fiber.HeaderOrigin, "http://example.com")
+	req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
+	req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
+
+	ctx.Init(req, nil, nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		h(ctx)
+	}
+}
+
+// go test -v -run=^$ -bench=Benchmark_CORS_NewHandlerSingleOriginParallel -benchmem -count=4
+func Benchmark_CORS_NewHandlerSingleOriginParallel(b *testing.B) {
+	app := fiber.New()
+	c := New(Config{
+		AllowOrigins:     "http://example.com",
+		AllowMethods:     "GET,POST,PUT,DELETE",
+		AllowHeaders:     "Origin,Content-Type,Accept",
+		AllowCredentials: true,
+		MaxAge:           600,
+	})
+
+	app.Use(c)
+	app.Use(func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	h := app.Handler()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		ctx := &fasthttp.RequestCtx{}
+
+		req := &fasthttp.Request{}
+		req.Header.SetMethod(fiber.MethodGet)
+		req.SetRequestURI("/")
+		req.Header.Set(fiber.HeaderOrigin, "http://example.com")
+		req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
+		req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
+
+		ctx.Init(req, nil, nil)
+
+		for pb.Next() {
+			h(ctx)
+		}
+	})
+}
+
+// go test -v -run=^$ -bench=Benchmark_CORS_NewHandlerWildcard -benchmem -count=4
+func Benchmark_CORS_NewHandlerWildcard(b *testing.B) {
+	app := fiber.New()
+	c := New(Config{
+		AllowOrigins:     "*",
+		AllowMethods:     "GET,POST,PUT,DELETE",
+		AllowHeaders:     "Origin,Content-Type,Accept",
+		AllowCredentials: false,
+		MaxAge:           600,
+	})
+
+	app.Use(c)
+	app.Use(func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	h := app.Handler()
+	ctx := &fasthttp.RequestCtx{}
+
+	req := &fasthttp.Request{}
+	req.Header.SetMethod(fiber.MethodGet)
+	req.SetRequestURI("/")
+	req.Header.Set(fiber.HeaderOrigin, "http://example.com")
+	req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
+	req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
+
+	ctx.Init(req, nil, nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		h(ctx)
+	}
+}
+
+// go test -v -run=^$ -bench=Benchmark_CORS_NewHandlerWildcardParallel -benchmem -count=4
+func Benchmark_CORS_NewHandlerWildcardParallel(b *testing.B) {
+	app := fiber.New()
+	c := New(Config{
+		AllowOrigins:     "*",
+		AllowMethods:     "GET,POST,PUT,DELETE",
+		AllowHeaders:     "Origin,Content-Type,Accept",
+		AllowCredentials: false,
+		MaxAge:           600,
+	})
+
+	app.Use(c)
+	app.Use(func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	h := app.Handler()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		ctx := &fasthttp.RequestCtx{}
+
+		req := &fasthttp.Request{}
+		req.Header.SetMethod(fiber.MethodGet)
+		req.SetRequestURI("/")
+		req.Header.Set(fiber.HeaderOrigin, "http://example.com")
+		req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
+		req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
+
+		ctx.Init(req, nil, nil)
+
+		for pb.Next() {
+			h(ctx)
+		}
+	})
+}
+
 // go test -v -run=^$ -bench=Benchmark_CORS_NewHandlerPreflight -benchmem -count=4
 func Benchmark_CORS_NewHandlerPreflight(b *testing.B) {
 	app := fiber.New()
@@ -748,7 +937,7 @@ func Benchmark_CORS_NewHandlerPreflight(b *testing.B) {
 	req := &fasthttp.Request{}
 	req.Header.SetMethod(fiber.MethodOptions)
 	req.SetRequestURI("/")
-	req.Header.Set(fiber.HeaderOrigin, "http://localhost")
+	req.Header.Set(fiber.HeaderOrigin, "http://example.com")
 	req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodPost)
 	req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
 
@@ -760,4 +949,193 @@ func Benchmark_CORS_NewHandlerPreflight(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		h(ctx)
 	}
+}
+
+// go test -v -run=^$ -bench=Benchmark_CORS_NewHandlerPreflightParallel -benchmem -count=4
+func Benchmark_CORS_NewHandlerPreflightParallel(b *testing.B) {
+	app := fiber.New()
+	c := New(Config{
+		AllowOrigins:     "http://localhost,http://example.com",
+		AllowMethods:     "GET,POST,PUT,DELETE",
+		AllowHeaders:     "Origin,Content-Type,Accept",
+		AllowCredentials: true,
+		MaxAge:           600,
+	})
+
+	app.Use(c)
+	app.Use(func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	h := app.Handler()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		ctx := &fasthttp.RequestCtx{}
+
+		req := &fasthttp.Request{}
+		req.Header.SetMethod(fiber.MethodOptions)
+		req.SetRequestURI("/")
+		req.Header.Set(fiber.HeaderOrigin, "http://example.com")
+		req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodPost)
+		req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
+
+		ctx.Init(req, nil, nil)
+
+		for pb.Next() {
+			h(ctx)
+		}
+	})
+}
+
+// go test -v -run=^$ -bench=Benchmark_CORS_NewHandlerPreflightSingleOrigin -benchmem -count=4
+func Benchmark_CORS_NewHandlerPreflightSingleOrigin(b *testing.B) {
+	app := fiber.New()
+	c := New(Config{
+		AllowOrigins:     "http://example.com",
+		AllowMethods:     "GET,POST,PUT,DELETE",
+		AllowHeaders:     "Origin,Content-Type,Accept",
+		AllowCredentials: true,
+		MaxAge:           600,
+	})
+
+	app.Use(c)
+	app.Use(func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	h := app.Handler()
+	ctx := &fasthttp.RequestCtx{}
+
+	req := &fasthttp.Request{}
+	req.Header.SetMethod(fiber.MethodOptions)
+	req.SetRequestURI("/")
+	req.Header.Set(fiber.HeaderOrigin, "http://example.com")
+	req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodPost)
+	req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
+
+	ctx.Init(req, nil, nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		h(ctx)
+	}
+}
+
+// go test -v -run=^$ -bench=Benchmark_CORS_NewHandlerPreflightSingleOriginParallel -benchmem -count=4
+func Benchmark_CORS_NewHandlerPreflightSingleOriginParallel(b *testing.B) {
+	app := fiber.New()
+	c := New(Config{
+		AllowOrigins:     "http://example.com",
+		AllowMethods:     "GET,POST,PUT,DELETE",
+		AllowHeaders:     "Origin,Content-Type,Accept",
+		AllowCredentials: true,
+		MaxAge:           600,
+	})
+
+	app.Use(c)
+	app.Use(func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	h := app.Handler()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		ctx := &fasthttp.RequestCtx{}
+
+		req := &fasthttp.Request{}
+		req.Header.SetMethod(fiber.MethodOptions)
+		req.SetRequestURI("/")
+		req.Header.Set(fiber.HeaderOrigin, "http://example.com")
+		req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodPost)
+		req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
+
+		ctx.Init(req, nil, nil)
+
+		for pb.Next() {
+			h(ctx)
+		}
+	})
+}
+
+// go test -v -run=^$ -bench=Benchmark_CORS_NewHandlerPreflightWildcard -benchmem -count=4
+func Benchmark_CORS_NewHandlerPreflightWildcard(b *testing.B) {
+	app := fiber.New()
+	c := New(Config{
+		AllowOrigins:     "*",
+		AllowMethods:     "GET,POST,PUT,DELETE",
+		AllowHeaders:     "Origin,Content-Type,Accept",
+		AllowCredentials: false,
+		MaxAge:           600,
+	})
+
+	app.Use(c)
+	app.Use(func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	h := app.Handler()
+	ctx := &fasthttp.RequestCtx{}
+
+	req := &fasthttp.Request{}
+	req.Header.SetMethod(fiber.MethodOptions)
+	req.SetRequestURI("/")
+	req.Header.Set(fiber.HeaderOrigin, "http://example.com")
+	req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodPost)
+	req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
+
+	ctx.Init(req, nil, nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		h(ctx)
+	}
+}
+
+// go test -v -run=^$ -bench=Benchmark_CORS_NewHandlerPreflightWildcardParallel -benchmem -count=4
+func Benchmark_CORS_NewHandlerPreflightWildcardParallel(b *testing.B) {
+	app := fiber.New()
+	c := New(Config{
+		AllowOrigins:     "*",
+		AllowMethods:     "GET,POST,PUT,DELETE",
+		AllowHeaders:     "Origin,Content-Type,Accept",
+		AllowCredentials: false,
+		MaxAge:           600,
+	})
+
+	app.Use(c)
+	app.Use(func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	h := app.Handler()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		ctx := &fasthttp.RequestCtx{}
+
+		req := &fasthttp.Request{}
+		req.Header.SetMethod(fiber.MethodOptions)
+		req.SetRequestURI("/")
+		req.Header.Set(fiber.HeaderOrigin, "http://example.com")
+		req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodPost)
+		req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
+
+		ctx.Init(req, nil, nil)
+
+		for pb.Next() {
+			h(ctx)
+		}
+	})
 }

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -674,3 +674,43 @@ func Test_CORS_AllowCredentials(t *testing.T) {
 		})
 	}
 }
+
+func Benchmark_CORS_NewHandler(b *testing.B) {
+	app := fiber.New()
+	app.Use(New(Config{
+		AllowOrigins:     "http://localhost,http://example.com",
+		AllowMethods:     "GET,POST,PUT,DELETE",
+		AllowHeaders:     "Origin,Content-Type,Accept",
+		AllowCredentials: true,
+		MaxAge:           600,
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set(fiber.HeaderOrigin, "http://localhost")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		app.Test(req)
+	}
+}
+
+func Benchmark_CORS_NewHandlerPreflight(b *testing.B) {
+	app := fiber.New()
+	app.Use(New(Config{
+		AllowOrigins:     "http://localhost,http://example.com",
+		AllowMethods:     "GET,POST,PUT,DELETE",
+		AllowHeaders:     "Origin,Content-Type,Accept",
+		AllowCredentials: true,
+		MaxAge:           600,
+	}))
+
+	req := httptest.NewRequest("OPTIONS", "/", nil)
+	req.Header.Set(fiber.HeaderOrigin, "http://localhost")
+	req.Header.Set(fiber.HeaderAccessControlRequestMethod, "POST")
+	req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		app.Test(req)
+	}
+}

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -307,6 +307,21 @@ func Test_CORS_AllowOriginScheme(t *testing.T) {
 			reqOrigin:         "http://ccc.bbb.example.com",
 			shouldAllowOrigin: false,
 		},
+		{
+			pattern:           "http://domain-1.com, http://example.com",
+			reqOrigin:         "http://example.com",
+			shouldAllowOrigin: true,
+		},
+		{
+			pattern:           "http://domain-1.com, http://example.com",
+			reqOrigin:         "http://domain-2.com",
+			shouldAllowOrigin: false,
+		},
+		{
+			pattern:           "http://domain-1.com,http://example.com",
+			reqOrigin:         "http://domain-1.com",
+			shouldAllowOrigin: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -453,6 +453,33 @@ func Test_CORS_AllowOriginsAndAllowOriginsFunc_AllUseCases(t *testing.T) {
 			ResponseOrigin: "http://aaa.com",
 		},
 		{
+			Name: "AllowOriginsDefined/AllowOriginsFuncUndefined/MultipleOrigins/NoWhitespace/OriginAllowed",
+			Config: Config{
+				AllowOrigins:     "http://aaa.com,http://bbb.com",
+				AllowOriginsFunc: nil,
+			},
+			RequestOrigin:  "http://bbb.com",
+			ResponseOrigin: "http://bbb.com",
+		},
+		{
+			Name: "AllowOriginsDefined/AllowOriginsFuncUndefined/MultipleOrigins/NoWhitespace/OriginNotAllowed",
+			Config: Config{
+				AllowOrigins:     "http://aaa.com,http://bbb.com",
+				AllowOriginsFunc: nil,
+			},
+			RequestOrigin:  "http://ccc.com",
+			ResponseOrigin: "",
+		},
+		{
+			Name: "AllowOriginsDefined/AllowOriginsFuncUndefined/MultipleOrigins/Whitespace/OriginAllowed",
+			Config: Config{
+				AllowOrigins:     "http://aaa.com, http://bbb.com",
+				AllowOriginsFunc: nil,
+			},
+			RequestOrigin:  "http://aaa.com",
+			ResponseOrigin: "http://aaa.com",
+		},
+		{
 			Name: "AllowOriginsDefined/AllowOriginsFuncUndefined/OriginNotAllowed",
 			Config: Config{
 				AllowOrigins:     "http://aaa.com",

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -685,12 +685,16 @@ func Benchmark_CORS_NewHandler(b *testing.B) {
 		MaxAge:           600,
 	}))
 
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
 	req.Header.Set(fiber.HeaderOrigin, "http://localhost")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		app.Test(req)
+		resp, err := app.Test(req)
+		if err != nil {
+			b.Fatalf("Failed to perform request: %v", err)
+		}
+		_ = resp
 	}
 }
 
@@ -704,13 +708,17 @@ func Benchmark_CORS_NewHandlerPreflight(b *testing.B) {
 		MaxAge:           600,
 	}))
 
-	req := httptest.NewRequest("OPTIONS", "/", nil)
+	req := httptest.NewRequest(fiber.MethodOptions, "/", nil)
 	req.Header.Set(fiber.HeaderOrigin, "http://localhost")
-	req.Header.Set(fiber.HeaderAccessControlRequestMethod, "POST")
+	req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodPost)
 	req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		app.Test(req)
+		resp, err := app.Test(req)
+		if err != nil {
+			b.Fatalf("Failed to perform request: %v", err)
+		}
+		_ = resp
 	}
 }


### PR DESCRIPTION
## Description

Refactor CORS origin validation and normalization to trim leading or trailing whitespace in the cfg.AllowOrigins string [list]. URLs with whitespace inside the URL are invalid, so the normalizeOrigin will return false because url.Parse will fail, and the middleware will panic.

in addition it adds benchmarks to the middleware

Related to #2882

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Aimed for optimal performance with minimal allocations in the new code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved handling and validation of CORS (Cross-Origin Resource Sharing) settings to support wildcards and specific origins more effectively.
- **Tests**
	- Added new test cases and benchmarks for enhanced testing of CORS configurations and preflight request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->