### PR TITLE
🧹 chore: Refactor EnvVar middleware

### DIFF
--- a/docs/middleware/envvar.md
+++ b/docs/middleware/envvar.md
@@ -26,14 +26,13 @@ import (
 After you initiate your Fiber app, you can use the following possibilities:
 
 ```go
-// Initialize default config
+// Initialize default config (exports no variables)
 app.Use("/expose/envvars", envvar.New())
 
 // Or extend your config for customization
 app.Use("/expose/envvars", envvar.New(
     envvar.Config{
-        ExportVars:  map[string]string{"testKey": "", "testDefaultKey": "testDefaultVal"},
-        ExcludeVars: map[string]string{"excludeKey": ""},
+        ExportVars: map[string]string{"testKey": "", "testDefaultKey": "testDefaultVal"},
     }),
 )
 ```
@@ -60,11 +59,11 @@ Http response contract:
 
 | Property    | Type                | Description                                                                  | Default |
 |:------------|:--------------------|:-----------------------------------------------------------------------------|:--------|
-| ExportVars  | `map[string]string` | ExportVars specifies the environment variables that should be exported.      | `nil`   |
-| ExcludeVars | `map[string]string` | ExcludeVars specifies the environment variables that should not be exported. | `nil`   |
+| ExportVars  | `map[string]string` | ExportVars specifies the environment variables that should be exported. | `nil` |
 
 ## Default Config
 
 ```go
 Config{}
+// Exports no environment variables
 ```

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1012,6 +1012,10 @@ We've added support for `zstd` compression on top of `gzip`, `deflate`, and `bro
 
 Added support for specifying Key length when using `encryptcookie.GenerateKey(length)`. This allows the user to generate keys compatible with `AES-128`, `AES-192`, and `AES-256` (Default).
 
+### EnvVar
+
+The `ExcludeVars` field has been removed from the EnvVar middleware configuration. When upgrading, remove any references to this field and explicitly list the variables you wish to expose using `ExportVars`.
+
 ### Filesystem
 
 We've decided to remove filesystem middleware to clear up the confusion between static and filesystem middleware.

--- a/middleware/envvar/envvar.go
+++ b/middleware/envvar/envvar.go
@@ -2,7 +2,6 @@ package envvar
 
 import (
 	"os"
-	"strings"
 
 	"github.com/gofiber/fiber/v3"
 )
@@ -11,8 +10,6 @@ import (
 type Config struct {
 	// ExportVars specifies the environment variables that should export
 	ExportVars map[string]string
-	// ExcludeVars specifies the environment variables that should not export
-	ExcludeVars map[string]string
 }
 
 type EnvVar struct {
@@ -55,13 +52,9 @@ func newEnvVar(cfg Config) *EnvVar {
 			}
 		}
 	} else {
-		const numElems = 2
-		for _, envVal := range os.Environ() {
-			keyVal := strings.SplitN(envVal, "=", numElems)
-			if _, exists := cfg.ExcludeVars[keyVal[0]]; !exists {
-				vars.set(keyVal[0], keyVal[1])
-			}
-		}
+		// do not expose environment variables when no configuration
+		// is supplied to prevent accidental information disclosure
+		return vars
 	}
 
 	return vars

--- a/middleware/envvar/envvar.go
+++ b/middleware/envvar/envvar.go
@@ -44,17 +44,17 @@ func New(config ...Config) fiber.Handler {
 func newEnvVar(cfg Config) *EnvVar {
 	vars := &EnvVar{Vars: make(map[string]string)}
 
-	if len(cfg.ExportVars) > 0 {
-		for key, defaultVal := range cfg.ExportVars {
-			vars.set(key, defaultVal)
-			if envVal, exists := os.LookupEnv(key); exists {
-				vars.set(key, envVal)
-			}
-		}
-	} else {
+	if len(cfg.ExportVars) == 0 {
 		// do not expose environment variables when no configuration
 		// is supplied to prevent accidental information disclosure
 		return vars
+	}
+
+	for key, defaultVal := range cfg.ExportVars {
+		vars.set(key, defaultVal)
+		if envVal, exists := os.LookupEnv(key); exists {
+			vars.set(key, envVal)
+		}
 	}
 
 	return vars


### PR DESCRIPTION
### Summary:
- Prevent exposure of environment variables when using the `EnvVar` middleware with default settings.
- Update tests to reflect the new behavior.
- Document that the default configuration no longer exports all environment variables.