### PR TITLE
Fix middleware immutable handling

### DIFF
--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -46,7 +46,12 @@ func New(config Config) fiber.Handler {
 		}
 
 		// Get the credentials
-		creds := utils.UnsafeString(raw)
+		var creds string
+		if c.App().Config().Immutable {
+			creds = string(raw)
+		} else {
+			creds = utils.UnsafeString(raw)
+		}
 
 		// Check if the credentials are in the correct form
 		// which is "username:password".

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -77,7 +77,11 @@ func Balancer(config Config) fiber.Handler {
 			}
 		}
 
-		req.SetRequestURI(utils.UnsafeString(req.RequestURI()))
+		if c.App().Config().Immutable {
+			req.SetRequestURIBytes(req.RequestURI())
+		} else {
+			req.SetRequestURI(utils.UnsafeString(req.RequestURI()))
+		}
 
 		// Forward request
 		if err := lbc.Do(req, res); err != nil {


### PR DESCRIPTION
## Summary
- ensure basic auth doesn't rely on unsafe string conversion when immutable
- use SetRequestURI or SetRequestURIBytes in proxy middleware based on Immutable flag

## Testing
- `go vet ./...` *(fails: EncodeMsg passes lock by value)*
- `go test ./...`
