### PR TITLE
Force the use of terminal colors via config option

### DIFF
--- a/middleware/logger/config.go
+++ b/middleware/logger/config.go
@@ -89,6 +89,11 @@ type Config struct {
 	// Default: false
 	DisableColors bool
 
+	// ForceColors forces the colors to be enabled even if the output is not a terminal
+	//
+	// Default: false
+	ForceColors bool
+
 	enableColors  bool
 	enableLatency bool
 }
@@ -174,7 +179,7 @@ func configDefault(config ...Config) Config {
 	}
 
 	// Enable colors if no custom format or output is given
-	if !cfg.DisableColors && cfg.Stream == ConfigDefault.Stream {
+	if (!cfg.DisableColors && cfg.Stream == ConfigDefault.Stream) || cfg.ForceColors {
 		cfg.enableColors = true
 	}
 

--- a/middleware/logger/default_logger.go
+++ b/middleware/logger/default_logger.go
@@ -148,7 +148,7 @@ func beforeHandlerFunc(cfg Config) {
 	// If colors are enabled, check terminal compatibility
 	if cfg.enableColors {
 		cfg.Stream = colorable.NewColorableStdout()
-		if os.Getenv("TERM") == "dumb" || os.Getenv("NO_COLOR") == "1" || (!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd())) {
+		if !cfg.ForceColors && (os.Getenv("TERM") == "dumb" || os.Getenv("NO_COLOR") == "1" || (!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()))) {
 			cfg.Stream = colorable.NewNonColorable(os.Stdout)
 		}
 	}

--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -1018,6 +1018,32 @@ func Test_Logger_EnableColors(t *testing.T) {
 	require.EqualValues(t, 1, *o)
 }
 
+// go test -run Test_Logger_ForceColors
+func Test_Logger_ForceColors(t *testing.T) {
+	t.Parallel()
+	buf := bytebufferpool.Get()
+	defer bytebufferpool.Put(buf)
+
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Format:        "${ip}${status}${method}${path}${error}\n",
+		Stream:        buf,
+		DisableColors: true,
+		ForceColors:   true,
+	}))
+
+	// Alias colors
+	colors := app.Config().ColorScheme
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+
+	expected := fmt.Sprintf("0.0.0.0%s404%s%sGET%s/%sCannot GET /%s\n", colors.Yellow, colors.Reset, colors.Cyan, colors.Reset, colors.Red, colors.Reset)
+	require.Equal(t, expected, buf.String())
+}
+
 // go test -v -run=^$ -bench=Benchmark_Logger$ -benchmem -count=4
 func Benchmark_Logger(b *testing.B) {
 	b.Run("NoMiddleware", func(bb *testing.B) {


### PR DESCRIPTION
# Description

Force the use of colors in the terminal if the user enables this explicitly.

As discussed in #3400

Included a single unit test `Test_Logger_ForceColors` to test this behavior
