### PR TITLE
:bug: bug: fix redirection flash messages violate cookie structure

### DIFF
--- a/redirect.go
+++ b/redirect.go
@@ -297,9 +297,12 @@ func (r *Redirect) Back(fallback ...string) error {
 // parseAndClearFlashMessages is a method to get flash messages before they are getting removed
 func (r *Redirect) parseAndClearFlashMessages() {
 	// parse flash messages
-	cookieValue, _ := hex.DecodeString(r.c.Cookies(FlashCookieName))
+	cookieValue, err := hex.DecodeString(r.c.Cookies(FlashCookieName))
+	if err != nil {
+		return
+	}
 
-	_, err := r.c.flashMessages.UnmarshalMsg(cookieValue)
+	_, err = r.c.flashMessages.UnmarshalMsg(cookieValue)
 	if err != nil {
 		return
 	}

--- a/redirect.go
+++ b/redirect.go
@@ -5,6 +5,7 @@
 package fiber
 
 import (
+	"encoding/hex"
 	"errors"
 	"sync"
 
@@ -296,9 +297,9 @@ func (r *Redirect) Back(fallback ...string) error {
 // parseAndClearFlashMessages is a method to get flash messages before they are getting removed
 func (r *Redirect) parseAndClearFlashMessages() {
 	// parse flash messages
-	cookieValue := r.c.Cookies(FlashCookieName)
+	cookieValue, _ := hex.DecodeString(r.c.Cookies(FlashCookieName))
 
-	_, err := r.c.flashMessages.UnmarshalMsg(r.c.app.getBytes(cookieValue))
+	_, err := r.c.flashMessages.UnmarshalMsg(cookieValue)
 	if err != nil {
 		return
 	}
@@ -316,9 +317,12 @@ func (r *Redirect) processFlashMessages() {
 		return
 	}
 
+	dst := make([]byte, hex.EncodedLen(len(val)))
+	hex.Encode(dst, val)
+
 	r.c.Cookie(&Cookie{
 		Name:        FlashCookieName,
-		Value:       r.c.app.getString(val),
+		Value:       r.c.app.getString(dst),
 		SessionOnly: true,
 	})
 }

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -6,6 +6,7 @@ package fiber
 
 import (
 	"bytes"
+	"encoding/hex"
 	"mime/multipart"
 	"net/url"
 	"testing"
@@ -45,7 +46,9 @@ func Test_Redirect_To_WithFlashMessages(t *testing.T) {
 	c.RequestCtx().Request.Header.Set(HeaderCookie, c.GetRespHeader(HeaderSetCookie)) // necessary for testing
 
 	var msgs redirectionMsgs
-	_, err = msgs.UnmarshalMsg([]byte(c.Cookies(FlashCookieName)))
+	decoded, err := hex.DecodeString(c.Cookies(FlashCookieName))
+	require.NoError(t, err)
+	_, err = msgs.UnmarshalMsg(decoded)
 	require.NoError(t, err)
 
 	require.Len(t, msgs, 2)
@@ -188,7 +191,9 @@ func Test_Redirect_Back_WithFlashMessages(t *testing.T) {
 	c.RequestCtx().Request.Header.Set(HeaderCookie, c.GetRespHeader(HeaderSetCookie)) // necessary for testing
 
 	var msgs redirectionMsgs
-	_, err = msgs.UnmarshalMsg([]byte(c.Cookies(FlashCookieName)))
+	decoded, err := hex.DecodeString(c.Cookies(FlashCookieName))
+	require.NoError(t, err)
+	_, err = msgs.UnmarshalMsg(decoded)
 	require.NoError(t, err)
 
 	require.Len(t, msgs, 2)
@@ -239,7 +244,9 @@ func Test_Redirect_Route_WithFlashMessages(t *testing.T) {
 	c.RequestCtx().Request.Header.Set(HeaderCookie, c.GetRespHeader(HeaderSetCookie)) // necessary for testing
 
 	var msgs redirectionMsgs
-	_, err = msgs.UnmarshalMsg([]byte(c.Cookies(FlashCookieName)))
+	decoded, err := hex.DecodeString(c.Cookies(FlashCookieName))
+	require.NoError(t, err)
+	_, err = msgs.UnmarshalMsg(decoded)
 	require.NoError(t, err)
 
 	require.Len(t, msgs, 2)
@@ -276,7 +283,9 @@ func Test_Redirect_Route_WithOldInput(t *testing.T) {
 		c.RequestCtx().Request.Header.Set(HeaderCookie, c.GetRespHeader(HeaderSetCookie)) // necessary for testing
 
 		var msgs redirectionMsgs
-		_, err = msgs.UnmarshalMsg([]byte(c.Cookies(FlashCookieName)))
+		decoded, err := hex.DecodeString(c.Cookies(FlashCookieName))
+		require.NoError(t, err)
+		_, err = msgs.UnmarshalMsg(decoded)
 		require.NoError(t, err)
 
 		require.Len(t, msgs, 4)
@@ -312,7 +321,8 @@ func Test_Redirect_Route_WithOldInput(t *testing.T) {
 		c.RequestCtx().Request.Header.Set(HeaderCookie, c.GetRespHeader(HeaderSetCookie)) // necessary for testing
 
 		var msgs redirectionMsgs
-		_, err = msgs.UnmarshalMsg([]byte(c.Cookies(FlashCookieName)))
+		decoded, err := hex.DecodeString(c.Cookies(FlashCookieName))
+		_, err = msgs.UnmarshalMsg(decoded)
 		require.NoError(t, err)
 
 		require.Len(t, msgs, 4)
@@ -356,7 +366,9 @@ func Test_Redirect_Route_WithOldInput(t *testing.T) {
 		c.RequestCtx().Request.Header.Set(HeaderCookie, c.GetRespHeader(HeaderSetCookie)) // necessary for testing
 
 		var msgs redirectionMsgs
-		_, err = msgs.UnmarshalMsg([]byte(c.Cookies(FlashCookieName)))
+		decoded, err := hex.DecodeString(c.Cookies(FlashCookieName))
+		require.NoError(t, err)
+		_, err = msgs.UnmarshalMsg(decoded)
 		require.NoError(t, err)
 
 		require.Len(t, msgs, 4)
@@ -402,7 +414,7 @@ func Test_Redirect_parseAndClearFlashMessages(t *testing.T) {
 	val, err := msgs.MarshalMsg(nil)
 	require.NoError(t, err)
 
-	c.Request().Header.Set(HeaderCookie, "fiber_flash="+string(val))
+	c.Request().Header.Set(HeaderCookie, "fiber_flash="+hex.EncodeToString(val))
 
 	c.Redirect().parseAndClearFlashMessages()
 
@@ -541,7 +553,9 @@ func Benchmark_Redirect_Route_WithFlashMessages(b *testing.B) {
 	c.RequestCtx().Request.Header.Set(HeaderCookie, c.GetRespHeader(HeaderSetCookie)) // necessary for testing
 
 	var msgs redirectionMsgs
-	_, err = msgs.UnmarshalMsg([]byte(c.Cookies(FlashCookieName)))
+	decoded, err := hex.DecodeString(c.Cookies(FlashCookieName))
+	require.NoError(b, err)
+	_, err = msgs.UnmarshalMsg(decoded)
 	require.NoError(b, err)
 
 	require.Contains(b, msgs, redirectionMsg{key: "success", value: "1", level: 0, isOldInput: false})
@@ -581,7 +595,7 @@ func Benchmark_Redirect_parseAndClearFlashMessages(b *testing.B) {
 	val, err := testredirectionMsgs.MarshalMsg(nil)
 	require.NoError(b, err)
 
-	c.Request().Header.Set(HeaderCookie, "fiber_flash="+string(val))
+	c.Request().Header.Set(HeaderCookie, "fiber_flash="+hex.EncodeToString(val))
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -632,7 +646,9 @@ func Benchmark_Redirect_processFlashMessages(b *testing.B) {
 	c.RequestCtx().Request.Header.Set(HeaderCookie, c.GetRespHeader(HeaderSetCookie)) // necessary for testing
 
 	var msgs redirectionMsgs
-	_, err := msgs.UnmarshalMsg([]byte(c.Cookies(FlashCookieName)))
+	decoded, err := hex.DecodeString(c.Cookies(FlashCookieName))
+	require.NoError(b, err)
+	_, err = msgs.UnmarshalMsg(decoded)
 	require.NoError(b, err)
 
 	require.Len(b, msgs, 2)
@@ -652,7 +668,7 @@ func Benchmark_Redirect_Messages(b *testing.B) {
 	val, err := testredirectionMsgs.MarshalMsg(nil)
 	require.NoError(b, err)
 
-	c.Request().Header.Set(HeaderCookie, "fiber_flash="+string(val))
+	c.Request().Header.Set(HeaderCookie, "fiber_flash="+hex.EncodeToString(val))
 	c.Redirect().parseAndClearFlashMessages()
 
 	var msgs []FlashMessage
@@ -689,7 +705,7 @@ func Benchmark_Redirect_OldInputs(b *testing.B) {
 	val, err := testredirectionMsgs.MarshalMsg(nil)
 	require.NoError(b, err)
 
-	c.Request().Header.Set(HeaderCookie, "fiber_flash="+string(val))
+	c.Request().Header.Set(HeaderCookie, "fiber_flash="+hex.EncodeToString(val))
 	c.Redirect().parseAndClearFlashMessages()
 
 	var oldInputs []OldInputData
@@ -724,7 +740,7 @@ func Benchmark_Redirect_Message(b *testing.B) {
 	val, err := testredirectionMsgs.MarshalMsg(nil)
 	require.NoError(b, err)
 
-	c.Request().Header.Set(HeaderCookie, "fiber_flash="+string(val))
+	c.Request().Header.Set(HeaderCookie, "fiber_flash="+hex.EncodeToString(val))
 	c.Redirect().parseAndClearFlashMessages()
 
 	var msg FlashMessage
@@ -755,7 +771,7 @@ func Benchmark_Redirect_OldInput(b *testing.B) {
 	val, err := testredirectionMsgs.MarshalMsg(nil)
 	require.NoError(b, err)
 
-	c.Request().Header.Set(HeaderCookie, "fiber_flash="+string(val))
+	c.Request().Header.Set(HeaderCookie, "fiber_flash="+hex.EncodeToString(val))
 	c.Redirect().parseAndClearFlashMessages()
 
 	var input OldInputData

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -322,6 +322,7 @@ func Test_Redirect_Route_WithOldInput(t *testing.T) {
 
 		var msgs redirectionMsgs
 		decoded, err := hex.DecodeString(c.Cookies(FlashCookieName))
+		require.NoError(t, err)
 		_, err = msgs.UnmarshalMsg(decoded)
 		require.NoError(t, err)
 

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -468,6 +468,12 @@ func Test_Redirect_parseAndClearFlashMessages(t *testing.T) {
 			Value: "1",
 		},
 	}, c.Redirect().OldInputs())
+
+	c.Request().Header.Set(HeaderCookie, "fiber_flash=test")
+
+	c.Redirect().parseAndClearFlashMessages()
+
+	require.Empty(t, c.Redirect().messages)
 }
 
 // go test -v -run=^$ -bench=Benchmark_Redirect_Route -benchmem -count=4


### PR DESCRIPTION
# Description

This issue fixes redirection with flash messages breaks HTTP header format by encoding msgpack serialized binary data with hex. It has little overhead, but still we get benefit of using Messagepack. Here are the benchmark results:

```go
New:
Benchmark_Redirect_Route-16                         	 6792206	       173.7 ns/op	      16 B/op	       1 allocs/op
Benchmark_Redirect_Route_WithQueries-16             	 3043641	       391.3 ns/op	      40 B/op	       2 allocs/op
Benchmark_Redirect_Route_WithFlashMessages-16       	 2439327	       481.1 ns/op	     293 B/op	       3 allocs/op
Benchmark_Redirect_parseAndClearFlashMessages-16    	 2350215	       510.5 ns/op	     192 B/op	       7 allocs/op
Benchmark_Redirect_processFlashMessages-16          	 3483320	       344.6 ns/op	     288 B/op	       2 allocs/op
Benchmark_Redirect_Messages-16                      	13537572	        87.54 ns/op	     128 B/op	       2 allocs/op
Benchmark_Redirect_OldInputs-16                     	14712171	        77.44 ns/op	      96 B/op	       2 allocs/op
Benchmark_Redirect_Message-16                       	83187558	        14.43 ns/op	       0 B/op	       0 allocs/op
Benchmark_Redirect_OldInput-16                      	153820603	         7.814 ns/op	       0 B/op	       0 allocs/op

Old:
Benchmark_Redirect_Route-16                         	 6861298	       175.9 ns/op	      16 B/op	       1 allocs/op
Benchmark_Redirect_Route_WithQueries-16             	 2901906	       408.6 ns/op	      40 B/op	       2 allocs/op
Benchmark_Redirect_Route_WithFlashMessages-16       	 3456422	       328.7 ns/op	     117 B/op	       2 allocs/op
Benchmark_Redirect_parseAndClearFlashMessages-16    	 4298755	       278.1 ns/op	      32 B/op	       6 allocs/op
Benchmark_Redirect_processFlashMessages-16          	 6022623	       198.2 ns/op	     112 B/op	       1 allocs/op
Benchmark_Redirect_Messages-16                      	13548512	        87.84 ns/op	     128 B/op	       2 allocs/op
Benchmark_Redirect_OldInputs-16                     	14798696	        78.96 ns/op	      96 B/op	       2 allocs/op
Benchmark_Redirect_Message-16                       	82884747	        14.44 ns/op	       0 B/op	       0 allocs/op
Benchmark_Redirect_OldInput-16                      	148364563	         8.104 ns/op	       0 B/op	       0 allocs/op
```

Fixes https://github.com/gofiber/fiber/issues/3437

## Type of change

- [x] Enhancement (improvement to existing features and functionality)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [ ] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [ ] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/master/.github/CONTRIBUTING.md#pull-requests-or-commits)
