### PR TITLE
🐛 bug: Fix Body() handling of Content-Encoding per RFC 9110

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -293,11 +293,12 @@ const (
 
 // Compression types
 const (
-	StrGzip    = "gzip"
-	StrBr      = "br"
-	StrDeflate = "deflate"
-	StrBrotli  = "brotli"
-	StrZstd    = "zstd"
+	StrGzip     = "gzip"
+	StrCompress = "compress"
+	StrBr       = "br"
+	StrDeflate  = "deflate"
+	StrBrotli   = "brotli"
+	StrZstd     = "zstd"
 )
 
 // Cookie SameSite

--- a/constants.go
+++ b/constants.go
@@ -295,6 +295,7 @@ const (
 const (
 	StrGzip     = "gzip"
 	StrCompress = "compress"
+	StrIdentity = "identity"
 	StrBr       = "br"
 	StrDeflate  = "deflate"
 	StrBrotli   = "brotli"

--- a/ctx.go
+++ b/ctx.go
@@ -372,9 +372,9 @@ func (c *DefaultCtx) Body() []byte {
 	if err != nil {
 		switch err {
 		case ErrUnsupportedMediaType:
-			_ = c.SendStatus(StatusUnsupportedMediaType)
+			_ = c.SendStatus(StatusUnsupportedMediaType) //nolint:errcheck // It is fine to ignore the error
 		case ErrNotImplemented:
-			_ = c.SendStatus(StatusNotImplemented)
+			_ = c.SendStatus(StatusNotImplemented) //nolint:errcheck // It is fine to ignore the error
 		}
 		return []byte(err.Error())
 	}

--- a/ctx.go
+++ b/ctx.go
@@ -370,10 +370,10 @@ func (c *DefaultCtx) Body() []byte {
 		c.fasthttp.Request.SetBodyRaw(originalBody)
 	}
 	if err != nil {
-		switch err {
-		case ErrUnsupportedMediaType:
+		switch {
+		case errors.Is(err, ErrUnsupportedMediaType):
 			_ = c.SendStatus(StatusUnsupportedMediaType) //nolint:errcheck // It is fine to ignore the error
-		case ErrNotImplemented:
+		case errors.Is(err, ErrNotImplemented):
 			_ = c.SendStatus(StatusNotImplemented) //nolint:errcheck // It is fine to ignore the error
 		}
 		return []byte(err.Error())

--- a/ctx.go
+++ b/ctx.go
@@ -298,7 +298,7 @@ func (c *DefaultCtx) tryDecodeBodyInOrder(
 		encoding := encodings[i]
 		decodesRealized++
 		switch encoding {
-		case StrGzip:
+		case StrGzip, "x-gzip":
 			body, err = c.fasthttp.Request.BodyGunzip()
 		case StrBr, StrBrotli:
 			body, err = c.fasthttp.Request.BodyUnbrotli()
@@ -306,6 +306,8 @@ func (c *DefaultCtx) tryDecodeBodyInOrder(
 			body, err = c.fasthttp.Request.BodyInflate()
 		case StrZstd:
 			body, err = c.fasthttp.Request.BodyUnzstd()
+		case StrIdentity:
+			body = c.fasthttp.Request.Body()
 		case StrCompress, "x-compress":
 			_ = c.SendStatus(StatusNotImplemented)
 			return c.Response().Body(), decodesRealized - 1, ErrNotImplemented

--- a/ctx.go
+++ b/ctx.go
@@ -309,11 +309,9 @@ func (c *DefaultCtx) tryDecodeBodyInOrder(
 		case StrIdentity:
 			body = c.fasthttp.Request.Body()
 		case StrCompress, "x-compress":
-			_ = c.SendStatus(StatusNotImplemented)
-			return c.Response().Body(), decodesRealized - 1, ErrNotImplemented
+			return nil, decodesRealized - 1, ErrNotImplemented
 		default:
-			_ = c.SendStatus(StatusUnsupportedMediaType)
-			return c.Response().Body(), decodesRealized - 1, ErrUnsupportedMediaType
+			return nil, decodesRealized - 1, ErrUnsupportedMediaType
 		}
 
 		if err != nil {
@@ -372,6 +370,12 @@ func (c *DefaultCtx) Body() []byte {
 		c.fasthttp.Request.SetBodyRaw(originalBody)
 	}
 	if err != nil {
+		switch err {
+		case ErrUnsupportedMediaType:
+			_ = c.SendStatus(StatusUnsupportedMediaType)
+		case ErrNotImplemented:
+			_ = c.SendStatus(StatusNotImplemented)
+		}
 		return []byte(err.Error())
 	}
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -488,13 +488,13 @@ func Test_Ctx_Body_With_Compression(t *testing.T) {
 			name:            "unsupported_encoding",
 			contentEncoding: "undefined",
 			body:            []byte("keeps_ORIGINAL"),
-			expectedBody:    []byte("keeps_ORIGINAL"),
+			expectedBody:    []byte("Unsupported Media Type"),
 		},
 		{
 			name:            "gzip then unsupported",
 			contentEncoding: "gzip, undefined",
 			body:            []byte("Go, be gzipped"),
-			expectedBody:    []byte("Go, be gzipped"),
+			expectedBody:    []byte("Unsupported Media Type"),
 		},
 		{
 			name:            "invalid_deflate",
@@ -530,6 +530,12 @@ func Test_Ctx_Body_With_Compression(t *testing.T) {
 			c.Request().SetBody(tCase.body)
 			body := c.Body()
 			require.Equal(t, tCase.expectedBody, body)
+
+			if strings.Contains(tCase.name, "unsupported") {
+				require.Equal(t, StatusUnsupportedMediaType, c.Response().StatusCode())
+			} else {
+				require.Equal(t, StatusOK, c.Response().StatusCode())
+			}
 
 			// Check if body raw is the same as previous before decompression
 			require.Equal(
@@ -679,13 +685,13 @@ func Test_Ctx_Body_With_Compression_Immutable(t *testing.T) {
 			name:            "unsupported_encoding",
 			contentEncoding: "undefined",
 			body:            []byte("keeps_ORIGINAL"),
-			expectedBody:    []byte("keeps_ORIGINAL"),
+			expectedBody:    []byte("Unsupported Media Type"),
 		},
 		{
 			name:            "gzip then unsupported",
 			contentEncoding: "gzip, undefined",
 			body:            []byte("Go, be gzipped"),
-			expectedBody:    []byte("Go, be gzipped"),
+			expectedBody:    []byte("Unsupported Media Type"),
 		},
 		{
 			name:            "invalid_deflate",
@@ -722,6 +728,12 @@ func Test_Ctx_Body_With_Compression_Immutable(t *testing.T) {
 			c.Request().SetBody(tCase.body)
 			body := c.Body()
 			require.Equal(t, tCase.expectedBody, body)
+
+			if strings.Contains(tCase.name, "unsupported") {
+				require.Equal(t, StatusUnsupportedMediaType, c.Response().StatusCode())
+			} else {
+				require.Equal(t, StatusOK, c.Response().StatusCode())
+			}
 
 			// Check if body raw is the same as previous before decompression
 			require.Equal(

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -491,6 +491,12 @@ func Test_Ctx_Body_With_Compression(t *testing.T) {
 			expectedBody:    []byte("Unsupported Media Type"),
 		},
 		{
+			name:            "compress_not_implemented",
+			contentEncoding: "compress",
+			body:            []byte("foo"),
+			expectedBody:    []byte("Not Implemented"),
+		},
+		{
 			name:            "gzip then unsupported",
 			contentEncoding: "gzip, undefined",
 			body:            []byte("Go, be gzipped"),
@@ -501,6 +507,12 @@ func Test_Ctx_Body_With_Compression(t *testing.T) {
 			contentEncoding: "gzip,deflate",
 			body:            []byte("I'm not correctly compressed"),
 			expectedBody:    []byte(zlib.ErrHeader.Error()),
+		},
+		{
+			name:            "identity",
+			contentEncoding: "identity",
+			body:            []byte("bar"),
+			expectedBody:    []byte("bar"),
 		},
 	}
 
@@ -531,9 +543,12 @@ func Test_Ctx_Body_With_Compression(t *testing.T) {
 			body := c.Body()
 			require.Equal(t, tCase.expectedBody, body)
 
-			if strings.Contains(tCase.name, "unsupported") {
+			switch {
+			case strings.Contains(tCase.name, "unsupported"):
 				require.Equal(t, StatusUnsupportedMediaType, c.Response().StatusCode())
-			} else {
+			case strings.Contains(tCase.name, "compress_not_implemented"):
+				require.Equal(t, StatusNotImplemented, c.Response().StatusCode())
+			default:
 				require.Equal(t, StatusOK, c.Response().StatusCode())
 			}
 
@@ -688,6 +703,12 @@ func Test_Ctx_Body_With_Compression_Immutable(t *testing.T) {
 			expectedBody:    []byte("Unsupported Media Type"),
 		},
 		{
+			name:            "compress_not_implemented",
+			contentEncoding: "compress",
+			body:            []byte("foo"),
+			expectedBody:    []byte("Not Implemented"),
+		},
+		{
 			name:            "gzip then unsupported",
 			contentEncoding: "gzip, undefined",
 			body:            []byte("Go, be gzipped"),
@@ -698,6 +719,12 @@ func Test_Ctx_Body_With_Compression_Immutable(t *testing.T) {
 			contentEncoding: "gzip,deflate",
 			body:            []byte("I'm not correctly compressed"),
 			expectedBody:    []byte(zlib.ErrHeader.Error()),
+		},
+		{
+			name:            "identity",
+			contentEncoding: "identity",
+			body:            []byte("bar"),
+			expectedBody:    []byte("bar"),
 		},
 	}
 
@@ -729,9 +756,12 @@ func Test_Ctx_Body_With_Compression_Immutable(t *testing.T) {
 			body := c.Body()
 			require.Equal(t, tCase.expectedBody, body)
 
-			if strings.Contains(tCase.name, "unsupported") {
+			switch {
+			case strings.Contains(tCase.name, "unsupported"):
 				require.Equal(t, StatusUnsupportedMediaType, c.Response().StatusCode())
-			} else {
+			case strings.Contains(tCase.name, "compress_not_implemented"):
+				require.Equal(t, StatusNotImplemented, c.Response().StatusCode())
+			default:
 				require.Equal(t, StatusOK, c.Response().StatusCode())
 			}
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -533,7 +533,7 @@ func Test_Ctx_Body_With_Compression(t *testing.T) {
 			encs := strings.Split(tCase.contentEncoding, ",")
 			for _, enc := range encs {
 				enc = strings.TrimSpace(enc)
-				if strings.Contains(tCase.name, "invalid_deflate") && enc == "deflate" {
+				if strings.Contains(tCase.name, "invalid_deflate") && enc == StrDeflate {
 					continue
 				}
 				switch enc {
@@ -545,7 +545,7 @@ func Test_Ctx_Body_With_Compression(t *testing.T) {
 					require.NoError(t, gz.Flush())
 					require.NoError(t, gz.Close())
 					tCase.body = b.Bytes()
-				case "deflate":
+				case StrDeflate:
 					var b bytes.Buffer
 					fl := zlib.NewWriter(&b)
 					_, err := fl.Write(tCase.body)
@@ -625,7 +625,7 @@ func Benchmark_Ctx_Body_With_Compression(b *testing.B) {
 			compressWriter:  compressGzip,
 		},
 		{
-			contentEncoding: "deflate",
+			contentEncoding: StrDeflate,
 			compressWriter:  compressDeflate,
 		},
 		{
@@ -763,7 +763,7 @@ func Test_Ctx_Body_With_Compression_Immutable(t *testing.T) {
 			encs := strings.Split(tCase.contentEncoding, ",")
 			for _, enc := range encs {
 				enc = strings.TrimSpace(enc)
-				if strings.Contains(tCase.name, "invalid_deflate") && enc == "deflate" {
+				if strings.Contains(tCase.name, "invalid_deflate") && enc == StrDeflate {
 					continue
 				}
 				switch enc {
@@ -775,7 +775,7 @@ func Test_Ctx_Body_With_Compression_Immutable(t *testing.T) {
 					require.NoError(t, gz.Flush())
 					require.NoError(t, gz.Close())
 					tCase.body = b.Bytes()
-				case "deflate":
+				case StrDeflate:
 					var b bytes.Buffer
 					fl := zlib.NewWriter(&b)
 					_, err := fl.Write(tCase.body)
@@ -855,7 +855,7 @@ func Benchmark_Ctx_Body_With_Compression_Immutable(b *testing.B) {
 			compressWriter:  compressGzip,
 		},
 		{
-			contentEncoding: "deflate",
+			contentEncoding: StrDeflate,
 			compressWriter:  compressDeflate,
 		},
 		{

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -541,7 +541,7 @@ app.Get("/", func(c fiber.Ctx) error {
 
 ### Body
 
-As per the header `Content-Encoding`, this method will try to perform a file decompression from the **body** bytes. In case no `Content-Encoding` header is sent, it will perform as [BodyRaw](#bodyraw). If an unknown or unsupported encoding is encountered, the response status will be `415 Unsupported Media Type` or `501 Not Implemented`.
+As per the header `Content-Encoding`, this method will try to perform a file decompression from the **body** bytes. In case no `Content-Encoding` header is sent (or when it is set to `identity`), it will perform as [BodyRaw](#bodyraw). If an unknown or unsupported encoding is encountered, the response status will be `415 Unsupported Media Type` or `501 Not Implemented`.
 
 ```go title="Signature"
 func (c fiber.Ctx) Body() []byte

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -541,7 +541,7 @@ app.Get("/", func(c fiber.Ctx) error {
 
 ### Body
 
-As per the header `Content-Encoding`, this method will try to perform a file decompression from the **body** bytes. In case no `Content-Encoding` header is sent, it will perform as [BodyRaw](#bodyraw).
+As per the header `Content-Encoding`, this method will try to perform a file decompression from the **body** bytes. In case no `Content-Encoding` header is sent, it will perform as [BodyRaw](#bodyraw). If an unknown or unsupported encoding is encountered, the response status will be `415 Unsupported Media Type` or `501 Not Implemented`.
 
 ```go title="Signature"
 func (c fiber.Ctx) Body() []byte


### PR DESCRIPTION
## Summary
- enforce RFC9110 handling for unknown content-encodings
- document new 415/501 behaviour in Body()
- test unsupported encodings