### PR TITLE
🩹 Fix: genericParseType parsing large uint leads to overflow

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5522,6 +5522,10 @@ func Test_GenericParseTypeUints(t *testing.T) {
 			value: uint(4),
 			str:   "4",
 		},
+		{
+			value: ^uint(0),
+			str:   fmt.Sprintf("%d", ^uint(0)),
+		},
 	}
 
 	for _, test := range uints {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5524,7 +5524,7 @@ func Test_GenericParseTypeUints(t *testing.T) {
 		},
 		{
 			value: ^uint(0),
-			str:   fmt.Sprintf("%d", ^uint(0)),
+			str:   strconv.FormatUint(uint64(^uint(0)), 10),
 		},
 	}
 

--- a/helpers.go
+++ b/helpers.go
@@ -796,7 +796,7 @@ func genericParseType[V GenericType](str string, v V, defaultValue ...V) V {
 	case int64:
 		return genericParseInt[V](str, 64, func(i int64) V { return assertValueType[V, int64](i) }, defaultValue...)
 	case uint:
-		return genericParseUint[V](str, 32, func(i uint64) V { return assertValueType[V, uint](uint(i)) }, defaultValue...)
+		return genericParseUint[V](str, 0, func(i uint64) V { return assertValueType[V, uint](uint(i)) }, defaultValue...)
 	case uint8:
 		return genericParseUint[V](str, 8, func(i uint64) V { return assertValueType[V, uint8](uint8(i)) }, defaultValue...)
 	case uint16:


### PR DESCRIPTION
# Description

`genericParseType` parsing a large `uint` leads to overflow. When parsing `uint` string, the `bitSize` of `strconv.ParseUint` should be `0` instead of `32`.

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.
