### PR TITLE
🧹 chore: Enhance KeyAuth middleware to better comply with RFC 6750

### DIFF
--- a/docs/middleware/keyauth.md
+++ b/docs/middleware/keyauth.md
@@ -217,10 +217,11 @@ curl --header "Authorization: Bearer my-super-secret-key"  http://localhost:3000
 |:----------------|:-----------------------------------------|:-------------------------------------------------------------------------------------------------------|:------------------------------|
 | Next            | `func(fiber.Ctx) bool`                   | Next defines a function to skip this middleware when returned true.                                    | `nil`                         |
 | SuccessHandler  | `fiber.Handler`                          | SuccessHandler defines a function which is executed for a valid key.                                   | `nil`                         |
-| ErrorHandler    | `fiber.ErrorHandler`                     | ErrorHandler defines a function which is executed for an invalid key.                                  | `401 Invalid or expired key`  |
+| ErrorHandler    | `fiber.ErrorHandler`                     | ErrorHandler defines a function which is executed for an invalid key. By default a 401 response with a `WWW-Authenticate` challenge is sent. | `nil`  |
 | KeyLookup       | `string`                                 | KeyLookup is a string in the form of "`<source>:<name>`" that is used to extract the key from the request. | "header:Authorization"        |
 | CustomKeyLookup | `KeyLookupFunc` aka `func(c fiber.Ctx) (string, error)` | If more complex logic is required to extract the key from the request, an arbitrary function to extract it can be specified here. Utility helper functions are described below. |  `nil` |
 | AuthScheme      | `string`                                 | AuthScheme to be used in the Authorization header.                                                     | "Bearer"                      |
+| Realm           | `string`                                 | Realm specifies the protected area name used in the `WWW-Authenticate` header. | `"Restricted"` |
 | Validator       | `func(fiber.Ctx, string) (bool, error)`  | Validator is a function to validate the key.                                                           | A function for key validation |
 
 ## Default Config
