### PR TITLE
🧹 v3 (chore): Bump minimum version of Go to 1.21

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -136,7 +136,7 @@ These tests are performed by [TechEmpower](https://www.techempower.com/benchmark
 
 ## ⚙️ Installation
 
-Make sure you have Go installed ([download](https://go.dev/dl/)). Version `1.20` or higher is required.
+Make sure you have Go installed ([download](https://go.dev/dl/)). Version `1.21` or higher is required.
 
 Initialize your project by creating a folder and then running `go mod init github.com/your/repo` ([learn more](https://go.dev/blog/using-go-modules)) inside the folder. Then install Fiber with the [`go get`](https://pkg.go.dev/cmd/go/#hdr-Add_dependencies_to_current_module_and_install_them) command:
 
@@ -170,7 +170,7 @@ We **listen** to our users in [issues](https://github.com/gofiber/fiber/issues),
 
 ## ⚠️ Limitations
 
--   Due to Fiber's usage of unsafe, the library may not always be compatible with the latest Go version. Fiber 3.0.0 has been tested with Go versions 1.20 to 1.22.
+-   Due to Fiber's usage of unsafe, the library may not always be compatible with the latest Go version. Fiber 3.0.0 has been tested with Go versions 1.21 and 1.22.
 -   Fiber is not compatible with net/http interfaces. This means you will not be able to use projects like gqlgen, go-swagger, or any others which are part of the net/http ecosystem.
 
 ## 👀 Examples
@@ -651,10 +651,9 @@ List of externally hosted middleware modules and maintained by the [Fiber team](
 
 | Middleware                                        | Description                                                                                                           |
 | :------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------- |
-| [jwt](https://github.com/gofiber/jwt)             | JWT returns a JSON Web Token \(JWT\) auth middleware.                                                                 |
+| [contrib](https://github.com/gofiber/contrib)     | Third party middlewares                                                                                               |
 | [storage](https://github.com/gofiber/storage)     | Premade storage drivers that implement the Storage interface, designed to be used with various Fiber middlewares.     |
-| [template](https://github.com/gofiber/template)   | This package contains 8 template engines that can be used with Fiber `v1.10.x` Go version 1.13 or higher is required. |
-| [websocket](https://github.com/gofiber/websocket) | Based on Fasthttp WebSocket for Fiber with Locals support!                                                            |
+| [template](https://github.com/gofiber/template)   | This package contains 9 template engines that can be used with Fiber `v3` Go version 1.21 or higher is required.      |
 
 ## 🕶️ Awesome List
 

--- a/.github/README_az.md
+++ b/.github/README_az.md
@@ -164,7 +164,7 @@ Biz istifadəçilərdən gələn [issue-a](https://github.com/gofiber/fiber/issu
 
 ## ⚠️ Limitlər
 
--   Fiber unsafe prinsiplərə əsaslanaraq çalışdığından, o hər zaman Go-nun son versiyası ilə uyğunlaşmaya bilər. Buna görə də, Fiber 3.0.0 — Go 1.20 və 1.22 versiyaları ilə test edilərək saz vəziyyətə gətirilmişdir.
+-   Fiber unsafe prinsiplərə əsaslanaraq çalışdığından, o hər zaman Go-nun son versiyası ilə uyğunlaşmaya bilər. Buna görə də, Fiber 3.0.0 — Go 1.21 və 1.22 versiyaları ilə test edilərək saz vəziyyətə gətirilmişdir.
 -   Fiber net/http interfeysləri ilə uyğun deyil. Yəni gqlgen, go-swagger kimi net/http ekosisteminin parçası olan layihələri istifadə edə bilməzsiniz.
 
 ## 👀 Misallar

--- a/.github/README_es.md
+++ b/.github/README_es.md
@@ -160,7 +160,7 @@ Fiber está **inspirado** en Expressjs, el framework web más popular en Interne
 
 ## ⚠️ Limitantes
 
--   Debido a que Fiber utiliza unsafe, la biblioteca no siempre será compatible con la última versión de Go. Fiber 3.0.0 ha sido probado con las versiones de Go 1.20 a 1.22.
+-   Debido a que Fiber utiliza unsafe, la biblioteca no siempre será compatible con la última versión de Go. Fiber 3.0.0 ha sido probado con las versiones de Go 1.21 a 1.22.
 -   Fiber no es compatible con interfaces net/http. Esto significa que no lo podrá usar en proyectos como qglgen, go-swagger, u otros que son parte del ecosistema net/http.
 
 ## 👀 Ejemplos

--- a/.github/README_tr.md
+++ b/.github/README_tr.md
@@ -160,7 +160,7 @@ Fiber, internet üzerinde en popüler web framework'ü olan Express'ten **esinle
 
 ## ⚠️ Sınırlamalar
 
--   Fiber unsafe kullanımı sebebiyle Go'nun son sürümüyle her zaman uyumlu olmayabilir. Fiber 3.0.0, Go 1.20 ile 1.22 sürümleriyle test edildi.
+-   Fiber unsafe kullanımı sebebiyle Go'nun son sürümüyle her zaman uyumlu olmayabilir. Fiber 3.0.0, Go 1.21 ile 1.22 sürümleriyle test edildi.
 -   Fiber net/http arabirimiyle uyumlu değildir. Yani gqlgen veya go-swagger gibi net/http ekosisteminin parçası olan projeleri kullanamazsınız.
 
 ## 👀 Örnekler

--- a/.github/README_zh-CN.md
+++ b/.github/README_zh-CN.md
@@ -166,7 +166,7 @@ go get -u github.com/gofiber/fiber/v3
 以及在互联网上的所有诉求，为了创建一个能让有着任何技术栈的开发者都能在 deadline 前完成任务的**迅速**，**灵活**以及**友好**的 `Go web` 框架，就像 `Express` 在 `JavaScript` 世界中一样。
 
 ## ⚠️ 限制
-* 由于 Fiber 使用了 unsafe 特性，导致其可能与最新的 Go 版本不兼容。Fiber 3.0.0 已经在 Go 1.20 到 1.22 上测试过。
+* 由于 Fiber 使用了 unsafe 特性，导致其可能与最新的 Go 版本不兼容。Fiber 3.0.0 已经在 Go 1.21 到 1.22 上测试过。
 * Fiber 与 net/http 接口不兼容。也就是说你无法直接使用例如 gqlen，go-swagger 或者任何其他属于 net/http 生态的项目。
 
 ## 👀 示例

--- a/.github/README_zh-TW.md
+++ b/.github/README_zh-TW.md
@@ -173,7 +173,7 @@ Fiber **啟發自** Express——網際網路上最知名的 Web 框架，我們
 
 ## ⚠️ 限制
 
--   由於 Fiber 有用到 Unsafe，本函式庫有時可能無法相容最新版的 Go 語言。Fiber 3.0.0 已在 Go 1.20 至 1.22 的版本測試過。
+-   由於 Fiber 有用到 Unsafe，本函式庫有時可能無法相容最新版的 Go 語言。Fiber 3.0.0 已在 Go 1.21 至 1.22 的版本測試過。
 -   Fiber 不相容 net/http 的介面，意味著您無法使用像是 gqlgen、go-swagger 或其他任何屬於 net/http 生態系統的專案。
 
 ## 👀 範例

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: "1.20.x"
+          go-version: "1.21.x"
 
       - name: Run Benchmark
         run: set -o pipefail; go test ./... -benchmem -run=^$ -bench . | tee output.txt

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: "1.20.x"
+          go-version: "1.21.x"
           cache: false
 
       - name: golangci-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.21.x, 1.22.x]
         platform: [ubuntu-latest, windows-latest, macos-latest, macos-14]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofiber/fiber/v3
 
-go 1.20
+go 1.21
 
 require (
 	github.com/gofiber/utils/v2 v2.0.0-beta.3

--- a/middleware/pprof/pprof.go
+++ b/middleware/pprof/pprof.go
@@ -40,7 +40,7 @@ func New(config ...Config) fiber.Handler {
 
 		path := c.Path()
 		// We are only interested in /debug/pprof routes
-		path, found := cutPrefix(path, prefix)
+		path, found := strings.CutPrefix(path, prefix)
 		if !found {
 			return c.Next()
 		}
@@ -80,15 +80,4 @@ func New(config ...Config) fiber.Handler {
 		}
 		return nil
 	}
-}
-
-// cutPrefix is a copy of [strings.CutPrefix] added in Go 1.20.
-// Remove this function when we drop support for Go 1.19.
-//
-//nolint:nonamedreturns // Align with its original form in std.
-func cutPrefix(s, prefix string) (after string, found bool) {
-	if !strings.HasPrefix(s, prefix) {
-		return s, false
-	}
-	return s[len(prefix):], true
 }


### PR DESCRIPTION
## Description

Bump the minimum Go version to 1.21. Remove support for go1.20 which is End of Life since last month as noted here: https://endoflife.date/go

## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [ ] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [x] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [ ] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [ ] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [ ] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [ ] Examples: Provide examples demonstrating the new features or changes in action.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to existing features and functionality)
- [x] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated compatibility information in README files across multiple languages to reflect the supported Go versions for the Fiber library, now indicating Go 1.21-1.22.
- **Chores**
  - Updated GitHub Actions workflows to use Go version "1.21.x".
- **Refactor**
  - Replaced a custom function with `strings.CutPrefix` in the pprof middleware to align with Go 1.20 standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->