### PR TITLE
chore(middleware/csrf): Update config TrustedOrigin comments

### DIFF
--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -95,9 +95,9 @@ type Config struct {
 	// For secure requests, that do not include the Origin header, the Referer
 	// header must match the Host header or one of the TrustedOrigins.
 	//
-	// This supports subdomain matching, so you can use a value like "https://.example.com"
-	// to allow any subdomain of example.com to submit requests.
-	//
+	// This supports matching subdomains at any level. This means you can use a value like
+	// `"https://*.example.com"` to allow any subdomain of `example.com` to submit requests,
+	// including multiple subdomain levels such as `"https://sub.sub.example.com"`.
 	//
 	// Optional. Default: []
 	TrustedOrigins []string


### PR DESCRIPTION
This pull request updates the comments about the TrustedOrigins config field in the middleware/csrf/config.go file to reflect the behaviour introduced in PR #2925.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the CSRF middleware configuration documentation to clarify that subdomains can be matched at any level, enhancing understanding of wildcard subdomain capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->