@@ -230,15 +231,11 @@ var ConfigDefault = Config{
     SuccessHandler: func(c fiber.Ctx) error {
         return c.Next()
     },
-    ErrorHandler: func(c fiber.Ctx, err error) error {
-        if err == ErrMissingOrMalformedAPIKey {
-            return c.Status(fiber.StatusUnauthorized).SendString(err.Error())
-        }
-        return c.Status(fiber.StatusUnauthorized).SendString("Invalid or expired API Key")
-    },
-    KeyLookup:  "header:" + fiber.HeaderAuthorization,
+    ErrorHandler:    nil,
+    KeyLookup:       "header:" + fiber.HeaderAuthorization,
     CustomKeyLookup: nil,
-    AuthScheme: "Bearer",
+    AuthScheme:      "Bearer",
+    Realm:           "Restricted",
 }
 ```
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -36,6 +36,7 @@ Here's a quick overview of the changes in Fiber `v3`:
   - [EncryptCookie](#encryptcookie)
   - [Filesystem](#filesystem)
   - [Healthcheck](#healthcheck)
+  - [KeyAuth](#keyauth)
   - [Logger](#logger)
   - [Monitor](#monitor)
   - [Proxy](#proxy)
@@ -1019,6 +1020,10 @@ The Healthcheck middleware has been enhanced to support more than two routes, wi
     - The configuration for each health check endpoint has been simplified. Each endpoint can be configured separately, allowing for more flexibility and readability.
 
 Refer to the [healthcheck middleware migration guide](./middleware/healthcheck.md) or the [general migration guide](#-migration-guide) to review the changes.
+
+### KeyAuth
+
+The keyauth middleware was updated to introduce a configurable `Realm` field for the `WWW-Authenticate` header.
 
 ### Logger
 

--- a/middleware/keyauth/keyauth.go
+++ b/middleware/keyauth/keyauth.go
@@ -124,7 +124,7 @@ func DefaultKeyLookup(keyLookup, authScheme string) (KeyLookupFunc, error) {
 // keyFromHeader returns a function that extracts api key from the request header.
 func KeyFromHeader(header, authScheme string) KeyLookupFunc {
 	return func(c fiber.Ctx) (string, error) {
-		auth := strings.TrimSpace(c.Get(header))
+		auth := utils.Trim(c.Get(header), ' ')
 		if auth == "" {
 			return "", ErrMissingOrMalformedAPIKey
 		}
@@ -134,7 +134,7 @@ func KeyFromHeader(header, authScheme string) KeyLookupFunc {
 		}
 
 		l := len(authScheme)
-		if len(auth) <= l || !strings.EqualFold(auth[:l], authScheme) {
+		if len(auth) <= l || !utils.EqualFold(auth[:l], authScheme) {
 			return "", ErrMissingOrMalformedAPIKey
 		}
 

--- a/middleware/keyauth/keyauth.go
+++ b/middleware/keyauth/keyauth.go
@@ -137,11 +137,18 @@ func KeyFromHeader(header, authScheme string) KeyLookupFunc {
 		if len(auth) <= l || !strings.EqualFold(auth[:l], authScheme) {
 			return "", ErrMissingOrMalformedAPIKey
 		}
-		if len(auth) <= l+1 || auth[l] != ' ' {
+
+		rest := auth[l:]
+		if len(rest) == 0 || (rest[0] != ' ' && rest[0] != '\t') {
 			return "", ErrMissingOrMalformedAPIKey
 		}
 
-		return strings.TrimSpace(auth[l+1:]), nil
+		token := strings.TrimLeft(rest, " \t")
+		if token == "" {
+			return "", ErrMissingOrMalformedAPIKey
+		}
+
+		return token, nil
 	}
 }
 

--- a/middleware/keyauth/keyauth.go
+++ b/middleware/keyauth/keyauth.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/utils/v2"
 )
 
 // The contextKey type is unexported to prevent collisions with context keys defined in

--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -753,6 +753,7 @@ func Test_HeaderSchemeEmptyTokenAfterTrim(t *testing.T) {
 	app.Use(New(Config{
 		Validator: func(_ fiber.Ctx, _ string) (bool, error) {
 			return false, ErrMissingOrMalformedAPIKey
+		},
 	}))
 	app.Get("/", func(c fiber.Ctx) error { return c.SendString("OK") })
 

--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -2,6 +2,7 @@ package keyauth
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"

--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -767,11 +767,3 @@ func Test_HeaderSchemeEmptyTokenAfterTrim(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
 	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
 }
-
-func TestKeyFromHeader_EmptyTokenAfterScheme(t *testing.T) {
-    // Header: "Bearer " (scheme + space but no token)
-    _, err := KeyFromHeader(&fakeContext{
-        headers: map[string]string{"Authorization": "Bearer "},
-    }, "Authorization", "Bearer")
-    require.Equal(t, ErrMissingOrMalformedAPIKey, err)
-}

--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -767,3 +767,11 @@ func Test_HeaderSchemeEmptyTokenAfterTrim(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
 	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
 }
+
+func TestKeyFromHeader_EmptyTokenAfterScheme(t *testing.T) {
+    // Header: "Bearer " (scheme + space but no token)
+    _, err := KeyFromHeader(&fakeContext{
+        headers: map[string]string{"Authorization": "Bearer "},
+    }, "Authorization", "Bearer")
+    require.Equal(t, ErrMissingOrMalformedAPIKey, err)
+}

--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -728,3 +728,22 @@ func Test_HeaderSchemeNoToken(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
 	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
 }
+
+func Test_HeaderSchemeNoSeparator(t *testing.T) {
+    app := fiber.New()
+    app.Use(New(Config{Validator: func(_ fiber.Ctx, _ string) (bool, error) {
+        return false, ErrMissingOrMalformedAPIKey
+    }}))
+    app.Get("/", func(c fiber.Ctx) error { return c.SendString("OK") })
+
+    req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+    // No space between "Bearer" and token
+    req.Header.Add("Authorization", "BearerTokenWithoutSpace")
+    res, err := app.Test(req)
+    require.NoError(t, err)
+
+    body, err := io.ReadAll(res.Body)
+    require.NoError(t, err)
+    require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+    require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
+}

--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -747,3 +747,23 @@ func Test_HeaderSchemeNoSeparator(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
 	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
 }
+
+func Test_HeaderSchemeEmptyTokenAfterTrim(t *testing.T) {
+	app := fiber.New()
+	app.Use(New(Config{
+		Validator: func(_ fiber.Ctx, _ string) (bool, error) {
+			return false, ErrMissingOrMalformedAPIKey
+		,
+	}))
+	app.Get("/", func(c fiber.Ctx) error { return c.SendString("OK") })
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	// Authorization header with scheme followed by only spaces/tabs (no actual token)
+	req.Header.Add("Authorization", "Bearer \t  \t ")
+	res, err := app.Test(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
+}

--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -730,20 +730,20 @@ func Test_HeaderSchemeNoToken(t *testing.T) {
 }
 
 func Test_HeaderSchemeNoSeparator(t *testing.T) {
-    app := fiber.New()
-    app.Use(New(Config{Validator: func(_ fiber.Ctx, _ string) (bool, error) {
-        return false, ErrMissingOrMalformedAPIKey
-    }}))
-    app.Get("/", func(c fiber.Ctx) error { return c.SendString("OK") })
+	app := fiber.New()
+	app.Use(New(Config{Validator: func(_ fiber.Ctx, _ string) (bool, error) {
+		return false, ErrMissingOrMalformedAPIKey
+	}}))
+	app.Get("/", func(c fiber.Ctx) error { return c.SendString("OK") })
 
-    req := httptest.NewRequest(fiber.MethodGet, "/", nil)
-    // No space between "Bearer" and token
-    req.Header.Add("Authorization", "BearerTokenWithoutSpace")
-    res, err := app.Test(req)
-    require.NoError(t, err)
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	// No space between "Bearer" and token
+	req.Header.Add("Authorization", "BearerTokenWithoutSpace")
+	res, err := app.Test(req)
+	require.NoError(t, err)
 
-    body, err := io.ReadAll(res.Body)
-    require.NoError(t, err)
-    require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-    require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
 }

--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -753,7 +753,6 @@ func Test_HeaderSchemeEmptyTokenAfterTrim(t *testing.T) {
 	app.Use(New(Config{
 		Validator: func(_ fiber.Ctx, _ string) (bool, error) {
 			return false, ErrMissingOrMalformedAPIKey
-		,
 	}))
 	app.Get("/", func(c fiber.Ctx) error { return c.SendString("OK") })
 


### PR DESCRIPTION
## Summary
- make authorization header parsing RFC 6750 compliant
- return standard `WWW-Authenticate` challenge when authentication fails
- add optional Realm config
- improve test-cases for the middleware
- document Realm option
