### PR TITLE
🧹 Maintenance: Fix merge conflict in documentation

### DIFF
--- a/docs/api/middleware/earlydata.md
+++ b/docs/api/middleware/earlydata.md
@@ -50,38 +50,6 @@ app.Use(earlydata.New(earlydata.Config{
 
 ## Config
 
-<<<<<<< HEAD:middleware/earlydata/README.md
-```go
-type Config struct {
-	// Next defines a function to skip this middleware when returned true.
-	//
-	// Optional. Default: nil
-	Next func(c fiber.Ctx) bool
-
-	// IsEarlyData returns whether the request is an early-data request.
-	//
-	// Optional. Default: a function which checks if the "Early-Data" request header equals "1".
-	IsEarlyData func(c fiber.Ctx) bool
-
-	// AllowEarlyData returns whether the early-data request should be allowed or rejected.
-	//
-	// Optional. Default: a function which rejects the request on unsafe and allows the request on safe HTTP request methods.
-	AllowEarlyData func(c fiber.Ctx) bool
-
-	// Error is returned in case an early-data request is rejected.
-	//
-	// Optional. Default: fiber.ErrTooEarly.
-	Error error
-}
-```
-
-### Default Config
-
-```go
-var ConfigDefault = Config{
-	IsEarlyData: func(c fiber.Ctx) bool {
-		return c.Get("Early-Data") == "1"
-=======
 | Property       | Type                    | Description                                                                          | Default                                                |
 |:---------------|:------------------------|:-------------------------------------------------------------------------------------|:-------------------------------------------------------|
 | Next           | `func(fiber.Ctx) bool` | Next defines a function to skip this middleware when returned true.                  | `nil`                                                  |
@@ -95,13 +63,10 @@ var ConfigDefault = Config{
 var ConfigDefault = Config{
 	IsEarlyData: func(c fiber.Ctx) bool {
 		return c.Get(DefaultHeaderName) == DefaultHeaderTrueValue
->>>>>>> origin/master:docs/api/middleware/earlydata.md
 	},
-
 	AllowEarlyData: func(c fiber.Ctx) bool {
 		return fiber.IsMethodSafe(c.Method())
 	},
-
 	Error: fiber.ErrTooEarly,
 }
 ```


### PR DESCRIPTION
## Description

Fix merge conflict in `EarlyData` middleware documentation

Fixes #2956 

## Changes introduced

- [x] Documentation Update: Detail the updates made to the documentation and links to the changed files.

## Type of change

Please delete options that are not relevant.

- [x] Documentation update (changes to documentation)
