### PR TITLE
🐛 [Bug]: cache middleware: runtime error: index out of range [0] with length 0

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -117,46 +117,49 @@ func New(config ...Config) fiber.Handler {
 		// Get timestamp
 		ts := atomic.LoadUint64(&timestamp)
 
-		// Invalidate cache if requested
-		if cfg.CacheInvalidator != nil && cfg.CacheInvalidator(c) && e != nil {
-			e.exp = ts - 1
-		}
-
-		// Check if entry is expired
-		if e.exp != 0 && ts >= e.exp {
-			deleteKey(key)
-			if cfg.MaxBytes > 0 {
-				_, size := heap.remove(e.heapidx)
-				storedBytes -= size
-			}
-		} else if e.exp != 0 && !hasRequestDirective(c, noCache) {
-			// Separate body value to avoid msgp serialization
-			// We can store raw bytes with Storage 👍
-			if cfg.Storage != nil {
-				e.body = manager.getRaw(key + "_body")
-			}
-			// Set response headers from cache
-			c.Response().SetBodyRaw(e.body)
-			c.Response().SetStatusCode(e.status)
-			c.Response().Header.SetContentTypeBytes(e.ctype)
-			if len(e.cencoding) > 0 {
-				c.Response().Header.SetBytesV(fiber.HeaderContentEncoding, e.cencoding)
-			}
-			for k, v := range e.headers {
-				c.Response().Header.SetBytesV(k, v)
-			}
-			// Set Cache-Control header if enabled
-			if cfg.CacheControl {
-				maxAge := strconv.FormatUint(e.exp-ts, 10)
-				c.Set(fiber.HeaderCacheControl, "public, max-age="+maxAge)
+		// Cache Entry not found
+		if e != nil {
+			// Invalidate cache if requested
+			if cfg.CacheInvalidator != nil && cfg.CacheInvalidator(c) {
+				e.exp = ts - 1
 			}
 
-			c.Set(cfg.CacheHeader, cacheHit)
+			// Check if entry is expired
+			if e.exp != 0 && ts >= e.exp {
+				deleteKey(key)
+				if cfg.MaxBytes > 0 {
+					_, size := heap.remove(e.heapidx)
+					storedBytes -= size
+				}
+			} else if e.exp != 0 && !hasRequestDirective(c, noCache) {
+				// Separate body value to avoid msgp serialization
+				// We can store raw bytes with Storage 👍
+				if cfg.Storage != nil {
+					e.body = manager.getRaw(key + "_body")
+				}
+				// Set response headers from cache
+				c.Response().SetBodyRaw(e.body)
+				c.Response().SetStatusCode(e.status)
+				c.Response().Header.SetContentTypeBytes(e.ctype)
+				if len(e.cencoding) > 0 {
+					c.Response().Header.SetBytesV(fiber.HeaderContentEncoding, e.cencoding)
+				}
+				for k, v := range e.headers {
+					c.Response().Header.SetBytesV(k, v)
+				}
+				// Set Cache-Control header if enabled
+				if cfg.CacheControl {
+					maxAge := strconv.FormatUint(e.exp-ts, 10)
+					c.Set(fiber.HeaderCacheControl, "public, max-age="+maxAge)
+				}
 
-			mux.Unlock()
+				c.Set(cfg.CacheHeader, cacheHit)
 
-			// Return response
-			return nil
+				mux.Unlock()
+
+				// Return response
+				return nil
+			}
 		}
 
 		// make sure we're not blocking concurrent requests - do unlock
@@ -193,6 +196,7 @@ func New(config ...Config) fiber.Handler {
 			}
 		}
 
+		e = manager.acquire()
 		// Cache response
 		e.body = utils.CopyBytes(c.Response().Body())
 		e.status = c.Response().StatusCode()

--- a/middleware/cache/heap.go
+++ b/middleware/cache/heap.go
@@ -15,7 +15,7 @@ type heapEntry struct {
 // elements in constant time. It does so by handing out special indices
 // and tracking entry movement.
 //
-// indexdedHeap is used for quickly finding entries with the lowest
+// indexedHeap is used for quickly finding entries with the lowest
 // expiration timestamp and deleting arbitrary entries.
 type indexedHeap struct {
 	// Slice the heap is built on

--- a/middleware/cache/manager.go
+++ b/middleware/cache/manager.go
@@ -83,8 +83,7 @@ func (m *manager) get(key string) *item {
 		return it
 	}
 	if it, _ = m.memory.Get(key).(*item); it == nil { //nolint:errcheck // We store nothing else in the pool
-		it = m.acquire()
-		return it
+		return nil
 	}
 	return it
 }

--- a/middleware/cache/manager_test.go
+++ b/middleware/cache/manager_test.go
@@ -1,0 +1,26 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gofiber/utils/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_manager_get(t *testing.T) {
+	t.Parallel()
+	cacheManager := newManager(nil)
+	t.Run("Item not found in cache", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, cacheManager.get(utils.UUID()))
+	})
+	t.Run("Item found in cache", func(t *testing.T) {
+		t.Parallel()
+		id := utils.UUID()
+		cacheItem := cacheManager.acquire()
+		cacheItem.body = []byte("test-body")
+		cacheManager.set(id, cacheItem, 10*time.Second)
+		assert.NotNil(t, cacheManager.get(id))
+	})
+}


### PR DESCRIPTION
# Description

Fixes #3072 

The bug happens due to some scenarios together: 

- The cache middleware always create a pointer `item` even though the cache entry was not found. 
- The application can define a `CacheInvalidator` that commands to expire the cache **even though** it doesn't not have any entry

In case the application defines a `MaxBytes` size for the cache, it will try to remove it from the heap, resulting in a runtime error due to the heap not having even initialized.

To fix the issue, I made the following changes:

- The cache will return `nil` in case it does not found the entry. 
- The expiration flow will not be triggered if no cache entry was found, this will avoid unexpected behaviors.


## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [ ] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [ ] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [ ] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [ ] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [ ] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [ ] Examples: Provide examples demonstrating the new features or changes in action.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
