### PR TITLE
fix(middleware/session): mutex for thread safety

### DIFF
--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -43,6 +43,7 @@ func acquireSession() *Session {
 }
 
 func releaseSession(s *Session) {
+	s.mu.Lock()
 	s.id = ""
 	s.exp = 0
 	s.ctx = nil
@@ -53,6 +54,7 @@ func releaseSession(s *Session) {
 	if s.byteBuffer != nil {
 		s.byteBuffer.Reset()
 	}
+	s.mu.Unlock()
 	sessionPool.Put(s)
 }
 
@@ -107,8 +109,8 @@ func (s *Session) Destroy() error {
 	// Reset local data
 	s.data.Reset()
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	// Use external Storage if exist
 	if err := s.config.Storage.Delete(s.id); err != nil {
@@ -142,15 +144,16 @@ func (s *Session) Reset() error {
 	if s.data != nil {
 		s.data.Reset()
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// Reset byte buffer
 	if s.byteBuffer != nil {
 		s.byteBuffer.Reset()
 	}
 	// Reset expiration
 	s.exp = 0
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	// Delete old id from storage
 	if err := s.config.Storage.Delete(s.id); err != nil {
@@ -173,6 +176,11 @@ func (s *Session) refresh() {
 }
 
 // Save will update the storage and client cookie
+//
+// sess.Save() will save the session data to the storage and update the
+// client cookie, and it will release the session after saving.
+//
+// It's not safe to use the session after calling Save().
 func (s *Session) Save() error {
 	// Better safe than sorry
 	if s.data == nil {
@@ -180,7 +188,6 @@ func (s *Session) Save() error {
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	// Check if session has your own expiration, otherwise use default value
 	if s.exp <= 0 {
@@ -205,6 +212,8 @@ func (s *Session) Save() error {
 	if err := s.config.Storage.Set(s.id, encodedBytes, s.exp); err != nil {
 		return err
 	}
+
+	s.mu.Unlock()
 
 	// Release session
 	// TODO: It's not safe to use the Session after calling Save()

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -276,3 +276,13 @@ func (s *Session) delSession() {
 		fasthttp.ReleaseCookie(fcookie)
 	}
 }
+
+// decodeSessionData decodes the session data from raw bytes.
+func (s *Session) decodeSessionData(rawData []byte) error {
+	_, _ = s.byteBuffer.Write(rawData) //nolint:errcheck // This will never fail
+	encCache := gob.NewDecoder(s.byteBuffer)
+	if err := encCache.Decode(&s.data.Data); err != nil {
+		return fmt.Errorf("failed to decode session data: %w", err)
+	}
+	return nil
+}

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -672,4 +674,151 @@ func Benchmark_Session(b *testing.B) {
 
 		utils.AssertEqual(b, nil, err)
 	})
+}
+
+// go test -v -run=^$ -bench=Benchmark_Session_Asserted_Parallel -benchmem -count=4
+func Benchmark_Session_Asserted_Parallel(b *testing.B) {
+	b.Run("default", func(b *testing.B) {
+		app, store := fiber.New(), New()
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				c := app.AcquireCtx(&fasthttp.RequestCtx{})
+				c.Request().Header.SetCookie(store.sessionName, "12356789")
+
+				sess, err := store.Get(c)
+				utils.AssertEqual(b, nil, err)
+				sess.Set("john", "doe")
+				utils.AssertEqual(b, nil, sess.Save())
+				app.ReleaseCtx(c)
+			}
+		})
+	})
+
+	b.Run("storage", func(b *testing.B) {
+		app := fiber.New()
+		store := New(Config{
+			Storage: memory.New(),
+		})
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				c := app.AcquireCtx(&fasthttp.RequestCtx{})
+				c.Request().Header.SetCookie(store.sessionName, "12356789")
+
+				sess, err := store.Get(c)
+				utils.AssertEqual(b, nil, err)
+				sess.Set("john", "doe")
+				utils.AssertEqual(b, nil, sess.Save())
+				app.ReleaseCtx(c)
+			}
+		})
+	})
+}
+
+// go test -v -race -run Test_Session_Concurrency ./...
+func Test_Session_Concurrency(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	store := New()
+
+	var wg sync.WaitGroup
+	errChan := make(chan error, 10) // Buffered channel to collect errors
+	const numGoroutines = 10        // Number of concurrent goroutines to test
+
+	// Start numGoroutines goroutines
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			localCtx := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+			sess, err := store.Get(localCtx)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			// Set a value
+			sess.Set("name", "john")
+
+			// get the session id
+			id := sess.ID()
+
+			// Check if the session is fresh
+			if !sess.Fresh() {
+				errChan <- errors.New("session should be fresh")
+				return
+			}
+
+			// Save the session
+			if err := sess.Save(); err != nil {
+				errChan <- err
+				return
+			}
+
+			// Release the context
+			app.ReleaseCtx(localCtx)
+
+			// Acquire a new context
+			localCtx = app.AcquireCtx(&fasthttp.RequestCtx{})
+			defer app.ReleaseCtx(localCtx)
+
+			// Set the session id in the header
+			localCtx.Request().Header.SetCookie(store.sessionName, id)
+
+			// Get the session
+			sess, err = store.Get(localCtx)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			// Get the value
+			name := sess.Get("name")
+			if name != "john" {
+				errChan <- errors.New("name should be john")
+				return
+			}
+
+			// Get ID from the session
+			if sess.ID() != id {
+				errChan <- errors.New("id should be the same")
+				return
+			}
+
+			// Check if the session is fresh
+			if sess.Fresh() {
+				errChan <- errors.New("session should not be fresh")
+				return
+			}
+
+			// Delete the key
+			sess.Delete("name")
+
+			// Get the value
+			name = sess.Get("name")
+			if name != nil {
+				errChan <- errors.New("name should be nil")
+				return
+			}
+
+			// Destroy the session
+			if err := sess.Destroy(); err != nil {
+				errChan <- err
+				return
+			}
+		}()
+	}
+
+	wg.Wait()      // Wait for all goroutines to finish
+	close(errChan) // Close the channel to signal no more errors will be sent
+
+	// Check for errors sent to errChan
+	for err := range errChan {
+		utils.AssertEqual(t, nil, err)
+	}
 }

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -4,7 +4,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/internal/storage/memory"
@@ -13,9 +12,6 @@ import (
 
 // ErrEmptySessionID is an error that occurs when the session ID is empty.
 var ErrEmptySessionID = errors.New("session id cannot be empty")
-
-// mux is a global mutex for session operations.
-var mux sync.Mutex
 
 // sessionIDKey is the local key type used to store and retrieve the session ID in context.
 type sessionIDKey int

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -132,15 +132,3 @@ func (s *Store) Delete(id string) error {
 	}
 	return s.Storage.Delete(id)
 }
