### PR TITLE
🩹 Fix: behavior of `DefaultCtx.Fresh` when 'Last-Modified' and 'If-Modified-Since' are equal

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -624,7 +624,7 @@ func (c *DefaultCtx) Fresh() bool {
 				if err != nil {
 					return false
 				}
-				return lastModifiedTime.Before(modifiedSinceTime)
+				return lastModifiedTime.Compare(modifiedSinceTime) != 1
 			}
 		}
 	}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1421,9 +1421,9 @@ func Benchmark_Ctx_Fresh_LastModified(b *testing.B) {
 	app := New()
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 
+	c.Response().Header.Set(HeaderLastModified, "Wed, 21 Oct 2015 07:28:00 GMT")
+	c.Request().Header.Set(HeaderIfModifiedSince, "Wed, 21 Oct 2015 07:28:00 GMT")
 	for n := 0; n < b.N; n++ {
-		c.Response().Header.Set(HeaderLastModified, "Wed, 21 Oct 2015 07:28:00 GMT")
-		c.Request().Header.Set(HeaderIfModifiedSince, "Wed, 21 Oct 2015 07:28:00 GMT")
 		c.Fresh()
 	}
 }

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1397,6 +1397,10 @@ func Test_Ctx_Fresh(t *testing.T) {
 	require.False(t, c.Fresh())
 
 	c.Request().Header.Set(HeaderIfModifiedSince, "Wed, 21 Oct 2015 07:28:00 GMT")
+	require.True(t, c.Fresh())
+
+	c.Request().Header.Set(HeaderIfModifiedSince, "Wed, 21 Oct 2015 07:27:59 GMT")
+	c.Response().Header.Set(HeaderLastModified, "Wed, 21 Oct 2015 07:28:00 GMT")
 	require.False(t, c.Fresh())
 }
 
@@ -1408,6 +1412,18 @@ func Benchmark_Ctx_Fresh_WithNoCache(b *testing.B) {
 	c.Request().Header.Set(HeaderIfNoneMatch, "*")
 	c.Request().Header.Set(HeaderCacheControl, "no-cache")
 	for n := 0; n < b.N; n++ {
+		c.Fresh()
+	}
+}
+
+// go test -v -run=^$ -bench=Benchmark_Ctx_Fresh_LastModified -benchmem -count=4
+func Benchmark_Ctx_Fresh_LastModified(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	for n := 0; n < b.N; n++ {
+		c.Response().Header.Set(HeaderLastModified, "Wed, 21 Oct 2015 07:28:00 GMT")
+		c.Request().Header.Set(HeaderIfModifiedSince, "Wed, 21 Oct 2015 07:28:00 GMT")
 		c.Fresh()
 	}
 }


### PR DESCRIPTION
# Description

If 'Last-Modified' and 'If-Modified-Since' are equal, then `DefaultCtx.Fresh` returns false.
However, if no updates have been made, the cache should not to be stale.
Thank you.

## Type of change

- [x] Enhancement (improvement to existing features and functionality)

## Checklist

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.

## Benchmarks(on GitHub Codespaces)

```sh
go test -v -run=^$ -bench=Benchmark_Ctx_Fresh_LastModified -benchmem -count=4
```


### Before
```
goos: linux
goarch: amd64
pkg: github.com/gofiber/fiber/v3
cpu: AMD EPYC 7763 64-Core Processor                
Benchmark_Ctx_Fresh_LastModified
Benchmark_Ctx_Fresh_LastModified-2      10880254               123.4 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_Fresh_LastModified-2      10743270               109.9 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_Fresh_LastModified-2      10766181               114.0 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_Fresh_LastModified-2      10719219               108.6 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/gofiber/fiber/v3     6.345s
```

### After
```
goos: linux
goarch: amd64
pkg: github.com/gofiber/fiber/v3
cpu: AMD EPYC 7763 64-Core Processor                
Benchmark_Ctx_Fresh_LastModified
Benchmark_Ctx_Fresh_LastModified-2      10672034               110.4 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_Fresh_LastModified-2      10670136               126.8 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_Fresh_LastModified-2      10492482               114.3 ns/op             0 B/op          0 allocs/op
Benchmark_Ctx_Fresh_LastModified-2      10615524               114.2 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/gofiber/fiber/v3     5.414s
```
