### PR TITLE
feat: Add support for longtests during CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
 
 name: Test
 jobs:
-  Build:
+  test:
     strategy:
       matrix:
         go-version: [1.21.x, 1.22.x]
@@ -30,11 +30,8 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.11.0
-
       - name: Test
-        run: gotestsum -f testname -- ./... -race -count=1 -coverprofile=coverage.txt -covermode=atomic -shuffle=on
+        run: go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1 -coverprofile=coverage.txt -covermode=atomic -shuffle=on
 
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.22.x' }}
@@ -44,3 +41,21 @@ jobs:
           file: ./coverage.txt
           flags: unittests
           slug: gofiber/fiber
+
+  LongTest:
+    needs: test
+    strategy:
+      matrix:
+        go-version: [1.21.x, 1.22.x]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Repository
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Test
+        run: go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=25 -shuffle=on

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+name: Test
+
 on:
   push:
     branches:
@@ -13,9 +15,8 @@ on:
       - "!docs/**"
       - "!**.md"
 
-name: Test
 jobs:
-  test:
+  unit:
     strategy:
       matrix:
         go-version: [1.21.x, 1.22.x]
@@ -42,8 +43,8 @@ jobs:
           flags: unittests
           slug: gofiber/fiber
 
-  LongTest:
-    needs: test
+  repeated:
+    needs: unit
     strategy:
       matrix:
         go-version: [1.21.x, 1.22.x]
@@ -58,4 +59,4 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Test
-        run: go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=25 -shuffle=on
+        run: go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=15 -shuffle=on

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test:
 ## longtest: 🚦 Execute all tests 10x
 .PHONY: longtest
 longtest:
-	go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=10 -shuffle=on
+	go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=15 -shuffle=on
 
 ## tidy: 📌 Clean and tidy dependencies
 .PHONY: tidy


### PR DESCRIPTION
## Description

- Added support for running tests 15 times with go1.21 and go1.22 using `ubuntu-latest`.
- Renamed `build` to `unit` in the test.yml workflow
- Remove installation of gotestsum, since it can be called using `go run`
- Always use `latest` gotestsum.

This should help detect future race-conditions that only happen when tests are run more than once but using GitHub Actions.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)