### PR TITLE
feat: Add Drop method to DefaultCtx for silent connection termination

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1980,7 +1980,6 @@ func (c *DefaultCtx) setRoute(route *Route) {
 }
 
 func (c *DefaultCtx) Drop() error {
-	conn := c.RequestCtx().Conn()
 	//nolint:wrapcheck // This must not be wrapped
-	return conn.Close()
+	return c.RequestCtx().Conn().Close()
 }

--- a/ctx.go
+++ b/ctx.go
@@ -1979,6 +1979,7 @@ func (c *DefaultCtx) setRoute(route *Route) {
 	c.route = route
 }
 
+// Drop closes the connection without sending a response.
 func (c *DefaultCtx) Drop() error {
 	//nolint:wrapcheck // This must not be wrapped
 	return c.RequestCtx().Conn().Close()

--- a/ctx.go
+++ b/ctx.go
@@ -1979,7 +1979,9 @@ func (c *DefaultCtx) setRoute(route *Route) {
 	c.route = route
 }
 
-// Drop closes the connection without sending a response.
+// Drop closes the underlying connection without sending any response headers or body.
+// This can be useful for silently terminating client connections, such as in DDoS mitigation
+// or when blocking access to sensitive endpoints.
 func (c *DefaultCtx) Drop() error {
 	//nolint:wrapcheck // error wrapping is avoided to keep the operation lightweight and focused on connection closure.
 	return c.RequestCtx().Conn().Close()

--- a/ctx.go
+++ b/ctx.go
@@ -1978,3 +1978,9 @@ func (c *DefaultCtx) setMatched(matched bool) {
 func (c *DefaultCtx) setRoute(route *Route) {
 	c.route = route
 }
+
+func (c *DefaultCtx) Drop() error {
+	conn := c.RequestCtx().Conn()
+	//nolint:wrapcheck // This must not be wrapped
+	return conn.Close()
+}

--- a/ctx.go
+++ b/ctx.go
@@ -1981,6 +1981,6 @@ func (c *DefaultCtx) setRoute(route *Route) {
 
 // Drop closes the connection without sending a response.
 func (c *DefaultCtx) Drop() error {
-	//nolint:wrapcheck // This must not be wrapped
+	//nolint:wrapcheck // error wrapping is avoided to keep the operation lightweight and focused on connection closure.
 	return c.RequestCtx().Conn().Close()
 }

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -350,4 +350,5 @@ type Ctx interface {
 	setIndexRoute(route int)
 	setMatched(matched bool)
 	setRoute(route *Route)
+	Drop() error
 }

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5847,6 +5847,20 @@ func Test_GenericParseTypeBoolean(t *testing.T) {
 	}
 }
 
+// go test -run Test_Ctx_Drop -v
+func Test_Ctx_Drop(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	app.Get("/block-me", func(c Ctx) error {
+		return c.Drop()
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/block-me", nil))
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
 // go test -run Test_GenericParseTypeString
 func Test_GenericParseTypeString(t *testing.T) {
 	t.Parallel()

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5872,7 +5872,7 @@ func Test_Ctx_Drop(t *testing.T) {
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/no-response", nil))
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	require.Equal(t, 200, resp.StatusCode)
+	require.Equal(t, StatusOK, resp.StatusCode)
 	require.Equal(t, "0", resp.Header.Get("Content-Length"))
 }
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5859,7 +5859,7 @@ func Test_Ctx_Drop(t *testing.T) {
 	})
 
 	// Additional handler that just calls return
-	app.Get("/no-response", func(c Ctx) error {
+	app.Get("/no-response", func(_ Ctx) error {
 		return nil
 	})
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5885,7 +5885,7 @@ func Test_Ctx_DropWithMiddleware(t *testing.T) {
 	// Middleware that calls Drop
 	app.Use(func(c Ctx) error {
 		err := c.Next()
-		c.Response().Header.Set("X-Test", "test")
+		c.Set("X-Test", "test")
 		return err
 	})
 
@@ -5898,10 +5898,6 @@ func Test_Ctx_DropWithMiddleware(t *testing.T) {
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/block-me", nil))
 	require.Error(t, err)
 	require.Nil(t, resp)
-	require.Panics(t, func() {
-		// panic: cannot read response body after it was closed
-		require.Equal(t, "test", resp.Header.Get("X-Test"))
-	})
 }
 
 // go test -run Test_GenericParseTypeString

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5852,13 +5852,28 @@ func Test_Ctx_Drop(t *testing.T) {
 	t.Parallel()
 
 	app := New()
+
+	// Handler that calls Drop
 	app.Get("/block-me", func(c Ctx) error {
 		return c.Drop()
 	})
 
+	// Additional handler that just calls return
+	app.Get("/no-response", func(c Ctx) error {
+		return nil
+	})
+
+	// Test the Drop method
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/block-me", nil))
 	require.Error(t, err)
 	require.Nil(t, resp)
+
+	// Test the no-response handler
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/no-response", nil))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, 200, resp.StatusCode)
+	require.Equal(t, "0", resp.Header.Get("Content-Length"))
 }
 
 // go test -run Test_GenericParseTypeString

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -480,7 +480,7 @@ app.Get("/", func(c fiber.Ctx) error {
     return c.Drop()
   }
 
-  return c.SendString("Hello, " + name)
+  return c.SendString("Hello World!")
 })
 ```
 

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -484,7 +484,6 @@ app.Get("/", func(c fiber.Ctx) error {
 })
 ```
 
-
 ## Format
 
 Performs content-negotiation on the [Accept](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) HTTP header. It uses [Accepts](ctx.md#accepts) to select a proper format from the supplied offers. A default handler can be provided by setting the `MediaType` to `"default"`. If no offers match and no default is provided, a 406 (Not Acceptable) response is sent. The Content-Type is automatically set when a handler is selected.

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -463,6 +463,28 @@ app.Get("/", func(c fiber.Ctx) error {
 })
 ```
 
+## Drop
+
+Terminates the client connection silently without sending any HTTP headers or response body.
+
+This can be used for scenarios where you want to block certain requests without notifying the client, such as mitigating
+DDoS attacks or protecting sensitive endpoints from unauthorized access.
+
+```go title="Signature"
+func (c fiber.Ctx) Drop() error
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  if c.IP() == "192.168.1.1" {
+    return c.Drop()
+  }
+
+  return c.SendString("Hello, " + name)
+})
+```
+
+
 ## Format
 
 Performs content-negotiation on the [Accept](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) HTTP header. It uses [Accepts](ctx.md#accepts) to select a proper format from the supplied offers. A default handler can be provided by setting the `MediaType` to `"default"`. If no offers match and no default is provided, a 406 (Not Acceptable) response is sent. The Content-Type is automatically set when a handler is selected.

--- a/middleware/cache/manager_msgp.go
+++ b/middleware/cache/manager_msgp.go
@@ -52,9 +52,6 @@ func (z *item) DecodeMsg(dc *msgp.Reader) (err error) {
 					err = msgp.WrapError(err, "headers", za0001)
 					return
 				}
-				if za0002 == nil {
-					za0002 = make([]byte, 0)
-				}
 				z.headers[za0001] = za0002
 			}
 		case "body":
@@ -269,9 +266,6 @@ func (z *item) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				if err != nil {
 					err = msgp.WrapError(err, "headers", za0001)
 					return
-				}
-				if za0002 == nil {
-					za0002 = make([]byte, 0)
 				}
 				z.headers[za0001] = za0002
 			}


### PR DESCRIPTION
# Description

This pull request introduces the Drop method to the DefaultCtx structure. The Drop method allows developers to silently terminate client connections without sending any HTTP headers or response body. This functionality is particularly useful for scenarios such as:

- Mitigating DDoS attacks.
- Blocking access to sensitive endpoints.
- Enhancing resource management by closing unwanted connections.

This addition aligns with Fiber’s goal of providing high-performance web server functionalities with fine-grained control.

Fixes #3252 

## Changes introduced

- [ ] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [ ] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [ ] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [ ] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [ ] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [ ] Examples: Provide examples demonstrating the new features or changes in action.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
