### PR TITLE
Revert "🔥 feat: Add support for context.Context in keyauth middleware"

### DIFF
--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -503,67 +503,33 @@ func Test_TokenFromContext_None(t *testing.T) {
 }
 
 func Test_TokenFromContext(t *testing.T) {
-	// Test that TokenFromContext returns the correct token
-	t.Run("fiber.Ctx", func(t *testing.T) {
-		app := fiber.New()
-		app.Use(New(Config{
-			KeyLookup:  "header:Authorization",
-			AuthScheme: "Basic",
-			Validator: func(_ fiber.Ctx, key string) (bool, error) {
-				if key == CorrectKey {
-					return true, nil
-				}
-				return false, ErrMissingOrMalformedAPIKey
-			},
-		}))
-		app.Get("/", func(c fiber.Ctx) error {
-			return c.SendString(TokenFromContext(c))
-		})
-
-		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
-		req.Header.Add("Authorization", "Basic "+CorrectKey)
-		res, err := app.Test(req)
-		require.NoError(t, err)
-
-		body, err := io.ReadAll(res.Body)
-		require.NoError(t, err)
-		require.Equal(t, CorrectKey, string(body))
+	app := fiber.New()
+	// Wire up keyauth middleware to set TokenFromContext now
+	app.Use(New(Config{
+		KeyLookup:  "header:Authorization",
+		AuthScheme: "Basic",
+		Validator: func(_ fiber.Ctx, key string) (bool, error) {
+			if key == CorrectKey {
+				return true, nil
+			}
+			return false, ErrMissingOrMalformedAPIKey
+		},
+	}))
+	// Define a test handler that checks TokenFromContext
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString(TokenFromContext(c))
 	})
 
-	t.Run("context.Context", func(t *testing.T) {
-		app := fiber.New()
-		app.Use(New(Config{
-			KeyLookup:  "header:Authorization",
-			AuthScheme: "Basic",
-			Validator: func(_ fiber.Ctx, key string) (bool, error) {
-				if key == CorrectKey {
-					return true, nil
-				}
-				return false, ErrMissingOrMalformedAPIKey
-			},
-		}))
-		// Verify that TokenFromContext works with context.Context
-		app.Get("/", func(c fiber.Ctx) error {
-			ctx := c.Context()
-			token := TokenFromContext(ctx)
-			return c.SendString(token)
-		})
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Add("Authorization", "Basic "+CorrectKey)
+	// Send
+	res, err := app.Test(req)
+	require.NoError(t, err)
 
-		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
-		req.Header.Add("Authorization", "Basic "+CorrectKey)
-		res, err := app.Test(req)
-		require.NoError(t, err)
-
-		body, err := io.ReadAll(res.Body)
-		require.NoError(t, err)
-		require.Equal(t, CorrectKey, string(body))
-	})
-
-	t.Run("invalid context type", func(t *testing.T) {
-		require.Panics(t, func() {
-			_ = TokenFromContext("invalid")
-		})
-	})
+	// Read the response body into a string
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.Equal(t, CorrectKey, string(body))
 }
 
 func Test_AuthSchemeToken(t *testing.T) {


### PR DESCRIPTION
Reverts gofiber/fiber#3287

# **Reversion of Middleware Changes in Fiber v3**  

Following discussions in [issue #3358](https://github.com/gofiber/fiber/issues/3358), we have reverted changes that attempted to copy values into `context.Context` within various middlewares. These changes were removed to maintain Fiber’s lightweight design, improve performance, and avoid unnecessary complexity for users who do not require `context.Context`.  

## **Why Were These Changes Reverted?**  
- **Fiber prioritizes performance**, and modifying `context.Context` for every request introduces unnecessary overhead.  
- **Values are already accessible via `c.Locals()`**, making context modifications redundant.  
- **Users who need `context.Context` values can implement a trivial custom middleware** without affecting default behavior.  
