### PR TITLE
🧹 chore: Add parallel benchmark for Next()

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -903,11 +903,11 @@ func Benchmark_Router_Next_Default_Parallel(b *testing.B) {
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			fctx := &fasthttp.RequestCtx{}
-			fctx.Request.Header.SetMethod(MethodGet)
-			fctx.Request.SetRequestURI("/")
+		fctx := &fasthttp.RequestCtx{}
+		fctx.Request.Header.SetMethod(MethodGet)
+		fctx.Request.SetRequestURI("/")
 
+		for pb.Next() {
 			h(fctx)
 		}
 	})

--- a/router_test.go
+++ b/router_test.go
@@ -889,3 +889,26 @@ func Benchmark_Router_Next_Default(b *testing.B) {
 		h(fctx)
 	}
 }
+
+// go test -v ./... -run=^$ -bench=Benchmark_Router_Next_Default_Parallel -benchmem -count=4
+func Benchmark_Router_Next_Default_Parallel(b *testing.B) {
+	app := New()
+	app.Get("/", func(_ *Ctx) error {
+		return nil
+	})
+
+	h := app.Handler()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			fctx := &fasthttp.RequestCtx{}
+			fctx.Request.Header.SetMethod(MethodGet)
+			fctx.Request.SetRequestURI("/")
+
+			h(fctx)
+		}
+	})
+}


### PR DESCRIPTION
# Description

- Add `b.RunParallel()` version of the `Next()` benchmark.

# Results:

```bash
ubuntu@ubuntu:~/Desktop/git/fiber$ go test -benchmem -run=^$ -bench ^Benchmark_Router_Next_Default_Parallel$ github.com/gofiber/fiber/v2 -count=10
goos: linux
goarch: amd64
pkg: github.com/gofiber/fiber/v2
cpu: AMD Ryzen 7 7800X3D 8-Core Processor           
Benchmark_Router_Next_Default_Parallel-4   	143252916	         9.433 ns/op	       0 B/op	       0 allocs/op
Benchmark_Router_Next_Default_Parallel-4   	145309903	         8.137 ns/op	       0 B/op	       0 allocs/op
Benchmark_Router_Next_Default_Parallel-4   	146474128	         8.073 ns/op	       0 B/op	       0 allocs/op
Benchmark_Router_Next_Default_Parallel-4   	146365718	         8.013 ns/op	       0 B/op	       0 allocs/op
Benchmark_Router_Next_Default_Parallel-4   	148128357	         8.101 ns/op	       0 B/op	       0 allocs/op
Benchmark_Router_Next_Default_Parallel-4   	123850269	         8.106 ns/op	       0 B/op	       0 allocs/op
Benchmark_Router_Next_Default_Parallel-4   	146204302	         8.759 ns/op	       0 B/op	       0 allocs/op
Benchmark_Router_Next_Default_Parallel-4   	145994517	         8.156 ns/op	       0 B/op	       0 allocs/op
Benchmark_Router_Next_Default_Parallel-4   	146355158	         8.048 ns/op	       0 B/op	       0 allocs/op
Benchmark_Router_Next_Default_Parallel-4   	147689376	         8.131 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/gofiber/fiber/v2	20.460s
```