### PR TITLE
Update README.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -73,7 +73,7 @@ func main() {
     app := fiber.New()
 
     // Define a route for the GET method on the root path '/'
-    app.Get("/", func(c fiber.Ctx) error {
+    app.Get("/", func(c *fiber.Ctx) error {
         // Send a string response to the client
         return c.SendString("Hello, World 👋!")
     })


### PR DESCRIPTION
Missing a pointer reference when passing the context object in the route handler function. In Fiber, the context (c) is a pointer, so it should be *fiber.Ctx instead of fiber.Ctx.


