### PR TITLE
🧹 chore: Update codecov configuration

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -11,8 +11,14 @@ coverage:
         threshold: 0.5%
         base: auto
 ignore:
-  - "**/*_msgp.go"
+  # Ignore generated root files
+  - "*_msgp.go"
+  - "*_msgp_test.go"
+  - "*_gen.go"
+  # Ignore generated files below root
+  - '**/*_msgp.go'
   - "**/*_msgp_test.go"
   - "**/*_gen.go"
+  # Ignore internal and docs
   - "internal/**"
-  - "./docs/"
+  - "docs/**"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -16,7 +16,7 @@ ignore:
   - "*_msgp_test.go"
   - "*_gen.go"
   # Ignore generated files below root
-  - '**/*_msgp.go'
+  - "**/*_msgp.go"
   - "**/*_msgp_test.go"
   - "**/*_gen.go"
   # Ignore internal and docs


### PR DESCRIPTION
# Description
- Ignore `root` level generated files from `codecov`.
- Codecov is now ignoring `msgp` everywhere. See here https://app.codecov.io/gh/gofiber/fiber/pull/3528/tree 