### PR TITLE
test(middleware/csrf): Fix Benchmark Tests

### DIFF
--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/url"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -220,7 +221,7 @@ func isCsrfFromCookie(extractor interface{}) bool {
 // returns an error if the referer header is not present or is invalid
 // returns nil if the referer header is valid
 func refererMatchesHost(c *fiber.Ctx) error {
-	referer := c.Get(fiber.HeaderReferer)
+	referer := strings.ToLower(c.Get(fiber.HeaderReferer))
 	if referer == "" {
 		return ErrNoReferer
 	}
@@ -230,9 +231,9 @@ func refererMatchesHost(c *fiber.Ctx) error {
 		return ErrBadReferer
 	}
 
-	if refererURL.Scheme+"://"+refererURL.Host != c.Protocol()+"://"+c.Hostname() {
-		return ErrBadReferer
+	if refererURL.Scheme == c.Protocol() && refererURL.Host == c.Hostname() {
+		return nil
 	}
 
-	return nil
+	return ErrBadReferer
 }

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -992,7 +992,10 @@ func Benchmark_Middleware_CSRF_Check(b *testing.B) {
 		return c.SendStatus(fiber.StatusTeapot)
 	})
 
-	fctx := &fasthttp.RequestCtx{}
+	app.Post("/", func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusTeapot)
+	})
+
 	h := app.Handler()
 	ctx := &fasthttp.RequestCtx{}
 
@@ -1002,17 +1005,27 @@ func Benchmark_Middleware_CSRF_Check(b *testing.B) {
 	token := string(ctx.Response.Header.Peek(fiber.HeaderSetCookie))
 	token = strings.Split(strings.Split(token, ";")[0], "=")[1]
 
+	// Test Correct Referer POST
+	ctx.Request.Reset()
+	ctx.Response.Reset()
 	ctx.Request.Header.SetMethod(fiber.MethodPost)
+	ctx.Request.Header.Set(fiber.HeaderXForwardedProto, "https")
+	ctx.Request.URI().SetScheme("https")
+	ctx.Request.URI().SetHost("example.com")
+	ctx.Request.Header.SetProtocol("https")
+	ctx.Request.Header.SetHost("example.com")
+	ctx.Request.Header.Set(fiber.HeaderReferer, "https://example.com")
 	ctx.Request.Header.Set(HeaderName, token)
+	ctx.Request.Header.SetCookie(ConfigDefault.CookieName, token)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		h(fctx)
+		h(ctx)
 	}
 
-	utils.AssertEqual(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+	utils.AssertEqual(b, fiber.StatusTeapot, ctx.Response.Header.StatusCode())
 }
 
 // go test -v -run=^$ -bench=Benchmark_Middleware_CSRF_GenerateToken -benchmem -count=4
@@ -1024,7 +1037,6 @@ func Benchmark_Middleware_CSRF_GenerateToken(b *testing.B) {
 		return c.SendStatus(fiber.StatusTeapot)
 	})
 
-	fctx := &fasthttp.RequestCtx{}
 	h := app.Handler()
 	ctx := &fasthttp.RequestCtx{}
 
@@ -1034,8 +1046,9 @@ func Benchmark_Middleware_CSRF_GenerateToken(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		h(fctx)
+		h(ctx)
 	}
 
-	utils.AssertEqual(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+	// Ensure the GET request returns a 418 status code
+	utils.AssertEqual(b, fiber.StatusTeapot, ctx.Response.Header.StatusCode())
 }


### PR DESCRIPTION
### PR Description:

This PR addresses a bug in the CSRF middleware test suite and enhances the referer header validation logic for improved efficiency. Here's a summary of the changes:

#### Changes Made:

- **Bug Fix**:
  - Fixed a bug in the benchmark tests of `csrf_test.go` where headers were not properly set for POST requests, causing incorrect test results. The fix ensures that the referer header is correctly set with different schemes and hosts, covering various scenarios.
  - Fixed a bug in the benchmark tests of `csrf_test.go` where there were two contexts and only one had anything set, causing all requests to be made with an empty context.

- **Code Logic Enhancement**:
  - Refactored the logic to convert the referer header to lowercase before comparison, ensuring consistent handling of the header case.
  - Simplified the comparison logic by directly comparing the scheme and host components of the referer URL with those of the request, eliminating unnecessary string concatenation.

#### Notes for Review:

- **V2 Target**: This is a backport of Benchmark Test and `refererMatchesHost` logic from PR #2925 