### PR TITLE
🔥 Feature: BodyParser Now Automatically Parses File Fields in Multipart Requests

### DIFF
--- a/binder/form_test.go
+++ b/binder/form_test.go
@@ -265,8 +265,7 @@ func Test_FormBinder_ShouldBindMultipartFormWithMixedFileAndNumberFields(t *test
 	type Document struct {
 		File1    *multipart.FileHeader `form:"file1"`
 		File2    *multipart.FileHeader `form:"file2"`
-		FileSize int64                 `form:"file_size"` // Dosya boyutu için int64 alan
-
+		FileSize int64                 `form:"file_size"`
 	}
 
 	var doc Document


### PR DESCRIPTION
# Description

This pull request introduces improvements to the multipart form data binding functionality in the Fiber framework. The changes address issues related to binding complex data structures, including nested fields and file uploads, enhancing the overall usability and flexibility of form handling. Made to be compatible with fiber v3.

Fixes #3286

## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [x] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [ ] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [ ] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [ ] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [ ] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [ ] Examples: Provide examples demonstrating the new features or changes in action.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
