### PR TITLE
🐛 bug: Fix Cache middleware handling of Age

### DIFF
--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -51,22 +51,28 @@ type Ctx interface {
 	RequestCtx() *fasthttp.RequestCtx
 	// Cookie sets a cookie by passing a cookie struct.
 	Cookie(cookie *Cookie)
+	// Deadline returns the time when work done on behalf of this context
+	// should be canceled. Deadline returns ok==false when no deadline is
+	// set. Successive calls to Deadline return the same results.
+	//
+	// Due to current limitations in how fasthttp works, Deadline operates as a nop.
+	// See: https://github.com/valyala/fasthttp/issues/965#issuecomment-777268945
+	Deadline() (time.Time, bool)
+	// Done returns a channel that's closed when work done on behalf of this
+	// context should be canceled. Done may return nil if this context can
+	// never be canceled. Successive calls to Done return the same value.
+	// The close of the Done channel may happen asynchronously,
+	// after the cancel function returns.
+	//
+	// Due to current limitations in how fasthttp works, Done operates as a nop.
+	// See: https://github.com/valyala/fasthttp/issues/965#issuecomment-777268945
+	Done() <-chan struct{}
 	// Cookies are used for getting a cookie value by key.
 	// Defaults to the empty string "" if the cookie doesn't exist.
 	// If a default value is given, it will return that value if the cookie doesn't exist.
 	// The returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Cookies(key string, defaultValue ...string) string
-	// Deadline returns the time when work done on behalf of this context
-	// should be canceled. Deadline returns ok==false when no deadline is
-	// set. Successive calls to Deadline return the same results.
-	Deadline() (deadline time.Time, ok bool)
-	// Done returns a channel that's closed when work done on behalf of this
-	// context should be canceled. Done may return nil if this context can
-	// never be canceled. Successive calls to Done return the same value.
-	// The close of the Done channel may happen asynchronously,
-	// after the cancel function returns.
-	Done() <-chan struct{}
 	// Download transfers the file from path as an attachment.
 	// Typically, browsers will prompt the user for download.
 	// By default, the Content-Disposition header filename= parameter is the filepath (this typically appears in the browser dialog).
@@ -74,9 +80,12 @@ type Ctx interface {
 	Download(file string, filename ...string) error
 	// If Done is not yet closed, Err returns nil.
 	// If Done is closed, Err returns a non-nil error explaining why:
-	// DeadlineExceeded if the context's deadline passed,
-	// or Canceled if the context was canceled for some other reason.
+	// context.DeadlineExceeded if the context's deadline passed,
+	// or context.Canceled if the context was canceled for some other reason.
 	// After Err returns a non-nil error, successive calls to Err return the same error.
+	//
+	// Due to current limitations in how fasthttp works, Err operates as a nop.
+	// See: https://github.com/valyala/fasthttp/issues/965#issuecomment-777268945
 	Err() error
 	// Request return the *fasthttp.Request object
 	// This allows you to use all fasthttp request methods
@@ -224,6 +233,7 @@ type Ctx interface {
 	Params(key string, defaultValue ...string) string
 	// Path returns the path part of the request URL.
 	// Optionally, you could override the path.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Path(override ...string) string
 	// Scheme contains the request protocol string: http or https for TLS requests.
 	// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
@@ -311,8 +321,9 @@ type Ctx interface {
 	// Set sets the response's HTTP header field to the specified key, value.
 	Set(key, val string)
 	setCanonical(key, val string)
-	// Subdomains returns a string slice of subdomains in the domain name of the request.
-	// The subdomain offset, which defaults to 2, is used for determining the beginning of the subdomain segments.
+	// Subdomains returns a slice of subdomains from the host, excluding the last `offset` components.
+	// If the offset is negative or exceeds the number of subdomains, an empty slice is returned.
+	// If the offset is zero every label (no trimming) is returned.
 	Subdomains(offset ...int) []string
 	// Stale is not implemented yet, pull requests are welcome!
 	Stale() bool

--- a/docs/middleware/cache.md
+++ b/docs/middleware/cache.md
@@ -26,7 +26,6 @@ This middleware caches responses with the following status codes according to RF
 - `414: URI Too Long`
 - `501: Not Implemented`
 
-Additionally, `418: I'm a teapot` is not originally cacheable but is cached by this middleware.
 If the status code is other than these, you will always get an `unreachable` cache status.
 
 For more information about cacheable status codes or RFC7231, please refer to the following resources:

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -59,7 +59,6 @@ var cacheableStatusCodes = map[int]bool{
 	fiber.StatusMethodNotAllowed:            true,
 	fiber.StatusGone:                        true,
 	fiber.StatusRequestURITooLong:           true,
-	fiber.StatusTeapot:                      true,
 	fiber.StatusNotImplemented:              true,
 }
 
@@ -168,8 +167,9 @@ func New(config ...Config) fiber.Handler {
 					c.Set(fiber.HeaderCacheControl, "public, max-age="+maxAge)
 				}
 
-				// RFC-compliant Age header
-				age := strconv.FormatUint(e.ttl-(e.exp-ts), 10)
+				// RFC-compliant Age header (RFC 9111)
+				resident := e.ttl - (e.exp - ts)
+				age := strconv.FormatUint(e.age+resident, 10)
 				c.Response().Header.Set(fiber.HeaderAge, age)
 
 				c.Set(cfg.CacheHeader, cacheHit)
@@ -239,9 +239,15 @@ func New(config ...Config) fiber.Handler {
 		e.ctype = utils.CopyBytes(c.Response().Header.ContentType())
 		e.cencoding = utils.CopyBytes(c.Response().Header.Peek(fiber.HeaderContentEncoding))
 
-		if len(c.Response().Header.Peek(fiber.HeaderAge)) == 0 {
+		ageVal := uint64(0)
+		if b := c.Response().Header.Peek(fiber.HeaderAge); len(b) > 0 {
+			if v, err := strconv.ParseUint(utils.UnsafeString(b), 10, 64); err == nil {
+				ageVal = v
+			}
+		} else {
 			c.Response().Header.Set(fiber.HeaderAge, "0")
 		}
+		e.age = ageVal
 
 		// Store all response headers
 		// (more: https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1)

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/utils/v2"
+	"github.com/valyala/fasthttp"
 )
 
 // timestampUpdatePeriod is the period which is used to check the cache expiration.
@@ -241,7 +242,7 @@ func New(config ...Config) fiber.Handler {
 
 		ageVal := uint64(0)
 		if b := c.Response().Header.Peek(fiber.HeaderAge); len(b) > 0 {
-			if v, err := strconv.ParseUint(utils.UnsafeString(b), 10, 64); err == nil {
+			if v, err := fasthttp.ParseUint(b); err == nil {
 				ageVal = v
 			}
 		} else {

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -243,7 +243,7 @@ func New(config ...Config) fiber.Handler {
 		ageVal := uint64(0)
 		if b := c.Response().Header.Peek(fiber.HeaderAge); len(b) > 0 {
 			if v, err := fasthttp.ParseUint(b); err == nil {
-				ageVal = v
+				ageVal = uint64(v)
 			}
 		} else {
 			c.Response().Header.Set(fiber.HeaderAge, "0")

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -243,7 +243,7 @@ func New(config ...Config) fiber.Handler {
 		ageVal := uint64(0)
 		if b := c.Response().Header.Peek(fiber.HeaderAge); len(b) > 0 {
 			if v, err := fasthttp.ParseUint(b); err == nil {
-				ageVal = uint64(v)
+				ageVal = uint64(v) //nolint:gosec //Not a concern
 			}
 		} else {
 			c.Response().Header.Set(fiber.HeaderAge, "0")

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -1050,6 +1050,7 @@ func Test_Cache_UncacheableStatusCodes(t *testing.T) {
 		fiber.StatusPreconditionRequired,
 		fiber.StatusTooManyRequests,
 		fiber.StatusRequestHeaderFieldsTooLarge,
+		fiber.StatusTeapot,
 		fiber.StatusUnavailableForLegalReasons,
 
 		// Server error responses

--- a/middleware/cache/manager.go
+++ b/middleware/cache/manager.go
@@ -17,6 +17,7 @@ type item struct {
 	ctype     []byte
 	cencoding []byte
 	status    int
+	age       uint64
 	exp       uint64
 	ttl       uint64
 	// used for finding the item in an indexed heap
@@ -63,7 +64,9 @@ func (m *manager) release(e *item) {
 	e.body = nil
 	e.ctype = nil
 	e.status = 0
+	e.age = 0
 	e.exp = 0
+	e.ttl = 0
 	e.headers = nil
 	m.pool.Put(e)
 }

--- a/middleware/cache/manager_msgp.go
+++ b/middleware/cache/manager_msgp.go
@@ -78,10 +78,22 @@ func (z *item) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "status")
 				return
 			}
+		case "age":
+			z.age, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "age")
+				return
+			}
 		case "exp":
 			z.exp, err = dc.ReadUint64()
 			if err != nil {
 				err = msgp.WrapError(err, "exp")
+				return
+			}
+		case "ttl":
+			z.ttl, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "ttl")
 				return
 			}
 		case "heapidx":
@@ -103,9 +115,9 @@ func (z *item) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *item) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 7
+	// map header, size 9
 	// write "headers"
-	err = en.Append(0x87, 0xa7, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72, 0x73)
+	err = en.Append(0x89, 0xa7, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72, 0x73)
 	if err != nil {
 		return
 	}
@@ -166,6 +178,16 @@ func (z *item) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "status")
 		return
 	}
+	// write "age"
+	err = en.Append(0xa3, 0x61, 0x67, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint64(z.age)
+	if err != nil {
+		err = msgp.WrapError(err, "age")
+		return
+	}
 	// write "exp"
 	err = en.Append(0xa3, 0x65, 0x78, 0x70)
 	if err != nil {
@@ -174,6 +196,16 @@ func (z *item) EncodeMsg(en *msgp.Writer) (err error) {
 	err = en.WriteUint64(z.exp)
 	if err != nil {
 		err = msgp.WrapError(err, "exp")
+		return
+	}
+	// write "ttl"
+	err = en.Append(0xa3, 0x74, 0x74, 0x6c)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint64(z.ttl)
+	if err != nil {
+		err = msgp.WrapError(err, "ttl")
 		return
 	}
 	// write "heapidx"
@@ -192,9 +224,9 @@ func (z *item) EncodeMsg(en *msgp.Writer) (err error) {
 // MarshalMsg implements msgp.Marshaler
 func (z *item) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 7
+	// map header, size 9
 	// string "headers"
-	o = append(o, 0x87, 0xa7, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72, 0x73)
+	o = append(o, 0x89, 0xa7, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72, 0x73)
 	o = msgp.AppendMapHeader(o, uint32(len(z.headers)))
 	for za0001, za0002 := range z.headers {
 		o = msgp.AppendString(o, za0001)
@@ -212,9 +244,15 @@ func (z *item) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "status"
 	o = append(o, 0xa6, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73)
 	o = msgp.AppendInt(o, z.status)
+	// string "age"
+	o = append(o, 0xa3, 0x61, 0x67, 0x65)
+	o = msgp.AppendUint64(o, z.age)
 	// string "exp"
 	o = append(o, 0xa3, 0x65, 0x78, 0x70)
 	o = msgp.AppendUint64(o, z.exp)
+	// string "ttl"
+	o = append(o, 0xa3, 0x74, 0x74, 0x6c)
+	o = msgp.AppendUint64(o, z.ttl)
 	// string "heapidx"
 	o = append(o, 0xa7, 0x68, 0x65, 0x61, 0x70, 0x69, 0x64, 0x78)
 	o = msgp.AppendInt(o, z.heapidx)
@@ -293,10 +331,22 @@ func (z *item) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "status")
 				return
 			}
+		case "age":
+			z.age, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "age")
+				return
+			}
 		case "exp":
 			z.exp, bts, err = msgp.ReadUint64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "exp")
+				return
+			}
+		case "ttl":
+			z.ttl, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ttl")
 				return
 			}
 		case "heapidx":
@@ -326,6 +376,6 @@ func (z *item) Msgsize() (s int) {
 			s += msgp.StringPrefixSize + len(za0001) + msgp.BytesPrefixSize + len(za0002)
 		}
 	}
-	s += 5 + msgp.BytesPrefixSize + len(z.body) + 6 + msgp.BytesPrefixSize + len(z.ctype) + 10 + msgp.BytesPrefixSize + len(z.cencoding) + 7 + msgp.IntSize + 4 + msgp.Uint64Size + 8 + msgp.IntSize
+	s += 5 + msgp.BytesPrefixSize + len(z.body) + 6 + msgp.BytesPrefixSize + len(z.ctype) + 10 + msgp.BytesPrefixSize + len(z.cencoding) + 7 + msgp.IntSize + 4 + msgp.Uint64Size + 4 + msgp.Uint64Size + 4 + msgp.Uint64Size + 8 + msgp.IntSize
 	return
 }

--- a/middleware/cache/manager_msgp_test.go
+++ b/middleware/cache/manager_msgp_test.go
@@ -35,7 +35,8 @@ func TestMarshalUnmarshalitem(t *testing.T) {
 func BenchmarkMarshalMsgitem(b *testing.B) {
 	v := item{}
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		v.MarshalMsg(nil)
 	}
 }
@@ -46,7 +47,8 @@ func BenchmarkAppendMsgitem(b *testing.B) {
 	bts, _ = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		bts, _ = v.MarshalMsg(bts[0:0])
 	}
 }
