### PR TITLE
🩹 Fix: goroutine leakage

### DIFF
--- a/app.go
+++ b/app.go
@@ -994,7 +994,7 @@ func (app *App) Test(req *http.Request, config ...TestConfig) (*http.Response, e
 	app.startupProcess()
 
 	// Serve conn to server
-	channel := make(chan error)
+	channel := make(chan error, 1)
 	go func() {
 		var returned bool
 		defer func() {

--- a/app_test.go
+++ b/app_test.go
@@ -57,6 +57,91 @@ func testErrorResponse(t *testing.T, err error, resp *http.Response, expectedBod
 	require.Equal(t, expectedBodyError, string(body), "Response body")
 }
 
+func Test_App_Test_Goroutine_Leak_Compare(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		handler    Handler
+		name       string
+		timeout    time.Duration
+		sleepTime  time.Duration
+		expectLeak bool
+	}{
+		{
+			name: "With timeout (potential leak)",
+			handler: func(c Ctx) error {
+				time.Sleep(300 * time.Millisecond) // Simulate time-consuming operation
+				return c.SendString("ok")
+			},
+			timeout:    50 * time.Millisecond,  // // Short timeout to ensure triggering
+			sleepTime:  500 * time.Millisecond, // Wait time longer than handler execution time
+			expectLeak: true,
+		},
+		{
+			name: "Without timeout (no leak)",
+			handler: func(c Ctx) error {
+				return c.SendString("ok") // Return immediately
+			},
+			timeout:    0, // Disable timeout
+			sleepTime:  100 * time.Millisecond,
+			expectLeak: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			app := New()
+
+			// Record initial goroutine count
+			initialGoroutines := runtime.NumGoroutine()
+			t.Logf("[%s] Initial goroutines: %d", tc.name, initialGoroutines)
+
+			app.Get("/", tc.handler)
+
+			// Send 10 requests
+			numRequests := 10
+			for i := 0; i < numRequests; i++ {
+				req := httptest.NewRequest(MethodGet, "/", nil)
+
+				if tc.timeout > 0 {
+					_, err := app.Test(req, TestConfig{
+						Timeout:       tc.timeout,
+						FailOnTimeout: true,
+					})
+					require.Error(t, err)
+					require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+				} else if resp, err := app.Test(req); err != nil {
+					t.Errorf("unexpected error: %v", err)
+				} else {
+					require.Equal(t, 200, resp.StatusCode)
+				}
+			}
+
+			// Wait for normal goroutines to complete
+			time.Sleep(tc.sleepTime)
+
+			// Check final goroutine count
+			finalGoroutines := runtime.NumGoroutine()
+			leakedGoroutines := finalGoroutines - initialGoroutines
+			t.Logf("[%s] Final goroutines: %d (leaked: %d)",
+				tc.name, finalGoroutines, leakedGoroutines)
+
+			if tc.expectLeak {
+				// before fix: If blocking exists, leaked goroutines should be at least equal to request count
+				// after fix: If no blocking exists, leaked goroutines should be less than request count
+				if leakedGoroutines >= numRequests {
+					t.Errorf("[%s] Expected at least %d leaked goroutines, but got %d",
+						tc.name, numRequests, leakedGoroutines)
+				}
+			} else if leakedGoroutines >= numRequests { // If no blocking exists, leaked goroutines should be less than request count
+				t.Errorf("[%s] Expected less than %d leaked goroutines, but got %d",
+					tc.name, numRequests, leakedGoroutines)
+			}
+		})
+	}
+}
+
 func Test_App_MethodNotAllowed(t *testing.T) {
 	t.Parallel()
 	app := New()


### PR DESCRIPTION
# Description

As mentioned in the #3304 , I modified the channel of the Test function to use a buffered channel, and added a unit test to verify goroutine leakage with and without a timeout.

Fixes #3304 

## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [x] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [ ] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [ ] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [ ] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [x] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [x] Examples: Provide examples demonstrating the new features or changes in action.

## Type of change

Please delete options that are not relevant.

- [x] Performance improvement (non-breaking change which improves efficiency)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
