### PR TITLE
🩹 Fix: handle un-matched open brackets in the query params

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1310,7 +1310,7 @@ func parseParamSquareBrackets(k string) (string, error) {
 
 	for i, b := range kbytes {
 		if b == '[' {
-			openBracketsCount += 1
+			openBracketsCount++
 			if i+1 < len(kbytes) && kbytes[i+1] != ']' {
 				if err := bb.WriteByte('.'); err != nil {
 					return "", fmt.Errorf("failed to write: %w", err)
@@ -1320,7 +1320,7 @@ func parseParamSquareBrackets(k string) (string, error) {
 		}
 
 		if b == ']' {
-			openBracketsCount -= 1
+			openBracketsCount--
 			if openBracketsCount < 0 {
 				return "", errors.New("unmatched brackets")
 			}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -4508,6 +4508,10 @@ func Test_Ctx_QueryParser(t *testing.T) {
 	utils.AssertEqual(t, nil, c.QueryParser(empty))
 	utils.AssertEqual(t, 0, len(empty.Hobby))
 
+	c.Request().URI().SetQueryString("id=1&name[=tom")
+	q = new(Query)
+	utils.AssertEqual(t, "unmatched brackets", c.QueryParser(q).Error())
+
 	type Query2 struct {
 		Bool            bool
 		ID              int
@@ -4789,6 +4793,10 @@ func Test_Ctx_QueryParser_Schema(t *testing.T) {
 	utils.AssertEqual(t, 10, cq.Data[0].Age)
 	utils.AssertEqual(t, "doe", cq.Data[1].Name)
 	utils.AssertEqual(t, 12, cq.Data[1].Age)
+
+	c.Request().URI().SetQueryString("data[0][name]=john&data[0][age]=10&data[1][name=doe&data[1][age]=12")
+	cq = new(CollectionQuery)
+	utils.AssertEqual(t, "unmatched brackets", c.QueryParser(cq).Error())
 
 	c.Request().URI().SetQueryString("data.0.name=john&data.0.age=10&data.1.name=doe&data.1.age=12")
 	cq = new(CollectionQuery)

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -4794,7 +4794,7 @@ func Test_Ctx_QueryParser_Schema(t *testing.T) {
 	utils.AssertEqual(t, "doe", cq.Data[1].Name)
 	utils.AssertEqual(t, 12, cq.Data[1].Age)
 
-	c.Request().URI().SetQueryString("data[0][name]=john&data[0][age]=10&data[1][name=doe&data[1][age]=12")
+	c.Request().URI().SetQueryString("data[0][name]=john&data[0][age]=10&data[1]name]=doe&data[1][age]=12")
 	cq = new(CollectionQuery)
 	utils.AssertEqual(t, "unmatched brackets", c.QueryParser(cq).Error())
 


### PR DESCRIPTION
# Description

Add logic to keep count of open brackets. If there's a mismatch between the number of open and close brackets, then return error.

Fixes #3120 

## Type of change

Please delete options that are not relevant.

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
