### PR TITLE
Add variadic message support to NewError

### DIFF
--- a/app.go
+++ b/app.go
@@ -881,14 +881,19 @@ func (e *Error) Error() string {
 	return e.Message
 }
 
-// NewError creates a new Error instance with an optional message
-func NewError(code int, message ...string) *Error {
+// NewError creates a new Error instance with an optional message.
+// Additional arguments are formatted using fmt.Sprintf when provided.
+func NewError(code int, message ...interface{}) *Error {
 	err := &Error{
 		Code:    code,
 		Message: utils.StatusMessage(code),
 	}
 	if len(message) > 0 {
-		err.Message = message[0]
+		if format, ok := message[0].(string); ok && len(message) > 1 {
+			err.Message = fmt.Sprintf(format, message[1:]...)
+		} else {
+			err.Message = fmt.Sprint(message[0])
+		}
 	}
 	return err
 }

--- a/app_test.go
+++ b/app_test.go
@@ -1310,6 +1310,13 @@ func Test_NewError(t *testing.T) {
 	require.Equal(t, "permission denied", e.Message)
 }
 
+func Test_NewError_Format(t *testing.T) {
+	t.Parallel()
+	e := NewError(StatusBadRequest, "invalid id %d", 10)
+	require.Equal(t, StatusBadRequest, e.Code)
+	require.Equal(t, "invalid id 10", e.Message)
+}
+
 // go test -run Test_Test_Timeout
 func Test_Test_Timeout(t *testing.T) {
 	t.Parallel()

--- a/ctx.go
+++ b/ctx.go
@@ -1652,7 +1652,7 @@ func (c *DefaultCtx) SendFile(file string, config ...SendFile) error {
 
 	// Check for error
 	if status != StatusNotFound && fsStatus == StatusNotFound {
-		return NewError(StatusNotFound, fmt.Sprintf("sendfile: file %s not found", filename))
+		return NewError(StatusNotFound, "sendfile: file %s not found", filename)
 	}
 
 	// Set the status code set by the user if it is different from the fasthttp status code and 200

--- a/docs/api/fiber.md
+++ b/docs/api/fiber.md
@@ -243,12 +243,12 @@ func (app *App) ShutdownWithContext(ctx context.Context) error
 NewError creates a new HTTPError instance with an optional message.
 
 ```go title="Signature"
-func NewError(code int, message ...string) *Error
+func NewError(code int, message ...any) *Error
 ```
 
 ```go title="Example"
 app.Get("/", func(c fiber.Ctx) error {
-    return fiber.NewError(782, "Custom error message")
+    return fiber.NewError(782, "Custom error %s", "message")
 })
 ```
 

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -61,7 +61,7 @@ app.Get("/", func(c fiber.Ctx) error {
     return fiber.ErrServiceUnavailable
 
     // 503 On vacation!
-    return fiber.NewError(fiber.StatusServiceUnavailable, "On vacation!")
+    return fiber.NewError(fiber.StatusServiceUnavailable, "On %s", "vacation!")
 })
 ```
 


### PR DESCRIPTION
## Summary
- support format string args for `NewError`
- update sendfile error to use `NewError` formatting
- document new `NewError` signature and examples
- test formatting support in `NewError`

## Testing
- `go test ./...` *(fails: lookup google.com: no such host)*