### PR TITLE
🩹 Fix: Fix app.Test() auto-failing when a connection is closed early

### DIFF
--- a/app.go
+++ b/app.go
@@ -1024,7 +1024,7 @@ func (app *App) Test(req *http.Request, config ...TestConfig) (*http.Response, e
 	}
 
 	// Check for errors
-	if err != nil && !errors.Is(err, fasthttp.ErrGetOnly) {
+	if err != nil && !errors.Is(err, fasthttp.ErrGetOnly) && !errors.Is(err, errTestConnClosed) {
 		return nil, err
 	}
 

--- a/app.go
+++ b/app.go
@@ -941,6 +941,8 @@ func (app *App) Hooks() *Hooks {
 	return app.hooks
 }
 
+var ErrTestGotEmptyResponse = errors.New("test: got empty response")
+
 // TestConfig is a struct holding Test settings
 type TestConfig struct {
 	// Timeout defines the maximum duration a
@@ -1033,7 +1035,7 @@ func (app *App) Test(req *http.Request, config ...TestConfig) (*http.Response, e
 	res, err := http.ReadResponse(buffer, req)
 	if err != nil {
 		if errors.Is(err, io.ErrUnexpectedEOF) {
-			return nil, errors.New("test: got empty response")
+			return nil, ErrTestGotEmptyResponse
 		}
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -1510,6 +1510,21 @@ func Test_App_Test_timeout_empty_response(t *testing.T) {
 	require.ErrorIs(t, err, ErrTestGotEmptyResponse)
 }
 
+func Test_App_Test_drop_empty_response(t *testing.T) {
+    t.Parallel()
+
+    app := New()
+    app.Get("/", func (c Ctx) error {
+        return c.Drop()
+    })
+
+    _, err := app.Test(httptest.NewRequest(MethodGet, "/", nil), TestConfig{
+        Timeout: 0,
+        FailOnTimeout: false,
+    })
+    require.ErrorIs(t, err, ErrTestGotEmptyResponse)
+}
+
 func Test_App_SetTLSHandler(t *testing.T) {
 	t.Parallel()
 	tlsHandler := &TLSHandler{clientHelloInfo: &tls.ClientHelloInfo{

--- a/app_test.go
+++ b/app_test.go
@@ -1491,7 +1491,7 @@ func Test_App_Test_timeout(t *testing.T) {
 		Timeout:       100 * time.Millisecond,
 		FailOnTimeout: true,
 	})
-	require.Equal(t, os.ErrDeadlineExceeded, err)
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
 }
 
 func Test_App_Test_timeout_empty_response(t *testing.T) {
@@ -1507,7 +1507,7 @@ func Test_App_Test_timeout_empty_response(t *testing.T) {
 		Timeout:       100 * time.Millisecond,
 		FailOnTimeout: false,
 	})
-	require.Equal(t, errors.New("test: got empty response"), err)
+	require.ErrorIs(t, err, ErrTestGotEmptyResponse)
 }
 
 func Test_App_SetTLSHandler(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -1514,12 +1514,12 @@ func Test_App_Test_drop_empty_response(t *testing.T) {
 	t.Parallel()
 
 	app := New()
-	app.Get("/", func (c Ctx) error {
+	app.Get("/", func(c Ctx) error {
 		return c.Drop()
 	})
 
 	_, err := app.Test(httptest.NewRequest(MethodGet, "/", nil), TestConfig{
-		Timeout: 0,
+		Timeout:       0,
 		FailOnTimeout: false,
 	})
 	require.ErrorIs(t, err, ErrTestGotEmptyResponse)

--- a/app_test.go
+++ b/app_test.go
@@ -1511,18 +1511,18 @@ func Test_App_Test_timeout_empty_response(t *testing.T) {
 }
 
 func Test_App_Test_drop_empty_response(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    app := New()
-    app.Get("/", func (c Ctx) error {
-        return c.Drop()
-    })
+	app := New()
+	app.Get("/", func (c Ctx) error {
+		return c.Drop()
+	})
 
-    _, err := app.Test(httptest.NewRequest(MethodGet, "/", nil), TestConfig{
-        Timeout: 0,
-        FailOnTimeout: false,
-    })
-    require.ErrorIs(t, err, ErrTestGotEmptyResponse)
+	_, err := app.Test(httptest.NewRequest(MethodGet, "/", nil), TestConfig{
+		Timeout: 0,
+		FailOnTimeout: false,
+	})
+	require.ErrorIs(t, err, ErrTestGotEmptyResponse)
 }
 
 func Test_App_SetTLSHandler(t *testing.T) {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5896,7 +5896,7 @@ func Test_Ctx_Drop(t *testing.T) {
 
 	// Test the Drop method
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/block-me", nil))
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTestGotEmptyResponse)
 	require.Nil(t, resp)
 
 	// Test the no-response handler
@@ -5927,7 +5927,7 @@ func Test_Ctx_DropWithMiddleware(t *testing.T) {
 
 	// Test the Drop method
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/block-me", nil))
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTestGotEmptyResponse)
 	require.Nil(t, resp)
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -612,6 +612,8 @@ func isNoCache(cacheControl string) bool {
 	return true
 }
 
+var errTestConnClosed = errors.New("testConn is closed")
+
 type testConn struct {
 	r        bytes.Buffer
 	w        bytes.Buffer
@@ -631,7 +633,7 @@ func (c *testConn) Write(b []byte) (int, error) {
 	defer c.Unlock()
 
 	if c.isClosed {
-		return 0, errors.New("testConn is closed")
+		return 0, errTestConnClosed
 	}
 	return c.w.Write(b) //nolint:wrapcheck // This must not be wrapped
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -548,7 +548,7 @@ func Test_Utils_TestConn_Closed_Write(t *testing.T) {
 	// Close early, write should fail
 	conn.Close() //nolint:errcheck, revive // It is fine to ignore the error here
 	_, err = conn.Write([]byte("Response 2\n"))
-	require.Error(t, err)
+	require.ErrorIs(t, err, errTestConnClosed)
 
 	res := make([]byte, 11)
 	_, err = conn.w.Read(res)


### PR DESCRIPTION
# Description

This PR fixes the bug where `app.Test()` auto-fails by returning `testConn is closed` if the underlying connection is closed during a `fiber.Handler`. Namely, `c.Drop()` falls under this category, as it calls `c.RequestCtx().Conn().Close()`.

To fix this, we do not return an error if the error matches with `errTestConnClosed`. If there was truly an error, it should return as `ErrTestGotEmptyResponse` due to an empty response (which should be expected when `c.Drop()` is called).

Fixes #3278

## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [ ] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [ ] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [ ] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [ ] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [X] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
  - This PR is a step to ensure that `app.Test()` is working as expected for new corner cases introduced in v3.
- [ ] Examples: Provide examples demonstrating the new features or changes in action.

## Type of change

- [X] Enhancement (improvement to existing features and functionality)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [X] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [X] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [X] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [X] Ensured that new and existing unit tests pass locally with the changes.
- [X] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [X] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
