### PR TITLE
docs: Improve ctx.Locals method documentation

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -967,6 +967,10 @@ func (c *Ctx) Links(link ...string) {
 
 // Locals makes it possible to pass interface{} values under keys scoped to the request
 // and therefore available to all following routes that match the request.
+//
+// All the values are removed from ctx after returning from the top
+// RequestHandler. Additionally, Close method is called on each value
+// implementing io.Closer before removing the value from ctx.
 func (c *Ctx) Locals(key interface{}, value ...interface{}) interface{} {
 	if len(value) == 0 {
 		return c.fasthttp.UserValue(key)


### PR DESCRIPTION
### Description
Improve the `ctx.Locals` inlone godocs to clarify the behavior of stored variables and their lifecycle to avoid unintentional resource closures. Following #3030 this adds inline docs to `ctx.go` file.

### Changes Introduced
- **Documentation Update:** 
  - Added a clarification that stored variables are removed after the request is handled.
  - Specified that if any stored data implements the `io.Closer` interface, its `Close` method will be called before it's removed.

#### Details
- **File Modified:** `ctx.go`
- **Benchmark Impact:** None
- **Documentation Updates:** Improved clarity in the `Locals` method documentation.
- **Changelog Entries:** 
  - Clarified behavior of `ctx.Locals` regarding variable removal and `io.Closer` interface handling.
- **Migration Guide:** Not applicable

These changes aim to prevent issues with unintentional resource closures, such as database connections, and enhance the clarity and safety of using `ctx.Locals` in `fiber`.
