### PR TITLE
v3: Improve and simplify logic of ctx.Next()

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1021,12 +1021,16 @@ func (c *DefaultCtx) ClientHelloInfo() *tls.ClientHelloInfo {
 
 // Next executes the next method in the stack that matches the current route.
 func (c *DefaultCtx) Next() error {
+	// Increment handler index
 	c.indexHandler++
 
+	// Did we execute all route handlers?
 	if c.indexHandler < len(c.route.Handlers) {
+		// Continue route stack
 		return c.route.Handlers[c.indexHandler](c)
 	}
 
+	// Continue handler stack
 	if c.app.newCtxFunc != nil {
 		_, err := c.app.nextCustom(c)
 		return err

--- a/ctx.go
+++ b/ctx.go
@@ -1021,21 +1021,18 @@ func (c *DefaultCtx) ClientHelloInfo() *tls.ClientHelloInfo {
 
 // Next executes the next method in the stack that matches the current route.
 func (c *DefaultCtx) Next() error {
-	// Increment handler index
 	c.indexHandler++
-	var err error
-	// Did we execute all route handlers?
+
 	if c.indexHandler < len(c.route.Handlers) {
-		// Continue route stack
-		err = c.route.Handlers[c.indexHandler](c)
-	} else {
-		// Continue handler stack
-		if c.app.newCtxFunc != nil {
-			_, err = c.app.nextCustom(c)
-		} else {
-			_, err = c.app.next(c)
-		}
+		return c.route.Handlers[c.indexHandler](c)
 	}
+
+	if c.app.newCtxFunc != nil {
+		_, err := c.app.nextCustom(c)
+		return err
+	}
+
+	_, err := c.app.next(c)
 	return err
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -542,6 +542,27 @@ func Benchmark_Router_Next(b *testing.B) {
 	require.Equal(b, 4, c.indexRoute)
 }
 
+// go test -v ./... -run=^$ -bench=Benchmark_Router_Next_Default -benchmem -count=4
+func Benchmark_Router_Next_Default(b *testing.B) {
+	app := New()
+	app.Get("/", func(_ Ctx) error {
+		return nil
+	})
+
+	h := app.Handler()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.SetMethod(MethodGet)
+	fctx.Request.SetRequestURI("/")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		h(fctx)
+	}
+}
+
 // go test -v ./... -run=^$ -bench=Benchmark_Route_Match -benchmem -count=4
 func Benchmark_Route_Match(b *testing.B) {
 	var match bool


### PR DESCRIPTION
## Description

- Removed unnecessary variable declaration: The var err error declaration is not needed; you can return the error directly where it occurs.
- Simplified control flow: The nested if-else logic has been streamlined to improve readability and reduce branching.

## Benchmarks (25 runs)

### Summary of ns/op differences:
#### Run 1 (Before):

- Min: 37.92 ns/op
- Max: 40.04 ns/op
- Mean: 38.75 ns/op

#### Run 2 (After):

- Min: 37.64 ns/op
- Max: 39.19 ns/op
- Mean: 38.68 ns/op

#### Conclusion:

#### Percent Differences:
- Min Percent Difference: 0.74%
- Max Percent Difference: 2.12%
- Mean Percent Difference: 0.18%

### Summary of Iteration Differences:

#### Run 1 (before):

- Min Iterations: 29071340
- Max Iterations: 31355298
- Mean Iterations: 30071851

#### Run 2 (after):

- Min Iterations: 28509068
- Max Iterations: 31645021
- Mean Iterations: 30259517

#### Percent Differences:

- Min Percent Difference: 1.93%
- Max Percent Difference: 0.93%
- Mean Percent Difference: 0.62%

#### Comments
- Run 2 is slightly faster than Run 1 based on the min and mean values.
- Min value: Run 2 (37.64 ns/op) is faster than Run 1 (37.92 ns/op).
- Max value: Run 2 (39.19 ns/op) is faster than Run 1 (40.04 ns/op).
- Mean value: Run 2 (38.68 ns/op) is faster than Run 1 (38.75 ns/op).

## Changes introduced

- [x] Benchmarks: Describe any performance benchmarks and improvements related to the changes.

## Type of change

Please delete options that are not relevant.

- [x] Performance improvement (non-breaking change which improves efficiency)