### PR TITLE
v3: Improve performance of helper functions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -65,7 +65,8 @@ jobs:
           # Do not save the data (This allows comparing benchmarks)
           save-data-file: false
           fail-on-alert: true
-          comment-on-alert: true
+          # Comment on the PR if the branch is not a fork
+          comment-on-alert: ${{ github.event.pull_request.head.repo.fork == false }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           summary-always: true
           alert-threshold: "150%"

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ format:
 
 ## format: 🎨 Find markdown format issues (Requires markdownlint-cli)
 .PHONY: markdown
-format:
+markdown:
 	markdownlint-cli2 "**/*.md" "#vendor"
 
 ## lint: 🚨 Run lint checks

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -138,6 +138,8 @@ func Benchmark_Utils_GetOffer(b *testing.B) {
 		},
 	}
 
+	b.ReportAllocs()
+	b.ResetTimer()
 	for _, tc := range testCases {
 		accept := []byte(tc.accept)
 		b.Run(tc.description, func(b *testing.B) {
@@ -205,6 +207,8 @@ func Benchmark_Utils_ParamsMatch(b *testing.B) {
 		"appLe": []byte("orange"),
 		"param": []byte("foo"),
 	}
+	b.ReportAllocs()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		match = paramsMatch(specParams, `;param=foo; apple=orange`)
 	}
@@ -317,6 +321,8 @@ func Benchmark_Utils_GetSplicedStrList(b *testing.B) {
 	destination := make([]string, 5)
 	result := destination
 	const input = `deflate, gzip,br,brotli,zstd`
+	b.ReportAllocs()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		result = getSplicedStrList(input, destination)
 	}
@@ -359,6 +365,8 @@ func Test_Utils_SortAcceptedTypes(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Utils_SortAcceptedTypes_Sorted -benchmem -count=4
 func Benchmark_Utils_SortAcceptedTypes_Sorted(b *testing.B) {
 	acceptedTypes := make([]acceptedType, 3)
+	b.ReportAllocs()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		acceptedTypes[0] = acceptedType{spec: "text/html", quality: 1, specificity: 1, order: 0}
 		acceptedTypes[1] = acceptedType{spec: "text/*", quality: 0.5, specificity: 1, order: 1}
@@ -373,6 +381,8 @@ func Benchmark_Utils_SortAcceptedTypes_Sorted(b *testing.B) {
 // go test -v -run=^$ -bench=Benchmark_Utils_SortAcceptedTypes_Unsorted -benchmem -count=4
 func Benchmark_Utils_SortAcceptedTypes_Unsorted(b *testing.B) {
 	acceptedTypes := make([]acceptedType, 11)
+	b.ReportAllocs()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		acceptedTypes[0] = acceptedType{spec: "text/html", quality: 1, specificity: 3, order: 0}
 		acceptedTypes[1] = acceptedType{spec: "text/*", quality: 0.5, specificity: 2, order: 1}
@@ -452,9 +462,10 @@ func Test_Utils_getGroupPath(t *testing.T) {
 }
 
 // go test -v -run=^$ -bench=Benchmark_Utils_ -benchmem -count=3
-
 func Benchmark_Utils_getGroupPath(b *testing.B) {
 	var res string
+	b.ReportAllocs()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		_ = getGroupPath("/v1/long/path/john/doe", "/why/this/name/is/so/awesome")
 		_ = getGroupPath("/v1", "/")
@@ -467,7 +478,8 @@ func Benchmark_Utils_getGroupPath(b *testing.B) {
 func Benchmark_Utils_Unescape(b *testing.B) {
 	unescaped := ""
 	dst := make([]byte, 0)
-
+	b.ReportAllocs()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		source := "/cr%C3%A9er"
 		pathBytes := utils.UnsafeBytes(source)
@@ -529,6 +541,8 @@ func Test_Utils_IsNoCache(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Utils_IsNoCache -benchmem -count=4
 func Benchmark_Utils_IsNoCache(b *testing.B) {
 	var ok bool
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = isNoCache("public")
 		_ = isNoCache("no-cache")
@@ -544,7 +558,10 @@ func Benchmark_Utils_IsNoCache(b *testing.B) {
 func Benchmark_SlashRecognition(b *testing.B) {
 	search := "wtf/1234"
 	var result bool
+
 	b.Run("indexBytes", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
 		result = false
 		for i := 0; i < b.N; i++ {
 			if strings.IndexByte(search, slashDelimiter) != -1 {
@@ -554,6 +571,8 @@ func Benchmark_SlashRecognition(b *testing.B) {
 		require.True(b, result)
 	})
 	b.Run("forEach", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
 		result = false
 		c := int32(slashDelimiter)
 		for i := 0; i < b.N; i++ {
@@ -567,6 +586,8 @@ func Benchmark_SlashRecognition(b *testing.B) {
 		require.True(b, result)
 	})
 	b.Run("IndexRune", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
 		result = false
 		c := int32(slashDelimiter)
 		for i := 0; i < b.N; i++ {


### PR DESCRIPTION
# Description

- Improve performance of `getOffer` helper function.
- Improve performance of `paramsMatch` helper function.
- Only add benchmark comments if branch is **not** from a fork.
- Note: Most of these optimizations were found using `GPT4o`.

## Changes introduced

- [x] Benchmarks: Describe any performance benchmarks and improvements related to the changes.

## Type of change

- [x] Performance improvement (non-breaking change which improves efficiency)