### PR TITLE
Improve proxy middleware

### DIFF
--- a/docs/middleware/proxy.md
+++ b/docs/middleware/proxy.md
@@ -43,15 +43,14 @@ import (
 After you initiate your Fiber app, you can use the following possibilities:
 
 ```go
-// if target https site uses a self-signed certificate, you should
-// call WithTLSConfig before Do and Forward
-proxy.WithTLSConfig(&tls.Config{
-    InsecureSkipVerify: true,
-})
 // if you need to use global self-custom client, you should use proxy.WithClient.
 proxy.WithClient(&fasthttp.Client{
     NoDefaultUserAgentHeader: true, 
     DisablePathNormalizing:   true,
+    // if target https site uses a self-signed certificate, you should
+    TLSConfig:                &tls.Config{
+        InsecureSkipVerify: true,
+    },
 })
 
 // Forward to url
@@ -164,7 +163,7 @@ app.Use(proxy.Balancer(proxy.Config{
 | Timeout         | `time.Duration`                                | Timeout is the request timeout used when calling the proxy client.                                                                                                                                                                 | 1 second        |
 | ReadBufferSize  | `int`                                          | Per-connection buffer size for requests' reading. This also limits the maximum header size. Increase this buffer if your clients send multi-KB RequestURIs and/or multi-KB headers (for example, BIG cookies).                     | (Not specified) |
 | WriteBufferSize | `int`                                          | Per-connection buffer size for responses' writing.                                                                                                                                                                                 | (Not specified) |
-| TlsConfig       | `*tls.Config` (or `*fasthttp.TLSConfig` in v3) | TLS config for the HTTP client.                                                                                                                                                                                                    | `nil`           |
+| TLSConfig       | `*tls.Config` (or `*fasthttp.TLSConfig` in v3) | TLS config for the HTTP client.                                                                                                                                                                                                    | `nil`           |
 | DialDualStack   | `bool`                                         | Client will attempt to connect to both IPv4 and IPv6 host addresses if set to true.                                                                                                                                                | `false`         |
 | Client          | `*fasthttp.LBClient`                           | Client is a custom client when client config is complex.                                                                                                                                                                           | `nil`           |
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -34,11 +34,12 @@ Here's a quick overview of the changes in Fiber `v3`:
   - [CSRF](#csrf)
   - [Compression](#compression)
   - [EncryptCookie](#encryptcookie)
-  - [Session](#session)
-  - [Logger](#logger)
   - [Filesystem](#filesystem)
-  - [Monitor](#monitor)
   - [Healthcheck](#healthcheck)
+  - [Logger](#logger)
+  - [Monitor](#monitor)
+  - [Proxy](#proxy)
+  - [Session](#session)
 - [🔌 Addons](#-addons)
 - [📋 Migration guide](#-migration-guide)
 
@@ -988,21 +989,29 @@ We've added support for `zstd` compression on top of `gzip`, `deflate`, and `bro
 
 Added support for specifying Key length when using `encryptcookie.GenerateKey(length)`. This allows the user to generate keys compatible with `AES-128`, `AES-192`, and `AES-256` (Default).
 
-### Session
+### Filesystem
 
-The Session middleware has undergone key changes in v3 to improve functionality and flexibility. While v2 methods remain available for backward compatibility, we now recommend using the new middleware handler for session management.
+We've decided to remove filesystem middleware to clear up the confusion between static and filesystem middleware.
+Now, static middleware can do everything that filesystem middleware and static do. You can check out [static middleware](./middleware/static.md) or [migration guide](#-migration-guide) to see what has been changed.
 
-#### Key Updates
+### Healthcheck
 
-- **New Middleware Handler**: The `New` function now returns a middleware handler instead of a `*Store`. To access the session store, use the `Store` method on the middleware, or opt for `NewStore` or `NewWithStore` for custom store integration.
+The Healthcheck middleware has been enhanced to support more than two routes, with default endpoints for liveliness, readiness, and startup checks. Here's a detailed breakdown of the changes and how to use the new features.
 
-- **Manual Session Release**: Session instances are no longer automatically released after being saved. To ensure proper lifecycle management, you must manually call `sess.Release()`.
+1. **Support for More Than Two Routes**:
+    - The updated middleware now supports multiple routes beyond the default liveliness and readiness endpoints. This allows for more granular health checks, such as startup probes.
 
-- **Idle Timeout**: The `Expiration` field has been replaced with `IdleTimeout`, which handles session inactivity. If the session is idle for the specified duration, it will expire. The idle timeout is updated when the session is saved. If you are using the middleware handler, the idle timeout will be updated automatically.
+2. **Default Endpoints**:
+    - Three default endpoints are now available:
+        - **Liveness**: `/livez`
+        - **Readiness**: `/readyz`
+        - **Startup**: `/startupz`
+    - These endpoints can be customized or replaced with user-defined routes.
 
-- **Absolute Timeout**: The `AbsoluteTimeout` field has been added. If you need to set an absolute session timeout, you can use this field to define the duration. The session will expire after the specified duration, regardless of activity.
+3. **Simplified Configuration**:
+    - The configuration for each health check endpoint has been simplified. Each endpoint can be configured separately, allowing for more flexibility and readability.
 
-For more details on these changes and migration instructions, check the [Session Middleware Migration Guide](./middleware/session.md#migration-guide).
+Refer to the [healthcheck middleware migration guide](./middleware/healthcheck.md) or the [general migration guide](#-migration-guide) to review the changes.
 
 ### Logger
 
@@ -1161,33 +1170,29 @@ app.Use(logger.New(logger.Config{
 See more in [Logger](./middleware/logger.md#predefined-formats)
 </details>
 
-### Filesystem
-
-We've decided to remove filesystem middleware to clear up the confusion between static and filesystem middleware.
-Now, static middleware can do everything that filesystem middleware and static do. You can check out [static middleware](./middleware/static.md) or [migration guide](#-migration-guide) to see what has been changed.
-
 ### Monitor
 
 Monitor middleware is migrated to the [Contrib package](https://github.com/gofiber/contrib/tree/main/monitor) with [PR #1172](https://github.com/gofiber/contrib/pull/1172).
 
-### Healthcheck
+### Proxy
 
-The Healthcheck middleware has been enhanced to support more than two routes, with default endpoints for liveliness, readiness, and startup checks. Here's a detailed breakdown of the changes and how to use the new features.
+The proxy middleware has been updated to improve consistency with Go naming conventions. The `TlsConfig` field in the configuration struct has been renamed to `TLSConfig`. Additionally, the `WithTlsConfig` method has been removed; you should now configure TLS directly via the `TLSConfig` property within the `Config` struct.
 
-1. **Support for More Than Two Routes**:
-   - The updated middleware now supports multiple routes beyond the default liveliness and readiness endpoints. This allows for more granular health checks, such as startup probes.
+### Session
 
-2. **Default Endpoints**:
-   - Three default endpoints are now available:
-     - **Liveness**: `/livez`
-     - **Readiness**: `/readyz`
-     - **Startup**: `/startupz`
-   - These endpoints can be customized or replaced with user-defined routes.
+The Session middleware has undergone key changes in v3 to improve functionality and flexibility. While v2 methods remain available for backward compatibility, we now recommend using the new middleware handler for session management.
 
-3. **Simplified Configuration**:
-   - The configuration for each health check endpoint has been simplified. Each endpoint can be configured separately, allowing for more flexibility and readability.
+#### Key Updates
 
-Refer to the [healthcheck middleware migration guide](./middleware/healthcheck.md) or the [general migration guide](#-migration-guide) to review the changes.
+- **New Middleware Handler**: The `New` function now returns a middleware handler instead of a `*Store`. To access the session store, use the `Store` method on the middleware, or opt for `NewStore` or `NewWithStore` for custom store integration.
+
+- **Manual Session Release**: Session instances are no longer automatically released after being saved. To ensure proper lifecycle management, you must manually call `sess.Release()`.
+
+- **Idle Timeout**: The `Expiration` field has been replaced with `IdleTimeout`, which handles session inactivity. If the session is idle for the specified duration, it will expire. The idle timeout is updated when the session is saved. If you are using the middleware handler, the idle timeout will be updated automatically.
+
+- **Absolute Timeout**: The `AbsoluteTimeout` field has been added. If you need to set an absolute session timeout, you can use this field to define the duration. The session will expire after the specified duration, regardless of activity.
+
+For more details on these changes and migration instructions, check the [Session Middleware Migration Guide](./middleware/session.md#migration-guide).
 
 ## 🔌 Addons
 
@@ -1257,6 +1262,7 @@ func main() {
   - [Filesystem](#filesystem-1)
   - [Healthcheck](#healthcheck-1)
   - [Monitor](#monitor-1)
+  - [Proxy](#proxy-1)
 
 ### 🚀 App
 
@@ -1853,4 +1859,30 @@ You only need to change the import path to the contrib package.
 import "github.com/gofiber/contrib/monitor"
 
 app.Use("/metrics", monitor.New())
+```
+
+#### Proxy
+
+In previous versions, TLS settings for the proxy middleware were set using the `WithTlsConfig` method. This method has been removed in favor of a more idiomatic configuration via the `TLSConfig` field in the `Config` struct.
+
+#### Before (v2 usage)
+
+```go
+proxy.WithTlsConfig(&tls.Config{
+    InsecureSkipVerify: true,
+})
+
+// Forward to url
+app.Get("/gif", proxy.Forward("https://i.imgur.com/IWaBepg.gif"))
+```
+
+#### After (v3 usage)
+
+```go
+proxy.WithClient(&fasthttp.Client{
+    TLSConfig: &tls.Config{InsecureSkipVerify: true},
+})
+
+// Forward to url
+app.Get("/gif", proxy.Forward("https://i.imgur.com/IWaBepg.gif"))
 ```

--- a/middleware/proxy/config.go
+++ b/middleware/proxy/config.go
@@ -26,10 +26,10 @@ type Config struct {
 	ModifyResponse fiber.Handler
 
 	// tls config for the http client.
-	TlsConfig *tls.Config //nolint:stylecheck,revive // TODO: Rename to "TLSConfig" in v3
+	TLSConfig *tls.Config
 
 	// Client is custom client when client config is complex.
-	// Note that Servers, Timeout, WriteBufferSize, ReadBufferSize, TlsConfig
+	// Note that Servers, Timeout, WriteBufferSize, ReadBufferSize, TLSConfig
 	// and DialDualStack will not be used if the client are set.
 	Client *fasthttp.LBClient
 

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -20,7 +20,7 @@ func Balancer(config Config) fiber.Handler {
 
 	// Load balanced client
 	lbc := &fasthttp.LBClient{}
-	// Note that Servers, Timeout, WriteBufferSize, ReadBufferSize and TlsConfig
+	// Note that Servers, Timeout, WriteBufferSize, ReadBufferSize and TLSConfig
 	// will not be used if the client are set.
 	if config.Client == nil {
 		// Set timeout
@@ -44,7 +44,7 @@ func Balancer(config Config) fiber.Handler {
 				ReadBufferSize:  config.ReadBufferSize,
 				WriteBufferSize: config.WriteBufferSize,
 
-				TLSConfig: config.TlsConfig,
+				TLSConfig: config.TLSConfig,
 
 				DialDualStack: config.DialDualStack,
 			}

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -177,7 +177,7 @@ func Test_Proxy_Balancer_WithTlsConfig(t *testing.T) {
 	// disable certificate verification in Balancer
 	app.Use(Balancer(Config{
 		Servers:   []string{addr},
-		TlsConfig: clientTLSConf,
+		TLSConfig: clientTLSConf,
 	}))
 
 	startServer(app, ln)


### PR DESCRIPTION

# Proxy Middleware Improvements

This PR enhances the proxy middleware in Fiber v3 by improving API consistency and adhering to Go naming conventions:

## Key Changes
- Renamed `TlsConfig` to `TLSConfig` in the `Config` struct to follow proper Go naming conventions for acronyms
- Removed the `WithTlsConfig` method in favor of configuring TLS directly via the `TLSConfig` property or using the `WithClient` method
- Updated all code references, comments, and tests to use the new property name
- Added a comprehensive migration guide in the "What's New" documentation to help users transition from v2 to v3

## Migration Example
**Before (v2):**
```go
proxy.WithTlsConfig(&tls.Config{
    InsecureSkipVerify: true,
})
```

**After (v3):**
```go
proxy.WithClient(&fasthttp.Client{
    TLSConfig: &tls.Config{InsecureSkipVerify: true},
})
```

These changes are part of the broader effort to standardize APIs across the Fiber framework for v3, making the codebase more consistent and maintainable.