### PR TITLE
🧹 chore: Replace math/rand with crypto/rand

### DIFF
--- a/client/hooks.go
+++ b/client/hooks.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"math/big"
 	"mime/multipart"
 	"os"
 	"path/filepath"
@@ -31,12 +32,12 @@ const (
 // unsafeRandString returns a random string of length n.
 func unsafeRandString(n int) string {
 	b := make([]byte, n)
-	if _, err := rand.Read(b); err != nil {
-		panic(fmt.Errorf("failed to read random bytes: %w", err))
-	}
-
 	for i := 0; i < n; i++ {
-		b[i] = letterBytes[int(b[i])%len(letterBytes)]
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(letterBytes))))
+		if err != nil {
+			panic(fmt.Errorf("failed to read random index: %w", err))
+		}
+		b[i] = letterBytes[idx.Int64()]
 	}
 
 	return utils.UnsafeString(b)

--- a/client/hooks.go
+++ b/client/hooks.go
@@ -33,8 +33,9 @@ const (
 // An error is returned if the random source fails.
 func unsafeRandString(n int) (string, error) {
 	b := make([]byte, n)
+	bound := big.NewInt(int64(len(letterBytes)))
 	for i := 0; i < n; i++ {
-		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(letterBytes))))
+		idx, err := rand.Int(rand.Reader, bound)
 		if err != nil {
 			return "", fmt.Errorf("failed to read random index: %w", err)
 		}

--- a/client/hooks.go
+++ b/client/hooks.go
@@ -1,9 +1,9 @@
 package client
 
 import (
+	"crypto/rand"
 	"fmt"
 	"io"
-	"math/rand/v2"
 	"mime/multipart"
 	"os"
 	"path/filepath"
@@ -25,30 +25,18 @@ const (
 	applicationForm   = "application/x-www-form-urlencoded"
 	multipartFormData = "multipart/form-data"
 
-	letterBytes   = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	letterIdxBits = 6                    // 6 bits to represent a letter index
-	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
-	letterIdxMax  = 64 / letterIdxBits   // # of letter indices fitting into 64 bits
+	letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 )
 
 // unsafeRandString returns a random string of length n.
 func unsafeRandString(n int) string {
 	b := make([]byte, n)
-	const length = uint64(len(letterBytes))
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Errorf("failed to read random bytes: %w", err))
+	}
 
-	//nolint:gosec // Not a concern
-	for i, cache, remain := n-1, rand.Uint64(), letterIdxMax; i >= 0; {
-		if remain == 0 {
-			//nolint:gosec // Not a concern
-			cache, remain = rand.Uint64(), letterIdxMax
-		}
-
-		if idx := cache & letterIdxMask; idx < length {
-			b[i] = letterBytes[idx]
-			i--
-		}
-		cache >>= letterIdxBits
-		remain--
+	for i := 0; i < n; i++ {
+		b[i] = letterBytes[int(b[i])%len(letterBytes)]
 	}
 
 	return utils.UnsafeString(b)

--- a/client/hooks_test.go
+++ b/client/hooks_test.go
@@ -42,6 +42,14 @@ func Test_Rand_String(t *testing.T) {
 			require.Len(t, got, tt.args)
 		})
 	}
+
+	t.Run("valid characters", func(t *testing.T) {
+		t.Parallel()
+		got := unsafeRandString(32)
+		for i := 0; i < len(got); i++ {
+			require.Contains(t, letterBytes, string(got[i]))
+		}
+	})
 }
 
 func Test_Parser_Request_URL(t *testing.T) {

--- a/client/hooks_test.go
+++ b/client/hooks_test.go
@@ -38,14 +38,16 @@ func Test_Rand_String(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := unsafeRandString(tt.args)
+			got, err := unsafeRandString(tt.args)
+			require.NoError(t, err)
 			require.Len(t, got, tt.args)
 		})
 	}
 
 	t.Run("valid characters", func(t *testing.T) {
 		t.Parallel()
-		got := unsafeRandString(32)
+		got, err := unsafeRandString(32)
+		require.NoError(t, err)
 		for i := 0; i < len(got); i++ {
 			require.Contains(t, letterBytes, string(got[i]))
 		}


### PR DESCRIPTION
## Summary
- replace math/rand with crypto/rand
- remove unused constants from the multipart boundary helper
- verify generated random strings use only allowed characters