### PR TITLE
📚 Doc: removed zero width white space from logger docs

### DIFF
--- a/docs/middleware/logger.md
+++ b/docs/middleware/logger.md
@@ -44,7 +44,7 @@ app.Use(logger.New(logger.Config{
 app.Use(requestid.New())
 app.Use(logger.New(logger.Config{
     // For more options, see the Config section
-    Format: "${pid} ${locals:requestid} ${status} - ${method} ${path}​\n",
+    Format: "${pid} ${locals:requestid} ${status} - ${method} ${path}\n",
 }))
 
 // Changing TimeZone & TimeFormat


### PR DESCRIPTION
# Description

Documentation improvements were made in this branch.
Deleted zero width whitespace (u200b) character in logger documentation.

## Changes introduced

- [x] Documentation Update: [Logger Docs](https://github.com/gofiber/fiber/blob/main/docs/middleware/logger.md)

## Type of change

- [x] Documentation update (changes to documentation)

