### PR TITLE
🐛 [Bug]: logger locals:requestid not working

### DIFF
--- a/middleware/logger/tags.go
+++ b/middleware/logger/tags.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gofiber/fiber/v3/middleware/requestid"
+
 	"github.com/gofiber/fiber/v3"
 )
 
@@ -167,6 +169,9 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			return output.WriteString(c.Cookies(extraParam))
 		},
 		TagLocals: func(output Buffer, c fiber.Ctx, _ *Data, extraParam string) (int, error) {
+			if extraParam == "requestid" {
+				return output.WriteString(requestid.FromContext(c))
+			}
 			switch v := c.Locals(extraParam).(type) {
 			case []byte:
 				return output.Write(v)


### PR DESCRIPTION
# Description

Fixes #3436.

Changing the log format tags to read the `requestid` from the context, since the key values from `Locals` API was changed due to the keys collisions. See more on https://github.com/gofiber/fiber/issues/2684

## Type of change

- [x] Fix (non-breaking change which adds fix a functionality)
## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [ ] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [ ] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
