### PR TITLE
♻️ Refactor: Reduce the Memory Usage of ignoreHeaders

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -35,17 +35,17 @@ const (
 	noStore = "no-store"
 )
 
-var ignoreHeaders = map[string]any{
-	"Connection":          nil,
-	"Keep-Alive":          nil,
-	"Proxy-Authenticate":  nil,
-	"Proxy-Authorization": nil,
-	"TE":                  nil,
-	"Trailers":            nil,
-	"Transfer-Encoding":   nil,
-	"Upgrade":             nil,
-	"Content-Type":        nil, // already stored explicitly by the cache manager
-	"Content-Encoding":    nil, // already stored explicitly by the cache manager
+var ignoreHeaders = map[string]struct{}{
+	"Connection":          {},
+	"Keep-Alive":          {},
+	"Proxy-Authenticate":  {},
+	"Proxy-Authorization": {},
+	"TE":                  {},
+	"Trailers":            {},
+	"Transfer-Encoding":   {},
+	"Upgrade":             {},
+	"Content-Type":        {}, // already stored explicitly by the cache manager
+	"Content-Encoding":    {}, // already stored explicitly by the cache manager
 }
 
 var cacheableStatusCodes = map[int]bool{


### PR DESCRIPTION
# Description

When the value of a map is not used, using `struct{}` instead of `any`  can significantly reduce memory usage. The following experiment demonstrates the improvement:

+ Go 1.24: Memory usage reduced from **616** bytes to **456** bytes. (**-26%**)
+ Go 1.23: Memory usage reduced from **576** bytes to **288** bytes. (**-50%**)

This change helps optimize memory consumption, making it more efficient when the value is not needed.

Go 1.24 introduced optimizations in the map implementation, further affecting memory consumption.

```go
func main() {
	before := getMemUsage()
	ignoreHeaders := map[string]any{
		"Connection":          nil,
		"Keep-Alive":          nil,
		"Proxy-Authenticate":  nil,
		"Proxy-Authorization": nil,
		"TE":                  nil,
		"Trailers":            nil,
		"Transfer-Encoding":   nil,
		"Upgrade":             nil,
		"Content-Type":        nil,
		"Content-Encoding":    nil,
	}
	after := getMemUsage()
	fmt.Printf("Map memory usage: %d bytes\n", after-before)
	delete(ignoreHeaders, "")
}

func getMemUsage() uint64 {
	var m runtime.MemStats
	runtime.ReadMemStats(&m)
	return m.Alloc
}
```

+ In go 1.23: 576 bytes
+ In go 1.24: 616 bytes

```go
func main() {
	before := getMemUsage()
	ignoreHeaders := map[string]struct{}{
		"Connection":          {},
		"Keep-Alive":          {},
		"Proxy-Authenticate":  {},
		"Proxy-Authorization": {},
		"TE":                  {},
		"Trailers":            {},
		"Transfer-Encoding":   {},
		"Upgrade":             {},
		"Content-Type":        {},
		"Content-Encoding":    {},
	}
	after := getMemUsage()
	fmt.Printf("Map memory usage: %d bytes\n", after-before)
	delete(ignoreHeaders, "")
}

func getMemUsage() uint64 {
	var m runtime.MemStats
	runtime.ReadMemStats(&m)
	return m.Alloc
}
````

+ In go 1.23: 288 bytes
+ In go 1.24: 456 bytes

## Type of change

Please delete options that are not relevant.

- [x] Performance improvement (non-breaking change which improves efficiency)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.