### PR TITLE
Revert "🔥 feat: Add Context Support to RequestID Middleware"

### DIFF
--- a/docs/middleware/requestid.md
+++ b/docs/middleware/requestid.md
@@ -49,16 +49,6 @@ func handler(c fiber.Ctx) error {
 }
 ```
 
-In version v3, Fiber will inject `requestID` into the built-in `Context` of Go.
-
-```go
-func handler(c fiber.Ctx) error {
-    id := requestid.FromContext(c.Context())
-    log.Printf("Request ID: %s", id)
-    return c.SendString("Hello, World!")
-}
-```
-
 ## Config
 
 | Property   | Type                    | Description                                                                                       | Default        |

--- a/middleware/requestid/requestid.go
+++ b/middleware/requestid/requestid.go
@@ -1,10 +1,7 @@
 package requestid
 
 import (
-	"context"
-
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/fiber/v3/log"
 )
 
 // The contextKey type is unexported to prevent collisions with context keys defined in
@@ -39,10 +36,6 @@ func New(config ...Config) fiber.Handler {
 		// Add the request ID to locals
 		c.Locals(requestIDKey, rid)
 
-		// Add the request ID to UserContext
-		ctx := context.WithValue(c.Context(), requestIDKey, rid)
-		c.SetContext(ctx)
-
 		// Continue stack
 		return c.Next()
 	}
@@ -50,21 +43,9 @@ func New(config ...Config) fiber.Handler {
 
 // FromContext returns the request ID from context.
 // If there is no request ID, an empty string is returned.
-// Supported context types:
-// - fiber.Ctx: Retrieves request ID from Locals
-// - context.Context: Retrieves request ID from context values
-func FromContext(c any) string {
-	switch ctx := c.(type) {
-	case fiber.Ctx:
-		if rid, ok := ctx.Locals(requestIDKey).(string); ok {
-			return rid
-		}
-	case context.Context:
-		if rid, ok := ctx.Value(requestIDKey).(string); ok {
-			return rid
-		}
-	default:
-		log.Errorf("Unsupported context type: %T. Expected fiber.Ctx or context.Context", c)
+func FromContext(c fiber.Ctx) string {
+	if rid, ok := c.Locals(requestIDKey).(string); ok {
+		return rid
 	}
 	return ""
 }

--- a/middleware/requestid/requestid_test.go
+++ b/middleware/requestid/requestid_test.go
@@ -51,59 +51,26 @@ func Test_RequestID_Next(t *testing.T) {
 	require.Equal(t, fiber.StatusNotFound, resp.StatusCode)
 }
 
-// go test -run Test_RequestID_FromContext
+// go test -run Test_RequestID_Locals
 func Test_RequestID_FromContext(t *testing.T) {
 	t.Parallel()
-
 	reqID := "ThisIsARequestId"
 
-	type args struct {
-		inputFunc func(c fiber.Ctx) any
-	}
-
-	tests := []struct {
-		args args
-		name string
-	}{
-		{
-			name: "From fiber.Ctx",
-			args: args{
-				inputFunc: func(c fiber.Ctx) any {
-					return c
-				},
-			},
+	app := fiber.New()
+	app.Use(New(Config{
+		Generator: func() string {
+			return reqID
 		},
-		{
-			name: "From context.Context",
-			args: args{
-				inputFunc: func(c fiber.Ctx) any {
-					return c.Context()
-				},
-			},
-		},
-	}
+	}))
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	var ctxVal string
 
-			app := fiber.New()
-			app.Use(New(Config{
-				Generator: func() string {
-					return reqID
-				},
-			}))
+	app.Use(func(c fiber.Ctx) error {
+		ctxVal = FromContext(c)
+		return c.Next()
+	})
 
-			var ctxVal string
-
-			app.Use(func(c fiber.Ctx) error {
-				ctxVal = FromContext(tt.args.inputFunc(c))
-				return c.Next()
-			})
-
-			_, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
-			require.NoError(t, err)
-			require.Equal(t, reqID, ctxVal)
-		})
-	}
+	_, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
+	require.NoError(t, err)
+	require.Equal(t, reqID, ctxVal)
 }


### PR DESCRIPTION
Reverts gofiber/fiber#3200

# **Reversion of Middleware Changes in Fiber v3**  

Following discussions in [issue #3358](https://github.com/gofiber/fiber/issues/3358), we have reverted changes that attempted to copy values into `context.Context` within various middlewares. These changes were removed to maintain Fiber’s lightweight design, improve performance, and avoid unnecessary complexity for users who do not require `context.Context`.  

## **Why Were These Changes Reverted?**  
- **Fiber prioritizes performance**, and modifying `context.Context` for every request introduces unnecessary overhead.  
- **Values are already accessible via `c.Locals()`**, making context modifications redundant.  
- **Users who need `context.Context` values can implement a trivial custom middleware** without affecting default behavior.  
