### PR TITLE
Refine CORS middleware

### DIFF
--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -66,6 +66,37 @@ func Test_CORS_Negative_MaxAge(t *testing.T) {
 	require.Equal(t, "0", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlMaxAge)))
 }
 
+func Test_CORS_MaxAge_NotSetOnSimpleRequest(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{MaxAge: 100}))
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fiber.MethodGet)
+	ctx.Request.Header.Set(fiber.HeaderOrigin, "http://localhost")
+	app.Handler()(ctx)
+
+	require.Equal(t, "", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlMaxAge)))
+}
+
+func Test_CORS_Preserve_Origin_Case(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{AllowOrigins: []string{"http://example.com"}}))
+
+	origin := "HTTP://EXAMPLE.COM"
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fiber.MethodOptions)
+	ctx.Request.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
+	ctx.Request.Header.Set(fiber.HeaderOrigin, origin)
+	app.Handler()(ctx)
+
+	require.Equal(t, origin, string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
+}
+
 func testDefaultOrEmptyConfig(t *testing.T, app *fiber.App) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- keep the original casing of the `Origin` header when responding
- separate simple vs. preflight header helpers
- avoid `Access-Control-Max-Age` on simple requests
- add regression tests for new behaviours

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68353eb593148333ad76a9813eeccee2