### PR TITLE
📒 doc: Add ctx.Drop() to whats_new.md

### DIFF
--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -342,6 +342,7 @@ testConfig := fiber.TestConfig{
 - **ViewBind**: Binds data to a view, replacing the old `Bind` method.
 - **CBOR**: Introducing [CBOR](https://cbor.io/) binary encoding format for both request & response body. CBOR is a binary data serialization format which is both compact and efficient, making it ideal for use in web applications.
 - **End**: Similar to Express.js, immediately flushes the current response and closes the underlying connection.
+- **Drop**: Terminates the client connection silently without sending any HTTP headers or response body. This can be used for scenarios where you want to block certain requests without notifying the client, such as mitigating DDoS attacks or protecting sensitive endpoints from unauthorized access.
 
 ### Removed Methods
 


### PR DESCRIPTION
# Description

Added missing Drop() documentation to whats_new.md

Fixes #3282 

## Changes introduced


- [ :heavy_check_mark:  ] Documentation Update: Added missing Drop() documentation to whats_new.md. Link to the changed file: https://github.com/aliziyacevik/fiber/blob/master/docs/whats_new.md

## Type of change

- [ :heavy_check_mark: ] Documentation update (changes to documentation)


## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [ ] Conducted a self-review of the code and provided comments for complex or critical parts.
- [:heavy_check_mark:  ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [ ] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.


