### PR TITLE
🧹 chore: Add Immutable benchmarks for default case

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -656,6 +656,50 @@ func Benchmark_Router_Next_Default_Parallel(b *testing.B) {
 	})
 }
 
+// go test -v ./... -run=^$ -bench=Benchmark_Router_Next_Default_Immutable -benchmem -count=4
+func Benchmark_Router_Next_Default_Immutable(b *testing.B) {
+	app := New(Config{Immutable: true})
+	app.Get("/", func(_ Ctx) error {
+		return nil
+	})
+
+	h := app.Handler()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.SetMethod(MethodGet)
+	fctx.Request.SetRequestURI("/")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		h(fctx)
+	}
+}
+
+// go test -benchmem -run=^$ -bench ^Benchmark_Router_Next_Default_Parallel_Immutable$ github.com/gofiber/fiber/v3 -count=1
+func Benchmark_Router_Next_Default_Parallel_Immutable(b *testing.B) {
+	app := New(Config{Immutable: true})
+	app.Get("/", func(_ Ctx) error {
+		return nil
+	})
+
+	h := app.Handler()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		fctx := &fasthttp.RequestCtx{}
+		fctx.Request.Header.SetMethod(MethodGet)
+		fctx.Request.SetRequestURI("/")
+
+		for pb.Next() {
+			h(fctx)
+		}
+	})
+}
+
 // go test -v ./... -run=^$ -bench=Benchmark_Route_Match -benchmem -count=4
 func Benchmark_Route_Match(b *testing.B) {
 	var match bool


### PR DESCRIPTION
# Description

Add two benchmarks to cover the most basic use-case with `Immutable` flag enabled

How to run:

```console
go test -v ./... -run=^$ -bench=Benchmark_Router_Next_Default -benchmem -count=4
```

Related #3367 

## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [x] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)