### PR TITLE
📚 Doc: Fix CSRF extractor function

### DIFF
--- a/docs/middleware/csrf.md
+++ b/docs/middleware/csrf.md
@@ -36,7 +36,7 @@ app.Use(csrf.New(csrf.Config{
     CookieSameSite: "Lax",
     Expiration:     1 * time.Hour,
     KeyGenerator:   utils.UUIDv4,
-    Extractor:      func(c fiber.Ctx) (string, error) { ... },
+    Extractor:      func(c *fiber.Ctx) (string, error) { ... },
 }))
 ```
 


### PR DESCRIPTION
# Description

The documentation is wrong for the csrf extractor function, passing `fiber.Ctx` by value. The docs should be:

    func (c *fiber.Ctx) (string, error)

[the source](https://github.com/gofiber/fiber/blob/f668537c02db71d71d17202e3b420c2896ef3a6b/middleware/csrf/config.go#L48).

## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [ ] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [x] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [ ] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [ ] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [ ] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [ ] Examples: Provide examples demonstrating the new features or changes in action.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to existing features and functionality)
- [x] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)
