### PR TITLE
v2: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gofiber/maintainers


### PR DESCRIPTION
# Description

This will allow github to auto assign the `gofiber/maintainers` team as reviewers of each new `v2` Pull Request. Currently this is a manual process.