### PR TITLE
fix: math.MaxUint32 overflows int and test cases

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5474,11 +5474,11 @@ func Test_GenericParseTypeInt64s(t *testing.T) {
 		},
 		{
 			value: int64(math.MaxInt64),
-			str:   strconv.Itoa(math.MaxInt64),
+			str:   strconv.FormatInt(math.MaxInt64, 10),
 		},
 		{
 			value: int64(math.MinInt64),
-			str:   strconv.Itoa(math.MinInt64),
+			str:   strconv.FormatInt(math.MinInt64, 10),
 		},
 	}
 
@@ -5664,7 +5664,7 @@ func Test_GenericParseTypeUint32s(t *testing.T) {
 		},
 		{
 			value: uint32(math.MaxUint32),
-			str:   strconv.Itoa(math.MaxUint32),
+			str:   strconv.FormatUint(uint64(math.MaxUint32), 10),
 		},
 	}
 

--- a/middleware/etag/etag.go
+++ b/middleware/etag/etag.go
@@ -61,7 +61,7 @@ func New(config ...Config) fiber.Handler {
 		bb.WriteByte('"')
 
 		bodyLength := len(body)
-		if bodyLength > math.MaxUint32 {
+		if uint64(bodyLength) > uint64(math.MaxUint32) {
 			return c.SendStatus(fiber.StatusRequestEntityTooLarge)
 		}
 

--- a/middleware/etag/etag.go
+++ b/middleware/etag/etag.go
@@ -64,8 +64,8 @@ func New(config ...Config) fiber.Handler {
 		if uint64(bodyLength) > uint64(math.MaxUint32) {
 			return c.SendStatus(fiber.StatusRequestEntityTooLarge)
 		}
-
-		bb.B = appendUint(bb.Bytes(), uint32(bodyLength))
+		bodylength32 := uint32(bodyLength)
+		bb.B = appendUint(bb.Bytes(), bodylength32)
 		bb.WriteByte('-')
 		bb.B = appendUint(bb.Bytes(), crc32.Checksum(body, crc32q))
 		bb.WriteByte('"')

--- a/middleware/etag/etag.go
+++ b/middleware/etag/etag.go
@@ -64,8 +64,7 @@ func New(config ...Config) fiber.Handler {
 		if uint64(bodyLength) > uint64(math.MaxUint32) {
 			return c.SendStatus(fiber.StatusRequestEntityTooLarge)
 		}
-		bodylength32 := uint32(bodyLength)
-		bb.B = appendUint(bb.Bytes(), bodylength32)
+		bb.B = appendUint(bb.Bytes(), uint32(bodyLength))
 		bb.WriteByte('-')
 		bb.B = appendUint(bb.Bytes(), crc32.Checksum(body, crc32q))
 		bb.WriteByte('"')


### PR DESCRIPTION
# Description

Issue fixed:
This check prevents generating an ETag for response bodies larger than the maximum value of a 32-bit unsigned integer. Since the ETag calculation uses a uint32 for the body length, allowing larger bodies could cause integer overflows or incorrect ETag values. By returning a 413 Request Entity Too Large status, the middleware safely handles oversized responses. 

Fixes # (issue)
avoids potential bugs or vulnerabilities related to integer overflow.