### PR TITLE
🐛 fix: Parsing of IPv6 addresses

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -573,6 +573,39 @@ func parseAddr(raw string) (string, string) { //nolint:revive // Returns (host, 
 	return raw, ""
 }
 
+func parseAddr(raw string) (string, string) { //nolint:revive // Returns (host, port)
+	if raw == "" {
+		return "", ""
+	}
+
+	// Handle IPv6 addresses enclosed in brackets as defined by RFC 3986
+	if strings.HasPrefix(raw, "[") {
+		if end := strings.IndexByte(raw, ']'); end != -1 {
+			host := raw[:end+1] // keep the closing ]
+			if len(raw) > end+1 && raw[end+1] == ':' {
+				return host, raw[end+2:]
+			}
+			return host, ""
+		}
+	}
+
+	// Everything else with a colon
+	if i := strings.LastIndexByte(raw, ':'); i != -1 {
+		host, port := raw[:i], raw[i+1:]
+
+		// If “host” still contains ':', we must have hit an un-bracketed IPv6
+		// literal. In that form a port is impossible, so treat the whole thing
+		// as host.
+		if strings.Contains(host, ":") {
+			return raw, ""
+		}
+		return host, port
+	}
+
+	// No colon, nothing to split
+	return raw, ""
+}
+
 const noCacheValue = "no-cache"
 
 // isNoCache checks if the cacheControl header value is a `no-cache`.

