### PR TITLE
v2: Update benchmark-action to v1.20.3

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,7 +36,7 @@ jobs:
           key: ${{ runner.os }}-benchmark
 
       - name: Save Benchmark Results
-        uses: benchmark-action/github-action-benchmark@v1.16.2
+        uses: benchmark-action/github-action-benchmark@v1.20.3
         with:
           tool: "go"
           output-file-path: output.txt


### PR DESCRIPTION
# Description

We are using an older version of the `benchmark-action` in the v2 branch, this is causing the parsing when comparing to v3 to be broken.

This can be seen here https://github.com/gofiber/fiber/actions/runs/10040932098 where the values in the right column are not parsed correctly. This was a bug that was fixed a few versions ago after we reported it.