### PR TITLE
🩹 Fix (v3): handle un-matched open brackets in the query params

### DIFF
--- a/binder/mapping_test.go
+++ b/binder/mapping_test.go
@@ -33,34 +33,34 @@ func Test_EqualFieldType(t *testing.T) {
 
 func Test_ParseParamSquareBrackets(t *testing.T) {
 	tests := []struct {
+		err      error
 		input    string
 		expected string
-		err      error
 	}{
 		{
+			err:      nil,
 			input:    "foo[bar]",
 			expected: "foo.bar",
-			err:      nil,
 		},
 		{
+			err:      nil,
 			input:    "foo[bar][baz]",
 			expected: "foo.bar.baz",
-			err:      nil,
 		},
 		{
+			err:      errors.New("unmatched brackets"),
 			input:    "foo[bar",
 			expected: "",
-			err:      errors.New("unmatched brackets"),
 		},
 		{
+			err:      errors.New("unmatched brackets"),
 			input:    "foo[bar][baz",
 			expected: "",
-			err:      errors.New("unmatched brackets"),
 		},
 		{
+			err:      errors.New("unmatched brackets"),
 			input:    "foo]bar[",
 			expected: "",
-			err:      errors.New("unmatched brackets"),
 		},
 	}
 

--- a/binder/mapping_test.go
+++ b/binder/mapping_test.go
@@ -1,6 +1,7 @@
 package binder
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -28,4 +29,51 @@ func Test_EqualFieldType(t *testing.T) {
 	require.True(t, equalFieldType(&user, reflect.String, "Address"))
 	require.True(t, equalFieldType(&user, reflect.Int, "AGE"))
 	require.True(t, equalFieldType(&user, reflect.Int, "age"))
+}
+
+func Test_ParseParamSquareBrackets(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		err      error
+	}{
+		{
+			input:    "foo[bar]",
+			expected: "foo.bar",
+			err:      nil,
+		},
+		{
+			input:    "foo[bar][baz]",
+			expected: "foo.bar.baz",
+			err:      nil,
+		},
+		{
+			input:    "foo[bar",
+			expected: "",
+			err:      errors.New("unmatched brackets"),
+		},
+		{
+			input:    "foo[bar][baz",
+			expected: "",
+			err:      errors.New("unmatched brackets"),
+		},
+		{
+			input:    "foo]bar[",
+			expected: "",
+			err:      errors.New("unmatched brackets"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := parseParamSquareBrackets(tt.input)
+			if tt.err != nil {
+				require.Error(t, err)
+				require.EqualError(t, err, tt.err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
 }

--- a/binder/mapping_test.go
+++ b/binder/mapping_test.go
@@ -62,6 +62,26 @@ func Test_ParseParamSquareBrackets(t *testing.T) {
 			input:    "foo]bar[",
 			expected: "",
 		},
+		{
+			err:      nil,
+			input:    "foo[bar[baz]]",
+			expected: "foo.bar.baz",
+		},
+		{
+			err:      nil,
+			input:    "",
+			expected: "",
+		},
+		{
+			err:      nil,
+			input:    "[]",
+			expected: "",
+		},
+		{
+			err:      nil,
+			input:    "foo[]",
+			expected: "foo",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

Add logic to keep count of open brackets. If there's a mismatch between the number of open and close brackets, then return error.

Fixes #3120 

## Type of change

Please delete options that are not relevant.

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
