### PR TITLE
Update docs/workflows for Go 1.24

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -39,7 +39,7 @@ Fiber v3 is currently in beta and under active development. While it offers exci
 
 ## ⚙️ Installation
 
-Fiber requires **Go version `1.23` or higher** to run. If you need to install or upgrade Go, visit the [official Go download page](https://go.dev/dl/). To start setting up your project, create a new directory for your project and navigate into it. Then, initialize your project with Go modules by executing the following command in your terminal:
+Fiber requires **Go version `1.24` or higher** to run. If you need to install or upgrade Go, visit the [official Go download page](https://go.dev/dl/). To start setting up your project, create a new directory for your project and navigate into it. Then, initialize your project with Go modules by executing the following command in your terminal:
 
 ```bash
 go mod init github.com/your/repo
@@ -124,7 +124,7 @@ We **listen** to our users in [issues](https://github.com/gofiber/fiber/issues),
 
 ## ⚠️ Limitations
 
-- Due to Fiber's usage of unsafe, the library may not always be compatible with the latest Go version. Fiber v3 has been tested with Go version 1.23 or higher.
+- Due to Fiber's usage of unsafe, the library may not always be compatible with the latest Go version. Fiber v3 has been tested with Go version 1.24 or higher.
 - Fiber is not compatible with net/http interfaces. This means you will not be able to use projects like gqlgen, go-swagger, or any others which are part of the net/http ecosystem.
 
 ## 👀 Examples

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: "1.23.x"
+          go-version: "1.24.x"
 
       - name: Run Benchmark
         run: set -o pipefail; go test ./... -benchmem -run=^$ -bench . | tee output.txt

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: "1.23.x"
+          go-version: "1.24.x"
           cache: false
 
       - name: golangci-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   unit:
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x]
+        go-version: [1.24.x]
         platform: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -31,7 +31,7 @@ jobs:
         run: go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1 -coverprofile=coverage.txt -covermode=atomic -shuffle=on
 
       - name: Upload coverage reports to Codecov
-        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.23.x' }}
+        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.24.x' }}
         uses: codecov/codecov-action@v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -12,7 +12,7 @@ These docs are for **Fiber v3**, which was released on **Month xx, 202x**.
 
 ### Installation
 
-First, [download](https://go.dev/dl/) and install Go. Version `1.23` or higher is required.
+First, [download](https://go.dev/dl/) and install Go. Version `1.24` or higher is required.
 
 Installation is done using the [`go get`](https://pkg.go.dev/cmd/go/#hdr-Add_dependencies_to_current_module_and_install_them) command:
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -45,7 +45,7 @@ Here's a quick overview of the changes in Fiber `v3`:
 
 ## Drop for old Go versions
 
-Fiber `v3` drops support for Go versions below `1.23`. We recommend upgrading to Go `1.23` or higher to use Fiber `v3`.
+Fiber `v3` drops support for Go versions below `1.24`. We recommend upgrading to Go `1.24` or higher to use Fiber `v3`.
 
 ## 🚀 App
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofiber/fiber/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/gofiber/schema v1.4.0


### PR DESCRIPTION
## Summary
- require Go 1.24 in docs and go.mod
- update CI workflows to use Go 1.24

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.26.0.3:8080: connect: no route to host)*