### PR TITLE
🧹 chore: Fix and update golangci-lint workflow

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -37,7 +37,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           # NOTE: Keep this in sync with the version from .golangci.yml
-          version: v1.64.7
-          skip-cache: true
-          verify: true
-          args: --config=.golangci.yml
+          version: v1.64
+          # NOTE(ldez): temporary workaround
+          install-mode: goinstall
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -253,7 +253,6 @@ issues:
   exclude-case-sensitive: true
   max-issues-per-linter: 0
   max-same-issues: 0
-  uniq-by-line: false
   exclude-dirs:
     - internal # TODO: Do not ignore internal packages
   exclude-files:
@@ -271,7 +270,10 @@ issues:
       linters:
         - bodyclose
         - err113
-  # fix: true
+    - source: 'fmt.Fprintf?'
+      linters:
+        - errcheck
+        - revive
 
 linters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -255,7 +255,7 @@ issues:
   max-same-issues: 0
   uniq-by-line: false
   exclude-dirs:
-    - internal # TODO: Do not ignore interal packages
+    - internal # TODO: Do not ignore internal packages
   exclude-files:
     - '_msgp\.go'
     - '_msgp_test\.go'

--- a/app.go
+++ b/app.go
@@ -1024,7 +1024,7 @@ func (app *App) Test(req *http.Request, config ...TestConfig) (*http.Response, e
 		select {
 		case err = <-channel:
 		case <-time.After(cfg.Timeout):
-			conn.Close() //nolint:errcheck, revive // It is fine to ignore the error here
+			conn.Close() //nolint:errcheck,revive // It is fine to ignore the error here
 			if cfg.FailOnTimeout {
 				return nil, os.ErrDeadlineExceeded
 			}

--- a/app_test.go
+++ b/app_test.go
@@ -403,7 +403,7 @@ func Test_App_serverErrorHandler_Internal_Error(t *testing.T) {
 	t.Parallel()
 	app := New()
 	msg := "test err"
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	app.serverErrorHandler(c.fasthttp, errors.New(msg))
 	require.Equal(t, string(c.fasthttp.Response.Body()), msg)
@@ -413,7 +413,7 @@ func Test_App_serverErrorHandler_Internal_Error(t *testing.T) {
 func Test_App_serverErrorHandler_Network_Error(t *testing.T) {
 	t.Parallel()
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	app.serverErrorHandler(c.fasthttp, &net.DNSError{
 		Err:       "test error",

--- a/bind_test.go
+++ b/bind_test.go
@@ -1378,7 +1378,7 @@ func Benchmark_Bind_URI(b *testing.B) {
 	var err error
 
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.route = &Route{
 		Params: []string{
@@ -1415,7 +1415,7 @@ func Benchmark_Bind_URI_Map(b *testing.B) {
 	var err error
 
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.route = &Route{
 		Params: []string{

--- a/client/helper_test.go
+++ b/client/helper_test.go
@@ -131,7 +131,7 @@ func testRequestFail(t *testing.T, handler fiber.Handler, wrapAgent func(agent *
 	}
 }
 
-func testClient(t *testing.T, handler fiber.Handler, wrapAgent func(agent *Client), excepted string, count ...int) { //nolint: unparam // maybe needed
+func testClient(t *testing.T, handler fiber.Handler, wrapAgent func(agent *Client), excepted string, count ...int) { //nolint:unparam // maybe needed
 	t.Helper()
 
 	app, ln, start := createHelperServer(t)

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -4585,7 +4585,7 @@ func Test_Ctx_SendStreamWriter(t *testing.T) {
 
 	err = c.SendStreamWriter(func(w *bufio.Writer) {
 		for lineNum := 1; lineNum <= 5; lineNum++ {
-			fmt.Fprintf(w, "Line %d\n", lineNum) //nolint:errcheck,revive // It is fine to ignore the error
+			fmt.Fprintf(w, "Line %d\n", lineNum)
 			if err := w.Flush(); err != nil {
 				t.Errorf("unexpected error: %s", err)
 				return
@@ -4607,7 +4607,7 @@ func Test_Ctx_SendStreamWriter_Interrupted(t *testing.T) {
 	app.Get("/", func(c Ctx) error {
 		return c.SendStreamWriter(func(w *bufio.Writer) {
 			for lineNum := 1; lineNum <= 5; lineNum++ {
-				fmt.Fprintf(w, "Line %d\n", lineNum) //nolint:errcheck // It is fine to ignore the error
+				fmt.Fprintf(w, "Line %d\n", lineNum)
 
 				if err := w.Flush(); err != nil {
 					if lineNum < 3 {
@@ -4951,11 +4951,11 @@ func Test_Ctx_BodyStreamWriter(t *testing.T) {
 	ctx := &fasthttp.RequestCtx{}
 
 	ctx.SetBodyStreamWriter(func(w *bufio.Writer) {
-		fmt.Fprintf(w, "body writer line 1\n") //nolint:errcheck // It is fine to ignore the error
+		fmt.Fprintf(w, "body writer line 1\n")
 		if err := w.Flush(); err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}
-		fmt.Fprintf(w, "body writer line 2\n") //nolint:errcheck // It is fine to ignore the error
+		fmt.Fprintf(w, "body writer line 2\n")
 	})
 
 	require.True(t, ctx.IsBodyStream())

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -192,7 +192,7 @@ func Test_Ctx_AcceptsCharsets(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_AcceptsCharsets -benchmem -count=4
 func Benchmark_Ctx_AcceptsCharsets(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.Request().Header.Set("Accept-Charset", "utf-8, iso-8859-1;q=0.5")
 	var res string
@@ -218,7 +218,7 @@ func Test_Ctx_AcceptsEncodings(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_AcceptsEncodings -benchmem -count=4
 func Benchmark_Ctx_AcceptsEncodings(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.Request().Header.Set(HeaderAcceptEncoding, "deflate, gzip;q=1.0, *;q=0.5")
 	var res string
@@ -243,7 +243,7 @@ func Test_Ctx_AcceptsLanguages(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_AcceptsLanguages -benchmem -count=4
 func Benchmark_Ctx_AcceptsLanguages(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.Request().Header.Set(HeaderAcceptLanguage, "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5")
 	var res string
@@ -304,7 +304,7 @@ func Test_Ctx_Append(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_Append -benchmem -count=4
 func Benchmark_Ctx_Append(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -337,7 +337,7 @@ func Test_Ctx_Attachment(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_Attachment -benchmem -count=4
 func Benchmark_Ctx_Attachment(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -363,7 +363,7 @@ func Test_Ctx_BaseURL(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_BaseURL -benchmem
 func Benchmark_Ctx_BaseURL(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.Request().SetHost("google.com:1337")
 	c.Request().URI().SetPath("/haha/oke/lol")
@@ -380,7 +380,7 @@ func Benchmark_Ctx_BaseURL(b *testing.B) {
 func Test_Ctx_Body(t *testing.T) {
 	t.Parallel()
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.Request().SetBody([]byte("john=doe"))
 	require.Equal(t, []byte("john=doe"), c.Body())
@@ -390,7 +390,7 @@ func Test_Ctx_Body(t *testing.T) {
 func Test_Ctx_BodyRaw(t *testing.T) {
 	t.Parallel()
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.Request().SetBodyRaw([]byte("john=doe"))
 	require.Equal(t, []byte("john=doe"), c.BodyRaw())
@@ -400,7 +400,7 @@ func Test_Ctx_BodyRaw(t *testing.T) {
 func Test_Ctx_BodyRaw_Immutable(t *testing.T) {
 	t.Parallel()
 	app := New(Config{Immutable: true})
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.Request().SetBodyRaw([]byte("john=doe"))
 	require.Equal(t, []byte("john=doe"), c.BodyRaw())
@@ -411,7 +411,7 @@ func Benchmark_Ctx_Body(b *testing.B) {
 	const input = "john=doe"
 
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.Request().SetBody([]byte(input))
 	b.ReportAllocs()
@@ -428,7 +428,7 @@ func Benchmark_Ctx_BodyRaw(b *testing.B) {
 	const input = "john=doe"
 
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.Request().SetBodyRaw([]byte(input))
 	b.ReportAllocs()
@@ -445,7 +445,7 @@ func Benchmark_Ctx_BodyRaw_Immutable(b *testing.B) {
 	const input = "john=doe"
 
 	app := New(Config{Immutable: true})
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.Request().SetBodyRaw([]byte(input))
 	b.ReportAllocs()
@@ -462,7 +462,7 @@ func Test_Ctx_Body_Immutable(t *testing.T) {
 	t.Parallel()
 	app := New()
 	app.config.Immutable = true
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.Request().SetBody([]byte("john=doe"))
 	require.Equal(t, []byte("john=doe"), c.Body())
@@ -474,7 +474,7 @@ func Benchmark_Ctx_Body_Immutable(b *testing.B) {
 
 	app := New()
 	app.config.Immutable = true
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.Request().SetBody([]byte(input))
 	b.ReportAllocs()
@@ -527,7 +527,7 @@ func Test_Ctx_Body_With_Compression(t *testing.T) {
 		t.Run(tCase.name, func(t *testing.T) {
 			t.Parallel()
 			app := New()
-			c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+			c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 			c.Request().Header.Set("Content-Encoding", tCase.contentEncoding)
 
 			if strings.Contains(tCase.contentEncoding, "gzip") {
@@ -720,7 +720,7 @@ func Test_Ctx_Body_With_Compression_Immutable(t *testing.T) {
 			t.Parallel()
 			app := New()
 			app.config.Immutable = true
-			c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+			c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 			c.Request().Header.Set("Content-Encoding", tCase.contentEncoding)
 
 			if strings.Contains(tCase.contentEncoding, "gzip") {
@@ -897,7 +897,7 @@ func Test_Ctx_Context(t *testing.T) {
 		t.Parallel()
 		testKey := struct{}{}
 		testValue := "Test Value"
-		ctx := context.WithValue(context.Background(), testKey, testValue) //nolint: staticcheck // not needed for tests
+		ctx := context.WithValue(context.Background(), testKey, testValue) //nolint:staticcheck // not needed for tests
 		require.Equal(t, testValue, ctx.Value(testKey))
 	})
 }
@@ -910,7 +910,7 @@ func Test_Ctx_SetContext(t *testing.T) {
 
 	testKey := struct{}{}
 	testValue := "Test Value"
-	ctx := context.WithValue(context.Background(), testKey, testValue) //nolint: staticcheck // not needed for tests
+	ctx := context.WithValue(context.Background(), testKey, testValue) //nolint:staticcheck // not needed for tests
 	c.SetContext(ctx)
 	require.Equal(t, testValue, c.Context().Value(testKey))
 }
@@ -930,7 +930,7 @@ func Test_Ctx_Context_Multiple_Requests(t *testing.T) {
 		}
 
 		input := utils.CopyString(Query(c, "input", "NO_VALUE"))
-		ctx = context.WithValue(ctx, testKey, fmt.Sprintf("%s_%s", testValue, input)) //nolint: staticcheck // not needed for tests
+		ctx = context.WithValue(ctx, testKey, fmt.Sprintf("%s_%s", testValue, input)) //nolint:staticcheck // not needed for tests
 		c.SetContext(ctx)
 
 		return c.Status(StatusOK).SendString(fmt.Sprintf("resp_%s_returned", input))
@@ -1013,7 +1013,7 @@ func Test_Ctx_Cookie(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_Cookie -benchmem -count=4
 func Benchmark_Ctx_Cookie(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -1544,12 +1544,12 @@ func Test_Ctx_Binders(t *testing.T) {
 	t.Run("URI", func(t *testing.T) {
 		t.Skip("URI is not ready for v3")
 		//nolint:gocritic // TODO: uncomment
-		//t.Parallel()
-		//withValues(t, func(c Ctx, testStruct *TestStruct) error {
+		// t.Parallel()
+		// withValues(t, func(c Ctx, testStruct *TestStruct) error {
 		//	c.Route().Params = []string{"name", "name2", "class", "class2"}
 		//	c.Params().value = [30]string{"foo", "bar", "111", "222"}
 		//	return c.Bind().URI(testStruct)
-		//})
+		// })
 	})
 	t.Run("ReqHeader", func(t *testing.T) {
 		t.Parallel()
@@ -2566,7 +2566,7 @@ func Test_Ctx_Params_Case_Sensitive(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_Params -benchmem -count=4
 func Benchmark_Ctx_Params(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.route = &Route{
 		Params: []string{
@@ -3746,7 +3746,7 @@ func Benchmark_Ctx_CBOR(b *testing.B) {
 func Benchmark_Ctx_JSON_Ctype(b *testing.B) {
 	app := New()
 	// TODO: Check extra allocs because of the interface stuff
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 	type SomeStruct struct {
 		Name string
 		Age  uint8
@@ -3813,7 +3813,7 @@ func Test_Ctx_JSONP(t *testing.T) {
 // go test -v  -run=^$ -bench=Benchmark_Ctx_JSONP -benchmem -count=4
 func Benchmark_Ctx_JSONP(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	type SomeStruct struct {
 		Name string
@@ -3838,7 +3838,7 @@ func Benchmark_Ctx_JSONP(b *testing.B) {
 func Test_Ctx_XML(t *testing.T) {
 	t.Parallel()
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	require.Error(t, c.JSON(complex(1, 1)))
 
@@ -3897,7 +3897,7 @@ func Test_Ctx_XML(t *testing.T) {
 // go test -run=^$ -bench=Benchmark_Ctx_XML -benchmem -count=4
 func Benchmark_Ctx_XML(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 	type SomeStruct struct {
 		Name string `xml:"Name"`
 		Age  uint8  `xml:"Age"`
@@ -3936,7 +3936,7 @@ func Test_Ctx_Links(t *testing.T) {
 // go test -v  -run=^$ -bench=Benchmark_Ctx_Links -benchmem -count=4
 func Benchmark_Ctx_Links(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -4363,7 +4363,7 @@ func Benchmark_Ctx_Render_Engine(b *testing.B) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_Get_Location_From_Route -benchmem -count=4
 func Benchmark_Ctx_Get_Location_From_Route(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	app.Get("/user/:name", func(c Ctx) error {
 		return c.SendString(c.Params("name"))
@@ -4578,14 +4578,14 @@ func Test_Ctx_SendStreamWriter(t *testing.T) {
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 
 	err := c.SendStreamWriter(func(w *bufio.Writer) {
-		w.WriteString("Don't crash please") //nolint:errcheck, revive // It is fine to ignore the error
+		w.WriteString("Don't crash please") //nolint:errcheck,revive // It is fine to ignore the error
 	})
 	require.NoError(t, err)
 	require.Equal(t, "Don't crash please", string(c.Response().Body()))
 
 	err = c.SendStreamWriter(func(w *bufio.Writer) {
 		for lineNum := 1; lineNum <= 5; lineNum++ {
-			fmt.Fprintf(w, "Line %d\n", lineNum) //nolint:errcheck, revive // It is fine to ignore the error
+			fmt.Fprintf(w, "Line %d\n", lineNum) //nolint:errcheck,revive // It is fine to ignore the error
 			if err := w.Flush(); err != nil {
 				t.Errorf("unexpected error: %s", err)
 				return
@@ -4728,7 +4728,7 @@ func Benchmark_Ctx_Type(b *testing.B) {
 // go test -v  -run=^$ -bench=Benchmark_Ctx_Type_Charset -benchmem -count=4
 func Benchmark_Ctx_Type_Charset(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -4753,7 +4753,7 @@ func Test_Ctx_Vary(t *testing.T) {
 // go test -v  -run=^$ -bench=Benchmark_Ctx_Vary -benchmem -count=4
 func Benchmark_Ctx_Vary(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -4806,7 +4806,7 @@ func Test_Ctx_Writef(t *testing.T) {
 // go test -v -run=^$ -bench=Benchmark_Ctx_Writef -benchmem -count=4
 func Benchmark_Ctx_Writef(b *testing.B) {
 	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	world := "World!"
 	b.ReportAllocs()
@@ -4951,11 +4951,11 @@ func Test_Ctx_BodyStreamWriter(t *testing.T) {
 	ctx := &fasthttp.RequestCtx{}
 
 	ctx.SetBodyStreamWriter(func(w *bufio.Writer) {
-		fmt.Fprintf(w, "body writer line 1\n") //nolint: errcheck // It is fine to ignore the error
+		fmt.Fprintf(w, "body writer line 1\n") //nolint:errcheck // It is fine to ignore the error
 		if err := w.Flush(); err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}
-		fmt.Fprintf(w, "body writer line 2\n") //nolint: errcheck // It is fine to ignore the error
+		fmt.Fprintf(w, "body writer line 2\n") //nolint:errcheck // It is fine to ignore the error
 	})
 
 	require.True(t, ctx.IsBodyStream())

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -566,7 +566,7 @@ func Test_Utils_TestConn_Closed_Write(t *testing.T) {
 	require.NoError(t, err)
 
 	// Close early, write should fail
-	conn.Close() //nolint:errcheck, revive // It is fine to ignore the error here
+	conn.Close() //nolint:errcheck,revive // It is fine to ignore the error here
 	_, err = conn.Write([]byte("Response 2\n"))
 	require.ErrorIs(t, err, errTestConnClosed)
 

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -209,7 +209,7 @@ func Benchmark_Memory_Set(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = testStore.Set("john", []byte("doe"), 0) //nolint: errcheck // error not needed for benchmark
+		_ = testStore.Set("john", []byte("doe"), 0) //nolint:errcheck // error not needed for benchmark
 	}
 }
 
@@ -220,7 +220,7 @@ func Benchmark_Memory_Set_Parallel(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_ = testStore.Set("john", []byte("doe"), 0) //nolint: errcheck // error not needed for benchmark
+			_ = testStore.Set("john", []byte("doe"), 0) //nolint:errcheck // error not needed for benchmark
 		}
 	})
 }
@@ -259,7 +259,7 @@ func Benchmark_Memory_Get(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = testStore.Get("john") //nolint: errcheck // error not needed for benchmark
+		_, _ = testStore.Get("john") //nolint:errcheck // error not needed for benchmark
 	}
 }
 
@@ -273,7 +273,7 @@ func Benchmark_Memory_Get_Parallel(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_, _ = testStore.Get("john") //nolint: errcheck // error not needed for benchmark
+			_, _ = testStore.Get("john") //nolint:errcheck // error not needed for benchmark
 		}
 	})
 }
@@ -315,8 +315,8 @@ func Benchmark_Memory_SetAndDelete(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = testStore.Set("john", []byte("doe"), 0) //nolint: errcheck // error not needed for benchmark
-		_ = testStore.Delete("john")                //nolint: errcheck // error not needed for benchmark
+		_ = testStore.Set("john", []byte("doe"), 0) //nolint:errcheck // error not needed for benchmark
+		_ = testStore.Delete("john")                //nolint:errcheck // error not needed for benchmark
 	}
 }
 
@@ -327,8 +327,8 @@ func Benchmark_Memory_SetAndDelete_Parallel(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_ = testStore.Set("john", []byte("doe"), 0) //nolint: errcheck // error not needed for benchmark
-			_ = testStore.Delete("john")                //nolint: errcheck // error not needed for benchmark
+			_ = testStore.Set("john", []byte("doe"), 0) //nolint:errcheck // error not needed for benchmark
+			_ = testStore.Delete("john")                //nolint:errcheck // error not needed for benchmark
 		}
 	})
 }

--- a/listen.go
+++ b/listen.go
@@ -366,38 +366,35 @@ func (app *App) startupMessage(addr string, isTLS bool, pids string, cfg ListenC
 		out = colorable.NewNonColorable(os.Stdout)
 	}
 
-	fmt.Fprintf(out, "%s\n", fmt.Sprintf(figletFiberText, colors.Red+"v"+Version+colors.Reset)) //nolint:errcheck,revive // ignore error
-	fmt.Fprintf(out, strings.Repeat("-", 50)+"\n")                                              //nolint:errcheck,revive // ignore error
+	fmt.Fprintf(out, "%s\n", fmt.Sprintf(figletFiberText, colors.Red+"v"+Version+colors.Reset))
+	fmt.Fprintf(out, strings.Repeat("-", 50)+"\n")
 
 	if host == "0.0.0.0" {
-		//nolint:errcheck,revive // ignore error
 		fmt.Fprintf(out,
 			"%sINFO%s Server started on: \t%s%s://127.0.0.1:%s%s (bound on host 0.0.0.0 and port %s)\n",
 			colors.Green, colors.Reset, colors.Blue, scheme, port, colors.Reset, port)
 	} else {
-		//nolint:errcheck,revive // ignore error
 		fmt.Fprintf(out,
 			"%sINFO%s Server started on: \t%s%s%s\n",
 			colors.Green, colors.Reset, colors.Blue, fmt.Sprintf("%s://%s:%s", scheme, host, port), colors.Reset)
 	}
 
 	if app.config.AppName != "" {
-		fmt.Fprintf(out, "%sINFO%s Application name: \t\t%s%s%s\n", colors.Green, colors.Reset, colors.Blue, app.config.AppName, colors.Reset) //nolint:errcheck,revive // ignore error
+		fmt.Fprintf(out, "%sINFO%s Application name: \t\t%s%s%s\n", colors.Green, colors.Reset, colors.Blue, app.config.AppName, colors.Reset)
 	}
 
-	//nolint:errcheck,revive // ignore error
 	fmt.Fprintf(out,
 		"%sINFO%s Total handlers count: \t%s%s%s\n",
 		colors.Green, colors.Reset, colors.Blue, strconv.Itoa(int(app.handlersCount)), colors.Reset)
 
 	if isPrefork == "Enabled" {
-		fmt.Fprintf(out, "%sINFO%s Prefork: \t\t\t%s%s%s\n", colors.Green, colors.Reset, colors.Blue, isPrefork, colors.Reset) //nolint:errcheck,revive // ignore error
+		fmt.Fprintf(out, "%sINFO%s Prefork: \t\t\t%s%s%s\n", colors.Green, colors.Reset, colors.Blue, isPrefork, colors.Reset)
 	} else {
-		fmt.Fprintf(out, "%sINFO%s Prefork: \t\t\t%s%s%s\n", colors.Green, colors.Reset, colors.Red, isPrefork, colors.Reset) //nolint:errcheck,revive // ignore error
+		fmt.Fprintf(out, "%sINFO%s Prefork: \t\t\t%s%s%s\n", colors.Green, colors.Reset, colors.Red, isPrefork, colors.Reset)
 	}
 
-	fmt.Fprintf(out, "%sINFO%s PID: \t\t\t%s%v%s\n", colors.Green, colors.Reset, colors.Blue, os.Getpid(), colors.Reset)       //nolint:errcheck,revive // ignore error
-	fmt.Fprintf(out, "%sINFO%s Total process count: \t%s%s%s\n", colors.Green, colors.Reset, colors.Blue, procs, colors.Reset) //nolint:errcheck,revive // ignore error
+	fmt.Fprintf(out, "%sINFO%s PID: \t\t\t%s%v%s\n", colors.Green, colors.Reset, colors.Blue, os.Getpid(), colors.Reset)
+	fmt.Fprintf(out, "%sINFO%s Total process count: \t%s%s%s\n", colors.Green, colors.Reset, colors.Blue, procs, colors.Reset)
 
 	if cfg.EnablePrefork {
 		// Turn the `pids` variable (in the form ",a,b,c,d,e,f,etc") into a slice of PIDs
@@ -408,7 +405,7 @@ func (app *App) startupMessage(addr string, isTLS bool, pids string, cfg ListenC
 			}
 		}
 
-		fmt.Fprintf(out, "%sINFO%s Child PIDs: \t\t%s", colors.Green, colors.Reset, colors.Blue) //nolint:errcheck,revive // ignore error
+		fmt.Fprintf(out, "%sINFO%s Child PIDs: \t\t%s", colors.Green, colors.Reset, colors.Blue)
 		totalPids := len(pidSlice)
 		rowTotalPidCount := 10
 
@@ -421,17 +418,17 @@ func (app *App) startupMessage(addr string, isTLS bool, pids string, cfg ListenC
 			}
 
 			for n, pid := range pidSlice[start:end] {
-				fmt.Fprintf(out, "%s", pid) //nolint:errcheck,revive // ignore error
+				fmt.Fprintf(out, "%s", pid)
 				if n+1 != len(pidSlice[start:end]) {
-					fmt.Fprintf(out, ", ") //nolint:errcheck,revive // ignore error
+					fmt.Fprintf(out, ", ")
 				}
 			}
-			fmt.Fprintf(out, "\n%s", colors.Reset) //nolint:errcheck,revive // ignore error
+			fmt.Fprintf(out, "\n%s", colors.Reset)
 		}
 	}
 
 	// add new Line as spacer
-	fmt.Fprintf(out, "\n%s", colors.Reset) //nolint:errcheck,revive // ignore error
+	fmt.Fprintf(out, "\n%s", colors.Reset)
 }
 
 // printRoutesMessage print all routes with method, path, name and handlers
@@ -473,11 +470,10 @@ func (app *App) printRoutesMessage() {
 		return routes[i].path < routes[j].path
 	})
 
-	fmt.Fprintf(w, "%smethod\t%s| %spath\t%s| %sname\t%s| %shandlers\t%s\n", colors.Blue, colors.White, colors.Green, colors.White, colors.Cyan, colors.White, colors.Yellow, colors.Reset) //nolint:errcheck,revive // ignore error
-	fmt.Fprintf(w, "%s------\t%s| %s----\t%s| %s----\t%s| %s--------\t%s\n", colors.Blue, colors.White, colors.Green, colors.White, colors.Cyan, colors.White, colors.Yellow, colors.Reset) //nolint:errcheck,revive // ignore error
+	fmt.Fprintf(w, "%smethod\t%s| %spath\t%s| %sname\t%s| %shandlers\t%s\n", colors.Blue, colors.White, colors.Green, colors.White, colors.Cyan, colors.White, colors.Yellow, colors.Reset)
+	fmt.Fprintf(w, "%s------\t%s| %s----\t%s| %s----\t%s| %s--------\t%s\n", colors.Blue, colors.White, colors.Green, colors.White, colors.Cyan, colors.White, colors.Yellow, colors.Reset)
 
 	for _, route := range routes {
-		//nolint:errcheck,revive // ignore error
 		fmt.Fprintf(w, "%s%s\t%s| %s%s\t%s| %s%s\t%s| %s%s%s\n", colors.Blue, route.method, colors.White, colors.Green, route.path, colors.White, colors.Cyan, route.name, colors.White, colors.Yellow, route.handlers, colors.Reset)
 	}
 

--- a/listen.go
+++ b/listen.go
@@ -328,7 +328,7 @@ func (*App) prepareListenData(addr string, isTLS bool, cfg ListenConfig) ListenD
 }
 
 // startupMessage prepares the startup message with the handler number, port, address and other information
-func (app *App) startupMessage(addr string, isTLS bool, pids string, cfg ListenConfig) { //nolint: revive // Accepting a bool param named isTLS if fine here
+func (app *App) startupMessage(addr string, isTLS bool, pids string, cfg ListenConfig) { //nolint:revive // Accepting a bool param named isTLS if fine here
 	// ignore child processes
 	if IsChild() {
 		return

--- a/log/default.go
+++ b/log/default.go
@@ -53,9 +53,9 @@ func (l *defaultLogger) privateLogf(lv Level, format string, fmtArgs []any) {
 	buf.WriteString(level)
 
 	if len(fmtArgs) > 0 {
-		_, _ = fmt.Fprintf(buf, format, fmtArgs...) //nolint:errcheck // It is fine to ignore the error
+		_, _ = fmt.Fprintf(buf, format, fmtArgs...)
 	} else {
-		_, _ = fmt.Fprint(buf, fmtArgs...) //nolint:errcheck // It is fine to ignore the error
+		_, _ = fmt.Fprint(buf, fmtArgs...)
 	}
 
 	_ = l.stdlog.Output(l.depth, buf.String()) //nolint:errcheck // It is fine to ignore the error

--- a/log/default.go
+++ b/log/default.go
@@ -53,9 +53,9 @@ func (l *defaultLogger) privateLogf(lv Level, format string, fmtArgs []any) {
 	buf.WriteString(level)
 
 	if len(fmtArgs) > 0 {
-		_, _ = fmt.Fprintf(buf, format, fmtArgs...) //nolint: errcheck // It is fine to ignore the error
+		_, _ = fmt.Fprintf(buf, format, fmtArgs...) //nolint:errcheck // It is fine to ignore the error
 	} else {
-		_, _ = fmt.Fprint(buf, fmtArgs...) //nolint: errcheck // It is fine to ignore the error
+		_, _ = fmt.Fprint(buf, fmtArgs...) //nolint:errcheck // It is fine to ignore the error
 	}
 
 	_ = l.stdlog.Output(l.depth, buf.String()) //nolint:errcheck // It is fine to ignore the error

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -1,4 +1,4 @@
-//nolint:contextcheck, revive // Much easier to just ignore memory leaks in tests
+//nolint:contextcheck,revive // Much easier to just ignore memory leaks in tests
 package adaptor
 
 import (

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -68,7 +68,7 @@ func Test_HTTPHandler(t *testing.T) {
 		w.Header().Set("Header1", "value1")
 		w.Header().Set("Header2", "value2")
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "request body is %q", body) //nolint:errcheck // not needed
+		fmt.Fprintf(w, "request body is %q", body)
 	}
 	fiberH := HTTPHandlerFunc(http.HandlerFunc(nethttpH))
 	fiberH = setFiberContextValueMiddleware(fiberH, expectedContextKey, expectedContextValue)

--- a/middleware/logger/default_logger.go
+++ b/middleware/logger/default_logger.go
@@ -166,7 +166,7 @@ func writeLog(w io.Writer, msg []byte) {
 		// Write error to output
 		if _, err := w.Write([]byte(err.Error())); err != nil {
 			// There is something wrong with the given io.Writer
-			_, _ = fmt.Fprintf(os.Stderr, "Failed to write to log, %v\n", err) //nolint:errcheck // It is fine to ignore the error
+			_, _ = fmt.Fprintf(os.Stderr, "Failed to write to log, %v\n", err)
 		}
 	}
 }

--- a/middleware/logger/default_logger.go
+++ b/middleware/logger/default_logger.go
@@ -166,7 +166,7 @@ func writeLog(w io.Writer, msg []byte) {
 		// Write error to output
 		if _, err := w.Write([]byte(err.Error())); err != nil {
 			// There is something wrong with the given io.Writer
-			_, _ = fmt.Fprintf(os.Stderr, "Failed to write to log, %v\n", err) //nolint: errcheck // It is fine to ignore the error
+			_, _ = fmt.Fprintf(os.Stderr, "Failed to write to log, %v\n", err) //nolint:errcheck // It is fine to ignore the error
 		}
 	}
 }

--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -865,7 +865,7 @@ func Test_Logger_ByteSent_Streaming(t *testing.T) {
 			for {
 				i++
 				msg := fmt.Sprintf("%d - the time is %v", i, time.Now())
-				fmt.Fprintf(w, "data: Message: %s\n\n", msg) //nolint:errcheck // ignore error
+				fmt.Fprintf(w, "data: Message: %s\n\n", msg)
 				err := w.Flush()
 				if err != nil {
 					break
@@ -1049,7 +1049,7 @@ func Benchmark_Logger(b *testing.B) {
 				for {
 					i++
 					msg := fmt.Sprintf("%d - the time is %v", i, time.Now())
-					fmt.Fprintf(w, "data: Message: %s\n\n", msg) //nolint:errcheck // ignore error
+					fmt.Fprintf(w, "data: Message: %s\n\n", msg)
 					err := w.Flush()
 					if err != nil {
 						break
@@ -1217,7 +1217,7 @@ func Benchmark_Logger_Parallel(b *testing.B) {
 				for {
 					i++
 					msg := fmt.Sprintf("%d - the time is %v", i, time.Now())
-					fmt.Fprintf(w, "data: Message: %s\n\n", msg) //nolint:errcheck // ignore error
+					fmt.Fprintf(w, "data: Message: %s\n\n", msg)
 					err := w.Flush()
 					if err != nil {
 						break

--- a/path.go
+++ b/path.go
@@ -487,7 +487,7 @@ func splitNonEscaped(s, sep string) []string {
 }
 
 // getMatch parses the passed url and tries to match it against the route segments and determine the parameter positions
-func (parser *routeParser) getMatch(detectionPath, path string, params *[maxParams]string, partialCheck bool) bool { //nolint: revive // Accepting a bool param is fine here
+func (parser *routeParser) getMatch(detectionPath, path string, params *[maxParams]string, partialCheck bool) bool { //nolint:revive // Accepting a bool param is fine here
 	var i, paramsIterator, partLen int
 	for _, segment := range parser.segs {
 		partLen = len(detectionPath)

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -178,7 +178,7 @@ func Test_Redirect_Back_WithFlashMessages(t *testing.T) {
 		return c.SendString("user")
 	}).Name("user")
 
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	err := c.Redirect().With("success", "1").With("message", "test").Back("/")
 	require.NoError(t, err)
@@ -225,7 +225,7 @@ func Test_Redirect_Route_WithFlashMessages(t *testing.T) {
 		return c.SendString("user")
 	}).Name("user")
 
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	err := c.Redirect().With("success", "1").With("message", "test").Route("user")
 
@@ -259,7 +259,7 @@ func Test_Redirect_Route_WithOldInput(t *testing.T) {
 			return c.SendString("user")
 		}).Name("user")
 
-		c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+		c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 		c.Request().URI().SetQueryString("id=1&name=tom")
 		err := c.Redirect().With("success", "1").With("message", "test").WithInput().Route("user")
@@ -294,7 +294,7 @@ func Test_Redirect_Route_WithOldInput(t *testing.T) {
 			return c.SendString("user")
 		}).Name("user")
 
-		c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+		c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 		c.Request().Header.Set(HeaderContentType, MIMEApplicationForm)
 		c.Request().SetBodyString("id=1&name=tom")
@@ -330,7 +330,7 @@ func Test_Redirect_Route_WithOldInput(t *testing.T) {
 			return c.SendString("user")
 		}).Name("user")
 
-		c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+		c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 		body := &bytes.Buffer{}
 		writer := multipart.NewWriter(body)
@@ -376,7 +376,7 @@ func Test_Redirect_parseAndClearFlashMessages(t *testing.T) {
 		return c.SendString("user")
 	}).Name("user")
 
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	msgs := redirectionMsgs{
 		{
@@ -464,7 +464,7 @@ func Benchmark_Redirect_Route(b *testing.B) {
 		return c.JSON(c.Params("name"))
 	}).Name("user")
 
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -491,7 +491,7 @@ func Benchmark_Redirect_Route_WithQueries(b *testing.B) {
 		return c.JSON(c.Params("name"))
 	}).Name("user")
 
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -523,7 +523,7 @@ func Benchmark_Redirect_Route_WithFlashMessages(b *testing.B) {
 		return c.SendString("user")
 	}).Name("user")
 
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -576,7 +576,7 @@ func Benchmark_Redirect_parseAndClearFlashMessages(b *testing.B) {
 		return c.SendString("user")
 	}).Name("user")
 
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	val, err := testredirectionMsgs.MarshalMsg(nil)
 	require.NoError(b, err)
@@ -618,7 +618,7 @@ func Benchmark_Redirect_processFlashMessages(b *testing.B) {
 		return c.SendString("user")
 	}).Name("user")
 
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	c.Redirect().With("success", "1").With("message", "test")
 
@@ -647,7 +647,7 @@ func Benchmark_Redirect_Messages(b *testing.B) {
 		return c.SendString("user")
 	}).Name("user")
 
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	val, err := testredirectionMsgs.MarshalMsg(nil)
 	require.NoError(b, err)
@@ -684,7 +684,7 @@ func Benchmark_Redirect_OldInputs(b *testing.B) {
 		return c.SendString("user")
 	}).Name("user")
 
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	val, err := testredirectionMsgs.MarshalMsg(nil)
 	require.NoError(b, err)
@@ -719,7 +719,7 @@ func Benchmark_Redirect_Message(b *testing.B) {
 		return c.SendString("user")
 	}).Name("user")
 
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	val, err := testredirectionMsgs.MarshalMsg(nil)
 	require.NoError(b, err)
@@ -750,7 +750,7 @@ func Benchmark_Redirect_OldInput(b *testing.B) {
 		return c.SendString("user")
 	}).Name("user")
 
-	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	val, err := testredirectionMsgs.MarshalMsg(nil)
 	require.NoError(b, err)

--- a/router.go
+++ b/router.go
@@ -108,7 +108,7 @@ func (r *Route) match(detectionPath, path string, params *[maxParams]string) boo
 	return false
 }
 
-func (app *App) nextCustom(c CustomCtx) (bool, error) { //nolint: unparam // bool param might be useful for testing
+func (app *App) nextCustom(c CustomCtx) (bool, error) { //nolint:unparam // bool param might be useful for testing
 	// Get stack length
 	tree, ok := app.treeStack[c.getMethodINT()][c.getTreePath()]
 	if !ok {

--- a/router_test.go
+++ b/router_test.go
@@ -600,7 +600,7 @@ func Benchmark_Router_Next(b *testing.B) {
 	var res bool
 	var err error
 
-	c := app.AcquireCtx(request).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+	c := app.AcquireCtx(request).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -825,7 +825,7 @@ func Benchmark_Router_Github_API(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			c.URI().SetPath(routesFixture.TestRoutes[i].Path)
 
-			ctx := app.AcquireCtx(c).(*DefaultCtx) //nolint:errcheck, forcetypeassert // not needed
+			ctx := app.AcquireCtx(c).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
 
 			match, err = app.next(ctx)
 			app.ReleaseCtx(ctx)


### PR DESCRIPTION
This PR targets another PR (branch: `fix-lint`) #3354.

This is a workaround to unlock your situation (the workaround is to use `goinstall` mode).

I also improved a bit your configuration and fixed some malformed `nolint` directives.

This is just a workaround. I'm still working on a proper fix, but as you can imagine, it is not quick or simple to debug on the GitHub Action runner.

