### PR TITLE
🐛 bug: Fix Content-Type comparison in Is()

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -884,7 +884,6 @@ func (c *DefaultCtx) Is(extension string) bool {
 	}
 
 	ct := utils.UnsafeString(c.fasthttp.Request.Header.ContentType())
-ct := utils.UnsafeString(c.fasthttp.Request.Header.ContentType())
 	if i := strings.IndexByte(ct, ';'); i != -1 {
 		ct = ct[:i]
 	}

--- a/ctx.go
+++ b/ctx.go
@@ -887,7 +887,7 @@ func (c *DefaultCtx) Is(extension string) bool {
 	if i := strings.IndexByte(ct, ';'); i != -1 {
 		ct = ct[:i]
 	}
-	ct = strings.TrimSpace(ct)
+	ct = utils.Trim(ct, ' ')
 	return utils.EqualFold(ct, extensionHeader)
 }
 

--- a/ctx.go
+++ b/ctx.go
@@ -883,10 +883,13 @@ func (c *DefaultCtx) Is(extension string) bool {
 		return false
 	}
 
-	return strings.HasPrefix(
-		utils.TrimLeft(utils.UnsafeString(c.fasthttp.Request.Header.ContentType()), ' '),
-		extensionHeader,
-	)
+	ct := utils.UnsafeString(c.fasthttp.Request.Header.ContentType())
+	ct = utils.TrimLeft(ct, ' ')
+	if i := strings.IndexByte(ct, ';'); i != -1 {
+		ct = ct[:i]
+	}
+	ct = utils.TrimRight(ct, ' ')
+	return utils.EqualFold(ct, extensionHeader)
 }
 
 // JSON converts any interface or string to JSON.

--- a/ctx.go
+++ b/ctx.go
@@ -884,11 +884,11 @@ func (c *DefaultCtx) Is(extension string) bool {
 	}
 
 	ct := utils.UnsafeString(c.fasthttp.Request.Header.ContentType())
-	ct = utils.TrimLeft(ct, ' ')
+ct := utils.UnsafeString(c.fasthttp.Request.Header.ContentType())
 	if i := strings.IndexByte(ct, ';'); i != -1 {
 		ct = ct[:i]
 	}
-	ct = utils.TrimRight(ct, ' ')
+	ct = strings.TrimSpace(ct)
 	return utils.EqualFold(ct, extensionHeader)
 }
 

--- a/ctx.go
+++ b/ctx.go
@@ -883,7 +883,7 @@ func (c *DefaultCtx) Is(extension string) bool {
 		return false
 	}
 
-	ct := utils.UnsafeString(c.fasthttp.Request.Header.ContentType())
+	ct := c.app.getString(c.fasthttp.Request.Header.ContentType())
 	if i := strings.IndexByte(ct, ';'); i != -1 {
 		ct = ct[:i]
 	}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2134,6 +2134,16 @@ func Test_Ctx_Is(t *testing.T) {
 	require.False(t, c.Is("html"))
 	require.True(t, c.Is("txt"))
 	require.True(t, c.Is(".txt"))
+
+	// case-insensitive and trimmed
+	c.Request().Header.Set(HeaderContentType, "APPLICATION/JSON; charset=utf-8")
+	require.True(t, c.Is("json"))
+	require.True(t, c.Is(".json"))
+
+	// mismatched subtype should not match
+	c.Request().Header.Set(HeaderContentType, "application/json+xml")
+	require.False(t, c.Is("json"))
+	require.False(t, c.Is(".json"))
 }
 
 // go test -v -run=^$ -bench=Benchmark_Ctx_Is -benchmem -count=4


### PR DESCRIPTION
## Summary
- handle parameters and casing when comparing MIME types in `Ctx.Is`.
- update tests for case-insensitive comparison.
- add test that mismatched subtype does not match.