### PR TITLE
🐛 bug: Fix Range() parsing of bytes unit

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1281,14 +1281,17 @@ func (c *DefaultCtx) Range(size int) (Range, error) {
 		rangeData Range
 		ranges    string
 	)
-	rangeStr := c.Get(HeaderRange)
+	rangeStr := utils.Trim(c.Get(HeaderRange), ' ')
 
 	i := strings.IndexByte(rangeStr, '=')
 	if i == -1 || strings.Contains(rangeStr[i+1:], "=") {
 		return rangeData, ErrRangeMalformed
 	}
-	rangeData.Type = rangeStr[:i]
-	ranges = rangeStr[i+1:]
+	rangeData.Type = utils.ToLower(utils.Trim(rangeStr[:i], ' '))
+	if rangeData.Type != "bytes" {
+		return rangeData, ErrRangeMalformed
+	}
+	ranges = utils.Trim(rangeStr[i+1:], ' ')
 
 	var (
 		singleRange string
@@ -1298,10 +1301,12 @@ func (c *DefaultCtx) Range(size int) (Range, error) {
 		singleRange = moreRanges
 		if i := strings.IndexByte(moreRanges, ','); i >= 0 {
 			singleRange = moreRanges[:i]
-			moreRanges = moreRanges[i+1:]
+			moreRanges = utils.Trim(moreRanges[i+1:], ' ')
 		} else {
 			moreRanges = ""
 		}
+
+		singleRange = utils.Trim(singleRange, ' ')
 
 		var (
 			startStr, endStr string
@@ -1310,8 +1315,8 @@ func (c *DefaultCtx) Range(size int) (Range, error) {
 		if i = strings.IndexByte(singleRange, '-'); i == -1 {
 			return rangeData, ErrRangeMalformed
 		}
-		startStr = singleRange[:i]
-		endStr = singleRange[i+1:]
+		startStr = utils.Trim(singleRange[:i], ' ')
+		endStr = utils.Trim(singleRange[i+1:], ' ')
 
 		start, startErr := fasthttp.ParseUint(utils.UnsafeBytes(startStr))
 		end, endErr := fasthttp.ParseUint(utils.UnsafeBytes(endStr))

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2836,6 +2836,8 @@ func Test_Ctx_Range(t *testing.T) {
 	testRange("bytes=0-0,2-1000", RangeSet{Start: 0, End: 0}, RangeSet{Start: 2, End: 999})
 	testRange("bytes=0-99,450-549,-100", RangeSet{Start: 0, End: 99}, RangeSet{Start: 450, End: 549}, RangeSet{Start: 900, End: 999})
 	testRange("bytes=500-700,601-999", RangeSet{Start: 500, End: 700}, RangeSet{Start: 601, End: 999})
+	testRange("bytes= 0-1", RangeSet{Start: 0, End: 1})
+	testRange("seconds=0-1")
 }
 
 // go test -v -run=^$ -bench=Benchmark_Ctx_Range -benchmem -count=4

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -1213,6 +1213,9 @@ The generic `Query` function supports returning the following data types based o
 ### Range
 
 Returns a struct containing the type and a slice of ranges.
+Only the canonical `bytes` unit is recognized and any optional
+whitespace around range specifiers will be ignored, as specified
+in RFC 9110.
 
 ```go title="Signature"
 func (c fiber.Ctx) Range(size int) (Range, error)


### PR DESCRIPTION
## Summary
- enforce recognized `bytes` unit and trim whitespace when parsing Range header
- document Range behavior in API reference
- add regression tests for whitespace and unrecognized units
- improve rfc 9110 compliance.