### PR TITLE
:bug: bug: make Render bind parameter type any again

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1369,7 +1369,7 @@ func (c *DefaultCtx) GetRouteURL(routeName string, params Map) (string, error) {
 
 // Render a template with data and sends a text/html response.
 // We support the following engines: https://github.com/gofiber/template
-func (c *DefaultCtx) Render(name string, bind Map, layouts ...string) error {
+func (c *DefaultCtx) Render(name string, bind any, layouts ...string) error {
 	// Get new buffer from pool
 	buf := bytebufferpool.Get()
 	defer bytebufferpool.Put(buf)

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -12,8 +12,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// Ctx represents the Context which hold the HTTP request and response.
-// It has methods for the request query string, parameters, body, HTTP headers and so on.
+// Ctx represents the Context which hold the HTTP request and response.\nIt has methods for the request query string, parameters, body, HTTP headers and so on.
 type Ctx interface {
 	// Accepts checks if the specified extensions or content types are acceptable.
 	Accepts(offers ...string) string
@@ -263,7 +262,7 @@ type Ctx interface {
 	GetRouteURL(routeName string, params Map) (string, error)
 	// Render a template with data and sends a text/html response.
 	// We support the following engines: https://github.com/gofiber/template
-	Render(name string, bind Map, layouts ...string) error
+	Render(name string, bind any, layouts ...string) error
 	renderExtensions(bind any)
 	// Route returns the matched Route struct.
 	Route() *Route

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -1506,7 +1506,7 @@ app.Get("/teapot", func(c fiber.Ctx) error {
 Renders a view with data and sends a `text/html` response. By default, `Render` uses the default [**Go Template engine**](https://pkg.go.dev/html/template/). If you want to use another view engine, please take a look at our [**Template middleware**](https://docs.gofiber.io/template).
 
 ```go title="Signature"
-func (c fiber.Ctx) Render(name string, bind Map, layouts ...string) error
+func (c fiber.Ctx) Render(name string, bind any, layouts ...string) error
 ```
 
 ## Request


### PR DESCRIPTION
# Description

bind parameter of Render method has been converted from `any` to `map[string]any` by me a long time ago to keep the parameter type-safe. However this change breaks some usecases such as using bind as struct etc. Therefore, let's revert the change.

Example usecase that `html/template` supports struct types as binding data: https://pkg.go.dev/html/template#example-package, 

Fixes https://github.com/gofiber/fiber/issues/3219

## Changes introduced
- [ ] Documentation Update: Detail the updates made to the documentation and links to the changed files.

## Type of change
- [x] Revert a change.
 
## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [ ] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [ ] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
