### PR TITLE
Add index limit for parsers

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -676,7 +676,18 @@ func Test_Ctx_BodyParser_InvalidRequestData(t *testing.T) {
 	err := c.BodyParser(subject)
 
 	utils.AssertEqual(t, true, nil != err)
-	utils.AssertEqual(t, "failed to decode: schema: panic while decoding: reflect: slice index out of range", fmt.Sprintf("%v", err))
+	utils.AssertEqual(t, "failed to decode: schema: invalid path", fmt.Sprintf("%v", err))
+
+	c.Request().Reset()
+	c.Request().Header.SetContentType(MIMEApplicationForm)
+	c.Request().SetBody([]byte("nested-content[1001].value=Foo"))
+	c.Request().Header.SetContentLength(len(c.Body()))
+
+	subject = new(RequestBody)
+	err = c.BodyParser(subject)
+
+	utils.AssertEqual(t, true, nil != err)
+	utils.AssertEqual(t, "failed to decode: schema: index exceeds parser limit", fmt.Sprintf("%v", err))
 }
 
 func Test_Ctx_ParamParser(t *testing.T) {

--- a/internal/schema/cache.go
+++ b/internal/schema/cache.go
@@ -12,7 +12,12 @@ import (
 	"sync"
 )
 
-var errInvalidPath = errors.New("schema: invalid path")
+const maxParserIndex = 1000
+
+var (
+	errInvalidPath   = errors.New("schema: invalid path")
+	errIndexTooLarge = errors.New("schema: index exceeds parser limit")
+)
 
 // newCache returns a new cache.
 func newCache() *cache {
@@ -76,6 +81,12 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 			}
 			if index64, err = strconv.ParseInt(keys[i], 10, 0); err != nil {
 				return nil, errInvalidPath
+			}
+			if index64 < 0 {
+				return nil, errInvalidPath
+			}
+			if index64 > maxParserIndex {
+				return nil, errIndexTooLarge
 			}
 			parts = append(parts, pathPart{
 				path:  path,


### PR DESCRIPTION
## Summary
- avoid OOM for slices by limiting parsed indexes to 1000
- distinguish index overflow from invalid path
- update BodyParser tests for overflow handling

## Testing
- `make test` *(fails: Test_Proxy_Do_WithRealURL and related proxy tests due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6840ecc5afa48333aa04b21a7c296fe9