### PR TITLE
📒 [docs]: Fix broken link to slim template in FAQ

### DIFF
--- a/docs/extra/faq.md
+++ b/docs/extra/faq.md
@@ -86,7 +86,7 @@ Fiber currently supports 9 template engines in our [gofiber/template](https://do
 * [jet](https://docs.gofiber.io/template/jet)
 * [mustache](https://docs.gofiber.io/template/mustache)
 * [pug](https://docs.gofiber.io/template/pug)
-* [slim](https://docs.gofiber.io/template/pug)
+* [slim](https://docs.gofiber.io/template/slim)
 
 To learn more about using Templates in Fiber, see [Templates](../guide/templates.md).
 


### PR DESCRIPTION
## Description

Fix broken link in FAQ about template engines.

Fixes #2966 

## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [x] Documentation Update: Detail the updates made to the documentation and links to the changed files.

## Type of change

- [x] Documentation update (changes to documentation)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a broken link in the FAQ section of the Fiber documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->