### PR TITLE
📒 docs: Fix typos

### DIFF
--- a/client/request_test.go
+++ b/client/request_test.go
@@ -1267,7 +1267,7 @@ func Test_Request_Body_With_Server(t *testing.T) {
 
 		require.Equal(t, "myBoundary", req.Boundary())
 
-		resp, err := req.Post("http://exmaple.com")
+		resp, err := req.Post("http://example.com")
 		require.NoError(t, err)
 		require.Equal(t, fiber.StatusOK, resp.StatusCode())
 
@@ -1356,7 +1356,7 @@ func Test_Request_Body_With_Server(t *testing.T) {
 				SetFileReader(io.NopCloser(strings.NewReader("world"))),
 			))
 
-		resp, err := req.Post("http://exmaple.com")
+		resp, err := req.Post("http://example.com")
 		require.NoError(t, err)
 		require.Equal(t, fiber.StatusOK, resp.StatusCode())
 	})

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -1638,7 +1638,7 @@ app.Use(func(c fiber.Ctx) error {
         return c.Writef("(got error %v)", err)
     }
 
-    // No errors occured
+    // No errors occurred
     return nil
 })
 

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -19,7 +19,7 @@ app := fiber.New(fiber.Config{
     // Pass in Views Template Engine
     Views: engine,
 
-    // Default global path to search for views (can be overriden when calling Render())
+    // Default global path to search for views (can be overridden when calling Render())
     ViewsLayout: "layouts/main",
 
     // Enables/Disables access to `ctx.Locals()` entries in rendered views

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -302,7 +302,7 @@ Registering a subapp is now also possible via the [`Use`](./api/app#use) method 
 <summary>Example</summary>
 
 ```go
-// register mulitple prefixes
+// register multiple prefixes
 app.Use(["/v1", "/v2"], func(c fiber.Ctx) error {
     // Middleware for /v1 and /v2
     return c.Next()


### PR DESCRIPTION
## Summary
- fix typos in docs and tests