### PR TITLE
🧹chore: Improve BasicAuth middleware default security

### DIFF
--- a/docs/middleware/basicauth.md
+++ b/docs/middleware/basicauth.md
@@ -78,7 +78,7 @@ func handler(c fiber.Ctx) error {
 | Next            | `func(fiber.Ctx) bool`     | Next defines a function to skip this middleware when returned true.                                                                                                   | `nil`                 |
 | Users           | `map[string]string`         | Users defines the allowed credentials.                                                                                                                                | `map[string]string{}` |
 | Realm           | `string`                    | Realm is a string to define the realm attribute of BasicAuth. The realm identifies the system to authenticate against and can be used by clients to save credentials. | `"Restricted"`        |
-| Charset         | `string`                    | Charset sent in the `WWW-Authenticate` header so clients know how credentials are encoded. | `"UTF-8"` |
+| Charset         | `string`                    | Charset sent in the `WWW-Authenticate` header, so clients know how credentials are encoded. | `"UTF-8"` |
 | StorePassword   | `bool`                      | Store the plaintext password in the context and retrieve it via `PasswordFromContext`. | `false` |
 | Authorizer      | `func(string, string) bool` | Authorizer defines a function to check the credentials. It will be called with a username and password and is expected to return true or false to indicate approval.  | `nil`                 |
 | Unauthorized    | `fiber.Handler`             | Unauthorized defines the response body for unauthorized responses.                                                                                                    | `nil`                 |

--- a/docs/middleware/basicauth.md
+++ b/docs/middleware/basicauth.md
@@ -6,7 +6,7 @@ id: basicauth
 
 Basic Authentication middleware for [Fiber](https://github.com/gofiber/fiber) that provides an HTTP basic authentication. It calls the next handler for valid credentials and [401 Unauthorized](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) or a custom response for missing or invalid credentials.
 
-The default unauthorized response includes the header `WWW-Authenticate: Basic realm="Restricted"`.
+The default unauthorized response includes the header `WWW-Authenticate: Basic realm="Restricted", charset="UTF-8"` and sets `Cache-Control: no-store`.
 
 ## Signatures
 
@@ -78,6 +78,8 @@ func handler(c fiber.Ctx) error {
 | Next            | `func(fiber.Ctx) bool`     | Next defines a function to skip this middleware when returned true.                                                                                                   | `nil`                 |
 | Users           | `map[string]string`         | Users defines the allowed credentials.                                                                                                                                | `map[string]string{}` |
 | Realm           | `string`                    | Realm is a string to define the realm attribute of BasicAuth. The realm identifies the system to authenticate against and can be used by clients to save credentials. | `"Restricted"`        |
+| Charset         | `string`                    | Charset sent in the `WWW-Authenticate` header so clients know how credentials are encoded. | `"UTF-8"`
+| StorePassword   | `bool`                      | Store the plaintext password in the context and retrieve it via `PasswordFromContext`. | `false`
 | Authorizer      | `func(string, string) bool` | Authorizer defines a function to check the credentials. It will be called with a username and password and is expected to return true or false to indicate approval.  | `nil`                 |
 | Unauthorized    | `fiber.Handler`             | Unauthorized defines the response body for unauthorized responses.                                                                                                    | `nil`                 |
 
@@ -88,6 +90,8 @@ var ConfigDefault = Config{
     Next:            nil,
     Users:           map[string]string{},
     Realm:           "Restricted",
+    Charset:         "UTF-8",
+    StorePassword:   false,
     Authorizer:      nil,
     Unauthorized:    nil,
 }

--- a/docs/middleware/basicauth.md
+++ b/docs/middleware/basicauth.md
@@ -78,8 +78,8 @@ func handler(c fiber.Ctx) error {
 | Next            | `func(fiber.Ctx) bool`     | Next defines a function to skip this middleware when returned true.                                                                                                   | `nil`                 |
 | Users           | `map[string]string`         | Users defines the allowed credentials.                                                                                                                                | `map[string]string{}` |
 | Realm           | `string`                    | Realm is a string to define the realm attribute of BasicAuth. The realm identifies the system to authenticate against and can be used by clients to save credentials. | `"Restricted"`        |
-| Charset         | `string`                    | Charset sent in the `WWW-Authenticate` header so clients know how credentials are encoded. | `"UTF-8"`
-| StorePassword   | `bool`                      | Store the plaintext password in the context and retrieve it via `PasswordFromContext`. | `false`
+| Charset         | `string`                    | Charset sent in the `WWW-Authenticate` header so clients know how credentials are encoded. | `"UTF-8"` |
+| StorePassword   | `bool`                      | Store the plaintext password in the context and retrieve it via `PasswordFromContext`. | `false` |
 | Authorizer      | `func(string, string) bool` | Authorizer defines a function to check the credentials. It will be called with a username and password and is expected to return true or false to indicate approval.  | `nil`                 |
 | Unauthorized    | `fiber.Handler`             | Unauthorized defines the response body for unauthorized responses.                                                                                                    | `nil`                 |
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -975,7 +975,7 @@ The adaptor middleware has been significantly optimized for performance and effi
 
 ### BasicAuth
 
-The BasicAuth middleware was updated for improved robustness in parsing the Authorization header, with enhanced validation and whitespace handling. The default unauthorized response now uses a properly quoted and capitalized `WWW-Authenticate` header.
+The BasicAuth middleware now validates the `Authorization` header more rigorously and sets security-focused response headers. The default challenge includes the `charset="UTF-8"` parameter and disables caching. Passwords are no longer stored in the request context by default; use the new `StorePassword` option to retain them. A `Charset` option controls the value used in the challenge header.
 
 ### Cache
 

--- a/middleware/basicauth/config.go
+++ b/middleware/basicauth/config.go
@@ -41,15 +41,30 @@ type Config struct {
 	//
 	// Optional. Default: "Restricted".
 	Realm string
+
+	// Charset defines the value for the charset parameter in the
+	// WWW-Authenticate header. According to RFC 7617 clients can use
+	// this value to interpret credentials correctly.
+	//
+	// Optional. Default: "UTF-8".
+	Charset string
+
+	// StorePassword determines if the plaintext password should be stored
+	// in the context for later retrieval via PasswordFromContext.
+	//
+	// Optional. Default: false.
+	StorePassword bool
 }
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
-	Next:         nil,
-	Users:        map[string]string{},
-	Realm:        "Restricted",
-	Authorizer:   nil,
-	Unauthorized: nil,
+	Next:          nil,
+	Users:         map[string]string{},
+	Realm:         "Restricted",
+	Charset:       "UTF-8",
+	StorePassword: false,
+	Authorizer:    nil,
+	Unauthorized:  nil,
 }
 
 // Helper function to set default values
@@ -72,15 +87,35 @@ func configDefault(config ...Config) Config {
 	if cfg.Realm == "" {
 		cfg.Realm = ConfigDefault.Realm
 	}
+	if cfg.Charset == "" {
+		cfg.Charset = ConfigDefault.Charset
+	}
 	if cfg.Authorizer == nil {
 		cfg.Authorizer = func(user, pass string) bool {
-			userPwd, exist := cfg.Users[user]
-			return exist && subtle.ConstantTimeCompare(utils.UnsafeBytes(userPwd), utils.UnsafeBytes(pass)) == 1
+			var pwd string
+			var ok bool
+			for u, p := range cfg.Users {
+				match := subtle.ConstantTimeCompare(utils.UnsafeBytes(u), utils.UnsafeBytes(user)) == 1
+				if match {
+					pwd = p
+					ok = true
+				}
+			}
+			if !ok {
+				return false
+			}
+			return subtle.ConstantTimeCompare(utils.UnsafeBytes(pwd), utils.UnsafeBytes(pass)) == 1
 		}
 	}
 	if cfg.Unauthorized == nil {
 		cfg.Unauthorized = func(c fiber.Ctx) error {
-			c.Set(fiber.HeaderWWWAuthenticate, "Basic realm="+strconv.Quote(cfg.Realm))
+			header := "Basic realm=" + strconv.Quote(cfg.Realm)
+			if cfg.Charset != "" {
+				header += ", charset=" + strconv.Quote(cfg.Charset)
+			}
+			c.Set(fiber.HeaderWWWAuthenticate, header)
+			c.Set(fiber.HeaderCacheControl, "no-store")
+			c.Set(fiber.HeaderVary, fiber.HeaderAuthorization)
 			return c.SendStatus(fiber.StatusUnauthorized)
 		}
 	}

--- a/middleware/basicauth/config.go
+++ b/middleware/basicauth/config.go
@@ -92,19 +92,8 @@ func configDefault(config ...Config) Config {
 	}
 	if cfg.Authorizer == nil {
 		cfg.Authorizer = func(user, pass string) bool {
-			var pwd string
-			var ok bool
-			for u, p := range cfg.Users {
-				match := subtle.ConstantTimeCompare(utils.UnsafeBytes(u), utils.UnsafeBytes(user)) == 1
-				if match {
-					pwd = p
-					ok = true
-				}
-			}
-			if !ok {
-				return false
-			}
-			return subtle.ConstantTimeCompare(utils.UnsafeBytes(pwd), utils.UnsafeBytes(pass)) == 1
+			userPwd, exist := cfg.Users[user]
+			return exist && subtle.ConstantTimeCompare(utils.UnsafeBytes(userPwd), utils.UnsafeBytes(pass)) == 1
 		}
 	}
 	if cfg.Unauthorized == nil {


### PR DESCRIPTION
## Summary
- Add new `StorePassword` config option. Defaults to `False` to avoid leaking credentials via `Context`.
- Add `charset` parameter. Defaults to `UTF-8`.
- Set `"no-store"` header for Cache Control.