### PR TITLE
🐛 bug: Fix Accept-Language matching per RFC 4647

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -228,7 +228,7 @@ func (c *DefaultCtx) AcceptsEncodings(offers ...string) string {
 // AcceptsLanguages checks if the specified language is acceptable.
 func (c *DefaultCtx) AcceptsLanguages(offers ...string) string {
 	header := joinHeaderValues(c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage))
-	return getOffer(header, acceptsOffer, offers...)
+	return getOffer(header, acceptsLanguageOffer, offers...)
 }
 
 // App returns the *App reference to the instance of the Fiber application

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -274,6 +274,33 @@ func Test_Ctx_AcceptsLanguages_MultiHeader(t *testing.T) {
 	require.Equal(t, "en", c.AcceptsLanguages("de", "en"))
 }
 
+// go test -run Test_Ctx_AcceptsLanguages_BasicFiltering
+func Test_Ctx_AcceptsLanguages_BasicFiltering(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	c.Request().Header.Set(HeaderAcceptLanguage, "en-US")
+	require.Equal(t, "en-US", c.AcceptsLanguages("en", "en-US"))
+	require.Equal(t, "", c.AcceptsLanguages("en"))
+
+	c.Request().Header.Set(HeaderAcceptLanguage, "en-US, fr")
+	require.Equal(t, "en-US", c.AcceptsLanguages("de", "en-US", "fr"))
+
+	c.Request().Header.Set(HeaderAcceptLanguage, "en_US")
+	require.Equal(t, "", c.AcceptsLanguages("en-US"))
+}
+
+// go test -run Test_Ctx_AcceptsLanguages_CaseInsensitive
+func Test_Ctx_AcceptsLanguages_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	c.Request().Header.Set(HeaderAcceptLanguage, "EN-us")
+	require.Equal(t, "en-US", c.AcceptsLanguages("en-US"))
+}
+
 // go test -v -run=^$ -bench=Benchmark_Ctx_AcceptsLanguages -benchmem -count=4
 func Benchmark_Ctx_AcceptsLanguages(b *testing.B) {
 	app := New()

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -504,6 +504,8 @@ app.Get("/", func(c fiber.Ctx) error {
 
 Fiber provides similar functions for the other accept headers.
 
+For `Accept-Language`, Fiber uses the [Basic Filtering](https://www.rfc-editor.org/rfc/rfc4647#section-3.3.1) algorithm. A language range matches an offer only if it exactly equals the tag or is a prefix followed by a hyphen. For example, the range `en` matches `en-US`, but `en-US` does not match `en`.
+
 ```go
 // Accept-Charset: utf-8, iso-8859-1;q=0.2
 // Accept-Encoding: gzip, compress;q=0.2

--- a/helpers.go
+++ b/helpers.go
@@ -135,15 +135,23 @@ func getGroupPath(prefix, path string) string {
 	return utils.TrimRight(prefix, '/') + path
 }
 
-// acceptsOffer This function determines if an offer matches a given specification.
-// It checks if the specification ends with a '*' or if the offer has the prefix of the specification.
+// acceptsOffer determines if an offer matches a given specification.
+// It supports a trailing '*' wildcard and applies case-insensitive Basic Filtering
+// so a language range matches if it is a prefix of the offer tag.
 // Returns true if the offer matches the specification, false otherwise.
 func acceptsOffer(spec, offer string, _ headerParams) bool {
 	if len(spec) >= 1 && spec[len(spec)-1] == '*' {
 		return true
-	} else if strings.HasPrefix(spec, offer) {
+	}
+
+	if utils.EqualFold(spec, offer) {
 		return true
 	}
+
+	if len(offer) > len(spec) && utils.EqualFold(offer[:len(spec)], spec) && offer[len(spec)] == '-' {
+		return true
+	}
+
 	return false
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -136,10 +136,22 @@ func getGroupPath(prefix, path string) string {
 }
 
 // acceptsOffer determines if an offer matches a given specification.
-// It supports a trailing '*' wildcard and applies case-insensitive Basic Filtering
-// so a language range matches if it is a prefix of the offer tag.
+// It supports a trailing '*' wildcard and performs case-insensitive exact matching.
 // Returns true if the offer matches the specification, false otherwise.
 func acceptsOffer(spec, offer string, _ headerParams) bool {
+	if len(spec) >= 1 && spec[len(spec)-1] == '*' {
+		return true
+	}
+
+	return utils.EqualFold(spec, offer)
+}
+
+// acceptsLanguageOffer determines if a language tag offer matches a range
+// according to RFC 4647 Basic Filtering.
+// A match occurs if the range exactly equals the tag or is a prefix of the tag
+// followed by a hyphen. The comparison is case-insensitive. A trailing '*'
+// wildcard in the range matches any tag.
+func acceptsLanguageOffer(spec, offer string, _ headerParams) bool {
 	if len(spec) >= 1 && spec[len(spec)-1] == '*' {
 		return true
 	}
@@ -148,11 +160,7 @@ func acceptsOffer(spec, offer string, _ headerParams) bool {
 		return true
 	}
 
-	if len(offer) > len(spec) && utils.EqualFold(offer[:len(spec)], spec) && offer[len(spec)] == '-' {
-		return true
-	}
-
-	return false
+	return len(offer) > len(spec) && utils.EqualFold(offer[:len(spec)], spec) && offer[len(spec)] == '-'
 }
 
 // acceptsOfferType This function determines if an offer type matches a given specification.

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -64,12 +64,12 @@ func Test_Utils_GetOffer(t *testing.T) {
 	require.Equal(t, "", getOffer([]byte("gzip, deflate;q=0"), acceptsOffer, "deflate"))
 
 	// Accept-Language Basic Filtering
-	require.True(t, acceptsOffer("en", "en-US", nil))
-	require.False(t, acceptsOffer("en-US", "en", nil))
-	require.True(t, acceptsOffer("EN", "en-us", nil))
-	require.False(t, acceptsOffer("en", "en_US", nil))
-	require.Equal(t, "en-US", getOffer([]byte("fr-CA;q=0.8, en-US"), acceptsOffer, "en-US", "fr-CA"))
-	require.Equal(t, "", getOffer([]byte("xx"), acceptsOffer, "en"))
+	require.True(t, acceptsLanguageOffer("en", "en-US", nil))
+	require.False(t, acceptsLanguageOffer("en-US", "en", nil))
+	require.True(t, acceptsLanguageOffer("EN", "en-us", nil))
+	require.False(t, acceptsLanguageOffer("en", "en_US", nil))
+	require.Equal(t, "en-US", getOffer([]byte("fr-CA;q=0.8, en-US"), acceptsLanguageOffer, "en-US", "fr-CA"))
+	require.Equal(t, "", getOffer([]byte("xx"), acceptsLanguageOffer, "en"))
 }
 
 // go test -v -run=^$ -bench=Benchmark_Utils_GetOffer -benchmem -count=4

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -62,6 +62,14 @@ func Test_Utils_GetOffer(t *testing.T) {
 
 	require.Equal(t, "deflate", getOffer([]byte("gzip, deflate"), acceptsOffer, "deflate"))
 	require.Equal(t, "", getOffer([]byte("gzip, deflate;q=0"), acceptsOffer, "deflate"))
+
+	// Accept-Language Basic Filtering
+	require.True(t, acceptsOffer("en", "en-US", nil))
+	require.False(t, acceptsOffer("en-US", "en", nil))
+	require.True(t, acceptsOffer("EN", "en-us", nil))
+	require.False(t, acceptsOffer("en", "en_US", nil))
+	require.Equal(t, "en-US", getOffer([]byte("fr-CA;q=0.8, en-US"), acceptsOffer, "en-US", "fr-CA"))
+	require.Equal(t, "", getOffer([]byte("xx"), acceptsOffer, "en"))
 }
 
 // go test -v -run=^$ -bench=Benchmark_Utils_GetOffer -benchmem -count=4


### PR DESCRIPTION
## Summary
- follow RFC 4647 basic filtering for `Accept-Language`
- add tests for invalid and multi-language scenarios

Related #3383 