### PR TITLE
docs: Improve ctx.Locals method description, godoc and example

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -859,6 +859,10 @@ func (c *DefaultCtx) Links(link ...string) {
 
 // Locals makes it possible to pass any values under keys scoped to the request
 // and therefore available to all following routes that match the request.
+//
+// All the values are removed from ctx after returning from the top
+// RequestHandler. Additionally, Close method is called on each value
+// implementing io.Closer before removing the value from ctx.
 func (c *DefaultCtx) Locals(key any, value ...any) any {
 	if len(value) == 0 {
 		return c.fasthttp.UserValue(key)
@@ -868,7 +872,12 @@ func (c *DefaultCtx) Locals(key any, value ...any) any {
 }
 
 // Locals function utilizing Go's generics feature.
-// This function allows for manipulating and retrieving local values within a request context with a more specific data type.
+// This function allows for manipulating and retrieving local values within a
+// request context with a more specific data type.
+//
+// All the values are removed from ctx after returning from the top
+// RequestHandler. Additionally, Close method is called on each value
+// implementing io.Closer before removing the value from ctx.
 func Locals[V any](c Ctx, key any, value ...V) V {
 	var v V
 	var ok bool

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -174,6 +174,10 @@ type Ctx interface {
 	Links(link ...string)
 	// Locals makes it possible to pass any values under keys scoped to the request
 	// and therefore available to all following routes that match the request.
+	//
+	// All the values are removed from ctx after returning from the top
+	// RequestHandler. Additionally, Close method is called on each value
+	// implementing io.Closer before removing the value from ctx.
 	Locals(key any, value ...any) any
 	// Location sets the response Location HTTP header to the specified path parameter.
 	Location(path string)

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -966,12 +966,12 @@ type keyType int
 // instead of using this key directly.
 var userKey key
 
-app.Use(func(c *fiber.Ctx) error {
+app.Use(func(c fiber.Ctx) error {
   c.Locals(userKey, "admin") // Stores the string "admin" under a non-exported type key
   return c.Next()
 })
 
-app.Get("/admin", func(c *fiber.Ctx) error {
+app.Get("/admin", func(c fiber.Ctx) error {
   user, ok := c.Locals(userKey).(string) // Retrieves the data stored under the key and performs a type assertion
   if ok && user == "admin" {
     return c.Status(fiber.StatusOK).SendString("Welcome, admin!")

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -964,7 +964,7 @@ type keyType int
 // userKey is the key for user.User values in Contexts. It is
 // unexported; clients use user.NewContext and user.FromContext
 // instead of using this key directly.
-var userKey key
+var userKey keyType
 
 app.Use(func(c fiber.Ctx) error {
   c.Locals(userKey, "admin") // Stores the string "admin" under a non-exported type key

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -957,7 +957,7 @@ func (c Ctx) Locals(key any, value ...any) any
 
 ```go title="Example"
 
-// key is an unexported type for keys defined in this package.
+// keyType is an unexported type for keys defined in this package.
 // This prevents collisions with keys defined in other packages.
 type keyType int
 

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -945,10 +945,10 @@ app.Get("/", func(c fiber.Ctx) error {
 
 ## Locals
 
-A method that stores variables scoped to the request and, therefore, are available only to the routes that match the request.
+A method that stores variables scoped to the request and, therefore, are available only to the routes that match the request. The stored variables are removed after the request is handled. If any of the stored data implements the `io.Closer` interface, its `Close` method will be called before it's removed.
 
 :::tip
-This is useful if you want to pass some **specific** data to the next middleware.
+This is useful if you want to pass some **specific** data to the next middleware. Remember to perform type assertions when retrieving the data to ensure it is of the expected type. You can also use a non-exported type as a key to avoid collisions.
 :::
 
 ```go title="Signature"
@@ -959,24 +959,24 @@ func (c Ctx) Locals(key any, value ...any) any
 
 // key is an unexported type for keys defined in this package.
 // This prevents collisions with keys defined in other packages.
-type key int
+type keyType int
 
 // userKey is the key for user.User values in Contexts. It is
 // unexported; clients use user.NewContext and user.FromContext
 // instead of using this key directly.
 var userKey key
 
-app.Use(func(c fiber.Ctx) error {
-  c.Locals(userKey, "admin")
+app.Use(func(c *fiber.Ctx) error {
+  c.Locals(userKey, "admin") // Stores the string "admin" under a non-exported type key
   return c.Next()
 })
 
-app.Get("/admin", func(c fiber.Ctx) error {
-  if c.Locals(userKey) == "admin" {
+app.Get("/admin", func(c *fiber.Ctx) error {
+  user, ok := c.Locals(userKey).(string) // Retrieves the data stored under the key and performs a type assertion
+  if ok && user == "admin" {
     return c.Status(fiber.StatusOK).SendString("Welcome, admin!")
   }
   return c.SendStatus(fiber.StatusForbidden)
-
 })
 ```
 


### PR DESCRIPTION
### Description
Improve the `ctx.Locals` documentation to clarify the behavior of stored variables and their lifecycle to avoid unintentional resource closures, and provide best practices with keys and values.

### Changes Introduced
- **Documentation Update:** 
  - Added a clarification that stored variables are removed after the request is handled.
  - Specified that if any stored data implements the `io.Closer` interface, its `Close` method will be called before it's removed.
- **Example Code Enhancement:**
  - Demonstrated the use of a non-exported type as a key to avoid collisions.
  - Included type assertions when retrieving stored data to ensure it is of the expected type.

#### Details
- **Files Modified:** `docs/api/ctx.md` and `ctx.go`
- **Benchmark Impact:** None
- **Documentation Updates:** Improved clarity and provided best practices in the `Locals` method documentation.
- **Changelog Entries:** 
  - Clarified behavior of `ctx.Locals` regarding variable removal and `io.Closer` interface handling.
  - Updated example code to illustrate best practices for key usage and type assertions.
- **Migration Guide:** Not applicable

These changes aim to prevent issues with unintentional resource closures, such as database connections, and enhance the clarity and safety of using `ctx.Locals` in `fiber`.
