### PR TITLE
🧹 chore: Improve EarlyData middleware tests coverage

### DIFF
--- a/middleware/earlydata/earlydata_test.go
+++ b/middleware/earlydata/earlydata_test.go
@@ -1,14 +1,15 @@
-package earlydata_test
+package earlydata
 
 import (
 	"errors"
 	"fmt"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/fiber/v3/middleware/earlydata"
 	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
 )
 
 const (
@@ -28,12 +29,12 @@ func appWithConfig(t *testing.T, c *fiber.Config) *fiber.App {
 		app = fiber.New(*c)
 	}
 
-	app.Use(earlydata.New())
+	app.Use(New())
 
 	// Middleware to test IsEarly func
 	const localsKeyTestValid = "earlydata_testvalid"
 	app.Use(func(c fiber.Ctx) error {
-		isEarly := earlydata.IsEarly(c)
+		isEarly := IsEarly(c)
 
 		switch h := c.Get(headerName); h {
 		case "", headerValOff:
@@ -190,4 +191,73 @@ func Test_EarlyData(t *testing.T) {
 		})
 		trustedRun(t, app)
 	})
+}
+
+// Test_EarlyDataNext verifies that the middleware skips its logic when Next returns true.
+func Test_EarlyDataNext(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Next: func(fiber.Ctx) bool { return true },
+	}))
+
+	called := false
+	app.Get("/", func(c fiber.Ctx) error {
+		called = true
+		if IsEarly(c) {
+			return errors.New("next path should not set early flag")
+		}
+		return nil
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set(headerName, headerValOn)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.True(t, called)
+}
+
+// Test_configDefault_NoConfig verifies that calling configDefault without
+// providing a configuration returns ConfigDefault as-is.
+func Test_configDefault_NoConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configDefault()
+	require.Equal(t, ConfigDefault.Error, cfg.Error)
+	require.Equal(t, reflect.ValueOf(ConfigDefault.IsEarlyData).Pointer(), reflect.ValueOf(cfg.IsEarlyData).Pointer())
+	require.Equal(t, reflect.ValueOf(ConfigDefault.AllowEarlyData).Pointer(), reflect.ValueOf(cfg.AllowEarlyData).Pointer())
+}
+
+// Test_configDefault_WithConfig verifies that provided configuration fields are
+// kept while missing fields are populated with defaults.
+func Test_configDefault_WithConfig(t *testing.T) {
+	t.Parallel()
+	expectedErr := errors.New("boom")
+	called := false
+	custom := Config{
+		Next:  func(c fiber.Ctx) bool { called = true; return false },
+		Error: expectedErr,
+	}
+
+	cfg := configDefault(custom)
+
+	// Next should be preserved and not invoked by configDefault.
+	require.False(t, called)
+	require.Equal(t, reflect.ValueOf(custom.Next).Pointer(), reflect.ValueOf(cfg.Next).Pointer())
+	// Custom error must be preserved.
+	require.Equal(t, expectedErr, cfg.Error)
+	// Missing fields should be set to defaults.
+	require.NotNil(t, cfg.IsEarlyData)
+	require.NotNil(t, cfg.AllowEarlyData)
+	require.Equal(t, custom.Error, cfg.Error)
+
+	// Verify default functions behave as expected.
+	app := fiber.New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	c.Request().Header.Set(DefaultHeaderName, DefaultHeaderTrueValue)
+	c.Request().Header.SetMethod(fiber.MethodGet)
+	require.True(t, cfg.IsEarlyData(c))
+	require.True(t, cfg.AllowEarlyData(c))
+	app.ReleaseCtx(c)
 }

--- a/middleware/earlydata/earlydata_test.go
+++ b/middleware/earlydata/earlydata_test.go
@@ -206,7 +206,7 @@ func Test_EarlyDataNext(t *testing.T) {
 	app.Get("/", func(c fiber.Ctx) error {
 		called = true
 		if IsEarly(c) {
-			return errors.New("next path should not set early flag")
+			return errors.New("IsEarly(c) should be false when Next returns true")
 		}
 		return nil
 	})
@@ -236,7 +236,7 @@ func Test_configDefault_WithConfig(t *testing.T) {
 	expectedErr := errors.New("boom")
 	called := false
 	custom := Config{
-		Next:  func(c fiber.Ctx) bool { called = true; return false },
+		Next:  func(_ fiber.Ctx) bool { called = true; return false },
 		Error: expectedErr,
 	}
 
@@ -250,7 +250,6 @@ func Test_configDefault_WithConfig(t *testing.T) {
 	// Missing fields should be set to defaults.
 	require.NotNil(t, cfg.IsEarlyData)
 	require.NotNil(t, cfg.AllowEarlyData)
-	require.Equal(t, custom.Error, cfg.Error)
 
 	// Verify default functions behave as expected.
 	app := fiber.New()


### PR DESCRIPTION
## Summary
- add missing tests for config.go
- refactor earlydata_test.go
- add missing test for `next()`.