-
-// decodeSessionData decodes the session data from raw bytes.
-func (s *Session) decodeSessionData(rawData []byte) error {
-	mux.Lock()
-	defer mux.Unlock()
-	_, _ = s.byteBuffer.Write(rawData) //nolint:errcheck // This will never fail
-	encCache := gob.NewDecoder(s.byteBuffer)
-	if err := encCache.Decode(&s.data.Data); err != nil {
-		return fmt.Errorf("failed to decode session data: %w", err)
-	}
-	return nil
-}

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -77,6 +77,10 @@ func (s *Store) Get(c *fiber.Ctx) (*Session, error) {
 
 	// Create session object
 	sess := acquireSession()
+
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+
 	sess.ctx = c
 	sess.config = s
 	sess.id = id
@@ -84,6 +88,8 @@ func (s *Store) Get(c *fiber.Ctx) (*Session, error) {
 
 	// Decode session data if found
 	if rawData != nil {
+		sess.data.Lock()
+		defer sess.data.Unlock()
 		if err := sess.decodeSessionData(rawData); err != nil {
 			return nil, fmt.Errorf("failed to decode session data: %w", err)
 		}


### PR DESCRIPTION
This pull request adds a mutex to the session middleware to ensure thread safety when accessing session data. The mutex is used to protect non-data fields and prevent race conditions. This improves the reliability and stability of the session middleware.