### PR TITLE
refactor: Rename "ClientNew" Function to "New"

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -686,11 +686,11 @@ var (
 
 // init acquire a default client.
 func init() {
-	defaultClient = NewClient()
+	defaultClient = New()
 }
 
-// NewClient creates and returns a new Client object.
-func NewClient() *Client {
+// New creates and returns a new Client object.
+func New() *Client {
 	// FOllOW-UP performance optimization
 	// trie to use a pool to reduce the cost of memory allocation
 	// for the fiber client and the fasthttp client

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -62,7 +62,7 @@ func Test_Client_Add_Hook(t *testing.T) {
 		buf := bytebufferpool.Get()
 		defer bytebufferpool.Put(buf)
 
-		client := NewClient().AddRequestHook(func(_ *Client, _ *Request) error {
+		client := New().AddRequestHook(func(_ *Client, _ *Request) error {
 			buf.WriteString("hook1")
 			return nil
 		})
@@ -82,7 +82,7 @@ func Test_Client_Add_Hook(t *testing.T) {
 
 	t.Run("add response hooks", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().AddResponseHook(func(_ *Client, _ *Response, _ *Request) error {
+		client := New().AddResponseHook(func(_ *Client, _ *Response, _ *Request) error {
 			return nil
 		})
 
@@ -104,7 +104,7 @@ func Test_Client_Add_Hook_CheckOrder(t *testing.T) {
 	buf := bytebufferpool.Get()
 	defer bytebufferpool.Put(buf)
 
-	client := NewClient().
+	client := New().
 		AddRequestHook(func(_ *Client, _ *Request) error {
 			buf.WriteString("hook1")
 			return nil
@@ -130,7 +130,7 @@ func Test_Client_Marshal(t *testing.T) {
 
 	t.Run("set json marshal", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetJSONMarshal(func(_ any) ([]byte, error) {
 				return []byte("hello"), nil
 			})
@@ -144,7 +144,7 @@ func Test_Client_Marshal(t *testing.T) {
 		t.Parallel()
 
 		emptyErr := errors.New("empty json")
-		client := NewClient().
+		client := New().
 			SetJSONMarshal(func(_ any) ([]byte, error) {
 				return nil, emptyErr
 			})
@@ -156,7 +156,7 @@ func Test_Client_Marshal(t *testing.T) {
 
 	t.Run("set json unmarshal", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetJSONUnmarshal(func(_ []byte, _ any) error {
 				return errors.New("empty json")
 			})
@@ -167,7 +167,7 @@ func Test_Client_Marshal(t *testing.T) {
 
 	t.Run("set json unmarshal error", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetJSONUnmarshal(func(_ []byte, _ any) error {
 				return errors.New("empty json")
 			})
@@ -178,7 +178,7 @@ func Test_Client_Marshal(t *testing.T) {
 
 	t.Run("set xml marshal", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetXMLMarshal(func(_ any) ([]byte, error) {
 				return []byte("hello"), nil
 			})
@@ -190,7 +190,7 @@ func Test_Client_Marshal(t *testing.T) {
 
 	t.Run("set xml marshal error", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetXMLMarshal(func(_ any) ([]byte, error) {
 				return nil, errors.New("empty xml")
 			})
@@ -202,7 +202,7 @@ func Test_Client_Marshal(t *testing.T) {
 
 	t.Run("set xml unmarshal", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetXMLUnmarshal(func(_ []byte, _ any) error {
 				return errors.New("empty xml")
 			})
@@ -213,7 +213,7 @@ func Test_Client_Marshal(t *testing.T) {
 
 	t.Run("set xml unmarshal error", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetXMLUnmarshal(func(_ []byte, _ any) error {
 				return errors.New("empty xml")
 			})
@@ -226,7 +226,7 @@ func Test_Client_Marshal(t *testing.T) {
 func Test_Client_SetBaseURL(t *testing.T) {
 	t.Parallel()
 
-	client := NewClient().SetBaseURL("http://example.com")
+	client := New().SetBaseURL("http://example.com")
 
 	require.Equal(t, "http://example.com", client.BaseURL())
 }
@@ -242,7 +242,7 @@ func Test_Client_Invalid_URL(t *testing.T) {
 
 	go start()
 
-	_, err := NewClient().SetDial(dial).
+	_, err := New().SetDial(dial).
 		R().
 		Get("http//example")
 
@@ -252,7 +252,7 @@ func Test_Client_Invalid_URL(t *testing.T) {
 func Test_Client_Unsupported_Protocol(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewClient().
+	_, err := New().
 		R().
 		Get("ftp://example.com")
 
@@ -268,7 +268,7 @@ func Test_Client_ConcurrencyRequests(t *testing.T) {
 	})
 	go start()
 
-	client := NewClient().SetDial(dial)
+	client := New().SetDial(dial)
 
 	wg := sync.WaitGroup{}
 	for i := 0; i < 5; i++ {
@@ -320,7 +320,7 @@ func Test_Get(t *testing.T) {
 			require.NoError(t, app.Shutdown())
 		}()
 
-		resp, err := NewClient().Get("http://" + addr)
+		resp, err := New().Get("http://" + addr)
 		require.NoError(t, err)
 		require.Equal(t, "0.0.0.0", utils.UnsafeString(resp.RawResponse.Body()))
 	})
@@ -361,7 +361,7 @@ func Test_Head(t *testing.T) {
 			require.NoError(t, app.Shutdown())
 		}()
 
-		resp, err := NewClient().Head("http://" + addr)
+		resp, err := New().Head("http://" + addr)
 		require.NoError(t, err)
 		require.Equal(t, "7", resp.Header(fiber.HeaderContentLength))
 		require.Equal(t, "", utils.UnsafeString(resp.RawResponse.Body()))
@@ -412,7 +412,7 @@ func Test_Post(t *testing.T) {
 		}()
 
 		for i := 0; i < 5; i++ {
-			resp, err := NewClient().Post("http://"+addr, Config{
+			resp, err := New().Post("http://"+addr, Config{
 				FormData: map[string]string{
 					"foo": "bar",
 				},
@@ -468,7 +468,7 @@ func Test_Put(t *testing.T) {
 		}()
 
 		for i := 0; i < 5; i++ {
-			resp, err := NewClient().Put("http://"+addr, Config{
+			resp, err := New().Put("http://"+addr, Config{
 				FormData: map[string]string{
 					"foo": "bar",
 				},
@@ -527,7 +527,7 @@ func Test_Delete(t *testing.T) {
 		}()
 
 		for i := 0; i < 5; i++ {
-			resp, err := NewClient().Delete("http://"+addr, Config{
+			resp, err := New().Delete("http://"+addr, Config{
 				FormData: map[string]string{
 					"foo": "bar",
 				},
@@ -581,7 +581,7 @@ func Test_Options(t *testing.T) {
 		}()
 
 		for i := 0; i < 5; i++ {
-			resp, err := NewClient().Options("http://" + addr)
+			resp, err := New().Options("http://" + addr)
 
 			require.NoError(t, err)
 			require.Equal(t, "GET, POST, PUT, DELETE, PATCH", resp.Header(fiber.HeaderAllow))
@@ -636,7 +636,7 @@ func Test_Patch(t *testing.T) {
 		}()
 
 		for i := 0; i < 5; i++ {
-			resp, err := NewClient().Patch("http://"+addr, Config{
+			resp, err := New().Patch("http://"+addr, Config{
 				FormData: map[string]string{
 					"foo": "bar",
 				},
@@ -688,7 +688,7 @@ func Test_Client_UserAgent(t *testing.T) {
 		}()
 
 		for i := 0; i < 5; i++ {
-			c := NewClient().
+			c := New().
 				SetUserAgent("ua")
 
 			resp, err := c.Get("http://" + addr)
@@ -705,7 +705,7 @@ func Test_Client_Header(t *testing.T) {
 
 	t.Run("add header", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient()
+		req := New()
 		req.AddHeader("foo", "bar").AddHeader("foo", "fiber")
 
 		res := req.Header("foo")
@@ -716,7 +716,7 @@ func Test_Client_Header(t *testing.T) {
 
 	t.Run("set header", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient()
+		req := New()
 		req.AddHeader("foo", "bar").SetHeader("foo", "fiber")
 
 		res := req.Header("foo")
@@ -726,7 +726,7 @@ func Test_Client_Header(t *testing.T) {
 
 	t.Run("add headers", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient()
+		req := New()
 		req.SetHeader("foo", "bar").
 			AddHeaders(map[string][]string{
 				"foo": {"fiber", "buaa"},
@@ -746,7 +746,7 @@ func Test_Client_Header(t *testing.T) {
 
 	t.Run("set headers", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient()
+		req := New()
 		req.SetHeader("foo", "bar").
 			SetHeaders(map[string]string{
 				"foo": "fiber",
@@ -764,7 +764,7 @@ func Test_Client_Header(t *testing.T) {
 
 	t.Run("set header case insensitive", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient()
+		req := New()
 		req.SetHeader("foo", "bar").
 			AddHeader("FOO", "fiber")
 
@@ -806,7 +806,7 @@ func Test_Client_Cookie(t *testing.T) {
 
 	t.Run("set cookie", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient().
+		req := New().
 			SetCookie("foo", "bar")
 		require.Equal(t, "bar", req.Cookie("foo"))
 
@@ -816,7 +816,7 @@ func Test_Client_Cookie(t *testing.T) {
 
 	t.Run("set cookies", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient().
+		req := New().
 			SetCookies(map[string]string{
 				"foo": "bar",
 				"bar": "foo",
@@ -838,7 +838,7 @@ func Test_Client_Cookie(t *testing.T) {
 			CookieString string `cookie:"string"`
 		}
 
-		req := NewClient().SetCookiesWithStruct(&args{
+		req := New().SetCookiesWithStruct(&args{
 			CookieInt:    5,
 			CookieString: "foo",
 		})
@@ -849,7 +849,7 @@ func Test_Client_Cookie(t *testing.T) {
 
 	t.Run("del cookies", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient().
+		req := New().
 			SetCookies(map[string]string{
 				"foo": "bar",
 				"bar": "foo",
@@ -1025,7 +1025,7 @@ func Test_Client_QueryParam(t *testing.T) {
 
 	t.Run("add param", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient()
+		req := New()
 		req.AddParam("foo", "bar").AddParam("foo", "fiber")
 
 		res := req.Param("foo")
@@ -1036,7 +1036,7 @@ func Test_Client_QueryParam(t *testing.T) {
 
 	t.Run("set param", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient()
+		req := New()
 		req.AddParam("foo", "bar").SetParam("foo", "fiber")
 
 		res := req.Param("foo")
@@ -1046,7 +1046,7 @@ func Test_Client_QueryParam(t *testing.T) {
 
 	t.Run("add params", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient()
+		req := New()
 		req.SetParam("foo", "bar").
 			AddParams(map[string][]string{
 				"foo": {"fiber", "buaa"},
@@ -1066,7 +1066,7 @@ func Test_Client_QueryParam(t *testing.T) {
 
 	t.Run("set headers", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient()
+		req := New()
 		req.SetParam("foo", "bar").
 			SetParams(map[string]string{
 				"foo": "fiber",
@@ -1094,7 +1094,7 @@ func Test_Client_QueryParam(t *testing.T) {
 			TIntSlice []int `param:"int_slice"`
 		}
 
-		p := NewClient()
+		p := New()
 		p.SetParamsWithStruct(&args{
 			TInt:      5,
 			TString:   "string",
@@ -1130,7 +1130,7 @@ func Test_Client_QueryParam(t *testing.T) {
 
 	t.Run("del params", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient()
+		req := New()
 		req.SetParam("foo", "bar").
 			SetParams(map[string]string{
 				"foo": "fiber",
@@ -1166,7 +1166,7 @@ func Test_Client_PathParam(t *testing.T) {
 
 	t.Run("set path param", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient().
+		req := New().
 			SetPathParam("foo", "bar")
 		require.Equal(t, "bar", req.PathParam("foo"))
 
@@ -1176,7 +1176,7 @@ func Test_Client_PathParam(t *testing.T) {
 
 	t.Run("set path params", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient().
+		req := New().
 			SetPathParams(map[string]string{
 				"foo": "bar",
 				"bar": "foo",
@@ -1198,7 +1198,7 @@ func Test_Client_PathParam(t *testing.T) {
 			CookieString string `path:"string"`
 		}
 
-		req := NewClient().SetPathParamsWithStruct(&args{
+		req := New().SetPathParamsWithStruct(&args{
 			CookieInt:    5,
 			CookieString: "foo",
 		})
@@ -1209,7 +1209,7 @@ func Test_Client_PathParam(t *testing.T) {
 
 	t.Run("del path params", func(t *testing.T) {
 		t.Parallel()
-		req := NewClient().
+		req := New().
 			SetPathParams(map[string]string{
 				"foo": "bar",
 				"bar": "foo",
@@ -1232,7 +1232,7 @@ func Test_Client_PathParam_With_Server(t *testing.T) {
 
 	go start()
 
-	resp, err := NewClient().SetDial(dial).
+	resp, err := New().SetDial(dial).
 		SetPathParam("path", "test").
 		Get("http://example.com/:path")
 
@@ -1263,7 +1263,7 @@ func Test_Client_TLS(t *testing.T) {
 		}))
 	}()
 
-	client := NewClient()
+	client := New()
 	resp, err := client.SetTLSConfig(clientTLSConf).Get("https://" + ln.Addr().String())
 
 	require.NoError(t, err)
@@ -1296,7 +1296,7 @@ func Test_Client_TLS_Error(t *testing.T) {
 		}))
 	}()
 
-	client := NewClient()
+	client := New()
 	resp, err := client.SetTLSConfig(clientTLSConf).Get("https://" + ln.Addr().String())
 
 	require.Error(t, err)
@@ -1326,7 +1326,7 @@ func Test_Client_TLS_Empty_TLSConfig(t *testing.T) {
 		}))
 	}()
 
-	client := NewClient()
+	client := New()
 	resp, err := client.Get("https://" + ln.Addr().String())
 
 	require.Error(t, err)
@@ -1340,14 +1340,14 @@ func Test_Client_SetCertificates(t *testing.T) {
 	serverTLSConf, _, err := tlstest.GetTLSConfigs()
 	require.NoError(t, err)
 
-	client := NewClient().SetCertificates(serverTLSConf.Certificates...)
+	client := New().SetCertificates(serverTLSConf.Certificates...)
 	require.Len(t, client.TLSConfig().Certificates, 1)
 }
 
 func Test_Client_SetRootCertificate(t *testing.T) {
 	t.Parallel()
 
-	client := NewClient().SetRootCertificate("../.github/testdata/ssl.pem")
+	client := New().SetRootCertificate("../.github/testdata/ssl.pem")
 	require.NotNil(t, client.TLSConfig().RootCAs)
 }
 
@@ -1361,14 +1361,14 @@ func Test_Client_SetRootCertificateFromString(t *testing.T) {
 	pem, err := io.ReadAll(file)
 	require.NoError(t, err)
 
-	client := NewClient().SetRootCertificateFromString(string(pem))
+	client := New().SetRootCertificateFromString(string(pem))
 	require.NotNil(t, client.TLSConfig().RootCAs)
 }
 
 func Test_Client_R(t *testing.T) {
 	t.Parallel()
 
-	client := NewClient()
+	client := New()
 	req := client.R()
 
 	require.Equal(t, "Request", reflect.TypeOf(req).Elem().Name())
@@ -1391,7 +1391,7 @@ func Test_Replace(t *testing.T) {
 	require.Equal(t, fiber.StatusOK, resp.StatusCode())
 	require.Equal(t, "", resp.String())
 
-	r := NewClient().SetDial(dial).SetHeader("k1", "v1")
+	r := New().SetDial(dial).SetHeader("k1", "v1")
 	clean := Replace(r)
 	resp, err = Get("http://example.com")
 	require.NoError(t, err)
@@ -1548,7 +1548,7 @@ func Test_Client_SetProxyURL(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().SetDial(dial)
+		client := New().SetDial(dial)
 		err := client.SetProxyURL("http://test.com")
 
 		require.NoError(t, err)
@@ -1560,7 +1560,7 @@ func Test_Client_SetProxyURL(t *testing.T) {
 
 	t.Run("wrong url", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 
 		err := client.SetProxyURL(":this is not a url")
 
@@ -1569,7 +1569,7 @@ func Test_Client_SetProxyURL(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 
 		err := client.SetProxyURL("htgdftp://test.com")
 
@@ -1585,7 +1585,7 @@ func Test_Client_SetRetryConfig(t *testing.T) {
 		MaxRetryCount:   3,
 	}
 
-	core, client, req := newCore(), NewClient(), AcquireRequest()
+	core, client, req := newCore(), New(), AcquireRequest()
 	req.SetURL("http://example.com")
 	client.SetRetryConfig(retryConfig)
 	_, err := core.execute(context.Background(), client, req)
@@ -1603,7 +1603,7 @@ func Benchmark_Client_Request(b *testing.B) {
 
 	go start()
 
-	client := NewClient().SetDial(dial)
+	client := New().SetDial(dial)
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -1625,7 +1625,7 @@ func Benchmark_Client_Request_Parallel(b *testing.B) {
 
 	go start()
 
-	client := NewClient().SetDial(dial)
+	client := New().SetDial(dial)
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/client/core_test.go
+++ b/client/core_test.go
@@ -82,7 +82,7 @@ func Test_Exec_Func(t *testing.T) {
 
 	t.Run("normal request", func(t *testing.T) {
 		t.Parallel()
-		core, client, req := newCore(), NewClient(), AcquireRequest()
+		core, client, req := newCore(), New(), AcquireRequest()
 		core.ctx = context.Background()
 		core.client = client
 		core.req = req
@@ -98,7 +98,7 @@ func Test_Exec_Func(t *testing.T) {
 
 	t.Run("the request return an error", func(t *testing.T) {
 		t.Parallel()
-		core, client, req := newCore(), NewClient(), AcquireRequest()
+		core, client, req := newCore(), New(), AcquireRequest()
 		core.ctx = context.Background()
 		core.client = client
 		core.req = req
@@ -115,7 +115,7 @@ func Test_Exec_Func(t *testing.T) {
 
 	t.Run("the request timeout", func(t *testing.T) {
 		t.Parallel()
-		core, client, req := newCore(), NewClient(), AcquireRequest()
+		core, client, req := newCore(), New(), AcquireRequest()
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
 
@@ -157,7 +157,7 @@ func Test_Execute(t *testing.T) {
 
 	t.Run("add user request hooks", func(t *testing.T) {
 		t.Parallel()
-		core, client, req := newCore(), NewClient(), AcquireRequest()
+		core, client, req := newCore(), New(), AcquireRequest()
 		client.AddRequestHook(func(_ *Client, _ *Request) error {
 			require.Equal(t, "http://example.com", req.URL())
 			return nil
@@ -174,7 +174,7 @@ func Test_Execute(t *testing.T) {
 
 	t.Run("add user response hooks", func(t *testing.T) {
 		t.Parallel()
-		core, client, req := newCore(), NewClient(), AcquireRequest()
+		core, client, req := newCore(), New(), AcquireRequest()
 		client.AddResponseHook(func(_ *Client, _ *Response, req *Request) error {
 			require.Equal(t, "http://example.com", req.URL())
 			return nil
@@ -191,7 +191,7 @@ func Test_Execute(t *testing.T) {
 
 	t.Run("no timeout", func(t *testing.T) {
 		t.Parallel()
-		core, client, req := newCore(), NewClient(), AcquireRequest()
+		core, client, req := newCore(), New(), AcquireRequest()
 
 		client.SetDial(func(_ string) (net.Conn, error) {
 			return ln.Dial() //nolint:wrapcheck // not needed
@@ -205,7 +205,7 @@ func Test_Execute(t *testing.T) {
 
 	t.Run("client timeout", func(t *testing.T) {
 		t.Parallel()
-		core, client, req := newCore(), NewClient(), AcquireRequest()
+		core, client, req := newCore(), New(), AcquireRequest()
 		client.SetTimeout(500 * time.Millisecond)
 		client.SetDial(func(_ string) (net.Conn, error) {
 			return ln.Dial() //nolint:wrapcheck // not needed
@@ -218,7 +218,7 @@ func Test_Execute(t *testing.T) {
 
 	t.Run("request timeout", func(t *testing.T) {
 		t.Parallel()
-		core, client, req := newCore(), NewClient(), AcquireRequest()
+		core, client, req := newCore(), New(), AcquireRequest()
 
 		client.SetDial(func(_ string) (net.Conn, error) {
 			return ln.Dial() //nolint:wrapcheck // not needed
@@ -232,7 +232,7 @@ func Test_Execute(t *testing.T) {
 
 	t.Run("request timeout has higher level", func(t *testing.T) {
 		t.Parallel()
-		core, client, req := newCore(), NewClient(), AcquireRequest()
+		core, client, req := newCore(), New(), AcquireRequest()
 		client.SetTimeout(30 * time.Millisecond)
 
 		client.SetDial(func(_ string) (net.Conn, error) {

--- a/client/helper_test.go
+++ b/client/helper_test.go
@@ -92,7 +92,7 @@ func testRequest(t *testing.T, handler fiber.Handler, wrapAgent func(agent *Requ
 		c = count[0]
 	}
 
-	client := NewClient().SetDial(ln)
+	client := New().SetDial(ln)
 
 	for i := 0; i < c; i++ {
 		req := AcquireRequest().SetClient(client)
@@ -119,7 +119,7 @@ func testRequestFail(t *testing.T, handler fiber.Handler, wrapAgent func(agent *
 		c = count[0]
 	}
 
-	client := NewClient().SetDial(ln)
+	client := New().SetDial(ln)
 
 	for i := 0; i < c; i++ {
 		req := AcquireRequest().SetClient(client)
@@ -144,7 +144,7 @@ func testClient(t *testing.T, handler fiber.Handler, wrapAgent func(agent *Clien
 	}
 
 	for i := 0; i < c; i++ {
-		client := NewClient().SetDial(ln)
+		client := New().SetDial(ln)
 		wrapAgent(client)
 
 		resp, err := client.Get("http://example.com")

--- a/client/hooks_test.go
+++ b/client/hooks_test.go
@@ -48,7 +48,7 @@ func Test_Parser_Request_URL(t *testing.T) {
 
 	t.Run("client baseurl should be set", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().SetBaseURL("http://example.com/api")
+		client := New().SetBaseURL("http://example.com/api")
 		req := AcquireRequest().SetURL("")
 
 		err := parserRequestURL(client, req)
@@ -58,7 +58,7 @@ func Test_Parser_Request_URL(t *testing.T) {
 
 	t.Run("request url should be set", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().SetURL("http://example.com/api")
 
 		err := parserRequestURL(client, req)
@@ -68,7 +68,7 @@ func Test_Parser_Request_URL(t *testing.T) {
 
 	t.Run("the request url will override baseurl with protocol", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().SetBaseURL("http://example.com/api")
+		client := New().SetBaseURL("http://example.com/api")
 		req := AcquireRequest().SetURL("http://example.com/api/v1")
 
 		err := parserRequestURL(client, req)
@@ -78,7 +78,7 @@ func Test_Parser_Request_URL(t *testing.T) {
 
 	t.Run("the request url should be append after baseurl without protocol", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().SetBaseURL("http://example.com/api")
+		client := New().SetBaseURL("http://example.com/api")
 		req := AcquireRequest().SetURL("/v1")
 
 		err := parserRequestURL(client, req)
@@ -88,7 +88,7 @@ func Test_Parser_Request_URL(t *testing.T) {
 
 	t.Run("the url is error", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().SetBaseURL("example.com/api")
+		client := New().SetBaseURL("example.com/api")
 		req := AcquireRequest().SetURL("/v1")
 
 		err := parserRequestURL(client, req)
@@ -97,7 +97,7 @@ func Test_Parser_Request_URL(t *testing.T) {
 
 	t.Run("the path param from client", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetBaseURL("http://example.com/api/:id").
 			SetPathParam("id", "5")
 		req := AcquireRequest()
@@ -109,7 +109,7 @@ func Test_Parser_Request_URL(t *testing.T) {
 
 	t.Run("the path param from request", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetBaseURL("http://example.com/api/:id/:name").
 			SetPathParam("id", "5")
 		req := AcquireRequest().
@@ -127,7 +127,7 @@ func Test_Parser_Request_URL(t *testing.T) {
 
 	t.Run("the path param from request and client", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetBaseURL("http://example.com/api/:id/:name").
 			SetPathParam("id", "5")
 		req := AcquireRequest().
@@ -145,7 +145,7 @@ func Test_Parser_Request_URL(t *testing.T) {
 
 	t.Run("query params from client should be set", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetParam("foo", "bar")
 		req := AcquireRequest().SetURL("http://example.com/api/v1")
 
@@ -156,7 +156,7 @@ func Test_Parser_Request_URL(t *testing.T) {
 
 	t.Run("query params from request should be set", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().
 			SetURL("http://example.com/api/v1").
 			SetParam("bar", "foo")
@@ -168,7 +168,7 @@ func Test_Parser_Request_URL(t *testing.T) {
 
 	t.Run("query params should be merged", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetParam("bar", "foo1")
 		req := AcquireRequest().
 			SetURL("http://example.com/api/v1?bar=foo2").
@@ -201,7 +201,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 
 	t.Run("client header should be set", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetHeaders(map[string]string{
 				fiber.HeaderContentType: "application/json",
 			})
@@ -215,7 +215,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 
 	t.Run("request header should be set", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 
 		req := AcquireRequest().
 			SetHeaders(map[string]string{
@@ -229,7 +229,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 
 	t.Run("request header should override client header", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetHeader(fiber.HeaderContentType, "application/xml")
 
 		req := AcquireRequest().
@@ -245,7 +245,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 		type jsonData struct {
 			Name string `json:"name"`
 		}
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().
 			SetJSON(jsonData{
 				Name: "foo",
@@ -262,7 +262,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 			XMLName xml.Name `xml:"body"`
 			Name    string   `xml:"name"`
 		}
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().
 			SetXML(xmlData{
 				Name: "foo",
@@ -275,7 +275,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 
 	t.Run("auto set form data header", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().
 			SetFormDatas(map[string]string{
 				"foo":  "bar",
@@ -289,7 +289,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 
 	t.Run("auto set file header", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().
 			AddFileWithReader("hello", io.NopCloser(strings.NewReader("world"))).
 			SetFormData("foo", "bar")
@@ -302,7 +302,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 
 	t.Run("ua should have default value", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 		req := AcquireRequest()
 
 		err := parserRequestHeader(client, req)
@@ -312,7 +312,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 
 	t.Run("ua in client should be set", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().SetUserAgent("foo")
+		client := New().SetUserAgent("foo")
 		req := AcquireRequest()
 
 		err := parserRequestHeader(client, req)
@@ -322,7 +322,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 
 	t.Run("ua in request should have higher level", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().SetUserAgent("foo")
+		client := New().SetUserAgent("foo")
 		req := AcquireRequest().SetUserAgent("bar")
 
 		err := parserRequestHeader(client, req)
@@ -332,7 +332,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 
 	t.Run("referer in client should be set", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().SetReferer("https://example.com")
+		client := New().SetReferer("https://example.com")
 		req := AcquireRequest()
 
 		err := parserRequestHeader(client, req)
@@ -342,7 +342,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 
 	t.Run("referer in request should have higher level", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().SetReferer("http://example.com")
+		client := New().SetReferer("http://example.com")
 		req := AcquireRequest().SetReferer("https://example.com")
 
 		err := parserRequestHeader(client, req)
@@ -352,7 +352,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 
 	t.Run("client cookie should be set", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient().
+		client := New().
 			SetCookie("foo", "bar").
 			SetCookies(map[string]string{
 				"bar":  "foo",
@@ -376,7 +376,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 			Bar int    `cookie:"bar"`
 		}
 
-		client := NewClient()
+		client := New()
 
 		req := AcquireRequest().
 			SetCookiesWithStruct(&cookies{
@@ -398,7 +398,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 			Bar int    `cookie:"bar"`
 		}
 
-		client := NewClient().
+		client := New().
 			SetCookie("foo", "bar").
 			SetCookies(map[string]string{
 				"bar":  "foo",
@@ -427,7 +427,7 @@ func Test_Parser_Request_Body(t *testing.T) {
 		type jsonData struct {
 			Name string `json:"name"`
 		}
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().
 			SetJSON(jsonData{
 				Name: "foo",
@@ -444,7 +444,7 @@ func Test_Parser_Request_Body(t *testing.T) {
 			XMLName xml.Name `xml:"body"`
 			Name    string   `xml:"name"`
 		}
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().
 			SetXML(xmlData{
 				Name: "foo",
@@ -457,7 +457,7 @@ func Test_Parser_Request_Body(t *testing.T) {
 
 	t.Run("form data body", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().
 			SetFormDatas(map[string]string{
 				"ball": "cricle and square",
@@ -470,7 +470,7 @@ func Test_Parser_Request_Body(t *testing.T) {
 
 	t.Run("form data body error", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().
 			SetFormDatas(map[string]string{
 				"": "",
@@ -482,7 +482,7 @@ func Test_Parser_Request_Body(t *testing.T) {
 
 	t.Run("file body", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().
 			AddFileWithReader("hello", io.NopCloser(strings.NewReader("world")))
 
@@ -494,7 +494,7 @@ func Test_Parser_Request_Body(t *testing.T) {
 
 	t.Run("file and form data", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().
 			AddFileWithReader("hello", io.NopCloser(strings.NewReader("world"))).
 			SetFormData("foo", "bar")
@@ -508,7 +508,7 @@ func Test_Parser_Request_Body(t *testing.T) {
 
 	t.Run("raw body", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().
 			SetRawBody([]byte("hello world"))
 
@@ -519,7 +519,7 @@ func Test_Parser_Request_Body(t *testing.T) {
 
 	t.Run("raw body error", func(t *testing.T) {
 		t.Parallel()
-		client := NewClient()
+		client := New()
 		req := AcquireRequest().
 			SetRawBody([]byte("hello world"))
 
@@ -602,7 +602,7 @@ func Test_Client_Logger_Debug(t *testing.T) {
 	var buf bytes.Buffer
 	logger := &dummyLogger{buf: &buf}
 
-	client := NewClient()
+	client := New()
 	client.Debug().SetLogger(logger)
 
 	addr := <-addrChan
@@ -639,7 +639,7 @@ func Test_Client_Logger_DisableDebug(t *testing.T) {
 	var buf bytes.Buffer
 	logger := &dummyLogger{buf: &buf}
 
-	client := NewClient()
+	client := New()
 	client.DisableDebug().SetLogger(logger)
 
 	addr := <-addrChan

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -67,7 +67,7 @@ func Test_Request_URL(t *testing.T) {
 func Test_Request_Client(t *testing.T) {
 	t.Parallel()
 
-	client := NewClient()
+	client := New()
 	req := AcquireRequest()
 
 	req.SetClient(client)
@@ -646,7 +646,7 @@ func Test_Request_Get(t *testing.T) {
 	go start()
 	time.Sleep(100 * time.Millisecond)
 
-	client := NewClient().SetDial(ln)
+	client := New().SetDial(ln)
 
 	for i := 0; i < 5; i++ {
 		req := AcquireRequest().SetClient(client)
@@ -671,7 +671,7 @@ func Test_Request_Post(t *testing.T) {
 	go start()
 	time.Sleep(100 * time.Millisecond)
 
-	client := NewClient().SetDial(ln)
+	client := New().SetDial(ln)
 
 	for i := 0; i < 5; i++ {
 		resp, err := AcquireRequest().
@@ -697,7 +697,7 @@ func Test_Request_Head(t *testing.T) {
 	go start()
 	time.Sleep(100 * time.Millisecond)
 
-	client := NewClient().SetDial(ln)
+	client := New().SetDial(ln)
 
 	for i := 0; i < 5; i++ {
 		resp, err := AcquireRequest().
@@ -722,7 +722,7 @@ func Test_Request_Put(t *testing.T) {
 	go start()
 	time.Sleep(100 * time.Millisecond)
 
-	client := NewClient().SetDial(ln)
+	client := New().SetDial(ln)
 
 	for i := 0; i < 5; i++ {
 		resp, err := AcquireRequest().
@@ -751,7 +751,7 @@ func Test_Request_Delete(t *testing.T) {
 	go start()
 	time.Sleep(100 * time.Millisecond)
 
-	client := NewClient().SetDial(ln)
+	client := New().SetDial(ln)
 
 	for i := 0; i < 5; i++ {
 		resp, err := AcquireRequest().
@@ -779,7 +779,7 @@ func Test_Request_Options(t *testing.T) {
 	go start()
 	time.Sleep(100 * time.Millisecond)
 
-	client := NewClient().SetDial(ln)
+	client := New().SetDial(ln)
 
 	for i := 0; i < 5; i++ {
 		resp, err := AcquireRequest().
@@ -807,7 +807,7 @@ func Test_Request_Send(t *testing.T) {
 	go start()
 	time.Sleep(100 * time.Millisecond)
 
-	client := NewClient().SetDial(ln)
+	client := New().SetDial(ln)
 
 	for i := 0; i < 5; i++ {
 		resp, err := AcquireRequest().
@@ -836,7 +836,7 @@ func Test_Request_Patch(t *testing.T) {
 	go start()
 	time.Sleep(100 * time.Millisecond)
 
-	client := NewClient().SetDial(ln)
+	client := New().SetDial(ln)
 
 	for i := 0; i < 5; i++ {
 		resp, err := AcquireRequest().
@@ -1038,7 +1038,7 @@ func Test_Request_Body_With_Server(t *testing.T) {
 
 		go start()
 
-		client := NewClient().SetDial(ln)
+		client := New().SetDial(ln)
 
 		req := AcquireRequest().
 			SetClient(client).
@@ -1093,7 +1093,7 @@ func Test_Request_Body_With_Server(t *testing.T) {
 
 		go start()
 
-		client := NewClient().SetDial(ln)
+		client := New().SetDial(ln)
 
 		for i := 0; i < 5; i++ {
 			req := AcquireRequest().
@@ -1130,7 +1130,7 @@ func Test_Request_Body_With_Server(t *testing.T) {
 
 		go start()
 
-		client := NewClient().SetDial(ln)
+		client := New().SetDial(ln)
 
 		req := AcquireRequest().
 			SetClient(client).
@@ -1218,7 +1218,7 @@ func Test_Request_Timeout_With_Server(t *testing.T) {
 	})
 	go start()
 
-	client := NewClient().SetDial(ln)
+	client := New().SetDial(ln)
 
 	_, err := AcquireRequest().
 		SetClient(client).
@@ -1250,7 +1250,7 @@ func Test_Request_MaxRedirects(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
-		client := NewClient().SetDial(func(_ string) (net.Conn, error) { return ln.Dial() }) //nolint:wrapcheck // not needed
+		client := New().SetDial(func(_ string) (net.Conn, error) { return ln.Dial() }) //nolint:wrapcheck // not needed
 
 		resp, err := AcquireRequest().
 			SetClient(client).
@@ -1269,7 +1269,7 @@ func Test_Request_MaxRedirects(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		t.Parallel()
 
-		client := NewClient().SetDial(func(_ string) (net.Conn, error) { return ln.Dial() }) //nolint:wrapcheck // not needed
+		client := New().SetDial(func(_ string) (net.Conn, error) { return ln.Dial() }) //nolint:wrapcheck // not needed
 
 		resp, err := AcquireRequest().
 			SetClient(client).
@@ -1283,7 +1283,7 @@ func Test_Request_MaxRedirects(t *testing.T) {
 	t.Run("MaxRedirects", func(t *testing.T) {
 		t.Parallel()
 
-		client := NewClient().SetDial(func(_ string) (net.Conn, error) { return ln.Dial() }) //nolint:wrapcheck // not needed
+		client := New().SetDial(func(_ string) (net.Conn, error) { return ln.Dial() }) //nolint:wrapcheck // not needed
 
 		req := AcquireRequest().
 			SetClient(client).

--- a/client/response_test.go
+++ b/client/response_test.go
@@ -37,7 +37,7 @@ func Test_Response_Status(t *testing.T) {
 		server := setupApp()
 		defer server.stop()
 
-		client := NewClient().SetDial(server.dial())
+		client := New().SetDial(server.dial())
 
 		resp, err := AcquireRequest().
 			SetClient(client).
@@ -54,7 +54,7 @@ func Test_Response_Status(t *testing.T) {
 		server := setupApp()
 		defer server.stop()
 
-		client := NewClient().SetDial(server.dial())
+		client := New().SetDial(server.dial())
 
 		resp, err := AcquireRequest().
 			SetClient(client).
@@ -88,7 +88,7 @@ func Test_Response_Status_Code(t *testing.T) {
 		server := setupApp()
 		defer server.stop()
 
-		client := NewClient().SetDial(server.dial())
+		client := New().SetDial(server.dial())
 
 		resp, err := AcquireRequest().
 			SetClient(client).
@@ -105,7 +105,7 @@ func Test_Response_Status_Code(t *testing.T) {
 		server := setupApp()
 		defer server.stop()
 
-		client := NewClient().SetDial(server.dial())
+		client := New().SetDial(server.dial())
 
 		resp, err := AcquireRequest().
 			SetClient(client).
@@ -130,7 +130,7 @@ func Test_Response_Protocol(t *testing.T) {
 		})
 		defer server.stop()
 
-		client := NewClient().SetDial(server.dial())
+		client := New().SetDial(server.dial())
 
 		resp, err := AcquireRequest().
 			SetClient(client).
@@ -163,7 +163,7 @@ func Test_Response_Protocol(t *testing.T) {
 			}))
 		}()
 
-		client := NewClient()
+		client := New()
 		resp, err := client.SetTLSConfig(clientTLSConf).Get("https://" + ln.Addr().String())
 
 		require.NoError(t, err)
@@ -187,7 +187,7 @@ func Test_Response_Header(t *testing.T) {
 	})
 	defer server.stop()
 
-	client := NewClient().SetDial(server.dial())
+	client := New().SetDial(server.dial())
 
 	resp, err := AcquireRequest().
 		SetClient(client).
@@ -212,7 +212,7 @@ func Test_Response_Cookie(t *testing.T) {
 	})
 	defer server.stop()
 
-	client := NewClient().SetDial(server.dial())
+	client := New().SetDial(server.dial())
 
 	resp, err := AcquireRequest().
 		SetClient(client).
@@ -250,7 +250,7 @@ func Test_Response_Body(t *testing.T) {
 		server := setupApp()
 		defer server.stop()
 
-		client := NewClient().SetDial(server.dial())
+		client := New().SetDial(server.dial())
 
 		resp, err := AcquireRequest().
 			SetClient(client).
@@ -267,7 +267,7 @@ func Test_Response_Body(t *testing.T) {
 		server := setupApp()
 		defer server.stop()
 
-		client := NewClient().SetDial(server.dial())
+		client := New().SetDial(server.dial())
 
 		resp, err := AcquireRequest().
 			SetClient(client).
@@ -287,7 +287,7 @@ func Test_Response_Body(t *testing.T) {
 		server := setupApp()
 		defer server.stop()
 
-		client := NewClient().SetDial(server.dial())
+		client := New().SetDial(server.dial())
 
 		resp, err := AcquireRequest().
 			SetClient(client).
@@ -312,7 +312,7 @@ func Test_Response_Body(t *testing.T) {
 		server := setupApp()
 		defer server.stop()
 
-		client := NewClient().SetDial(server.dial())
+		client := New().SetDial(server.dial())
 
 		resp, err := AcquireRequest().
 			SetClient(client).
@@ -347,7 +347,7 @@ func Test_Response_Save(t *testing.T) {
 		server := setupApp()
 		defer server.stop()
 
-		client := NewClient().SetDial(server.dial())
+		client := New().SetDial(server.dial())
 
 		resp, err := AcquireRequest().
 			SetClient(client).
@@ -383,7 +383,7 @@ func Test_Response_Save(t *testing.T) {
 		server := setupApp()
 		defer server.stop()
 
-		client := NewClient().SetDial(server.dial())
+		client := New().SetDial(server.dial())
 
 		resp, err := AcquireRequest().
 			SetClient(client).
@@ -404,7 +404,7 @@ func Test_Response_Save(t *testing.T) {
 		server := setupApp()
 		defer server.stop()
 
-		client := NewClient().SetDial(server.dial())
+		client := New().SetDial(server.dial())
 
 		resp, err := AcquireRequest().
 			SetClient(client).

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -138,7 +138,7 @@ func Test_Proxy_Balancer_WithTlsConfig(t *testing.T) {
 		}))
 	}()
 
-	client := clientpkg.NewClient()
+	client := clientpkg.New()
 	client.SetTLSConfig(clientTLSConf)
 
 	resp, err := client.Get("https://" + addr + "/tlsbalancer")
@@ -176,7 +176,7 @@ func Test_Proxy_Forward_WithTlsConfig_To_Http(t *testing.T) {
 		}))
 	}()
 
-	client := clientpkg.NewClient()
+	client := clientpkg.New()
 	client.SetTimeout(5 * time.Second)
 	client.TLSConfig().InsecureSkipVerify = true
 
@@ -241,7 +241,7 @@ func Test_Proxy_Forward_WithClient_TLSConfig(t *testing.T) {
 		}))
 	}()
 
-	client := clientpkg.NewClient()
+	client := clientpkg.New()
 	client.SetTLSConfig(clientTLSConf)
 
 	resp, err := client.Get("https://" + addr)
@@ -596,7 +596,7 @@ func Test_Proxy_Forward_Global_Client(t *testing.T) {
 		}))
 	}()
 
-	client := clientpkg.NewClient()
+	client := clientpkg.New()
 
 	resp, err := client.Get("http://" + addr)
 	require.NoError(t, err)
@@ -628,7 +628,7 @@ func Test_Proxy_Forward_Local_Client(t *testing.T) {
 		}))
 	}()
 
-	client := clientpkg.NewClient()
+	client := clientpkg.New()
 
 	resp, err := client.Get("http://" + addr)
 	require.NoError(t, err)
@@ -706,7 +706,7 @@ func Test_Proxy_Domain_Forward_Local(t *testing.T) {
 		}))
 	}()
 
-	client := clientpkg.NewClient()
+	client := clientpkg.New()
 
 	resp, err := client.Get("http://" + localDomain + "/test?query_test=true")
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

I have refactored the "ClientNew" function in our gofiber/fiber/v3/client package to follow standard Go naming conventions. This change involves renaming the function to simply "New", as it aligns better with the recommendations for exported function names between packages and maintains consistency with similar functions within our projects.

1. The refactor follows the Go language's recommendation for function names within a package. By changing the name to "New", we are adhering to these guidelines, making our code more intuitive.
2. The move to the subpackage already signifies that it is a client-related function. Therefore, there is no need to include the term "Client" within the function name itself, as this information is already conveyed through its location in the package structure.
3. This change maintains consistency with other similar functions within our projects.

## Type of change

Please delete options that are not relevant.

- [x] Refactor, raneme function.

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed the client initialization function for consistency and updated all related test scenarios to reflect this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->