### PR TITLE
🧹 chore: Enhance BasicAuth middleware to better comply with RFC 6750

### DIFF
--- a/docs/middleware/basicauth.md
+++ b/docs/middleware/basicauth.md
@@ -6,6 +6,8 @@ id: basicauth
 
 Basic Authentication middleware for [Fiber](https://github.com/gofiber/fiber) that provides an HTTP basic authentication. It calls the next handler for valid credentials and [401 Unauthorized](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) or a custom response for missing or invalid credentials.
 
+The default unauthorized response includes the header `WWW-Authenticate: Basic realm="Restricted"`.
+
 ## Signatures
 
 ```go

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -29,6 +29,7 @@ Here's a quick overview of the changes in Fiber `v3`:
 - [🧬 Middlewares](#-middlewares)
   - [Important Change for Accessing Middleware Data](#important-change-for-accessing-middleware-data)
   - [Adaptor](#adaptor)
+  - [BasicAuth](#basicauth)
   - [Cache](#cache)
   - [CORS](#cors)
   - [CSRF](#csrf)
@@ -967,6 +968,10 @@ The adaptor middleware has been significantly optimized for performance and effi
 | 50MB         | Execution Time   | 1137 ns/op| 554.6 ns/op | -51.21%        |
 |              | Memory Usage     | 2734 B/op | 298 B/op    | -89.10%        |
 |              | Allocations      | 16 allocs/op | 5 allocs/op | -68.75%     |
+
+### BasicAuth
+
+The BasicAuth middleware was updated for improved robustness in parsing the Authorization header, with enhanced validation and whitespace handling. The default unauthorized response now uses a properly quoted and capitalized `WWW-Authenticate` header.
 
 ### Cache
 

--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -31,7 +31,7 @@ func New(config Config) fiber.Handler {
 		}
 
 		// Get authorization header
-		auth := strings.TrimSpace(c.Get(fiber.HeaderAuthorization))
+		auth := utils.Trim(c.Get(fiber.HeaderAuthorization), ' ')
 
 		// Expect a scheme token followed by credentials
 		parts := strings.Fields(auth)

--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -31,15 +31,16 @@ func New(config Config) fiber.Handler {
 		}
 
 		// Get authorization header
-		auth := c.Get(fiber.HeaderAuthorization)
+		auth := strings.TrimSpace(c.Get(fiber.HeaderAuthorization))
 
-		// Check if the header contains content besides "basic".
-		if len(auth) <= 6 || !utils.EqualFold(auth[:6], "basic ") {
+		// Expect a scheme token followed by credentials
+		parts := strings.Fields(auth)
+		if len(parts) != 2 || !utils.EqualFold(parts[0], "basic") {
 			return cfg.Unauthorized(c)
 		}
 
 		// Decode the header contents
-		raw, err := base64.StdEncoding.DecodeString(auth[6:])
+		raw, err := base64.StdEncoding.DecodeString(parts[1])
 		if err != nil {
 			return cfg.Unauthorized(c)
 		}

--- a/middleware/basicauth/basicauth_test.go
+++ b/middleware/basicauth/basicauth_test.go
@@ -91,6 +91,57 @@ func Test_Middleware_BasicAuth(t *testing.T) {
 	}
 }
 
+func Test_BasicAuth_WWWAuthenticateHeader(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New(Config{Users: map[string]string{"john": "doe"}}))
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	require.Equal(t, `Basic realm="Restricted"`, resp.Header.Get(fiber.HeaderWWWAuthenticate))
+}
+
+func Test_BasicAuth_InvalidHeader(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New(Config{Users: map[string]string{"john": "doe"}}))
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set(fiber.HeaderAuthorization, "Basic notbase64")
+	resp, err := app.Test(req)
+
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+}
+
+func Test_BasicAuth_WhitespaceHandling(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New(Config{Users: map[string]string{"john": "doe"}}))
+	app.Get("/", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusTeapot) })
+
+	creds := base64.StdEncoding.EncodeToString([]byte("john:doe"))
+
+	cases := []string{
+		"Basic " + creds,
+		" Basic \t" + creds,
+		"Basic  " + creds + "   ",
+	}
+
+	for _, h := range cases {
+		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+		req.Header.Set(fiber.HeaderAuthorization, h)
+		resp, err := app.Test(req)
+
+		require.NoError(t, err)
+		require.Equal(t, fiber.StatusTeapot, resp.StatusCode)
+	}
+}
+
 // go test -v -run=^$ -bench=Benchmark_Middleware_BasicAuth -benchmem -count=4
 func Benchmark_Middleware_BasicAuth(b *testing.B) {
 	app := fiber.New()

--- a/middleware/basicauth/config.go
+++ b/middleware/basicauth/config.go
@@ -2,6 +2,7 @@ package basicauth
 
 import (
 	"crypto/subtle"
+	"strconv"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/utils/v2"
@@ -79,7 +80,7 @@ func configDefault(config ...Config) Config {
 	}
 	if cfg.Unauthorized == nil {
 		cfg.Unauthorized = func(c fiber.Ctx) error {
-			c.Set(fiber.HeaderWWWAuthenticate, "basic realm="+cfg.Realm)
+			c.Set(fiber.HeaderWWWAuthenticate, "Basic realm="+strconv.Quote(cfg.Realm))
 			return c.SendStatus(fiber.StatusUnauthorized)
 		}
 	}


### PR DESCRIPTION
## Summary
- handle Basic authorization header more strictly
- quote `realm` parameter in `WWW-Authenticate` header
- document default challenge header
- add tests for whitespace around credentials