### PR TITLE
🩹Fix: Adaptor middleware duplicates cookies

### DIFF
--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -101,6 +101,8 @@ func HTTPMiddleware(mw func(http.Handler) http.Handler) fiber.Handler {
 			c.Request().SetHost(r.Host)
 			c.Request().Header.SetHost(r.Host)
 
+			// Remove all cookies before setting, see https://github.com/valyala/fasthttp/pull/1864
+			c.Request().Header.DelAllCookies()
 			for key, val := range r.Header {
 				for _, v := range val {
 					c.Request().Header.Set(key, v)


### PR DESCRIPTION
# Description

In `adapter.go`, add a step to clear existing cookies before introducing new ones in the `HTTPMiddleware` section, so that cookies are not duplicated after passing through the middleware.

Fixes [#3089](https://github.com/gofiber/fiber/issues/3089)

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