--- a/helpers.go
+++ b/helpers.go
@@ -567,13 +567,6 @@ func (app *App) isEtagStale(etag string, noneMatchBytes []byte) bool {
 }
 
 func parseAddr(raw string) (string, string) { //nolint:revive // Returns (host, port)
-	if i := strings.LastIndex(raw, ":"); i != -1 {
-		return raw[:i], raw[i+1:]
-	}
-	return raw, ""
-}
-
-func parseAddr(raw string) (string, string) { //nolint:revive // Returns (host, port)
 	if raw == "" {
 		return "", ""
 	}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -511,6 +511,7 @@ func Benchmark_Utils_Unescape(b *testing.B) {
 
 func Test_Utils_Parse_Address(t *testing.T) {
 	t.Parallel()
+
 	testCases := []struct {
 		addr, host, port string
 	}{
@@ -519,17 +520,13 @@ func Test_Utils_Parse_Address(t *testing.T) {
 		{addr: "[::1]", host: "[::1]", port: ""},
 		{addr: "2001:db8::1", host: "2001:db8::1", port: ""},
 		{addr: "/path/to/unix/socket", host: "/path/to/unix/socket", port: ""},
-		// IPv4 / hostname cases
 		{addr: "127.0.0.1", host: "127.0.0.1", port: ""},
 		{addr: "localhost:8080", host: "localhost", port: "8080"},
 		{addr: "example.com", host: "example.com", port: ""},
-		// IPv6 ­cases
-		// IPv6 cases
 		{addr: "[fe80::1%lo0]:1234", host: "[fe80::1%lo0]", port: "1234"}, // link-local with zone & port
 		{addr: "[fe80::1%lo0]", host: "[fe80::1%lo0]", port: ""}, // link-local with zone, no port
-		// “bare-port” & empty cases
 		{addr: ":9090", host: "", port: "9090"}, // useful when only port is supplied
-		{addr: "", host: "", port: ""}, // zero-value / unset address
+		{addr: "", host: "", port: ""},          // zero-value / unset address
 	}
 
 	for _, c := range testCases {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -524,6 +524,7 @@ func Test_Utils_Parse_Address(t *testing.T) {
 		{addr: "localhost:8080", host: "localhost", port: "8080"},
 		{addr: "example.com", host: "example.com", port: ""},
 		// IPv6 ­cases
+		// IPv6 cases
 		{addr: "[fe80::1%lo0]:1234", host: "[fe80::1%lo0]", port: "1234"}, // link-local with zone & port
 		{addr: "[fe80::1%lo0]", host: "[fe80::1%lo0]", port: ""}, // link-local with zone, no port
 		// “bare-port” & empty cases

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -523,10 +523,10 @@ func Test_Utils_Parse_Address(t *testing.T) {
 		{addr: "127.0.0.1", host: "127.0.0.1", port: ""},
 		{addr: "localhost:8080", host: "localhost", port: "8080"},
 		{addr: "example.com", host: "example.com", port: ""},
-		{addr: "[fe80::1%lo0]:1234", host: "[fe80::1%lo0]", port: "1234"}, // link-local with zone & port
-		{addr: "[fe80::1%lo0]", host: "[fe80::1%lo0]", port: ""}, // link-local with zone, no port
-		{addr: ":9090", host: "", port: "9090"}, // useful when only port is supplied
-		{addr: "", host: "", port: ""},          // zero-value / unset address
+		{addr: "[fe80::1%lo0]:1234", host: "[fe80::1%lo0]", port: "1234"},
+		{addr: "[fe80::1%lo0]", host: "[fe80::1%lo0]", port: ""},
+		{addr: ":9090", host: "", port: "9090"},
+		{addr: "", host: "", port: ""},
 	}
 
 	for _, c := range testCases {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -515,21 +515,21 @@ func Test_Utils_Parse_Address(t *testing.T) {
 		addr, host, port string
 	}{
 		// ――― existing cases ―――
-		{addr: "[::1]:3000",        host: "[::1]",        port: "3000"},
-		{addr: "127.0.0.1:3000",    host: "127.0.0.1",    port: "3000"},
-		{addr: "[::1]",             host: "[::1]",        port: ""},
-		{addr: "2001:db8::1",       host: "2001:db8::1",  port: ""},
+		{addr: "[::1]:3000", host: "[::1]", port: "3000"},
+		{addr: "127.0.0.1:3000", host: "127.0.0.1", port: "3000"},
+		{addr: "[::1]", host: "[::1]", port: ""},
+		{addr: "2001:db8::1", host: "2001:db8::1", port: ""},
 		{addr: "/path/to/unix/socket", host: "/path/to/unix/socket", port: ""},
 		// ――― new IPv4 / hostname cases ―――
-		{addr: "127.0.0.1",         host: "127.0.0.1",    port: ""},
-		{addr: "localhost:8080",    host: "localhost",    port: "8080"},
-		{addr: "example.com",       host: "example.com",  port: ""},
+		{addr: "127.0.0.1", host: "127.0.0.1", port: ""},
+		{addr: "localhost:8080", host: "localhost", port: "8080"},
+		{addr: "example.com", host: "example.com", port: ""},
 		// ――― new IPv6 ­cases ―――
 		{addr: "[fe80::1%lo0]:1234", host: "[fe80::1%lo0]", port: "1234"}, // link-local with zone & port
-		{addr: "[fe80::1%lo0]",     host: "[fe80::1%lo0]", port: ""},      // link-local with zone, no port
+		{addr: "[fe80::1%lo0]", host: "[fe80::1%lo0]", port: ""}, // link-local with zone, no port
 		// ――― “bare-port” & empty cases ―――
-		{addr: ":9090",             host: "",             port: "9090"},   // useful when only port is supplied
-		{addr: "",                  host: "",             port: ""},       // zero-value / unset address
+		{addr: ":9090", host: "", port: "9090"}, // useful when only port is supplied
+		{addr: "", host: "", port: ""}, // zero-value / unset address
 	}
 
 	for _, c := range testCases {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -514,20 +514,19 @@ func Test_Utils_Parse_Address(t *testing.T) {
 	testCases := []struct {
 		addr, host, port string
 	}{
-		// ――― existing cases ―――
 		{addr: "[::1]:3000", host: "[::1]", port: "3000"},
 		{addr: "127.0.0.1:3000", host: "127.0.0.1", port: "3000"},
 		{addr: "[::1]", host: "[::1]", port: ""},
 		{addr: "2001:db8::1", host: "2001:db8::1", port: ""},
 		{addr: "/path/to/unix/socket", host: "/path/to/unix/socket", port: ""},
-		// ――― new IPv4 / hostname cases ―――
+		// IPv4 / hostname cases
 		{addr: "127.0.0.1", host: "127.0.0.1", port: ""},
 		{addr: "localhost:8080", host: "localhost", port: "8080"},
 		{addr: "example.com", host: "example.com", port: ""},
-		// ――― new IPv6 ­cases ―――
+		// IPv6 ­cases
 		{addr: "[fe80::1%lo0]:1234", host: "[fe80::1%lo0]", port: "1234"}, // link-local with zone & port
 		{addr: "[fe80::1%lo0]", host: "[fe80::1%lo0]", port: ""}, // link-local with zone, no port
-		// ――― “bare-port” & empty cases ―――
+		// “bare-port” & empty cases
 		{addr: ":9090", host: "", port: "9090"}, // useful when only port is supplied
 		{addr: "", host: "", port: ""}, // zero-value / unset address
 	}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -514,15 +514,28 @@ func Test_Utils_Parse_Address(t *testing.T) {
 	testCases := []struct {
 		addr, host, port string
 	}{
-		{addr: "[::1]:3000", host: "[::1]", port: "3000"},
-		{addr: "127.0.0.1:3000", host: "127.0.0.1", port: "3000"},
+		// ――― existing cases ―――
+		{addr: "[::1]:3000",        host: "[::1]",        port: "3000"},
+		{addr: "127.0.0.1:3000",    host: "127.0.0.1",    port: "3000"},
+		{addr: "[::1]",             host: "[::1]",        port: ""},
+		{addr: "2001:db8::1",       host: "2001:db8::1",  port: ""},
 		{addr: "/path/to/unix/socket", host: "/path/to/unix/socket", port: ""},
+		// ――― new IPv4 / hostname cases ―――
+		{addr: "127.0.0.1",         host: "127.0.0.1",    port: ""},
+		{addr: "localhost:8080",    host: "localhost",    port: "8080"},
+		{addr: "example.com",       host: "example.com",  port: ""},
+		// ――― new IPv6 ­cases ―――
+		{addr: "[fe80::1%lo0]:1234", host: "[fe80::1%lo0]", port: "1234"}, // link-local with zone & port
+		{addr: "[fe80::1%lo0]",     host: "[fe80::1%lo0]", port: ""},      // link-local with zone, no port
+		// ――― “bare-port” & empty cases ―――
+		{addr: ":9090",             host: "",             port: "9090"},   // useful when only port is supplied
+		{addr: "",                  host: "",             port: ""},       // zero-value / unset address
 	}
 
 	for _, c := range testCases {
 		host, port := parseAddr(c.addr)
-		require.Equal(t, c.host, host, "addr host")
-		require.Equal(t, c.port, port, "addr port")
+		require.Equal(t, c.host, host, "addr host: %q", c.addr)
+		require.Equal(t, c.port, port, "addr port: %q", c.addr)
 	}
 }
 


### PR DESCRIPTION
# Description

- Expand the number of test cases for `parseAddr()`
- Fix parsing of ipv6 addresses (found by OpenAI Codex)