### PR TITLE
Fix deprecated VisitAll methods

### DIFF
--- a/binder/cookie.go
+++ b/binder/cookie.go
@@ -20,14 +20,15 @@ func (b *CookieBinding) Bind(req *fasthttp.Request, out any) error {
 	data := make(map[string][]string)
 	var err error
 
-	req.Header.VisitAllCookie(func(key, val []byte) {
+	req.Header.Cookies()(func(key, val []byte) bool {
 		if err != nil {
-			return
+			return true
 		}
 
 		k := utils.UnsafeString(key)
 		v := utils.UnsafeString(val)
 		err = formatBindData(b.Name(), out, data, k, v, b.EnableSplitting, false)
+		return true
 	})
 
 	if err != nil {

--- a/binder/form.go
+++ b/binder/form.go
@@ -29,14 +29,15 @@ func (b *FormBinding) Bind(req *fasthttp.Request, out any) error {
 		return b.bindMultipart(req, out)
 	}
 
-	req.PostArgs().VisitAll(func(key, val []byte) {
+	req.PostArgs().All()(func(key, val []byte) bool {
 		if err != nil {
-			return
+			return true
 		}
 
 		k := utils.UnsafeString(key)
 		v := utils.UnsafeString(val)
 		err = formatBindData(b.Name(), out, data, k, v, b.EnableSplitting, true)
+		return true
 	})
 
 	if err != nil {

--- a/binder/header.go
+++ b/binder/header.go
@@ -19,14 +19,15 @@ func (*HeaderBinding) Name() string {
 func (b *HeaderBinding) Bind(req *fasthttp.Request, out any) error {
 	data := make(map[string][]string)
 	var err error
-	req.Header.VisitAll(func(key, val []byte) {
+	req.Header.All()(func(key, val []byte) bool {
 		if err != nil {
-			return
+			return true
 		}
 
 		k := utils.UnsafeString(key)
 		v := utils.UnsafeString(val)
 		err = formatBindData(b.Name(), out, data, k, v, b.EnableSplitting, false)
+		return true
 	})
 
 	if err != nil {

--- a/binder/query.go
+++ b/binder/query.go
@@ -20,14 +20,15 @@ func (b *QueryBinding) Bind(reqCtx *fasthttp.Request, out any) error {
 	data := make(map[string][]string)
 	var err error
 
-	reqCtx.URI().QueryArgs().VisitAll(func(key, val []byte) {
+	reqCtx.URI().QueryArgs().All()(func(key, val []byte) bool {
 		if err != nil {
-			return
+			return true
 		}
 
 		k := utils.UnsafeString(key)
 		v := utils.UnsafeString(val)
 		err = formatBindData(b.Name(), out, data, k, v, b.EnableSplitting, true)
+		return true
 	})
 
 	if err != nil {

--- a/binder/resp_header.go
+++ b/binder/resp_header.go
@@ -20,14 +20,15 @@ func (b *RespHeaderBinding) Bind(resp *fasthttp.Response, out any) error {
 	data := make(map[string][]string)
 	var err error
 
-	resp.Header.VisitAll(func(key, val []byte) {
+	resp.Header.All()(func(key, val []byte) bool {
 		if err != nil {
-			return
+			return true
 		}
 
 		k := utils.UnsafeString(key)
 		v := utils.UnsafeString(val)
 		err = formatBindData(b.Name(), out, data, k, v, b.EnableSplitting, false)
+		return true
 	})
 
 	if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -830,11 +830,12 @@ func Test_Client_Header(t *testing.T) {
 
 func Test_Client_Header_With_Server(t *testing.T) {
 	handler := func(c fiber.Ctx) error {
-		c.Request().Header.VisitAll(func(key, value []byte) {
+		c.Request().Header.All()(func(key, value []byte) bool {
 			if k := string(key); k == "K1" || k == "K2" {
 				_, _ = c.Write(key)   //nolint:errcheck // It is fine to ignore the error here
 				_, _ = c.Write(value) //nolint:errcheck // It is fine to ignore the error here
 			}
+			return true
 		})
 		return nil
 	}
@@ -1613,8 +1614,9 @@ func Test_Client_SetProxyURL(t *testing.T) {
 		req.SetRequestURI(c.BaseURL())
 		req.Header.SetMethod(fasthttp.MethodGet)
 
-		c.Request().Header.VisitAll(func(key, value []byte) {
+		c.Request().Header.All()(func(key, value []byte) bool {
 			req.Header.AddBytesKV(key, value)
+			return true
 		})
 
 		req.Header.Set("isProxy", "true")

--- a/client/cookiejar.go
+++ b/client/cookiejar.go
@@ -198,7 +198,7 @@ func (cj *CookieJar) parseCookiesFromResp(host, path []byte, resp *fasthttp.Resp
 	}
 
 	now := time.Now()
-	resp.Header.VisitAllCookie(func(key, value []byte) {
+	resp.Header.Cookies()(func(key, value []byte) bool {
 		created := false
 		c := searchCookieByKeyAndPath(key, path, cookies)
 		if c == nil {
@@ -211,6 +211,7 @@ func (cj *CookieJar) parseCookiesFromResp(host, path []byte, resp *fasthttp.Resp
 		} else if created {
 			fasthttp.ReleaseCookie(c)
 		}
+		return true
 	})
 	cj.hostCookies[hostStr] = cookies
 }

--- a/client/hooks.go
+++ b/client/hooks.go
@@ -89,11 +89,13 @@ func parserRequestURL(c *Client, req *Request) error {
 
 	args.Parse(hashSplit[0])
 
-	c.params.VisitAll(func(key, value []byte) {
+	c.params.All()(func(key, value []byte) bool {
 		args.AddBytesKV(key, value)
+		return true
 	})
-	req.params.VisitAll(func(key, value []byte) {
+	req.params.All()(func(key, value []byte) bool {
 		args.AddBytesKV(key, value)
+		return true
 	})
 
 	req.RawRequest.URI().SetQueryStringBytes(utils.CopyBytes(args.QueryString()))
@@ -109,13 +111,15 @@ func parserRequestHeader(c *Client, req *Request) error {
 	req.RawRequest.Header.SetMethod(req.Method())
 
 	// Merge headers from the client.
-	c.header.VisitAll(func(key, value []byte) {
+	c.header.All()(func(key, value []byte) bool {
 		req.RawRequest.Header.AddBytesKV(key, value)
+		return true
 	})
 
 	// Merge headers from the request.
-	req.header.VisitAll(func(key, value []byte) {
+	req.header.All()(func(key, value []byte) bool {
 		req.RawRequest.Header.AddBytesKV(key, value)
+		return true
 	})
 
 	// Set Content-Type and Accept headers based on the request body type.
@@ -228,11 +232,12 @@ func parserRequestBodyFile(req *Request) error {
 	}()
 
 	// Add form data.
-	req.formData.VisitAll(func(key, value []byte) {
+	req.formData.All()(func(key, value []byte) bool {
 		if err != nil {
-			return
+			return true
 		}
 		err = mw.WriteField(utils.UnsafeString(key), utils.UnsafeString(value))
+		return true
 	})
 	if err != nil {
 		return fmt.Errorf("write formdata error: %w", err)
@@ -285,14 +290,15 @@ func parserRequestBodyFile(req *Request) error {
 // parserResponseCookie parses the Set-Cookie headers from the response and stores them.
 func parserResponseCookie(c *Client, resp *Response, req *Request) error {
 	var err error
-	resp.RawResponse.Header.VisitAllCookie(func(key, value []byte) {
+	resp.RawResponse.Header.Cookies()(func(key, value []byte) bool {
 		cookie := fasthttp.AcquireCookie()
 		err = cookie.ParseBytes(value)
 		if err != nil {
-			return
+			return true
 		}
 		cookie.SetKeyBytes(key)
 		resp.cookie = append(resp.cookie, cookie)
+		return true
 	})
 
 	if err != nil {

--- a/client/request.go
+++ b/client/request.go
@@ -668,10 +668,11 @@ type Header struct {
 func (h *Header) PeekMultiple(key string) []string {
 	var res []string
 	byteKey := []byte(key)
-	h.RequestHeader.VisitAll(func(k, value []byte) {
+	h.RequestHeader.All()(func(k, value []byte) bool {
 		if bytes.EqualFold(k, byteKey) {
 			res = append(res, utils.UnsafeString(value))
 		}
+		return true
 	})
 	return res
 }
@@ -701,8 +702,9 @@ type QueryParam struct {
 // Keys returns all keys from the query parameters.
 func (p *QueryParam) Keys() []string {
 	keys := make([]string, 0, p.Len())
-	p.VisitAll(func(key, _ []byte) {
+	p.All()(func(key, _ []byte) bool {
 		keys = append(keys, utils.UnsafeString(key))
+		return true
 	})
 	return slices.Compact(keys)
 }
@@ -837,8 +839,9 @@ type FormData struct {
 // Keys returns all keys from the form data.
 func (f *FormData) Keys() []string {
 	keys := make([]string, 0, f.Len())
-	f.VisitAll(func(key, _ []byte) {
+	f.All()(func(key, _ []byte) bool {
 		keys = append(keys, utils.UnsafeString(key))
+		return true
 	})
 	return slices.Compact(keys)
 }

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -1046,13 +1046,14 @@ func Test_Request_Patch(t *testing.T) {
 func Test_Request_Header_With_Server(t *testing.T) {
 	t.Parallel()
 	handler := func(c fiber.Ctx) error {
-		c.Request().Header.VisitAll(func(key, value []byte) {
+		c.Request().Header.All()(func(key, value []byte) bool {
 			if k := string(key); k == "K1" || k == "K2" {
 				_, err := c.Write(key)
 				require.NoError(t, err)
 				_, err = c.Write(value)
 				require.NoError(t, err)
 			}
+			return true
 		})
 		return nil
 	}

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -325,7 +325,7 @@ type Ctx interface {
 	// If the offset is negative or exceeds the number of subdomains, an empty slice is returned.
 	// If the offset is zero every label (no trimming) is returned.
 	Subdomains(offset ...int) []string
-// Stale returns the inverse of Fresh, indicating if the client's cached response is considered stale.
+	// Stale returns the inverse of Fresh, indicating if the client's cached response is considered stale.
 	Stale() bool
 	// Status sets the HTTP status for the response.
 	// This method is chainable.

--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -196,8 +196,9 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 		}
 
 		// Convert fasthttp Ctx -> net/http
-		fctx.Response.Header.VisitAll(func(k, v []byte) {
+		fctx.Response.Header.All()(func(k, v []byte) bool {
 			w.Header().Add(string(k), string(v))
+			return true
 		})
 		w.WriteHeader(fctx.Response.StatusCode())
 		_, _ = w.Write(fctx.Response.Body()) //nolint:errcheck // not needed

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -254,15 +254,14 @@ func New(config ...Config) fiber.Handler {
 		// (more: https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1)
 		if cfg.StoreResponseHeaders {
 			e.headers = make(map[string][]byte)
-			c.Response().Header.VisitAll(
-				func(key, value []byte) {
-					// create real copy
-					keyS := string(key)
-					if _, ok := ignoreHeaders[keyS]; !ok {
-						e.headers[keyS] = utils.CopyBytes(value)
-					}
-				},
-			)
+			c.Response().Header.All()(func(key, value []byte) bool {
+				// create real copy
+				keyS := string(key)
+				if _, ok := ignoreHeaders[keyS]; !ok {
+					e.headers[keyS] = utils.CopyBytes(value)
+				}
+				return true
+			})
 		}
 
 		// default cache expiration

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -524,10 +524,11 @@ func Test_CORS_AllowOriginHeader_NoMatch(t *testing.T) {
 	handler(ctx)
 
 	var headerExists bool
-	ctx.Response.Header.VisitAll(func(key, _ []byte) {
+	ctx.Response.Header.All()(func(key, _ []byte) bool {
 		if string(key) == fiber.HeaderAccessControlAllowOrigin {
 			headerExists = true
 		}
+		return true
 	})
 	require.False(t, headerExists, "Access-Control-Allow-Origin header should not be set")
 }

--- a/middleware/encryptcookie/encryptcookie.go
+++ b/middleware/encryptcookie/encryptcookie.go
@@ -18,7 +18,7 @@ func New(config ...Config) fiber.Handler {
 		}
 
 		// Decrypt request cookies
-		c.Request().Header.VisitAllCookie(func(key, value []byte) {
+		c.Request().Header.Cookies()(func(key, value []byte) bool {
 			keyString := string(key)
 			if !isDisabled(keyString, cfg.Except) {
 				decryptedValue, err := cfg.Decryptor(string(value), cfg.Key)
@@ -28,13 +28,14 @@ func New(config ...Config) fiber.Handler {
 					c.Request().Header.SetCookie(string(key), decryptedValue)
 				}
 			}
+			return true
 		})
 
 		// Continue stack
 		err := c.Next()
 
 		// Encrypt response cookies
-		c.Response().Header.VisitAllCookie(func(key, _ []byte) {
+		c.Response().Header.Cookies()(func(key, _ []byte) bool {
 			keyString := string(key)
 			if !isDisabled(keyString, cfg.Except) {
 				cookieValue := fasthttp.Cookie{}
@@ -49,6 +50,7 @@ func New(config ...Config) fiber.Handler {
 					c.Response().Header.SetCookie(&cookieValue)
 				}
 			}
+			return true
 		})
 
 		return err


### PR DESCRIPTION
## Summary
- replace deprecated `VisitAll` and `VisitAllCookie` calls with `All`/`Cookies` iterators
- apply `gofumpt` formatting
- update affected tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6863990d54688326a4c3a0a8c067d14e