### PR TITLE
:bug: bug: fix client iterators when using break statement

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -298,11 +298,13 @@ func (r *Request) Cookie(key string) string {
 // Use maps.Collect() to gather them into a map if needed.
 func (r *Request) Cookies() iter.Seq2[string, string] {
 	return func(yield func(string, string) bool) {
-		r.cookies.VisitAll(func(key, val string) {
-			if !yield(key, val) {
+		var res bool
+		for k, v := range *r.cookies {
+			res = yield(k, v)
+			if !res {
 				return
 			}
-		})
+		}
 	}
 }
 
@@ -343,11 +345,11 @@ func (r *Request) PathParam(key string) string {
 // Use maps.Collect() to gather them into a map if needed.
 func (r *Request) PathParams() iter.Seq2[string, string] {
 	return func(yield func(string, string) bool) {
-		r.path.VisitAll(func(key, val string) {
-			if !yield(key, val) {
+		for k, v := range *r.path {
+			if !yield(k, v) {
 				return
 			}
-		})
+		}
 	}
 }
 

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -451,6 +451,14 @@ func Test_Request_Cookies(t *testing.T) {
 	require.Equal(t, "bar", cookies["foo"])
 	require.Equal(t, "foo", cookies["bar"])
 
+	require.NotPanics(t, func() {
+		for _, v := range req.Cookies() {
+			if v == "bar" {
+				break
+			}
+		}
+	})
+
 	require.Len(t, cookies, 2)
 }
 
@@ -564,6 +572,14 @@ func Test_Request_PathParams(t *testing.T) {
 	require.Equal(t, "foo", pathParams["bar"])
 
 	require.Len(t, pathParams, 2)
+
+	require.NotPanics(t, func() {
+		for _, v := range req.PathParams() {
+			if v == "bar" {
+				break
+			}
+		}
+	})
 }
 
 func Benchmark_Request_PathParams(b *testing.B) {


### PR DESCRIPTION
# Description

When iterators don't finishes iterations in case yield(k, v) returns false, it causes panic like `range function continued iteration after loop body`. Some of client iterators are also affected from this issue. This PR fixes it and add testcases to ensure it doesn't panic.

Fixes # (issue)

## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [ ] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [ ] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [ ] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [ ] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [ ] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [ ] Examples: Provide examples demonstrating the new features or changes in action.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [ ] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [ ] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
