### PR TITLE
fix(middleware/cors): CORS handling

### DIFF
--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -164,6 +164,12 @@ func New(config ...Config) fiber.Handler {
 
 		// If the request does not have Origin header, the request is outside the scope of CORS
 		if originHeader == "" {
+			// See https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches
+			// Unless all origins are allowed, we include the Vary header to cache the response correctly
+			if !allowAllOrigins {
+				c.Vary(fiber.HeaderOrigin)
+			}
+
 			return c.Next()
 		}
 
@@ -208,13 +214,23 @@ func New(config ...Config) fiber.Handler {
 		// Simple request
 		// Ommit allowMethods and allowHeaders, only used for pre-flight requests
 		if c.Method() != fiber.MethodOptions {
+			if !allowAllOrigins {
+				// See https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches
+				c.Vary(fiber.HeaderOrigin)
+			}
 			setCORSHeaders(c, allowOrigin, "", "", exposeHeaders, maxAge, cfg)
 			return c.Next()
 		}
 
-		// Preflight request
+		// Pre-flight request
+
+		// Response to OPTIONS request should not be cached but,
+		// some caching can be configured to cache such responses.
+		// To Avoid poisoning the cache, we include the Vary header
+		// of preflight responses:
 		c.Vary(fiber.HeaderAccessControlRequestMethod)
 		c.Vary(fiber.HeaderAccessControlRequestHeaders)
+		c.Vary(fiber.HeaderOrigin)
 
 		setCORSHeaders(c, allowOrigin, allowMethods, allowHeaders, exposeHeaders, maxAge, cfg)
 
@@ -225,8 +241,6 @@ func New(config ...Config) fiber.Handler {
 
 // Function to set CORS headers
 func setCORSHeaders(c *fiber.Ctx, allowOrigin, allowMethods, allowHeaders, exposeHeaders, maxAge string, cfg Config) {
-	c.Vary(fiber.HeaderOrigin)
-
 	if cfg.AllowCredentials {
 		// When AllowCredentials is true, set the Access-Control-Allow-Origin to the specific origin instead of '*'
 		if allowOrigin == "*" {

--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -162,9 +162,13 @@ func New(config ...Config) fiber.Handler {
 		// Get originHeader header
 		originHeader := strings.ToLower(c.Get(fiber.HeaderOrigin))
 
-		// If the request does not have Origin and Access-Control-Request-Method
-		// headers, the request is outside the scope of CORS
-		if originHeader == "" || c.Get(fiber.HeaderAccessControlRequestMethod) == "" {
+		// If the request does not have Origin header, the request is outside the scope of CORS
+		if originHeader == "" {
+			return c.Next()
+		}
+
+		// If it's a preflight request and doesn't have Access-Control-Request-Method header, it's outside the scope of CORS
+		if c.Method() == fiber.MethodOptions && c.Get(fiber.HeaderAccessControlRequestMethod) == "" {
 			return c.Next()
 		}
 


### PR DESCRIPTION
This pull request addresses issue #2936, fixing a bug introduced in the Fiber v2.52.3 release. The bug caused incorrect checking of non-preflight requests using preflight conditions.

Fiber CORS middleware validation sample: https://github.com/sixcolors/fiber-cors-middleware-validation-sample

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- Refined CORS request handling logic to better determine scope based on specific headers.
- **Tests**
	- Updated and refactored CORS-related test cases to align with the new request handling logic.
- **Chores**
	- Removed setting `fiber.HeaderAccessControlRequestMethod` in various test cases.
	- Adjusted benchmark tests by removing `fiber.HeaderAccessControlRequestMethod` settings.
	- Updated test descriptions to reflect changes in headers handling.
	- Refactored test cases for different request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->