### PR TITLE
v3: Improve Performance of c.Body() by 125%

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -356,6 +356,16 @@ func Test_Ctx_Body(t *testing.T) {
 	require.Equal(t, []byte("john=doe"), c.Body())
 }
 
+// go test -run Test_Ctx_BodyRaw
+func Test_Ctx_BodyRaw(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+
+	c.Request().SetBodyRaw([]byte("john=doe"))
+	require.Equal(t, []byte("john=doe"), c.BodyRaw())
+}
+
 // go test -v -run=^$ -bench=Benchmark_Ctx_Body -benchmem -count=4
 func Benchmark_Ctx_Body(b *testing.B) {
 	const input = "john=doe"
@@ -371,6 +381,23 @@ func Benchmark_Ctx_Body(b *testing.B) {
 	}
 
 	require.Equal(b, []byte(input), c.Body())
+}
+
+// go test -v -run=^$ -bench=Benchmark_Ctx_BodyRaw -benchmem -count=4
+func Benchmark_Ctx_BodyRaw(b *testing.B) {
+	const input = "john=doe"
+
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+
+	c.Request().SetBodyRaw([]byte(input))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.BodyRaw()
+	}
+
+	require.Equal(b, []byte(input), c.BodyRaw())
 }
 
 // go test -run Test_Ctx_Body_Immutable

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -366,6 +366,16 @@ func Test_Ctx_BodyRaw(t *testing.T) {
 	require.Equal(t, []byte("john=doe"), c.BodyRaw())
 }
 
+// go test -run Test_Ctx_BodyRaw_Immutable
+func Test_Ctx_BodyRaw_Immutable(t *testing.T) {
+	t.Parallel()
+	app := New(Config{Immutable: true})
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+
+	c.Request().SetBodyRaw([]byte("john=doe"))
+	require.Equal(t, []byte("john=doe"), c.BodyRaw())
+}
+
 // go test -v -run=^$ -bench=Benchmark_Ctx_Body -benchmem -count=4
 func Benchmark_Ctx_Body(b *testing.B) {
 	const input = "john=doe"
@@ -388,6 +398,23 @@ func Benchmark_Ctx_BodyRaw(b *testing.B) {
 	const input = "john=doe"
 
 	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+
+	c.Request().SetBodyRaw([]byte(input))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.BodyRaw()
+	}
+
+	require.Equal(b, []byte(input), c.BodyRaw())
+}
+
+// go test -v -run=^$ -bench=Benchmark_Ctx_BodyRaw_Immutable -benchmem -count=4
+func Benchmark_Ctx_BodyRaw_Immutable(b *testing.B) {
+	const input = "john=doe"
+
+	app := New(Config{Immutable: true})
 	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
 
 	c.Request().SetBodyRaw([]byte(input))


### PR DESCRIPTION
# Description

- Improved performance of `Body()` across all cases by using the `Content-Encoding` from the request instead of iterating through all headers.
  - I found this improvement by accident while adding tests for `BodyRaw()`.
- Added missing unit-tests for `BodyRaw()`.
- Added missing benchmarks for `BodyRaw()`.

## Summary for Body()
### Before
- Iterations: Approximately 124-126 million iterations
- Time per Operation: Around 9.498 to 9.529 nanoseconds per operation

### After
- Iterations: Approximately 281-289 million iterations
- Time per Operation: Around 4.149 to 4.202 nanoseconds per operation

## Benchmark from Branch vs Main

![image](https://github.com/user-attachments/assets/0f1bac67-0878-4a79-be07-493586b9be5a)

## Changes introduced

- [x] Benchmarks: Describe any performance benchmarks and improvements related to the changes.

## Type of change

- [x] Enhancement (improvement to existing features and functionality)
- [x] Performance improvement (non-breaking change which improves efficiency)