### PR TITLE
🧹 chore: Fix proxy middleware tests for offline environments

### DIFF
--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -55,7 +55,7 @@ func createProxyTestServerIPv6(t *testing.T, handler fiber.Handler) (*fiber.App,
 	return createProxyTestServer(t, handler, fiber.NetworkTCP6, "[::1]:0")
 }
 
-func createRedirectServer(t *testing.T) (*fiber.App, string) {
+func createRedirectServer(t *testing.T) string {
 	t.Helper()
 	app := fiber.New()
 
@@ -74,7 +74,7 @@ func createRedirectServer(t *testing.T) (*fiber.App, string) {
 
 	startServer(app, ln)
 
-	return app, addr
+	return addr
 }
 
 // go test -run Test_Proxy_Empty_Host
@@ -549,8 +549,7 @@ func Test_Proxy_Do_WithRealURL(t *testing.T) {
 func Test_Proxy_Do_WithRedirect(t *testing.T) {
 	t.Parallel()
 
-	_, addr := createRedirectServer(t)
-
+	addr := createRedirectServer(t)
 	app := fiber.New()
 	app.Get("/test", func(c fiber.Ctx) error {
 		return Do(c, "http://"+addr)
@@ -571,8 +570,7 @@ func Test_Proxy_Do_WithRedirect(t *testing.T) {
 func Test_Proxy_DoRedirects_RestoreOriginalURL(t *testing.T) {
 	t.Parallel()
 
-	_, addr := createRedirectServer(t)
-
+	addr := createRedirectServer(t)
 	app := fiber.New()
 	app.Get("/test", func(c fiber.Ctx) error {
 		return DoRedirects(c, "http://"+addr, 1)
@@ -594,8 +592,7 @@ func Test_Proxy_DoRedirects_RestoreOriginalURL(t *testing.T) {
 func Test_Proxy_DoRedirects_TooManyRedirects(t *testing.T) {
 	t.Parallel()
 
-	_, addr := createRedirectServer(t)
-
+	addr := createRedirectServer(t)
 	app := fiber.New()
 	app.Get("/test", func(c fiber.Ctx) error {
 		return DoRedirects(c, "http://"+addr, 0)

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -70,7 +70,9 @@ func createRedirectServer(t *testing.T) string {
 
 	ln, err := net.Listen(fiber.NetworkTCP4, "127.0.0.1:0")
 	require.NoError(t, err)
-	t.Cleanup(func() { ln.Close() })
+	t.Cleanup(func() {
+		ln.Close() //nolint:errcheck // It is fine to ignore the error here
+	})
 	addr = ln.Addr().String()
 
 	startServer(app, ln)

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -70,6 +70,7 @@ func createRedirectServer(t *testing.T) string {
 
 	ln, err := net.Listen(fiber.NetworkTCP4, "127.0.0.1:0")
 	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
 	addr = ln.Addr().String()
 
 	startServer(app, ln)


### PR DESCRIPTION
## Summary
- adjust proxy tests to avoid external network dependencies
- add helper `createRedirectServer` used by updated tests

This change will help running the tests with agents like `codex` which disable internet access after environment is setup.

## Testing
- `go test ./middleware/proxy -run Test_Proxy_Do_WithRealURL -v`
- `go test ./middleware/proxy -run Test_Proxy_Do_WithRedirect -v`
- `go test ./middleware/proxy -run Test_Proxy_DoRedirects_RestoreOriginalURL -v`
- `go test ./middleware/proxy -run Test_Proxy_DoRedirects_TooManyRedirects -v`
- `go test ./...`