### PR TITLE
🐛 bug: Fix Etag validation per RFC 9110

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,5 +39,3 @@ jobs:
           version: v1.64.7
           # NOTE(ldez): temporary workaround
           install-mode: goinstall
-          # enable debug output
-          args: -v

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,6 +1,5 @@
-# Adapted from https://github.com/golangci/golangci-lint-action/blob/b56f6f529003f1c81d4d759be6bd5f10bf9a0fa0/README.md#how-to-use
-
 name: golangci-lint
+
 on:
   push:
     branches:
@@ -40,4 +39,5 @@ jobs:
           version: v1.64.7
           # NOTE(ldez): temporary workaround
           install-mode: goinstall
-
+          # enable debug output
+          args: -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -149,6 +149,8 @@ linters-settings:
         disabled: true
       - name: cognitive-complexity
         disabled: true
+      - name: confusing-results
+        disabled: true
       - name: comment-spacings
         arguments:
           - nolint

--- a/ctx.go
+++ b/ctx.go
@@ -656,7 +656,7 @@ func (c *DefaultCtx) FormValue(key string, defaultValue ...string) string {
 // and the full response should be sent.
 // When a client sends the Cache-Control: no-cache request header to indicate an end-to-end
 // reload request, this module will return false to make handling these requests transparent.
-// https://github.com/jshttp/fresh/blob/10e0471669dbbfbfd8de65bc6efac2ddd0bfa057/index.js#L33
+// https://github.com/jshttp/fresh/blob/master/index.js#L33
 func (c *DefaultCtx) Fresh() bool {
 	// fields
 	modifiedSince := c.Get(HeaderIfModifiedSince)

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1425,11 +1425,11 @@ func Benchmark_Ctx_Fresh_StaleEtag(b *testing.B) {
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 
 	for b.Loop() {
-		c.Request().Header.Set(HeaderIfNoneMatch, "\"a\", \"b\", \"c\", \"d\"")
+		c.Request().Header.Set(HeaderIfNoneMatch, `"a", "b", "c", "d"`)
 		c.Request().Header.Set(HeaderCacheControl, "c")
 		c.Fresh()
 
-		c.Request().Header.Set(HeaderIfNoneMatch, "\"a\", \"b\", \"c\", \"d\"")
+		c.Request().Header.Set(HeaderIfNoneMatch, `"a", "b", "c", "d"`)
 		c.Request().Header.Set(HeaderCacheControl, "e")
 		c.Fresh()
 	}
@@ -1459,15 +1459,15 @@ func Test_Ctx_Fresh(t *testing.T) {
 	c.Request().Header.Set(HeaderCacheControl, ",no-cache,bb")
 	require.False(t, c.Fresh())
 
-	c.Request().Header.Set(HeaderIfNoneMatch, "\"675af34563dc-tr34\"")
+	c.Request().Header.Set(HeaderIfNoneMatch, `"675af34563dc-tr34"`)
 	c.Request().Header.Set(HeaderCacheControl, "public")
 	require.False(t, c.Fresh())
 
-	c.Request().Header.Set(HeaderIfNoneMatch, "\"a\", \"b\"")
-	c.Response().Header.Set(HeaderETag, "\"c\"")
+	c.Request().Header.Set(HeaderIfNoneMatch, `"a", "b"`)
+	c.Response().Header.Set(HeaderETag, `"c"`)
 	require.False(t, c.Fresh())
 
-	c.Response().Header.Set(HeaderETag, "\"a\"")
+	c.Response().Header.Set(HeaderETag, `"a"`)
 	require.True(t, c.Fresh())
 
 	c.Request().Header.Set(HeaderIfModifiedSince, "xxWed, 21 Oct 2015 07:28:00 GMT")

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1425,11 +1425,11 @@ func Benchmark_Ctx_Fresh_StaleEtag(b *testing.B) {
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 
 	for b.Loop() {
-		c.Request().Header.Set(HeaderIfNoneMatch, "a, b, c, d")
+		c.Request().Header.Set(HeaderIfNoneMatch, "\"a\", \"b\", \"c\", \"d\"")
 		c.Request().Header.Set(HeaderCacheControl, "c")
 		c.Fresh()
 
-		c.Request().Header.Set(HeaderIfNoneMatch, "a, b, c, d")
+		c.Request().Header.Set(HeaderIfNoneMatch, "\"a\", \"b\", \"c\", \"d\"")
 		c.Request().Header.Set(HeaderCacheControl, "e")
 		c.Fresh()
 	}
@@ -1459,15 +1459,15 @@ func Test_Ctx_Fresh(t *testing.T) {
 	c.Request().Header.Set(HeaderCacheControl, ",no-cache,bb")
 	require.False(t, c.Fresh())
 
-	c.Request().Header.Set(HeaderIfNoneMatch, "675af34563dc-tr34")
+	c.Request().Header.Set(HeaderIfNoneMatch, "\"675af34563dc-tr34\"")
 	c.Request().Header.Set(HeaderCacheControl, "public")
 	require.False(t, c.Fresh())
 
-	c.Request().Header.Set(HeaderIfNoneMatch, "a, b")
-	c.Response().Header.Set(HeaderETag, "c")
+	c.Request().Header.Set(HeaderIfNoneMatch, "\"a\", \"b\"")
+	c.Response().Header.Set(HeaderETag, "\"c\"")
 	require.False(t, c.Fresh())
 
-	c.Response().Header.Set(HeaderETag, "a")
+	c.Response().Header.Set(HeaderETag, "\"a\"")
 	require.True(t, c.Fresh())
 
 	c.Request().Header.Set(HeaderIfModifiedSince, "xxWed, 21 Oct 2015 07:28:00 GMT")

--- a/docs/middleware/etag.md
+++ b/docs/middleware/etag.md
@@ -45,6 +45,12 @@ app.Get("/", func(c fiber.Ctx) error {
 })
 ```
 
+Entity tags in requests must follow RFC 9110 and therefore be quoted, for example:
+
+```text
+If-None-Match: "\x123"
+```
+
 ## Config
 
 | Property | Type                    | Description                                                                                                        | Default |

--- a/docs/middleware/etag.md
+++ b/docs/middleware/etag.md
@@ -48,7 +48,7 @@ app.Get("/", func(c fiber.Ctx) error {
 Entity tags in requests must follow RFC 9110 and therefore be quoted, for example:
 
 ```text
-If-None-Match: "\x123"
+If-None-Match: "example-etag"
 ```
 
 ## Config

--- a/helpers.go
+++ b/helpers.go
@@ -495,8 +495,8 @@ func sortAcceptedTypes(at []acceptedType) {
 
 // normalizeEtag validates an entity tag and returns the
 // value without quotes. weak is true if the tag has the "W/" prefix.
-func normalizeEtag(t string) (inner string, weak bool, ok bool) {
-	weak = strings.HasPrefix(t, "W/")
+func normalizeEtag(t string) (string, bool, bool) {
+	weak := strings.HasPrefix(t, "W/")
 	if weak {
 		t = t[2:]
 	}
@@ -504,10 +504,7 @@ func normalizeEtag(t string) (inner string, weak bool, ok bool) {
 	if len(t) < 2 || t[0] != '"' || t[len(t)-1] != '"' {
 		return "", weak, false
 	}
-
-	// strip the two surrounding quotes
-	inner = t[1 : len(t)-1]
-	return inner, weak, true
+	return t[1 : len(t)-1], weak, true
 }
 
 // matchEtag performs a weak comparison of entity tags according to
@@ -571,7 +568,7 @@ func (app *App) isEtagStale(etag string, noneMatchBytes []byte) bool {
 	return !matchEtag(app.getString(noneMatchBytes[start:end]), etag)
 }
 
-func parseAddr(raw string) (string, string) { //nolint:revive // Returns (host, port)
+func parseAddr(raw string) (string, string) {
 	if raw == "" {
 		return "", ""
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -491,14 +491,48 @@ func sortAcceptedTypes(at []acceptedType) {
 	}
 }
 
-func matchEtag(s, etag string) bool {
-	if s == etag || s == "W/"+etag || "W/"+s == etag {
-		return true
+// normalizeEtag validates an entity tag and returns the value without quotes.
+// weak is true if the tag has the "W/" prefix.
+func normalizeEtag(t string) (tag string, weak, ok bool) {
+	weak = strings.HasPrefix(t, "W/")
+	if weak {
+		t = t[2:]
 	}
-
-	return false
+	if len(t) < 2 || t[0] != '"' || t[len(t)-1] != '"' {
+		return "", weak, false
+	}
+	return t[1 : len(t)-1], weak, true
 }
 
+// matchEtag performs a weak comparison of entity tags according to
+// RFC 9110 §8.8.3.2. The weak indicator ("W/") is ignored, but both tags must
+// be properly quoted. Invalid tags result in a mismatch.
+func matchEtag(s, etag string) bool {
+	n1, _, ok1 := normalizeEtag(s)
+	n2, _, ok2 := normalizeEtag(etag)
+	if !ok1 || !ok2 {
+		return false
+	}
+
+	return n1 == n2
+}
+
+// matchEtagStrong performs a strong entity-tag comparison following
+// RFC 9110 §8.8.3.1. A weak tag never matches a strong one, even if the quoted
+// values are identical.
+func matchEtagStrong(s, etag string) bool {
+	n1, w1, ok1 := normalizeEtag(s)
+	n2, w2, ok2 := normalizeEtag(etag)
+	if !ok1 || !ok2 || w1 || w2 {
+		return false
+	}
+
+	return n1 == n2
+}
+
+// isEtagStale reports whether a response with the given ETag would be considered
+// stale when presented with the raw If-None-Match header value. Comparison is
+// weak as defined by RFC 9110 §8.8.3.2.
 func (app *App) isEtagStale(etag string, noneMatchBytes []byte) bool {
 	var start, end int
 

--- a/helpers.go
+++ b/helpers.go
@@ -539,7 +539,7 @@ func matchEtagStrong(s, etag string) bool {
 // weak as defined by RFC 9110 §8.8.3.2.
 func (app *App) isEtagStale(etag string, noneMatchBytes []byte) bool {
 	var start, end int
-	header := utils.Trim(noneMatchBytes, ' ')
+	header := utils.Trim(app.getString(noneMatchBytes), ' ')
 
 	// Short-circuit the wildcard case: "*" never counts as stale.
 	if header == "*" {

--- a/helpers.go
+++ b/helpers.go
@@ -39,6 +39,8 @@ type acceptedType struct {
 	order       int
 }
 
+const noCacheValue = "no-cache"
+
 type headerParams map[string][]byte
 
 // getTLSConfig returns a net listener's tls config
@@ -601,8 +603,6 @@ func parseAddr(raw string) (string, string) { //nolint:revive // Returns (host, 
 	// No colon, nothing to split
 	return raw, ""
 }
-
-const noCacheValue = "no-cache"
 
 // isNoCache checks if the cacheControl header value is a `no-cache`.
 func isNoCache(cacheControl string) bool {

--- a/helpers.go
+++ b/helpers.go
@@ -539,7 +539,7 @@ func matchEtagStrong(s, etag string) bool {
 // weak as defined by RFC 9110 §8.8.3.2.
 func (app *App) isEtagStale(etag string, noneMatchBytes []byte) bool {
 	var start, end int
-	header := utils.TrimSpace(noneMatchBytes)
+	header := utils.TrimSpace(noneMatchBytes, ' ')
 
 	// Short-circuit the wildcard case: "*" never counts as stale.
 	if header == "*" {

--- a/helpers.go
+++ b/helpers.go
@@ -494,7 +494,7 @@ func sortAcceptedTypes(at []acceptedType) {
 // normalizeEtag validates an entity tag and returns the value without quotes.
 // weak is true if the tag has the "W/" prefix.
 func normalizeEtag(t string) (inner string, weak bool, bool) {
-	weak := strings.HasPrefix(t, "W/")
+	weak = strings.HasPrefix(t, "W/")
 	if weak {
 		t = t[2:]
 	}
@@ -502,7 +502,7 @@ func normalizeEtag(t string) (inner string, weak bool, bool) {
 		return "", weak, false
 	}
 	// strip the two surrounding quotes
-	inner := t[1 : len(t)-1]
+	inner = t[1 : len(t)-1]
 	return inner, weak, true
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -539,6 +539,7 @@ func matchEtagStrong(s, etag string) bool {
 // weak as defined by RFC 9110 §8.8.3.2.
 func (app *App) isEtagStale(etag string, noneMatchBytes []byte) bool {
 	var start, end int
+	header := utils.TrimSpace(noneMatchBytes)
 
 	// Short-circuit the wildcard case: "*" never counts as stale.
 	if header == "*" {

--- a/helpers.go
+++ b/helpers.go
@@ -493,8 +493,8 @@ func sortAcceptedTypes(at []acceptedType) {
 	}
 }
 
-// normalizeEtag validates an entity tag and returns the value without quotes.
-// weak is true if the tag has the "W/" prefix.
+// normalizeEtag validates an entity tag and returns the
+// value without quotes. weak is true if the tag has the "W/" prefix.
 func normalizeEtag(t string) (inner string, weak bool, ok bool) {
 	weak = strings.HasPrefix(t, "W/")
 	if weak {

--- a/helpers.go
+++ b/helpers.go
@@ -493,7 +493,7 @@ func sortAcceptedTypes(at []acceptedType) {
 
 // normalizeEtag validates an entity tag and returns the value without quotes.
 // weak is true if the tag has the "W/" prefix.
-func normalizeEtag(t string) (inner string, weak bool, bool) {
+func normalizeEtag(t string) (inner string, weak bool, ok bool) {
 	weak = strings.HasPrefix(t, "W/")
 	if weak {
 		t = t[2:]

--- a/helpers.go
+++ b/helpers.go
@@ -498,9 +498,11 @@ func normalizeEtag(t string) (inner string, weak bool, ok bool) {
 	if weak {
 		t = t[2:]
 	}
+
 	if len(t) < 2 || t[0] != '"' || t[len(t)-1] != '"' {
 		return "", weak, false
 	}
+
 	// strip the two surrounding quotes
 	inner = t[1 : len(t)-1]
 	return inner, weak, true
@@ -538,8 +540,13 @@ func matchEtagStrong(s, etag string) bool {
 func (app *App) isEtagStale(etag string, noneMatchBytes []byte) bool {
 	var start, end int
 
+	// Short-circuit the wildcard case: "*" never counts as stale.
+	if header == "*" {
+		return false
+	}
+
 	// Adapted from:
-	// https://github.com/jshttp/fresh/blob/10e0471669dbbfbfd8de65bc6efac2ddd0bfa057/index.js#L110
+	// https://github.com/jshttp/fresh/blob/master/index.js#L110
 	for i := range noneMatchBytes {
 		switch noneMatchBytes[i] {
 		case 0x20:

--- a/helpers.go
+++ b/helpers.go
@@ -539,7 +539,7 @@ func matchEtagStrong(s, etag string) bool {
 // weak as defined by RFC 9110 §8.8.3.2.
 func (app *App) isEtagStale(etag string, noneMatchBytes []byte) bool {
 	var start, end int
-	header := utils.TrimSpace(noneMatchBytes, ' ')
+	header := utils.Trim(noneMatchBytes, ' ')
 
 	// Short-circuit the wildcard case: "*" never counts as stale.
 	if header == "*" {

--- a/helpers.go
+++ b/helpers.go
@@ -493,7 +493,7 @@ func sortAcceptedTypes(at []acceptedType) {
 
 // normalizeEtag validates an entity tag and returns the value without quotes.
 // weak is true if the tag has the "W/" prefix.
-func normalizeEtag(t string) (string, bool, bool) {
+func normalizeEtag(t string) (inner string, weak bool, bool) {
 	weak := strings.HasPrefix(t, "W/")
 	if weak {
 		t = t[2:]

--- a/helpers.go
+++ b/helpers.go
@@ -493,7 +493,7 @@ func sortAcceptedTypes(at []acceptedType) {
 
 // normalizeEtag validates an entity tag and returns the value without quotes.
 // weak is true if the tag has the "W/" prefix.
-func normalizeEtag(t string) (tag string, weak, ok bool) {
+func normalizeEtag(t string) (string, weak, ok bool) {
 	weak = strings.HasPrefix(t, "W/")
 	if weak {
 		t = t[2:]

--- a/helpers.go
+++ b/helpers.go
@@ -493,15 +493,17 @@ func sortAcceptedTypes(at []acceptedType) {
 
 // normalizeEtag validates an entity tag and returns the value without quotes.
 // weak is true if the tag has the "W/" prefix.
-func normalizeEtag(t string) (string, weak, ok bool) {
-	weak = strings.HasPrefix(t, "W/")
+func normalizeEtag(t string) (string, bool, bool) {
+	weak := strings.HasPrefix(t, "W/")
 	if weak {
 		t = t[2:]
 	}
 	if len(t) < 2 || t[0] != '"' || t[len(t)-1] != '"' {
 		return "", weak, false
 	}
-	return t[1 : len(t)-1], weak, true
+	// strip the two surrounding quotes
+	inner := t[1 : len(t)-1]
+	return inner, weak, true
 }
 
 // matchEtag performs a weak comparison of entity tags according to

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1401,6 +1401,7 @@ func Test_IsEtagStale(t *testing.T) {
 
 	// Wildcard
 	require.False(t, app.isEtagStale(`"a"`, []byte("*")))
+	require.False(t, app.isEtagStale(`"a"`, []byte(" * ")))
 	require.False(t, app.isEtagStale(`W/"a"`, []byte("*")))
 
 	// Empty case

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1401,11 +1401,12 @@ func Test_IsEtagStale(t *testing.T) {
 
 	// Wildcard
 	require.False(t, app.isEtagStale(`"a"`, []byte("*")))
-	require.False(t, app.isEtagStale(`"a"`, []byte(" * ")))
+	require.False(t, app.isEtagStale(`"a"`, []byte(" *   ")))
 	require.False(t, app.isEtagStale(`W/"a"`, []byte("*")))
 
 	// Empty case
 	require.True(t, app.isEtagStale(`"a"`, []byte("")))
+	require.True(t, app.isEtagStale(`"a"`, []byte("   ")))
 
 	// Weak vs. weak
 	require.False(t, app.isEtagStale(`W/"a"`, []byte(`W/"a"`)))

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1353,3 +1353,35 @@ func Test_ParamsMatch_InvalidEscape(t *testing.T) {
 	match := paramsMatch(headerParams{"foo": []byte("bar")}, `;foo="bar\\`)
 	require.False(t, match)
 }
+
+func Test_MatchEtag(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, matchEtag("\"a\"", "\"a\""))
+	require.True(t, matchEtag("W/\"a\"", "\"a\""))
+	require.True(t, matchEtag("\"a\"", "W/\"a\""))
+	require.False(t, matchEtag("\"a\"", "\"b\""))
+	require.False(t, matchEtag("a", "\"a\""))
+	require.False(t, matchEtag("\"a\"", "b"))
+}
+
+func Test_MatchEtagStrong(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, matchEtagStrong("\"a\"", "\"a\""))
+	require.False(t, matchEtagStrong("W/\"a\"", "\"a\""))
+	require.False(t, matchEtagStrong("\"a\"", "W/\"a\""))
+	require.False(t, matchEtagStrong("\"a\"", "\"b\""))
+	require.False(t, matchEtagStrong("a", "\"a\""))
+	require.False(t, matchEtagStrong("\"a\"", "b"))
+}
+
+func Test_IsEtagStale_Invalid(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	require.True(t, app.isEtagStale("\"a\"", []byte("b")))
+	require.True(t, app.isEtagStale("\"a\"", []byte("a")))
+	require.False(t, app.isEtagStale("\"a\"", []byte("\"a\"")))
+	require.False(t, app.isEtagStale("W/\"a\"", []byte("\"a\"")))
+}


### PR DESCRIPTION
## Summary
- enforce RFC 9110 quoted tags in `matchEtag`
- update ctx tests to use quoted ETags
- add tests for `matchEtag` and `isEtagStale`
- document requirement for quoting entity tags
- add strong ETag comparison helper

Related: #3383