### PR TITLE
fix(middleware/session): mutex for thread safety

### DIFF
--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -292,8 +292,6 @@ func (s *Session) delSession() {
 
 // decodeSessionData decodes the session data from raw bytes.
 func (s *Session) decodeSessionData(rawData []byte) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	_, _ = s.byteBuffer.Write(rawData)
 	encCache := gob.NewDecoder(s.byteBuffer)
 	if err := encCache.Decode(&s.data.Data); err != nil {

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Session struct {
+	mu         sync.RWMutex  // Mutex to protect non-data fields
 	id         string        // session id
 	fresh      bool          // if new session
 	ctx        fiber.Ctx     // fiber context
@@ -56,11 +57,15 @@ func releaseSession(s *Session) {
 
 // Fresh is true if the current session is new
 func (s *Session) Fresh() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.fresh
 }
 
 // ID returns the session id
 func (s *Session) ID() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.id
 }
 
@@ -101,6 +106,9 @@ func (s *Session) Destroy() error {
 	// Reset local data
 	s.data.Reset()
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// Use external Storage if exist
 	if err := s.config.Storage.Delete(s.id); err != nil {
 		return err
@@ -113,6 +121,9 @@ func (s *Session) Destroy() error {
 
 // Regenerate generates a new session id and delete the old one from Storage
 func (s *Session) Regenerate() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// Delete old id from storage
 	if err := s.config.Storage.Delete(s.id); err != nil {
 		return err
@@ -137,6 +148,9 @@ func (s *Session) Reset() error {
 	// Reset expiration
 	s.exp = 0
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// Delete old id from storage
 	if err := s.config.Storage.Delete(s.id); err != nil {
 		return err
@@ -153,10 +167,7 @@ func (s *Session) Reset() error {
 
 // refresh generates a new session, and set session.fresh to be true
 func (s *Session) refresh() {
-	// Create a new id
 	s.id = s.config.KeyGenerator()
-
-	// We assign a new id to the session, so the session must be fresh
 	s.fresh = true
 }
 
@@ -167,6 +178,9 @@ func (s *Session) Save() error {
 		return nil
 	}
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// Check if session has your own expiration, otherwise use default value
 	if s.exp <= 0 {
 		s.exp = s.config.Expiration
@@ -176,25 +190,23 @@ func (s *Session) Save() error {
 	s.setSession()
 
 	// Convert data to bytes
-	mux.Lock()
-	defer mux.Unlock()
 	encCache := gob.NewEncoder(s.byteBuffer)
 	err := encCache.Encode(&s.data.Data)
 	if err != nil {
 		return fmt.Errorf("failed to encode data: %w", err)
 	}
 
-	// copy the data in buffer
+	// Copy the data in buffer
 	encodedBytes := make([]byte, s.byteBuffer.Len())
 	copy(encodedBytes, s.byteBuffer.Bytes())
 
-	// pass copied bytes with session id to provider
+	// Pass copied bytes with session id to provider
 	if err := s.config.Storage.Set(s.id, encodedBytes, s.exp); err != nil {
 		return err
 	}
 
 	// Release session
-	// TODO: It's not safe to use the Session after called Save()
+	// TODO: It's not safe to use the Session after calling Save()
 	releaseSession(s)
 
 	return nil
@@ -210,6 +222,8 @@ func (s *Session) Keys() []string {
 
 // SetExpiry sets a specific expiration for this session
 func (s *Session) SetExpiry(exp time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.exp = exp
 }
 
@@ -274,4 +288,16 @@ func (s *Session) delSession() {
 		s.ctx.Response().Header.SetCookie(fcookie)
 		fasthttp.ReleaseCookie(fcookie)
 	}
+}
+
+// decodeSessionData decodes the session data from raw bytes.
+func (s *Session) decodeSessionData(rawData []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, _ = s.byteBuffer.Write(rawData)
+	encCache := gob.NewDecoder(s.byteBuffer)
+	if err := encCache.Decode(&s.data.Data); err != nil {
+		return fmt.Errorf("failed to decode session data: %w", err)
+	}
+	return nil
 }

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -864,8 +864,6 @@ func Test_Session_Concurrency(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
 	store := New()
-	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
-	defer app.ReleaseCtx(ctx)
 
 	var wg sync.WaitGroup
 	errChan := make(chan error, 10) // Buffered channel to collect errors
@@ -878,7 +876,6 @@ func Test_Session_Concurrency(t *testing.T) {
 			defer wg.Done()
 
 			localCtx := app.AcquireCtx(&fasthttp.RequestCtx{})
-			defer app.ReleaseCtx(localCtx)
 
 			sess, err := store.Get(localCtx)
 			if err != nil {

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -4,7 +4,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/internal/storage/memory"
@@ -13,9 +12,6 @@ import (
 
 // ErrEmptySessionID is an error that occurs when the session ID is empty.
 var ErrEmptySessionID = errors.New("session id cannot be empty")
-
-// mux is a global mutex for session operations.
-var mux sync.Mutex
 
 // sessionIDKey is the local key type used to store and retrieve the session ID in context.
 type sessionIDKey int
@@ -131,16 +127,4 @@ func (s *Store) Delete(id string) error {
 		return ErrEmptySessionID
 	}
 	return s.Storage.Delete(id)
-}
-
-// decodeSessionData decodes the session data from raw bytes.
-func (s *Session) decodeSessionData(rawData []byte) error {
-	mux.Lock()
-	defer mux.Unlock()
-	_, _ = s.byteBuffer.Write(rawData)
-	encCache := gob.NewDecoder(s.byteBuffer)
-	if err := encCache.Decode(&s.data.Data); err != nil {
-		return fmt.Errorf("failed to decode session data: %w", err)
-	}
-	return nil
 }


### PR DESCRIPTION
This pull request adds a mutex to the session middleware to ensure thread safety when accessing session data. The mutex is used to protect non-data fields and prevent race conditions. This improves the reliability and stability of the session middleware.