### PR TITLE
session id can be specified within the function

### DIFF
--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -42,10 +42,13 @@ func (*Store) RegisterType(i any) {
 
 // Get will get/create a session
 func (s *Store) Get(c fiber.Ctx) (*Session, error) {
+	return s.GetByID(c, s.getSessionID(c))
+}
+
+// GetByID will get/create a session
+func (s *Store) GetByID(c fiber.Ctx, id string) (*Session, error) {
 	var fresh bool
 	loadData := true
-
-	id := s.getSessionID(c)
 
 	if len(id) == 0 {
 		fresh = true


### PR DESCRIPTION
## Description

This feature provides a way to get a session provided by an ID within a function argument. This could be useful if the ID is stored in a different place than the default methods.

Fixes # (issue)

## Changes introduced

It's just a small change that accepts developers to gather the ID of the session from somewhere else.

## Commit formatting

🩹 Fix: Improved the session middleware with a function that allow developers to get session by an ID they specified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved session handling by introducing a method to get or create sessions by ID, enhancing the efficiency of session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->