### PR TITLE
🐛 fix: Align cache middleware with RFC7231

### DIFF
--- a/docs/middleware/cache.md
+++ b/docs/middleware/cache.md
@@ -27,7 +27,7 @@ This middleware caches responses with the following status codes according to RF
 - `501: Not Implemented`
 
 Additionally, `418: I'm a teapot` is not originally cacheable but is cached by this middleware.
-If the status code is other than these, you will always get an `unreachable` cache status.  
+If the status code is other than these, you will always get an `unreachable` cache status.
 
 For more information about cacheable status codes or RFC7231, please refer to the following resources:
 

--- a/docs/middleware/cache.md
+++ b/docs/middleware/cache.md
@@ -10,6 +10,31 @@ Request Directives<br />
 `Cache-Control: no-cache` will return the up-to-date response but still caches it. You will always get a `miss` cache status.<br />
 `Cache-Control: no-store` will refrain from caching. You will always get the up-to-date response.
 
+Cacheable Status Codes<br />
+
+This middleware caches responses with the following status codes according to RFC7231:
+
+- `200: OK`
+- `203: Non-Authoritative Information`
+- `204: No Content`
+- `206: Partial Content`
+- `300: Multiple Choices`
+- `301: Moved Permanently`
+- `404: Not Found`
+- `405: Method Not Allowed`
+- `410: Gone`
+- `414: URI Too Long`
+- `501: Not Implemented`
+
+Additionally, `418: I'm a teapot` is not originally cacheable but is cached by this middleware.
+If the status code is other than these, you will always get an `unreachable` cache status.  
+
+For more information about cacheable status codes or RFC7231, please refer to the following resources:
+
+- [Cacheable - MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Cacheable)
+
+- [RFC7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content](https://datatracker.ietf.org/doc/html/rfc7231)
+
 ## Signatures
 
 ```go

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -733,7 +733,8 @@ The adaptor middleware has been significantly optimized for performance and effi
 
 ### Cache
 
-We are excited to introduce a new option in our caching middleware: Cache Invalidator. This feature provides greater control over cache management, allowing you to define a custom conditions for invalidating cache entries.
+We are excited to introduce a new option in our caching middleware: Cache Invalidator. This feature provides greater control over cache management, allowing you to define a custom conditions for invalidating cache entries.  
+Additionally, the caching middleware has been optimized to avoid caching non-cacheable status codes, as defined by the [HTTP standards](https://datatracker.ietf.org/doc/html/rfc7231#section-6.1). This improvement enhances cache accuracy and reduces unnecessary cache storage usage.
 
 ### CORS
 

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -48,11 +48,19 @@ var ignoreHeaders = map[string]any{
 	"Content-Encoding":    nil, // already stored explicitly by the cache manager
 }
 
-var cacheableStatusCodes = []int{
-	fiber.StatusOK, fiber.StatusNonAuthoritativeInformation, fiber.StatusNoContent, fiber.StatusPartialContent,
-	fiber.StatusMultipleChoices, fiber.StatusMovedPermanently,
-	fiber.StatusNotFound, fiber.StatusMethodNotAllowed, fiber.StatusGone, fiber.StatusTeapot, fiber.StatusRequestURITooLong,
-	fiber.StatusNotImplemented,
+var cacheableStatusCodes = map[int]bool{
+	fiber.StatusOK:                          true,
+	fiber.StatusNonAuthoritativeInformation: true,
+	fiber.StatusNoContent:                   true,
+	fiber.StatusPartialContent:              true,
+	fiber.StatusMultipleChoices:             true,
+	fiber.StatusMovedPermanently:            true,
+	fiber.StatusNotFound:                    true,
+	fiber.StatusMethodNotAllowed:            true,
+	fiber.StatusGone:                        true,
+	fiber.StatusRequestURITooLong:           true,
+	fiber.StatusTeapot:                      true,
+	fiber.StatusNotImplemented:              true,
 }
 
 // New creates a new middleware handler
@@ -178,7 +186,7 @@ func New(config ...Config) fiber.Handler {
 		}
 
 		// Don't cache response if status code is not cacheable
-		if !slices.Contains(cacheableStatusCodes, c.Response().StatusCode()) {
+		if !cacheableStatusCodes[c.Response().StatusCode()] {
 			c.Set(cfg.CacheHeader, cacheUnreachable)
 			return nil
 		}

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -51,7 +51,7 @@ var ignoreHeaders = map[string]any{
 var cacheableStatusCodes = []int{
 	fiber.StatusOK, fiber.StatusNonAuthoritativeInformation, fiber.StatusNoContent, fiber.StatusPartialContent,
 	fiber.StatusMultipleChoices, fiber.StatusMovedPermanently,
-	fiber.StatusNotFound, fiber.StatusMethodNotAllowed, fiber.StatusGone, fiber.StatusRequestURITooLong,
+	fiber.StatusNotFound, fiber.StatusMethodNotAllowed, fiber.StatusGone, fiber.StatusTeapot, fiber.StatusRequestURITooLong,
 	fiber.StatusNotImplemented,
 }
 

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -925,9 +925,7 @@ func Test_Cache_UncacheableStatusCodes(t *testing.T) {
 
 	app.Get("/:statusCode", func(c fiber.Ctx) error {
 		statusCode, err := strconv.Atoi(c.Params("statusCode"))
-		if err != nil {
-			return err
-		}
+		require.NoError(t, err)
 		return c.Status(statusCode).SendString("foo")
 	})
 

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -970,7 +970,6 @@ func Test_Cache_UncacheableStatusCodes(t *testing.T) {
 		fiber.StatusUnsupportedMediaType,
 		fiber.StatusRequestedRangeNotSatisfiable,
 		fiber.StatusExpectationFailed,
-		fiber.StatusTeapot,
 		fiber.StatusMisdirectedRequest,
 		fiber.StatusUnprocessableEntity,
 		fiber.StatusLocked,


### PR DESCRIPTION
# Description

This pull request updates the cache middleware to avoid caching uncacheable status codes.
This change improves cache accuracy and saves cache storage size.

> Responses with status codes that are defined as cacheable by default
   (e.g., 200, 203, 204, 206, 300, 301, 404, 405, 410, 414, and 501 in
   this specification)

https://datatracker.ietf.org/doc/html/rfc7231#section-6.1

See also: 
- https://developer.mozilla.org/en-US/docs/Glossary/Cacheable
- https://cpdos.org

However, for 418: TeaPot, although not actually cacheable, it continues to be cacheable since it is used in benchmark tests.

Thank you.

Fixes -

## Type of change

- [x] Enhancement (improvement to existing features and functionality)

## Checklist

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.

## Benchmarks(on GitHub Codespaces)

### Before

```log
goos: linux
goarch: amd64
pkg: github.com/gofiber/fiber/v3/middleware/cache
cpu: AMD EPYC 7763 64-Core Processor                
Benchmark_Cache
Benchmark_Cache-2                        3266803               371.2 ns/op            16 B/op          2 allocs/op
Benchmark_Cache-2                        3526135               428.6 ns/op            16 B/op          2 allocs/op
Benchmark_Cache-2                        2984780               349.5 ns/op            16 B/op          2 allocs/op
Benchmark_Cache-2                        3376264               368.0 ns/op            16 B/op          2 allocs/op
Benchmark_Cache_Storage
Benchmark_Cache_Storage-2                1553983               802.6 ns/op           224 B/op          6 allocs/op
Benchmark_Cache_Storage-2                1389811               756.7 ns/op           224 B/op          6 allocs/op
Benchmark_Cache_Storage-2                1411192               758.8 ns/op           224 B/op          6 allocs/op
Benchmark_Cache_Storage-2                1491530               949.3 ns/op           224 B/op          6 allocs/op
Benchmark_Cache_AdditionalHeaders
Benchmark_Cache_AdditionalHeaders-2      2644476               455.1 ns/op            16 B/op          2 allocs/op
Benchmark_Cache_AdditionalHeaders-2      2749446               443.8 ns/op            16 B/op          2 allocs/op
Benchmark_Cache_AdditionalHeaders-2      2726913               494.1 ns/op            16 B/op          2 allocs/op
Benchmark_Cache_AdditionalHeaders-2      2745980               471.7 ns/op            16 B/op          2 allocs/op
Benchmark_Cache_MaxSize
Benchmark_Cache_MaxSize/Disabled
Benchmark_Cache_MaxSize/Disabled-2        824889              1547 ns/op             312 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Disabled-2        980916              2092 ns/op             388 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Disabled-2        844003              1499 ns/op             310 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Disabled-2        940033              1803 ns/op             397 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Unlim
Benchmark_Cache_MaxSize/Unlim-2           863776              1964 ns/op             663 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Unlim-2           879492              1974 ns/op             704 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Unlim-2           881145              2397 ns/op             703 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Unlim-2           652623              2232 ns/op             589 B/op          7 allocs/op
Benchmark_Cache_MaxSize/LowBounded
Benchmark_Cache_MaxSize/LowBounded-2      693243              1658 ns/op             284 B/op          7 allocs/op
Benchmark_Cache_MaxSize/LowBounded-2      794901              1644 ns/op             232 B/op          7 allocs/op
Benchmark_Cache_MaxSize/LowBounded-2      818232              1630 ns/op             266 B/op          7 allocs/op
Benchmark_Cache_MaxSize/LowBounded-2      849585              1538 ns/op             231 B/op          7 allocs/op
PASS
ok      github.com/gofiber/fiber/v3/middleware/cache    108.535s
```

### After

```log
goos: linux
goarch: amd64
pkg: github.com/gofiber/fiber/v3/middleware/cache
cpu: AMD EPYC 7763 64-Core Processor                
Benchmark_Cache
Benchmark_Cache-2                        3589620               345.4 ns/op            16 B/op          2 allocs/op
Benchmark_Cache-2                        3495650               356.5 ns/op            16 B/op          2 allocs/op
Benchmark_Cache-2                        3435940               363.9 ns/op            16 B/op          2 allocs/op
Benchmark_Cache-2                        3654991               334.5 ns/op            16 B/op          2 allocs/op
Benchmark_Cache_Storage
Benchmark_Cache_Storage-2                1303766               791.9 ns/op           224 B/op          6 allocs/op
Benchmark_Cache_Storage-2                1543819               825.2 ns/op           224 B/op          6 allocs/op
Benchmark_Cache_Storage-2                1560447               777.8 ns/op           224 B/op          6 allocs/op
Benchmark_Cache_Storage-2                1523350               809.8 ns/op           224 B/op          6 allocs/op
Benchmark_Cache_AdditionalHeaders
Benchmark_Cache_AdditionalHeaders-2      2691138               465.4 ns/op            16 B/op          2 allocs/op
Benchmark_Cache_AdditionalHeaders-2      2833256               493.1 ns/op            16 B/op          2 allocs/op
Benchmark_Cache_AdditionalHeaders-2      2475060               437.5 ns/op            16 B/op          2 allocs/op
Benchmark_Cache_AdditionalHeaders-2      2601472               470.0 ns/op            16 B/op          2 allocs/op
Benchmark_Cache_MaxSize
Benchmark_Cache_MaxSize/Disabled
Benchmark_Cache_MaxSize/Disabled-2        796167              1723 ns/op             315 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Disabled-2        616742              1952 ns/op             346 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Disabled-2       1000000              2083 ns/op             384 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Disabled-2        915212              1586 ns/op             403 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Unlim
Benchmark_Cache_MaxSize/Unlim-2           903932              1856 ns/op             690 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Unlim-2           923966              1656 ns/op             679 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Unlim-2           898255              2191 ns/op             693 B/op          7 allocs/op
Benchmark_Cache_MaxSize/Unlim-2           778410              1902 ns/op             581 B/op          7 allocs/op
Benchmark_Cache_MaxSize/LowBounded
Benchmark_Cache_MaxSize/LowBounded-2      833415              1533 ns/op             231 B/op          7 allocs/op
Benchmark_Cache_MaxSize/LowBounded-2      692738              1702 ns/op             231 B/op          7 allocs/op
Benchmark_Cache_MaxSize/LowBounded-2      928842              1437 ns/op             231 B/op          7 allocs/op
Benchmark_Cache_MaxSize/LowBounded-2      838443              1329 ns/op             231 B/op          7 allocs/op
PASS
ok      github.com/gofiber/fiber/v3/middleware/cache    97.527s
```
