### PR TITLE
♻️Refactor: reduce DefaultCtx from 736 to 728 bytes

### DIFF
--- a/app.go
+++ b/app.go
@@ -109,7 +109,7 @@ type App struct {
 	// Route stack divided by HTTP methods
 	stack [][]*Route
 	// Route stack divided by HTTP methods and route prefixes
-	treeStack []map[string][]*Route
+	treeStack []map[int][]*Route
 	// custom binders
 	customBinders []CustomBinder
 	// customConstraints is a list of external constraints
@@ -581,7 +581,7 @@ func New(config ...Config) *App {
 
 	// Create router stack
 	app.stack = make([][]*Route, len(app.config.RequestMethods))
-	app.treeStack = make([]map[string][]*Route, len(app.config.RequestMethods))
+	app.treeStack = make([]map[int][]*Route, len(app.config.RequestMethods))
 
 	// Override colors
 	app.config.ColorScheme = defaultColors(app.config.ColorScheme)

--- a/ctx_interface.go
+++ b/ctx_interface.go
@@ -19,7 +19,7 @@ type CustomCtx interface {
 	// Methods to use with next stack.
 	getMethodINT() int
 	getIndexRoute() int
-	getTreePath() string
+	getTreePathHash() int
 	getDetectionPath() string
 	getPathOriginal() string
 	getValues() *[maxParams]string

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -347,7 +347,7 @@ type Ctx interface {
 	// Methods to use with next stack.
 	getMethodINT() int
 	getIndexRoute() int
-	getTreePath() string
+	getTreePathHash() int
 	getDetectionPath() string
 	getPathOriginal() string
 	getValues() *[maxParams]string

--- a/helpers.go
+++ b/helpers.go
@@ -113,9 +113,9 @@ func (app *App) methodExist(c *DefaultCtx) bool {
 		// Reset stack index
 		c.setIndexRoute(-1)
 
-		tree, ok := c.App().treeStack[i][c.getTreePath()]
+		tree, ok := c.App().treeStack[i][c.treePathHash]
 		if !ok {
-			tree = c.App().treeStack[i][""]
+			tree = c.App().treeStack[i][0]
 		}
 		// Get stack length
 		lenr := len(tree) - 1
@@ -157,9 +157,9 @@ func (app *App) methodExistCustom(c CustomCtx) bool {
 		// Reset stack index
 		c.setIndexRoute(-1)
 
-		tree, ok := c.App().treeStack[i][c.getTreePath()]
+		tree, ok := c.App().treeStack[i][c.getTreePathHash()]
 		if !ok {
-			tree = c.App().treeStack[i][""]
+			tree = c.App().treeStack[i][0]
 		}
 		// Get stack length
 		lenr := len(tree) - 1


### PR DESCRIPTION
# Description

In the default context, the 3-byte-long `treePath` can be encoded as an int. Therefore, reduce the size of `DefaultCtx` and `treeStack`

```
goos: linux
goarch: amd64
pkg: github.com/gofiber/fiber/v3
cpu: AMD EPYC 9J14 96-Core Processor                
                                 │   old.txt     │               new.txt                │
                                 │    sec/op     │    sec/op     vs base                │
_Router_NotFound-16                 546.5n ±  1%   467.3n ±  0%  -14.50% (p=0.000 n=20)
_Router_Handler-16                 101.50n ±  0%   96.75n ±  1%   -4.68% (p=0.000 n=20)
_Router_Handler_Strict_Case-16      91.91n ±  0%   86.66n ±  1%   -5.71% (p=0.000 n=20)
_Router_Chain-16                    308.1n ±  1%   305.4n ±  0%   -0.89% (p=0.000 n=20)
_Router_WithCompression-16          310.8n ±  0%   305.4n ±  0%   -1.72% (p=0.000 n=20)
_Router_Next-16                     57.34n ±  1%   54.20n ±  1%   -5.48% (p=0.000 n=20)
_Router_Next_Default-16             46.96n ±  1%   41.56n ±  1%  -11.49% (p=0.000 n=20)
_Router_Next_Default_Parallel-16    7.491n ± 24%   7.886n ± 24%        ~ (p=0.565 n=20)
_Router_Handler_CaseSensitive-16    92.55n ±  1%   86.89n ±  1%   -6.12% (p=0.000 n=20)
_Router_Handler_Unescape-16         114.9n ±  1%   114.5n ±  0%   -0.26% (p=0.008 n=20)
_Router_Handler_StrictRouting-16    92.55n ±  1%   86.98n ±  0%   -6.01% (p=0.000 n=20)
_Router_Github_API-16               149.5µ ±  0%   147.4µ ±  0%   -1.38% (p=0.000 n=20)
geomean                             183.4n         175.1n         -4.55%

                                 │   old.txt    │              new.txt                │
                                 │     B/op     │    B/op     vs base                 │
_Router_NotFound-16                80.00 ± 0%     80.00 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Handler-16                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Handler_Strict_Case-16     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Chain-16                   48.00 ± 0%     48.00 ± 0%       ~ (p=1.000 n=20) ¹
_Router_WithCompression-16         48.00 ± 0%     48.00 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Next-16                    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Next_Default-16            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Next_Default_Parallel-16   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Handler_CaseSensitive-16   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Handler_Unescape-16        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Handler_StrictRouting-16   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Github_API-16              0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
geomean                                       ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                 │   old.txt    │              new.txt                │
                                 │  allocs/op   │ allocs/op   vs base                 │
_Router_NotFound-16                3.000 ± 0%     3.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Handler-16                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Handler_Strict_Case-16     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Chain-16                   3.000 ± 0%     3.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_WithCompression-16         3.000 ± 0%     3.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Next-16                    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Next_Default-16            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Next_Default_Parallel-16   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Handler_CaseSensitive-16   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Handler_Unescape-16        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Handler_StrictRouting-16   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
_Router_Github_API-16              0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
geomean                                       ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

## Type of change

Please delete options that are not relevant.

- [x] Performance improvement (non-breaking change which improves efficiency)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.
