### PR TITLE
🐛 bug: Use Content-Length for bytesReceived and bytesSent tags in Logger Middleware in v2

### DIFF
--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -386,13 +386,14 @@ func Test_Logger_AppendUint(t *testing.T) {
 	}))
 
 	app.Get("/", func(c *fiber.Ctx) error {
+		c.Response().Header.SetContentLength(5)
 		return c.SendString("hello")
 	})
 
 	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
-	utils.AssertEqual(t, "0 5 200", buf.String())
+	utils.AssertEqual(t, "-2 5 200", buf.String())
 }
 
 // go test -run Test_Logger_Data_Race -race
@@ -629,7 +630,7 @@ func Test_Logger_ByteSent_Streaming(t *testing.T) {
 	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, fiber.StatusOK, resp.StatusCode)
-	utils.AssertEqual(t, "0 0 200", buf.String())
+	utils.AssertEqual(t, "-2 -1 200", buf.String())
 }
 
 // go test -run Test_Logger_EnableColors

--- a/middleware/logger/tags.go
+++ b/middleware/logger/tags.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
@@ -85,13 +86,10 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			return output.Write(c.Body())
 		},
 		TagBytesReceived: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
-			return appendInt(output, len(c.Request().Body()))
+			return output.WriteString(strconv.Itoa((c.Request().Header.ContentLength())))
 		},
 		TagBytesSent: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
-			if c.Response().Header.ContentLength() < 0 {
-				return appendInt(output, 0)
-			}
-			return appendInt(output, len(c.Response().Body()))
+			return output.WriteString(strconv.Itoa((c.Response().Header.ContentLength())))
 		},
 		TagRoute: func(output Buffer, c *fiber.Ctx, data *Data, extraParam string) (int, error) {
 			return output.WriteString(c.Route().Path)


### PR DESCRIPTION
## Description

- Use `Content-Length` header when calculating the `bytesSent` and `bytesReceived` tags in the Logger Middleware.
  - The current implementation will load big files to memory to calculate the len causing Fiber to use a high amount of RAM.

Fixes #3060 

## Type of change

- [x] Performance improvement (non-breaking change which improves efficiency)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)