### PR TITLE
🔥 feat: Add support for configuring TLS Min Version

### DIFF
--- a/docs/api/fiber.md
+++ b/docs/api/fiber.md
@@ -116,7 +116,8 @@ app.Listen(":8080", fiber.ListenConfig{
 | <Reference id="onshutdownerror">OnShutdownError</Reference>             | `func(err error)`             | Allows to customize error behavior when gracefully shutting down the server by given signal.  Prints error with `log.Fatalf()`                | `nil`   |
 | <Reference id="onshutdownsuccess">OnShutdownSuccess</Reference>         | `func()`                      | Allows customizing success behavior when gracefully shutting down the server by given signal.                                                 | `nil`   |
 | <Reference id="tlsconfigfunc">TLSConfigFunc</Reference>                 | `func(tlsConfig *tls.Config)` | Allows customizing `tls.Config` as you want.                                                                                                  | `nil`   |
-| <Reference id="autocertmanager">AutoCertManager</Reference>                 | `func(tlsConfig *tls.Config)` | Manages TLS certificates automatically using the ACME protocol. Enables integration with Let's Encrypt or other ACME-compatible providers.                                                            | `nil`   |
+| <Reference id="autocertmanager">AutoCertManager</Reference>             | `*autocert.Manager`           | Manages TLS certificates automatically using the ACME protocol. Enables integration with Let's Encrypt or other ACME-compatible providers.    | `nil`   |
+| <Reference id="tlsminversion">TLSMinVersion</Reference>                 | `uint16`                      | Allows customizing the TLS minimum version.    | `tls.VersionTLS12`   |
 
 ### Listen
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -130,6 +130,14 @@ In this example, a custom context `CustomCtx` is created with an additional meth
 
 </details>
 
+### Configurable TLS Minimum Version
+
+We have added support for configuring the TLS minimum version. This field allows you to set the TLS minimum version for TLSAutoCert and the server listener.
+
+```go
+app.Listen(":444", fiber.ListenConfig{TLSMinVersion: tls.VersionTLS12})
+```
+
 #### TLS AutoCert support (ACME / Let's Encrypt)
 
 We have added native support for automatic certificates management from Let's Encrypt and any other ACME-based providers.

--- a/listen.go
+++ b/listen.go
@@ -111,6 +111,7 @@ type ListenConfig struct {
 	// TLSMinVersion allows to set tls minimum version.
 	//
 	// Default: VersionTLS12
+	// WARNING: TLS1.0 and TLS1.1 versions are not supported.
 	TLSMinVersion uint16 `json:"tls_min_version"`
 
 	// When set to true, it will not print out the «Fiber» ASCII art and listening address.
@@ -155,6 +156,10 @@ func listenConfigDefault(config ...ListenConfig) ListenConfig {
 
 	if cfg.TLSMinVersion == 0 {
 		cfg.TLSMinVersion = tls.VersionTLS12
+	}
+
+	if cfg.TLSMinVersion != tls.VersionTLS12 && cfg.TLSMinVersion != tls.VersionTLS13 {
+		panic("Supported TLS versions: 1.2, 1.3")
 	}
 
 	return cfg

--- a/listen.go
+++ b/listen.go
@@ -108,9 +108,9 @@ type ListenConfig struct {
 	// Default: 10 * time.Second
 	ShutdownTimeout time.Duration `json:"shutdown_timeout"`
 
-	// TLSMinVersion allows to set tls minimum version.
+	// TLSMinVersion allows to set TLS minimum version.
 	//
-	// Default: VersionTLS12
+	// Default: tls.VersionTLS12
 	// WARNING: TLS1.0 and TLS1.1 versions are not supported.
 	TLSMinVersion uint16 `json:"tls_min_version"`
 

--- a/listen.go
+++ b/listen.go
@@ -159,7 +159,7 @@ func listenConfigDefault(config ...ListenConfig) ListenConfig {
 	}
 
 	if cfg.TLSMinVersion != tls.VersionTLS12 && cfg.TLSMinVersion != tls.VersionTLS13 {
-		panic("Supported TLS versions: 1.2, 1.3")
+		panic("unsupported TLS version, please use tls.VersionTLS12 or tls.VersionTLS13")
 	}
 
 	return cfg
@@ -183,7 +183,7 @@ func (app *App) Listen(addr string, config ...ListenConfig) error {
 		}
 
 		tlsHandler := &TLSHandler{}
-		tlsConfig = &tls.Config{
+		tlsConfig = &tls.Config{ //nolint:gosec // This is a user input
 			MinVersion: cfg.TLSMinVersion,
 			Certificates: []tls.Certificate{
 				cert,
@@ -207,7 +207,7 @@ func (app *App) Listen(addr string, config ...ListenConfig) error {
 		// Attach the tlsHandler to the config
 		app.SetTLSHandler(tlsHandler)
 	} else if cfg.AutoCertManager != nil {
-		tlsConfig = &tls.Config{
+		tlsConfig = &tls.Config{ //nolint:gosec // This is a user input
 			MinVersion:     cfg.TLSMinVersion,
 			GetCertificate: cfg.AutoCertManager.GetCertificate,
 			NextProtos:     []string{"http/1.1", "acme-tls/1"},

--- a/listen.go
+++ b/listen.go
@@ -50,11 +50,6 @@ type ListenConfig struct {
 	// Default: nil
 	TLSConfigFunc func(tlsConfig *tls.Config) `json:"tls_config_func"`
 
-	// TLSMinVersion allows to set tls minimum version.
-	//
-	// Default: VersionTLS12
-	TLSMinVersion uint16 `json:"tls_min_version"`
-
 	// ListenerFunc allows accessing and customizing net.Listener.
 	//
 	// Default: nil
@@ -112,6 +107,11 @@ type ListenConfig struct {
 	//
 	// Default: 10 * time.Second
 	ShutdownTimeout time.Duration `json:"shutdown_timeout"`
+
+	// TLSMinVersion allows to set tls minimum version.
+	//
+	// Default: VersionTLS12
+	TLSMinVersion uint16 `json:"tls_min_version"`
 
 	// When set to true, it will not print out the «Fiber» ASCII art and listening address.
 	//

--- a/listen_test.go
+++ b/listen_test.go
@@ -233,19 +233,7 @@ func Test_Listen_Prefork(t *testing.T) {
 
 	app := New()
 
-	require.Panics(t, func() {
-		_ = app.Listen(":443", ListenConfig{TLSMinVersion: tls.VersionTLS10}) //nolint:errcheck // ignore error
-	})
-	require.Panics(t, func() {
-		_ = app.Listen(":443", ListenConfig{TLSMinVersion: tls.VersionTLS11}) //nolint:errcheck // ignore error
-	})
-
-	require.Panics(t, func() {
-		_ = app.Listen(":443", ListenConfig{DisableStartupMessage: true, EnablePrefork: true, TLSMinVersion: tls.VersionTLS10}) //nolint:errcheck // ignore error
-	})
-	require.Panics(t, func() {
-		_ = app.Listen(":443", ListenConfig{DisableStartupMessage: true, EnablePrefork: true, TLSMinVersion: tls.VersionTLS11}) //nolint:errcheck // ignore error
-	})
+	require.NoError(t, app.Listen(":99999", ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
 }
 
 // go test -run Test_Listen_TLSMinVersion
@@ -253,7 +241,36 @@ func Test_Listen_TLSMinVersion(t *testing.T) {
 	testPreforkMaster = true
 
 	app := New()
-	require.NoError(t, app.Listen(":99999", ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
+
+	// Invalid TLSMinVersion
+	require.Panics(t, func() {
+		_ = app.Listen(":443", ListenConfig{TLSMinVersion: tls.VersionTLS10}) //nolint:errcheck // ignore error
+	})
+	require.Panics(t, func() {
+		_ = app.Listen(":443", ListenConfig{TLSMinVersion: tls.VersionTLS11}) //nolint:errcheck // ignore error
+	})
+
+	// Prefork
+	require.Panics(t, func() {
+		_ = app.Listen(":443", ListenConfig{DisableStartupMessage: true, EnablePrefork: true, TLSMinVersion: tls.VersionTLS10}) //nolint:errcheck // ignore error
+	})
+	require.Panics(t, func() {
+		_ = app.Listen(":443", ListenConfig{DisableStartupMessage: true, EnablePrefork: true, TLSMinVersion: tls.VersionTLS11}) //nolint:errcheck // ignore error
+	})
+
+	// Valid TLSMinVersion
+	go func() {
+		time.Sleep(1000 * time.Millisecond)
+		assert.NoError(t, app.Shutdown())
+	}()
+	require.NoError(t, app.Listen(":0", ListenConfig{TLSMinVersion: tls.VersionTLS13}))
+
+	// Valid TLSMinVersion with Prefork
+	go func() {
+		time.Sleep(1000 * time.Millisecond)
+		assert.NoError(t, app.Shutdown())
+	}()
+	require.NoError(t, app.Listen(":99999", ListenConfig{DisableStartupMessage: true, EnablePrefork: true, TLSMinVersion: tls.VersionTLS13}))
 }
 
 // go test -run Test_Listen_TLS

--- a/listen_test.go
+++ b/listen_test.go
@@ -233,6 +233,26 @@ func Test_Listen_Prefork(t *testing.T) {
 
 	app := New()
 
+	require.Panics(t, func() {
+		_ = app.Listen(":443", ListenConfig{TLSMinVersion: tls.VersionTLS10}) //nolint:errcheck // ignore error
+	})
+	require.Panics(t, func() {
+		_ = app.Listen(":443", ListenConfig{TLSMinVersion: tls.VersionTLS11}) //nolint:errcheck // ignore error
+	})
+
+	require.Panics(t, func() {
+		_ = app.Listen(":443", ListenConfig{DisableStartupMessage: true, EnablePrefork: true, TLSMinVersion: tls.VersionTLS10}) //nolint:errcheck // ignore error
+	})
+	require.Panics(t, func() {
+		_ = app.Listen(":443", ListenConfig{DisableStartupMessage: true, EnablePrefork: true, TLSMinVersion: tls.VersionTLS11}) //nolint:errcheck // ignore error
+	})
+}
+
+// go test -run Test_Listen_TLSMinVersion
+func Test_Listen_TLSMinVersion(t *testing.T) {
+	testPreforkMaster = true
+
+	app := New()
 	require.NoError(t, app.Listen(":99999", ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
 }
 


### PR DESCRIPTION
This pull request introduces a new configuration option to set the minimum TLS version in the `listen.go` file. The most important changes include adding the `TLSMinVersion` field to the `ListenConfig` struct and updating the default configuration and relevant methods to use this new field.

### New TLS Configuration Option:

* [`listen.go`](diffhunk://#diff-8a6813f17ba53a53b4ca15776268eb3d32519867058e03351b87b7aea23b4978R53-R57): Added `TLSMinVersion` field to the `ListenConfig` struct to allow setting the minimum TLS version.
* [`listen.go`](diffhunk://#diff-8a6813f17ba53a53b4ca15776268eb3d32519867058e03351b87b7aea23b4978R136): Set the default value of `TLSMinVersion` to `tls.VersionTLS12` in the `listenConfigDefault` function.
* [`listen.go`](diffhunk://#diff-8a6813f17ba53a53b4ca15776268eb3d32519867058e03351b87b7aea23b4978R156-R159): Updated the `listenConfigDefault` function to ensure `TLSMinVersion` is set to `tls.VersionTLS12` if not provided.

### Code Updates to Use New Configuration:

* [`listen.go`](diffhunk://#diff-8a6813f17ba53a53b4ca15776268eb3d32519867058e03351b87b7aea23b4978L172-R182): Modified the `Listen` method to use the `TLSMinVersion` from the `ListenConfig` struct for the `tls.Config` object.

This commit will resolve #3239
