### PR TITLE
fix(middleware/cors): CORS handling

### DIFF
--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -171,6 +171,12 @@ func New(config ...Config) fiber.Handler {
 
 		// If the request does not have Origin header, the request is outside the scope of CORS
 		if originHeader == "" {
+			// See https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches
+			// Unless all origins are allowed, we include the Vary header to cache the response correctly
+			if !allowAllOrigins {
+				c.Vary(fiber.HeaderOrigin)
+			}
+
 			return c.Next()
 		}
 
@@ -215,17 +221,28 @@ func New(config ...Config) fiber.Handler {
 		// Simple request
 		// Ommit allowMethods and allowHeaders, only used for pre-flight requests
 		if c.Method() != fiber.MethodOptions {
+			if !allowAllOrigins {
+				// See https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches
+				c.Vary(fiber.HeaderOrigin)
+			}
 			setCORSHeaders(c, allowOrigin, "", "", exposeHeaders, maxAge, cfg)
 			return c.Next()
 		}
 
-		// Preflight request
+		// Pre-flight request
+
+		// Response to OPTIONS request should not be cached but,
+		// some caching can be configured to cache such responses.
+		// To Avoid poisoning the cache, we include the Vary header
+		// of preflight responses:
 		c.Vary(fiber.HeaderAccessControlRequestMethod)
 		c.Vary(fiber.HeaderAccessControlRequestHeaders)
 		if cfg.AllowPrivateNetwork && c.Get(fiber.HeaderAccessControlRequestPrivateNetwork) == "true" {
 			c.Vary(fiber.HeaderAccessControlRequestPrivateNetwork)
 			c.Set(fiber.HeaderAccessControlAllowPrivateNetwork, "true")
 		}
+		c.Vary(fiber.HeaderOrigin)
+
 		setCORSHeaders(c, allowOrigin, allowMethods, allowHeaders, exposeHeaders, maxAge, cfg)
 
 		// Send 204 No Content
@@ -235,8 +252,6 @@ func New(config ...Config) fiber.Handler {
 
 // Function to set CORS headers
 func setCORSHeaders(c fiber.Ctx, allowOrigin, allowMethods, allowHeaders, exposeHeaders, maxAge string, cfg Config) {
-	c.Vary(fiber.HeaderOrigin)
-
 	if cfg.AllowCredentials {
 		// When AllowCredentials is true, set the Access-Control-Allow-Origin to the specific origin instead of '*'
 		if allowOrigin == "*" {

--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -182,6 +182,11 @@ func New(config ...Config) fiber.Handler {
 
 		// If it's a preflight request and doesn't have Access-Control-Request-Method header, it's outside the scope of CORS
 		if c.Method() == fiber.MethodOptions && c.Get(fiber.HeaderAccessControlRequestMethod) == "" {
+			// Response to OPTIONS request should not be cached but,
+			// some caching can be configured to cache such responses.
+			// To Avoid poisoning the cache, we include the Vary header
+			// for non-CORS OPTIONS requests:
+			c.Vary(fiber.HeaderOrigin)
 			return c.Next()
 		}
 

--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -169,9 +169,13 @@ func New(config ...Config) fiber.Handler {
 		// Get originHeader header
 		originHeader := strings.ToLower(c.Get(fiber.HeaderOrigin))
 
-		// If the request does not have Origin and Access-Control-Request-Method
-		// headers, the request is outside the scope of CORS
-		if originHeader == "" || c.Get(fiber.HeaderAccessControlRequestMethod) == "" {
+		// If the request does not have Origin header, the request is outside the scope of CORS
+		if originHeader == "" {
+			return c.Next()
+		}
+
+		// If it's a preflight request and doesn't have Access-Control-Request-Method header, it's outside the scope of CORS
+		if c.Method() == fiber.MethodOptions && c.Get(fiber.HeaderAccessControlRequestMethod) == "" {
 			return c.Next()
 		}
 

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -49,7 +49,6 @@ func testDefaultOrEmptyConfig(t *testing.T, app *fiber.App) {
 	// Test default GET response headers
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fiber.MethodGet)
-	ctx.Request.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
 	ctx.Request.Header.Set(fiber.HeaderOrigin, "http://localhost")
 	h(ctx)
 
@@ -104,7 +103,6 @@ func Test_CORS_Wildcard(t *testing.T) {
 	ctx = &fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fiber.MethodGet)
 	ctx.Request.Header.Set(fiber.HeaderOrigin, "http://localhost")
-	ctx.Request.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
 	handler(ctx)
 
 	require.Equal(t, "", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowCredentials)))
@@ -146,7 +144,6 @@ func Test_CORS_Origin_AllowCredentials(t *testing.T) {
 	// Test non OPTIONS (preflight) response headers
 	ctx = &fasthttp.RequestCtx{}
 	ctx.Request.Header.Set(fiber.HeaderOrigin, "http://localhost")
-	ctx.Request.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
 	ctx.Request.Header.SetMethod(fiber.MethodGet)
 	handler(ctx)
 
@@ -465,41 +462,13 @@ func Test_CORS_Headers_BasedOnRequestType(t *testing.T) {
 	// Get handler pointer
 	handler := app.Handler()
 
-	t.Run("Without origin and Access-Control-Request-Method headers", func(t *testing.T) {
+	t.Run("Without origin", func(t *testing.T) {
 		t.Parallel()
 		// Make request without origin header, and without Access-Control-Request-Method
 		for _, method := range methods {
 			ctx := &fasthttp.RequestCtx{}
 			ctx.Request.Header.SetMethod(method)
 			ctx.Request.SetRequestURI("https://example.com/")
-			handler(ctx)
-			require.Equal(t, 200, ctx.Response.StatusCode(), "Status code should be 200")
-			require.Equal(t, "", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)), "Access-Control-Allow-Origin header should not be set")
-		}
-	})
-
-	t.Run("With origin but without Access-Control-Request-Method header", func(t *testing.T) {
-		t.Parallel()
-		// Make request with origin header, but without Access-Control-Request-Method
-		for _, method := range methods {
-			ctx := &fasthttp.RequestCtx{}
-			ctx.Request.Header.SetMethod(method)
-			ctx.Request.SetRequestURI("https://example.com/")
-			ctx.Request.Header.Set(fiber.HeaderOrigin, "http://example.com")
-			handler(ctx)
-			require.Equal(t, 200, ctx.Response.StatusCode(), "Status code should be 200")
-			require.Equal(t, "", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)), "Access-Control-Allow-Origin header should not be set")
-		}
-	})
-
-	t.Run("Without origin but with Access-Control-Request-Method header", func(t *testing.T) {
-		t.Parallel()
-		// Make request without origin header, but with Access-Control-Request-Method
-		for _, method := range methods {
-			ctx := &fasthttp.RequestCtx{}
-			ctx.Request.Header.SetMethod(method)
-			ctx.Request.SetRequestURI("https://example.com/")
-			ctx.Request.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
 			handler(ctx)
 			require.Equal(t, 200, ctx.Response.StatusCode(), "Status code should be 200")
 			require.Equal(t, "", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)), "Access-Control-Allow-Origin header should not be set")
@@ -523,7 +492,7 @@ func Test_CORS_Headers_BasedOnRequestType(t *testing.T) {
 		}
 	})
 
-	t.Run("Non-preflight request with origin and Access-Control-Request-Method headers", func(t *testing.T) {
+	t.Run("Non-preflight request with origin", func(t *testing.T) {
 		t.Parallel()
 		// Make non-preflight request with origin header and with Access-Control-Request-Method
 		for _, method := range methods {
@@ -531,7 +500,6 @@ func Test_CORS_Headers_BasedOnRequestType(t *testing.T) {
 			ctx.Request.Header.SetMethod(method)
 			ctx.Request.SetRequestURI("https://example.com/api/action")
 			ctx.Request.Header.Set(fiber.HeaderOrigin, "http://example.com")
-			ctx.Request.Header.Set(fiber.HeaderAccessControlRequestMethod, method)
 			handler(ctx)
 			require.Equal(t, 200, ctx.Response.StatusCode(), "Status code should be 200")
 			require.Equal(t, "*", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)), "Access-Control-Allow-Origin header should be set")
@@ -1008,7 +976,6 @@ func Benchmark_CORS_NewHandler(b *testing.B) {
 	req.Header.SetMethod(fiber.MethodGet)
 	req.SetRequestURI("/")
 	req.Header.Set(fiber.HeaderOrigin, "http://localhost")
-	req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
 	req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
 
 	ctx.Init(req, nil, nil)
@@ -1049,7 +1016,6 @@ func Benchmark_CORS_NewHandlerParallel(b *testing.B) {
 		req.Header.SetMethod(fiber.MethodGet)
 		req.SetRequestURI("/")
 		req.Header.Set(fiber.HeaderOrigin, "http://localhost")
-		req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
 		req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
 
 		ctx.Init(req, nil, nil)
@@ -1083,7 +1049,6 @@ func Benchmark_CORS_NewHandlerSingleOrigin(b *testing.B) {
 	req.Header.SetMethod(fiber.MethodGet)
 	req.SetRequestURI("/")
 	req.Header.Set(fiber.HeaderOrigin, "http://example.com")
-	req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
 	req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
 
 	ctx.Init(req, nil, nil)
@@ -1124,7 +1089,6 @@ func Benchmark_CORS_NewHandlerSingleOriginParallel(b *testing.B) {
 		req.Header.SetMethod(fiber.MethodGet)
 		req.SetRequestURI("/")
 		req.Header.Set(fiber.HeaderOrigin, "http://example.com")
-		req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
 		req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
 
 		ctx.Init(req, nil, nil)
@@ -1158,7 +1122,6 @@ func Benchmark_CORS_NewHandlerWildcard(b *testing.B) {
 	req.Header.SetMethod(fiber.MethodGet)
 	req.SetRequestURI("/")
 	req.Header.Set(fiber.HeaderOrigin, "http://example.com")
-	req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
 	req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
 
 	ctx.Init(req, nil, nil)
@@ -1199,7 +1162,6 @@ func Benchmark_CORS_NewHandlerWildcardParallel(b *testing.B) {
 		req.Header.SetMethod(fiber.MethodGet)
 		req.SetRequestURI("/")
 		req.Header.Set(fiber.HeaderOrigin, "http://example.com")
-		req.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
 		req.Header.Set(fiber.HeaderAccessControlRequestHeaders, "Origin,Content-Type,Accept")
 
 		ctx.Init(req, nil, nil)
@@ -1229,6 +1191,7 @@ func Benchmark_CORS_NewHandlerPreflight(b *testing.B) {
 	h := app.Handler()
 	ctx := &fasthttp.RequestCtx{}
 
+	// Preflight request
 	req := &fasthttp.Request{}
 	req.Header.SetMethod(fiber.MethodOptions)
 	req.SetRequestURI("/")


### PR DESCRIPTION
Merge changes from v2 PR #2937 

This pull request addresses issue #2936, fixing a bug introduced in the Fiber v2.52.3 release. The bug caused incorrect checking of non-preflight requests using preflight conditions.

Fiber CORS middleware validation sample: https://github.com/sixcolors/fiber-cors-middleware-validation-sample

Fixes #2936 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Refined logic for handling CORS requests in the `cors.go` middleware.
	- Added a new condition to handle preflight requests without the Access-Control-Request-Method header.
	- Removed setting `fiber.HeaderAccessControlRequestMethod` in `cors_test.go`.
	- Adjusted test case descriptions and refactored test cases for different request scenarios.
	- Updated benchmark functions in `cors_test.go`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->