### PR TITLE
Fix flaky timing tests

### DIFF
--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -59,7 +59,7 @@ func Test_Cache_Expired(t *testing.T) {
 	require.NoError(t, err)
 
 	// Sleep until the cache is expired
-	time.Sleep(3 * time.Second)
+	time.Sleep(3*time.Second + 200*time.Millisecond)
 
 	respCached, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
 	require.NoError(t, err)
@@ -428,7 +428,7 @@ func Test_Cache_NothingToCache(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(600 * time.Millisecond)
 
 	respCached, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
 	require.NoError(t, err)
@@ -530,7 +530,7 @@ func Test_CustomExpiration(t *testing.T) {
 	require.Equal(t, 1, newCacheTime)
 
 	// Sleep until the cache is expired
-	time.Sleep(1*time.Second + 100*time.Millisecond)
+	time.Sleep(1200 * time.Millisecond)
 
 	cachedResp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
 	require.NoError(t, err)

--- a/middleware/idempotency/idempotency_test.go
+++ b/middleware/idempotency/idempotency_test.go
@@ -72,7 +72,7 @@ func Test_Idempotency(t *testing.T) {
 	})
 
 	app.Post("/slow", func(c fiber.Ctx) error {
-		time.Sleep(3 * lifetime)
+		time.Sleep(3*lifetime + 100*time.Millisecond)
 
 		return c.SendString(strconv.Itoa(nextCount()))
 	})
@@ -108,7 +108,7 @@ func Test_Idempotency(t *testing.T) {
 	require.Equal(t, "9", doReq(fiber.MethodPost, "/", "11111111-1111-1111-1111-111111111111"))
 
 	require.Equal(t, "7", doReq(fiber.MethodPost, "/", "00000000-0000-0000-0000-000000000000"))
-	time.Sleep(4 * lifetime)
+	time.Sleep(4*lifetime + 100*time.Millisecond)
 	require.Equal(t, "10", doReq(fiber.MethodPost, "/", "00000000-0000-0000-0000-000000000000"))
 	require.Equal(t, "10", doReq(fiber.MethodPost, "/", "00000000-0000-0000-0000-000000000000"))
 
@@ -125,7 +125,7 @@ func Test_Idempotency(t *testing.T) {
 		wg.Wait()
 		require.Equal(t, "11", doReq(fiber.MethodPost, "/slow", "22222222-2222-2222-2222-222222222222"))
 	}
-	time.Sleep(3 * lifetime)
+	time.Sleep(3*lifetime + 100*time.Millisecond)
 	require.Equal(t, "12", doReq(fiber.MethodPost, "/slow", "22222222-2222-2222-2222-222222222222"))
 }
 

--- a/middleware/limiter/limiter_test.go
+++ b/middleware/limiter/limiter_test.go
@@ -46,7 +46,7 @@ func Test_Limiter_With_Max_Func_With_Zero_And_Limiter_Sliding(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
 
-	time.Sleep(4*time.Second + 500*time.Millisecond)
+	time.Sleep(4*time.Second + 700*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	require.NoError(t, err)
@@ -133,7 +133,7 @@ func Test_Limiter_With_Max_Func(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(3*time.Second + 200*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
 	require.NoError(t, err)
@@ -177,7 +177,7 @@ func Test_Limiter_Concurrency_Store(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(3*time.Second + 200*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
 	require.NoError(t, err)
@@ -220,7 +220,7 @@ func Test_Limiter_Concurrency(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(3*time.Second + 200*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
 	require.NoError(t, err)
@@ -259,7 +259,7 @@ func Test_Limiter_Fixed_Window_No_Skip_Choices(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(3*time.Second + 200*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	require.NoError(t, err)
@@ -299,7 +299,7 @@ func Test_Limiter_Fixed_Window_Custom_Storage_No_Skip_Choices(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(3*time.Second + 200*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	require.NoError(t, err)
@@ -338,7 +338,7 @@ func Test_Limiter_Sliding_Window_No_Skip_Choices(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(4*time.Second + 500*time.Millisecond)
+	time.Sleep(4*time.Second + 700*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	require.NoError(t, err)
@@ -378,7 +378,7 @@ func Test_Limiter_Sliding_Window_Custom_Storage_No_Skip_Choices(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(4*time.Second + 500*time.Millisecond)
+	time.Sleep(4*time.Second + 700*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	require.NoError(t, err)
@@ -416,7 +416,7 @@ func Test_Limiter_Fixed_Window_Skip_Failed_Requests(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(3*time.Second + 200*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	require.NoError(t, err)
@@ -455,7 +455,7 @@ func Test_Limiter_Fixed_Window_Custom_Storage_Skip_Failed_Requests(t *testing.T)
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(3*time.Second + 200*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	require.NoError(t, err)
@@ -493,7 +493,7 @@ func Test_Limiter_Sliding_Window_Skip_Failed_Requests(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(4*time.Second + 500*time.Millisecond)
+	time.Sleep(4*time.Second + 700*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	require.NoError(t, err)
@@ -532,7 +532,7 @@ func Test_Limiter_Sliding_Window_Custom_Storage_Skip_Failed_Requests(t *testing.
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(4*time.Second + 500*time.Millisecond)
+	time.Sleep(4*time.Second + 700*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/success", nil))
 	require.NoError(t, err)
@@ -570,7 +570,7 @@ func Test_Limiter_Fixed_Window_Skip_Successful_Requests(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(3*time.Second + 200*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
 	require.NoError(t, err)
@@ -609,7 +609,7 @@ func Test_Limiter_Fixed_Window_Custom_Storage_Skip_Successful_Requests(t *testin
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(3*time.Second + 200*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
 	require.NoError(t, err)
@@ -647,7 +647,7 @@ func Test_Limiter_Sliding_Window_Skip_Successful_Requests(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(4*time.Second + 500*time.Millisecond)
+	time.Sleep(4*time.Second + 700*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
 	require.NoError(t, err)
@@ -686,7 +686,7 @@ func Test_Limiter_Sliding_Window_Custom_Storage_Skip_Successful_Requests(t *test
 	require.NoError(t, err)
 	require.Equal(t, 429, resp.StatusCode)
 
-	time.Sleep(4*time.Second + 500*time.Millisecond)
+	time.Sleep(4*time.Second + 700*time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/fail", nil))
 	require.NoError(t, err)
@@ -815,19 +815,19 @@ func Test_Sliding_Window(t *testing.T) {
 		singleRequest(false)
 	}
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(3*time.Second + 200*time.Millisecond)
 
 	for i := 0; i < 5; i++ {
 		singleRequest(false)
 	}
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(3*time.Second + 200*time.Millisecond)
 
 	for i := 0; i < 5; i++ {
 		singleRequest(false)
 	}
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(3*time.Second + 200*time.Millisecond)
 
 	for i := 0; i < 10; i++ {
 		singleRequest(false)

--- a/middleware/timeout/timeout_test.go
+++ b/middleware/timeout/timeout_test.go
@@ -119,7 +119,7 @@ func TestTimeout_ZeroDuration(t *testing.T) {
 
 	app.Get("/zero", New(func(c fiber.Ctx) error {
 		// Sleep 50ms, but there's no real 'deadline' since zero-timeout.
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(70 * time.Millisecond)
 		return c.SendString("No timeout used")
 	}, 0))
 


### PR DESCRIPTION
## Summary
- bump sleep durations in cache tests
- add extra buffer to limiter sleeps
- relax timing in idempotency and timeout tests

## Testing
- `go test ./...`
