### PR TITLE
🐛 bug: Fix Range() handling of HTTP 416 per RFC 9110

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1384,7 +1384,9 @@ func (c *DefaultCtx) Range(size int) (Range, error) {
 		})
 	}
 	if len(rangeData.Ranges) < 1 {
-		return rangeData, ErrRangeUnsatisfiable
+		c.Status(StatusRequestedRangeNotSatisfiable)
+		c.Set(HeaderContentRange, fmt.Sprintf("bytes */%d", size))
+		return rangeData, ErrRequestedRangeNotSatisfiable
 	}
 
 	return rangeData, nil

--- a/ctx.go
+++ b/ctx.go
@@ -1385,7 +1385,7 @@ func (c *DefaultCtx) Range(size int) (Range, error) {
 	}
 	if len(rangeData.Ranges) < 1 {
 		c.Status(StatusRequestedRangeNotSatisfiable)
-		c.Set(HeaderContentRange, fmt.Sprintf("bytes */%d", size))
+c.Set(HeaderContentRange, "bytes */"+strconv.Itoa(size))
 		return rangeData, ErrRequestedRangeNotSatisfiable
 	}
 

--- a/ctx.go
+++ b/ctx.go
@@ -1385,7 +1385,7 @@ func (c *DefaultCtx) Range(size int) (Range, error) {
 	}
 	if len(rangeData.Ranges) < 1 {
 		c.Status(StatusRequestedRangeNotSatisfiable)
-c.Set(HeaderContentRange, "bytes */"+strconv.Itoa(size))
+		c.Set(HeaderContentRange, "bytes */"+strconv.Itoa(size))
 		return rangeData, ErrRequestedRangeNotSatisfiable
 	}
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2991,6 +2991,25 @@ func Test_Ctx_Range(t *testing.T) {
 	testRange("seconds=0-1")
 }
 
+func Test_Ctx_Range_Unsatisfiable(t *testing.T) {
+	t.Parallel()
+	app := New()
+	app.Get("/", func(c Ctx) error {
+		_, err := c.Range(10)
+		if err != nil {
+			return err
+		}
+		return c.SendString("ok")
+	})
+
+	req := httptest.NewRequest(MethodGet, "http://example.com/", nil)
+	req.Header.Set(HeaderRange, "bytes=20-30")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusRequestedRangeNotSatisfiable, resp.StatusCode)
+	require.Equal(t, "bytes */10", resp.Header.Get(HeaderContentRange))
+}
+
 // go test -v -run=^$ -bench=Benchmark_Ctx_Range -benchmem -count=4
 func Benchmark_Ctx_Range(b *testing.B) {
 	app := New()

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -1216,6 +1216,9 @@ Returns a struct containing the type and a slice of ranges.
 Only the canonical `bytes` unit is recognized and any optional
 whitespace around range specifiers will be ignored, as specified
 in RFC 9110.
+If none of the requested ranges are satisfiable, the method automatically
+sets the HTTP status code to **416 Range Not Satisfiable** and populates the
+`Content-Range` header with the current representation size.
 
 ```go title="Signature"
 func (c fiber.Ctx) Range(size int) (Range, error)


### PR DESCRIPTION
## Summary
- send 416 status automatically for unsatisfiable ranges
- document automatic 416 handling in Range()
- test 416 Range Not Satisfiable response

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/416