### PR TITLE
🧹 chore: Fix linter workflow failures

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -37,4 +37,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           # NOTE: Keep this in sync with the version from .golangci.yml
-          version: v1.62.2
+          version: v1.64.7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ run:
 
 output:
   sort-results: true
-  uniq-by-line: false
 
 linters-settings:
   depguard:
@@ -97,6 +96,11 @@ linters-settings:
       global:
         # show-ignored: true # TODO: Enable this
         audit: true
+
+  staticcheck:
+    checks:
+      - all
+      - '-SA4023' # disable the rule SA4023
 
   govet:
     enable-all: true
@@ -249,8 +253,12 @@ issues:
   exclude-case-sensitive: true
   max-issues-per-linter: 0
   max-same-issues: 0
+  uniq-by-line: false
   exclude-dirs:
     - internal # TODO: Do not ignore interal packages
+  exclude-files:
+    - '_msgp\.go'
+    - '_msgp_test\.go'
   exclude-rules:
     - linters:
         - err113
@@ -358,7 +366,6 @@ linters:
     - stylecheck
     # - tagalign # TODO: Enable
     - tagliatelle
-    - tenv
     - testableexamples
     - testifylint
     # - testpackage # TODO: Enable

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ markdown:
 ## lint: 🚨 Run lint checks
 .PHONY: lint
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2 run ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.7 run ./...
 
 ## test: 🚦 Execute all tests
 .PHONY: test

--- a/client/hooks.go
+++ b/client/hooks.go
@@ -199,7 +199,7 @@ func parserRequestBody(c *Client, req *Request) error {
 	case filesBody:
 		return parserRequestBodyFile(req)
 	case rawBody:
-		if body, ok := req.body.([]byte); ok {
+		if body, ok := req.body.([]byte); ok { //nolint:revive // ignore simplicity
 			req.RawRequest.SetBody(body)
 		} else {
 			return ErrBodyType

--- a/listen.go
+++ b/listen.go
@@ -367,7 +367,7 @@ func (app *App) startupMessage(addr string, isTLS bool, pids string, cfg ListenC
 	}
 
 	fmt.Fprintf(out, "%s\n", fmt.Sprintf(figletFiberText, colors.Red+"v"+Version+colors.Reset)) //nolint:errcheck,revive // ignore error
-	fmt.Fprintf(out, strings.Repeat("-", 50)+"\n")                                              //nolint:errcheck,revive,govet // ignore error
+	fmt.Fprintf(out, strings.Repeat("-", 50)+"\n")                                              //nolint:errcheck,revive // ignore error
 
 	if host == "0.0.0.0" {
 		//nolint:errcheck,revive // ignore error


### PR DESCRIPTION
- Bump golangci-lint to v1.64.x
- Update configuration to ignore msgp files.