### PR TITLE
v3: Optimize IsFromLocal() performance

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1841,21 +1841,9 @@ func (c *DefaultCtx) IsProxyTrusted() bool {
 	return false
 }
 
-var localHosts = [...]string{"127.0.0.1", "::1"}
-
-// IsLocalHost will return true if address is a localhost address.
-func (*DefaultCtx) isLocalHost(address string) bool {
-	for _, h := range localHosts {
-		if address == h {
-			return true
-		}
-	}
-	return false
-}
-
 // IsFromLocal will return true if request came from local.
 func (c *DefaultCtx) IsFromLocal() bool {
-	return c.isLocalHost(c.fasthttp.RemoteIP().String())
+	return c.fasthttp.RemoteIP().IsLoopback()
 }
 
 // Bind You can bind body, cookie, headers etc. into the map, map slice, struct easily by using Binding method.

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -318,8 +318,6 @@ type Ctx interface {
 	// If EnableTrustedProxyCheck false, it returns true
 	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
 	IsProxyTrusted() bool
-	// IsLocalHost will return true if address is a localhost address.
-	isLocalHost(address string) bool
 	// IsFromLocal will return true if request came from local.
 	IsFromLocal() bool
 	// Bind You can bind body, cookie, headers etc. into the map, map slice, struct easily by using Binding method.

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -6352,3 +6352,61 @@ func Benchmark_Ctx_IsProxyTrusted(b *testing.B) {
 		})
 	})
 }
+
+func Benchmark_Ctx_IsFromLocalhost(b *testing.B) {
+	// Scenario without localhost check
+	b.Run("Non_Localhost", func(b *testing.B) {
+		app := New()
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		c.Request().SetRequestURI("http://google.com:8080/test")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			c.IsFromLocal()
+		}
+		app.ReleaseCtx(c)
+	})
+
+	// Scenario without localhost check in parallel
+	b.Run("Non_Localhost_Parallel", func(b *testing.B) {
+		app := New()
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			c := app.AcquireCtx(&fasthttp.RequestCtx{})
+			c.Request().SetRequestURI("http://google.com:8080/test")
+			for pb.Next() {
+				c.IsFromLocal()
+			}
+			app.ReleaseCtx(c)
+		})
+	})
+
+	// Scenario with localhost check
+	b.Run("Localhost", func(b *testing.B) {
+		app := New()
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		c.Request().SetRequestURI("http://localhost:8080/test")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			c.IsFromLocal()
+		}
+		app.ReleaseCtx(c)
+	})
+
+	// Scenario with localhost check in parallel
+	b.Run("Localhost_Parallel", func(b *testing.B) {
+		app := New()
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			c := app.AcquireCtx(&fasthttp.RequestCtx{})
+			c.Request().SetRequestURI("http://localhost:8080/test")
+			for pb.Next() {
+				c.IsFromLocal()
+			}
+			app.ReleaseCtx(c)
+		})
+	})
+}


### PR DESCRIPTION
# Description

- Add Benchmarks for `ctx.IsFromLocal()`
- Optimize performance of `ctx.IsFromLocal()` by using `net.IP` functions to detect if IP is from loopback address.
- Reduce memory allocations by using `net.IP` directly instead of strings.

## Benchmark Results:

| **Benchmark**                  | **Before ns/op** | **After ns/op** | **Speedup**     | **Before Allocations** | **After Allocations** | **Improvement**        |
|--------------------------------|-----------------|-----------------|-----------------|-----------------------|-----------------------|-------------------------|
| **Non_Localhost**              | 26.45           | 7.51            | ~3.52× faster    | 1 allocs/op            | 0 allocs/op            | Allocations Eliminated  |
| **Non_Localhost_Parallel**     | 6.824           | 1.30            | ~5.25× faster    | 1 allocs/op            | 0 allocs/op            | Allocations Eliminated  |
| **Localhost**                  | 26.48           | 7.52            | ~3.52× faster    | 1 allocs/op            | 0 allocs/op            | Allocations Eliminated  |
| **Localhost_Parallel**         | 6.974           | 1.31            | ~5.33× faster    | 1 allocs/op            | 0 allocs/op            | Allocations Eliminated  |


## Changes introduced

- [x] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [x] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.

## Type of change

- [x] Performance improvement (non-breaking change which improves efficiency)
