### PR TITLE
♻️ refactor: use maps.Copy to simplify code

### DIFF
--- a/binder/mapping.go
+++ b/binder/mapping.go
@@ -3,6 +3,7 @@ package binder
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"mime/multipart"
 	"reflect"
 	"strings"
@@ -115,9 +116,7 @@ func parseToMap(ptr any, data map[string][]string) error {
 			return ErrMapNotConvertable
 		}
 
-		for k, v := range data {
-			newMap[k] = v
-		}
+		maps.Copy(newMap, data)
 	case reflect.String, reflect.Interface:
 		newMap, ok := ptr.(map[string]string)
 		if !ok {

--- a/client/request.go
+++ b/client/request.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"iter"
+	"maps"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -748,9 +749,7 @@ func (c Cookie) SetCookie(key, val string) {
 
 // SetCookies sets multiple cookies from a map.
 func (c Cookie) SetCookies(m map[string]string) {
-	for k, v := range m {
-		c[k] = v
-	}
+	maps.Copy(c, m)
 }
 
 // SetCookiesWithStruct sets cookies from a struct.
@@ -800,9 +799,7 @@ func (p PathParam) SetParam(key, val string) {
 
 // SetParams sets multiple path parameters from a map.
 func (p PathParam) SetParams(m map[string]string) {
-	for k, v := range m {
-		p[k] = v
-	}
+	maps.Copy(p, m)
 }
 
 // SetParamsWithStruct sets multiple path parameters from a struct.

--- a/middleware/logger/tags.go
+++ b/middleware/logger/tags.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
@@ -204,9 +205,7 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 		},
 	}
 	// merge with custom tags from user
-	for k, v := range cfg.CustomTags {
-		tagFunctions[k] = v
-	}
+	maps.Copy(tagFunctions, cfg.CustomTags)
 
 	return tagFunctions
 }


### PR DESCRIPTION
# Description

There is a [new function](https://pkg.go.dev/maps@go1.21.0#Copy) added in the Go 1.21 standard library, which can make the code more concise and easy to read.

## Changes introduced

- [x] Pure refactoring: replace some `for` loops with `maps.Copy`.

## Type of change

- [x] Enhancement (improvement to existing features and functionality)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [ ] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.