@@ -56,7 +58,8 @@ func BenchmarkUnmarshalitem(b *testing.B) {
 	bts, _ := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		_, err := v.UnmarshalMsg(bts)
 		if err != nil {
 			b.Fatal(err)
@@ -95,7 +98,8 @@ func BenchmarkEncodeitem(b *testing.B) {
 	b.SetBytes(int64(buf.Len()))
 	en := msgp.NewWriter(msgp.Nowhere)
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		v.EncodeMsg(en)
 	}
 	en.Flush()
@@ -109,7 +113,8 @@ func BenchmarkDecodeitem(b *testing.B) {
 	rd := msgp.NewEndlessReader(buf.Bytes(), b)
 	dc := msgp.NewReader(rd)
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		err := v.DecodeMsg(dc)
 		if err != nil {
 			b.Fatal(err)

--- a/middleware/csrf/storage_manager_msgp_test.go
+++ b/middleware/csrf/storage_manager_msgp_test.go
@@ -35,7 +35,8 @@ func TestMarshalUnmarshalitem(t *testing.T) {
 func BenchmarkMarshalMsgitem(b *testing.B) {
 	v := item{}
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		v.MarshalMsg(nil)
 	}
 }
@@ -46,7 +47,8 @@ func BenchmarkAppendMsgitem(b *testing.B) {
 	bts, _ = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		bts, _ = v.MarshalMsg(bts[0:0])
 	}
 }
@@ -56,7 +58,8 @@ func BenchmarkUnmarshalitem(b *testing.B) {
 	bts, _ := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		_, err := v.UnmarshalMsg(bts)
 		if err != nil {
 			b.Fatal(err)
@@ -95,7 +98,8 @@ func BenchmarkEncodeitem(b *testing.B) {
 	b.SetBytes(int64(buf.Len()))
 	en := msgp.NewWriter(msgp.Nowhere)
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		v.EncodeMsg(en)
 	}
 	en.Flush()
@@ -109,7 +113,8 @@ func BenchmarkDecodeitem(b *testing.B) {
 	rd := msgp.NewEndlessReader(buf.Bytes(), b)
 	dc := msgp.NewReader(rd)
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		err := v.DecodeMsg(dc)
 		if err != nil {
 			b.Fatal(err)
@@ -143,7 +148,8 @@ func TestMarshalUnmarshalstorageManager(t *testing.T) {
 func BenchmarkMarshalMsgstorageManager(b *testing.B) {
 	v := storageManager{}
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		v.MarshalMsg(nil)
 	}
 }
@@ -154,7 +160,8 @@ func BenchmarkAppendMsgstorageManager(b *testing.B) {
 	bts, _ = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		bts, _ = v.MarshalMsg(bts[0:0])
 	}
 }
@@ -164,7 +171,8 @@ func BenchmarkUnmarshalstorageManager(b *testing.B) {
 	bts, _ := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		_, err := v.UnmarshalMsg(bts)
 		if err != nil {
 			b.Fatal(err)
@@ -203,7 +211,8 @@ func BenchmarkEncodestorageManager(b *testing.B) {
 	b.SetBytes(int64(buf.Len()))
 	en := msgp.NewWriter(msgp.Nowhere)
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		v.EncodeMsg(en)
 	}
 	en.Flush()
@@ -217,7 +226,8 @@ func BenchmarkDecodestorageManager(b *testing.B) {
 	rd := msgp.NewEndlessReader(buf.Bytes(), b)
 	dc := msgp.NewReader(rd)
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		err := v.DecodeMsg(dc)
 		if err != nil {
 			b.Fatal(err)

--- a/middleware/idempotency/response_msgp_test.go
+++ b/middleware/idempotency/response_msgp_test.go
@@ -35,7 +35,8 @@ func TestMarshalUnmarshalresponse(t *testing.T) {
 func BenchmarkMarshalMsgresponse(b *testing.B) {
 	v := response{}
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		v.MarshalMsg(nil)
 	}
 }
@@ -46,7 +47,8 @@ func BenchmarkAppendMsgresponse(b *testing.B) {
 	bts, _ = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		bts, _ = v.MarshalMsg(bts[0:0])
 	}
 }
@@ -56,7 +58,8 @@ func BenchmarkUnmarshalresponse(b *testing.B) {
 	bts, _ := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		_, err := v.UnmarshalMsg(bts)
 		if err != nil {
 			b.Fatal(err)
@@ -95,7 +98,8 @@ func BenchmarkEncoderesponse(b *testing.B) {
 	b.SetBytes(int64(buf.Len()))
 	en := msgp.NewWriter(msgp.Nowhere)
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		v.EncodeMsg(en)
 	}
 	en.Flush()
@@ -109,7 +113,8 @@ func BenchmarkDecoderesponse(b *testing.B) {
 	rd := msgp.NewEndlessReader(buf.Bytes(), b)
 	dc := msgp.NewReader(rd)
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		err := v.DecodeMsg(dc)
 		if err != nil {
 			b.Fatal(err)

--- a/middleware/session/data_msgp_test.go
+++ b/middleware/session/data_msgp_test.go
@@ -35,7 +35,8 @@ func TestMarshalUnmarshaldata(t *testing.T) {
 func BenchmarkMarshalMsgdata(b *testing.B) {
 	v := data{}
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		v.MarshalMsg(nil)
 	}
 }
@@ -46,7 +47,8 @@ func BenchmarkAppendMsgdata(b *testing.B) {
 	bts, _ = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		bts, _ = v.MarshalMsg(bts[0:0])
 	}
 }
@@ -56,7 +58,8 @@ func BenchmarkUnmarshaldata(b *testing.B) {
 	bts, _ := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		_, err := v.UnmarshalMsg(bts)
 		if err != nil {
 			b.Fatal(err)
@@ -95,7 +98,8 @@ func BenchmarkEncodedata(b *testing.B) {
 	b.SetBytes(int64(buf.Len()))
 	en := msgp.NewWriter(msgp.Nowhere)
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		v.EncodeMsg(en)
 	}
 	en.Flush()
@@ -109,7 +113,8 @@ func BenchmarkDecodedata(b *testing.B) {
 	rd := msgp.NewEndlessReader(buf.Bytes(), b)
 	dc := msgp.NewReader(rd)
 	b.ReportAllocs()
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		err := v.DecodeMsg(dc)
 		if err != nil {
 			b.Fatal(err)


### PR DESCRIPTION
## Summary
- RFC 9111 Compliance for Age Header: The cache middleware now correctly calculates and sets the Age header for cached responses. It achieves this by storing the Age value received from the upstream server and adding the time the response has been resident in the cache, adhering to the specifications of RFC 9111.
- Stop Caching 418 I'm a teapot Responses: The middleware has been updated to no longer cache responses with the 418 I'm a teapot status code. This change removes a non-standard caching behavior and aligns the middleware with typical HTTP caching practices.