### PR TITLE
🩹 Fix: improper query/body parsing with embedded structs

### DIFF
--- a/binder/mapping.go
+++ b/binder/mapping.go
@@ -182,6 +182,24 @@ func equalFieldType(out any, kind reflect.Kind, key string) bool {
 		structFieldKind := structField.Kind()
 		// Does the field type equals input?
 		if structFieldKind != kind {
+			// Is the field an embedded struct?
+			if structFieldKind == reflect.Struct {
+				// Loop over embedded struct fields
+				for j := 0; j < structField.NumField(); j++ {
+					structFieldField := structField.Field(j)
+
+					// Can this embedded field be changed?
+					if !structFieldField.CanSet() {
+						continue
+					}
+
+					// Is the embedded struct field type equal to the input?
+					if structFieldField.Kind() == kind {
+						return true
+					}
+				}
+			}
+
 			continue
 		}
 		// Get tag from field if exist


### PR DESCRIPTION
## Description

This PR fixes improper bodyparser/query parsing when using embedded structs within a schema.

Related to #2859 

## Type of change

- [x] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced comparison logic in `equalFieldType` to better handle embedded struct fields.
- **New Features**
	- Improved parsing logic for various data formats by including the `Names` field in the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->