### PR TITLE
fix: Apply default timeout on negative values and optimize skip path …

### DIFF
--- a/middleware/timeout/config.go
+++ b/middleware/timeout/config.go
@@ -52,6 +52,9 @@ func configDefault(config ...Config) Config {
 
 	cfg := config[0]
 
+	if cfg.Timeout < 0 {
+		cfg.Timeout = ConfigDefault.Timeout
+	}
 	if cfg.SkipPaths == nil {
 		cfg.SkipPaths = ConfigDefault.SkipPaths
 	}

--- a/middleware/timeout/timeout.go
+++ b/middleware/timeout/timeout.go
@@ -14,7 +14,7 @@ func New(h fiber.Handler, config ...Config) fiber.Handler {
 	cfg := configDefault(config...)
 
 	// Pre-build skip path map for faster lookups.
-	skip := map[string]struct{}{}
+	skip := make(map[string]struct{}, len(cfg.SkipPaths))
 	for _, p := range cfg.SkipPaths {
 		skip[p] = struct{}{}
 	}
@@ -55,7 +55,7 @@ func New(h fiber.Handler, config ...Config) fiber.Handler {
 // runHandler executes the handler and handles timeout-like errors.
 func runHandler(c fiber.Ctx, h fiber.Handler, cfg Config) error {
 	err := h(c)
-	if err != nil && (errors.Is(err, context.DeadlineExceeded) || isCustomError(err, cfg.Errors)) {
+	if err != nil && (errors.Is(err, context.DeadlineExceeded) || (len(cfg.Errors) > 0 && isCustomError(err, cfg.Errors))) {
 		if cfg.OnTimeout != nil {
 			return cfg.OnTimeout(c)
 		}


### PR DESCRIPTION
@gaby, this PR fixes what I suggested earlier.
It makes sure a default timeout is used if a wrong (negative) value is set.
It speeds up how skipped paths are set up.
It also avoids an unnecessary loop.