### PR TITLE
🔥 feat: Add support for creating Fiber client from existing FastHTTP client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -683,7 +683,7 @@ func New() *Client {
 	return NewWithClient(&fasthttp.Client{})
 }
 
-// NewWithClient creates and returns a new Client object from an eisting client object.
+// NewWithClient creates and returns a new Client object from an existing client object.
 func NewWithClient(c *fasthttp.Client) *Client {
 	return &Client{
 		fasthttp: c,

--- a/client/client.go
+++ b/client/client.go
@@ -683,7 +683,7 @@ func New() *Client {
 	return NewWithClient(&fasthttp.Client{})
 }
 
-// NewWithClient creates and returns a new Client object from an existing client object.
+// NewWithClient creates and returns a new Client object from an existing client.
 func NewWithClient(c *fasthttp.Client) *Client {
 	return &Client{
 		fasthttp: c,

--- a/client/client.go
+++ b/client/client.go
@@ -680,8 +680,13 @@ func New() *Client {
 	// trie to use a pool to reduce the cost of memory allocation
 	// for the fiber client and the fasthttp client
 	// if possible also for other structs -> request header, cookie, query param, path param...
+	return NewWithClient(&fasthttp.Client{})
+}
+
+// NewWithClient creates and returns a new Client object from an eisting client object.
+func NewWithClient(c *fasthttp.Client) *Client {
 	return &Client{
-		fasthttp: &fasthttp.Client{},
+		fasthttp: c,
 		header: &Header{
 			RequestHeader: &fasthttp.RequestHeader{},
 		},

--- a/client/client.go
+++ b/client/client.go
@@ -685,6 +685,9 @@ func New() *Client {
 
 // NewWithClient creates and returns a new Client object from an existing client.
 func NewWithClient(c *fasthttp.Client) *Client {
+	if c == nil {
+		panic("fasthttp.Client must not be nil")
+	}
 	return &Client{
 		fasthttp: c,
 		header: &Header{

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -55,6 +55,17 @@ func startTestServerWithPort(t *testing.T, beforeStarting func(app *fiber.App)) 
 	return nil, ""
 }
 
+func Test_New_With_Client(t *testing.T) {
+	t.Parallel()
+
+	c := &fasthttp.Client{
+		MaxConnsPerHost: 5,
+	}
+	client := NewWithClient(c)
+
+	require.NotNil(t, client)
+}
+
 func Test_Client_Add_Hook(t *testing.T) {
 	t.Parallel()
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -65,7 +65,7 @@ func Test_New_With_Client(t *testing.T) {
 			MaxConnsPerHost: 5,
 		}
 		client := NewWithClient(c)
-	
+
 		require.NotNil(t, client)
 	})
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -58,12 +58,24 @@ func startTestServerWithPort(t *testing.T, beforeStarting func(app *fiber.App)) 
 func Test_New_With_Client(t *testing.T) {
 	t.Parallel()
 
-	c := &fasthttp.Client{
-		MaxConnsPerHost: 5,
-	}
-	client := NewWithClient(c)
+	t.Run("with valid client", func(t *testing.T) {
+		t.Parallel()
 
-	require.NotNil(t, client)
+		c := &fasthttp.Client{
+			MaxConnsPerHost: 5,
+		}
+		client := NewWithClient(c)
+	
+		require.NotNil(t, client)
+	})
+
+	t.Run("with nil client", func(t *testing.T) {
+		t.Parallel()
+
+		require.PanicsWithValue(t, "fasthttp.Client must not be nil", func() {
+			NewWithClient(nil)
+		})
+	})
 }
 
 func Test_Client_Add_Hook(t *testing.T) {

--- a/docs/client/rest.md
+++ b/docs/client/rest.md
@@ -95,12 +95,20 @@ type Client struct {
 }
 ```
 
- New
+### New
 
 New creates and returns a new Client object.
 
 ```go title="Signature"
 func New() *Client
+```
+
+### NewWithClient
+
+NewWithClient creates and returns a new Client object from an existing client object.
+
+```go title="Signature"
+func NewWithClient(c *fasthttp.Client) *Client
 ```
 
 ## REST Methods


### PR DESCRIPTION
# Description

Add support for passing a custom fasthttp client to the fiber http client, to allow more granular fine tuning by the users.

Fixes #3107 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
  - Add `NewWithClient` method to client.
- [x] Documentation update (changes to documentation)
  - Add method to [client docs](https://github.com/gofiber/fiber/blob/main/docs/client/rest.md#usage).
- [x] Code consistency (non-breaking change which improves code reliability and robustness)
  - The `New` method calls `NewWithClient` internally.
  - Add unit tests for valid fasthttp client and nil client.
