### PR TITLE
🩹 Fix: Implement RFC 6265 Cookie Value Sanitization

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1035,6 +1035,18 @@ func Test_Ctx_Cookies(t *testing.T) {
 	c.Request().Header.Set("Cookie", "john=doe")
 	require.Equal(t, "doe", c.Req().Cookies("john"))
 	require.Equal(t, "default", c.Req().Cookies("unknown", "default"))
+
+	c.Request().Header.Set("Cookie", "special=value,with,commas") // commas are allowed
+	require.Equal(t, "value,with,commas", c.Req().Cookies("special"))
+
+	c.Request().Header.Set("Cookie", "quotes=value\"with\"quotes")
+	require.Equal(t, "valuewithquotes", c.Req().Cookies("quotes"))
+
+	c.Request().Header.Set("Cookie", "semicolons=value;with;semicolons")
+	require.Equal(t, "valuewithsemicolons", c.Req().Cookies("semicolons"))
+
+	c.Request().Header.Set("Cookie", "backslash=value\\with\\backslash")
+	require.Equal(t, "valuewithbackslash", c.Req().Cookies("backslash"))
 }
 
 // go test -run Test_Ctx_Format

--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const CorrectKey = "specials: !$%,.#\"!?~`<>@$^*(){}[]|/\\123"
+const CorrectKey = "specials: !$%,.#!?~`<>@$^*(){}[]|/123"
 
 var testConfig = fiber.TestConfig{
 	Timeout: 0,


### PR DESCRIPTION
# Description

Added cookie value sanitization according to RFC 6265 standards. The implementation validates and sanitizes cookie values by removing invalid characters (`""`,`;`, `\`), while intentionally allowing commas to maintain compatibility with Go's net/http package (see https://golang.org/issue/7243). Test cases have been updated accordingly to use RFC-compliant values.

Fixes #3176

## Changes introduced

- Implemented cookie value sanitization that ensures RFC 6265 compliance, removing invalid characters (", ;, \) from cookie values.
- Modified test key string in keyAuth tests to be RFC 6265 compliant.

## Breaking Change Notice

This change enforces RFC 6265 compliance for cookie values. If an existing application currently stores or relies on cookie values containing these characters, they will be silently removed when processed by Fiber. 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

