### PR TITLE
docs: Fix more typos across code base

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -529,7 +529,7 @@ func Test_App_Use_CaseSensitive(t *testing.T) {
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, StatusNotFound, resp.StatusCode, "Status code")
 
-	// right letters in the requrested route -> 200
+	// right letters in the requested route -> 200
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/abc", nil))
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
@@ -565,7 +565,7 @@ func Test_App_Not_Use_StrictRouting(t *testing.T) {
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
 
-	// right path in the requrested route -> 200
+	// right path in the requested route -> 200
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/abc", nil))
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
@@ -575,7 +575,7 @@ func Test_App_Not_Use_StrictRouting(t *testing.T) {
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
 
-	// right path with group in the requrested route -> 200
+	// right path with group in the requested route -> 200
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/foo/", nil))
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
@@ -645,7 +645,7 @@ func Test_App_Use_StrictRouting(t *testing.T) {
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, StatusNotFound, resp.StatusCode, "Status code")
 
-	// right path in the requrested route -> 200
+	// right path in the requested route -> 200
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/abc", nil))
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
@@ -655,7 +655,7 @@ func Test_App_Use_StrictRouting(t *testing.T) {
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, StatusNotFound, resp.StatusCode, "Status code")
 
-	// right path with group in the requrested route -> 200
+	// right path with group in the requested route -> 200
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/foo/", nil))
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, StatusOK, resp.StatusCode, "Status code")

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -48,7 +48,7 @@ So please be careful to write routes with variable parameters after the routes t
 
 ## Parameters
 
-Route parameters are dynamic elements in the route, which are **named** or **not named segments**. This segments that are used to capture the values specified at their position in the URL. The obtained values can be retrieved using the [Params](https://fiber.wiki/context#params) function, with the name of the route parameter specified in the path as their respective keys or for unnamed parameters the character\(\*, +\) and the counter of this.
+Route parameters are dynamic elements in the route, which are **named** or **not named segments**. These segments are used to capture the values specified at their position in the URL. The obtained values can be retrieved using the [Params](https://fiber.wiki/context#params) function, with the name of the route parameter specified in the path as their respective keys or, for unnamed parameters, the character\(\*, +\) and the counter of this.
 
 The characters :, +, and \* are characters that introduce a parameter.
 
@@ -56,7 +56,7 @@ Greedy parameters are indicated by wildcard\(\*\) or plus\(+\) signs.
 
 The routing also offers the possibility to use optional parameters, for the named parameters these are marked with a final "?", unlike the plus sign which is not optional, you can use the wildcard character for a parameter range which is optional and greedy.
 
-### Example of define routes with route parameters
+### Example of defining routes with route parameters
 
 ```go
 // Parameters

--- a/listen.go
+++ b/listen.go
@@ -309,7 +309,7 @@ func (app *App) printMessages(cfg ListenConfig, ln net.Listener) {
 	}
 }
 
-// prepareListenData create an slice of ListenData
+// prepareListenData creates a slice of ListenData
 func (*App) prepareListenData(addr string, isTLS bool, cfg ListenConfig) ListenData { //revive:disable-line:flag-parameter // Accepting a bool param named isTLS if fine here
 	host, port := parseAddr(addr)
 	if host == "" {

--- a/router.go
+++ b/router.go
@@ -509,7 +509,7 @@ func (app *App) addRoute(method string, route *Route) {
 // This method is useful when you want to register routes dynamically after the app has started.
 // It is not recommended to use this method on production environments because rebuilding
 // the tree is performance-intensive and not thread-safe in runtime. Since building the tree
-// is only done in the startupProcess of the app, this method does not makes sure that the
+// is only done in the startupProcess of the app, this method does not make sure that the
 // routeTree is being safely changed, as it would add a great deal of overhead in the request.
 // Latest benchmark results showed a degradation from 82.79 ns/op to 94.48 ns/op and can be found in:
 // https://github.com/gofiber/fiber/issues/2769#issuecomment-2227385283


### PR DESCRIPTION
## Summary
- revert 'bound' typo fixes in bind.go
- keep `binded` terminology in templates guide