### PR TITLE
Refactor fasthttp iter calls to range loops

### DIFF
--- a/binder/cookie.go
+++ b/binder/cookie.go
@@ -20,12 +20,14 @@ func (b *CookieBinding) Bind(req *fasthttp.Request, out any) error {
 	data := make(map[string][]string)
 	var err error
 
-	req.Header.Cookies()(func(key, val []byte) bool {
+	for key, val := range req.Header.Cookies() {
 		k := utils.UnsafeString(key)
 		v := utils.UnsafeString(val)
 		err = formatBindData(b.Name(), out, data, k, v, b.EnableSplitting, false)
-		return err == nil // Stop iteration on the first error
-	})
+		if err != nil {
+			break
+		}
+	}
 
 	if err != nil {
 		return err

--- a/binder/form.go
+++ b/binder/form.go
@@ -29,12 +29,14 @@ func (b *FormBinding) Bind(req *fasthttp.Request, out any) error {
 		return b.bindMultipart(req, out)
 	}
 
-	req.PostArgs().All()(func(key, val []byte) bool {
+	for key, val := range req.PostArgs().All() {
 		k := utils.UnsafeString(key)
 		v := utils.UnsafeString(val)
 		err = formatBindData(b.Name(), out, data, k, v, b.EnableSplitting, true)
-		return err == nil // Stop iteration on the first error
-	})
+		if err != nil {
+			break
+		}
+	}
 
 	if err != nil {
 		return err

--- a/binder/header.go
+++ b/binder/header.go
@@ -19,12 +19,14 @@ func (*HeaderBinding) Name() string {
 func (b *HeaderBinding) Bind(req *fasthttp.Request, out any) error {
 	data := make(map[string][]string)
 	var err error
-	req.Header.All()(func(key, val []byte) bool {
+	for key, val := range req.Header.All() {
 		k := utils.UnsafeString(key)
 		v := utils.UnsafeString(val)
 		err = formatBindData(b.Name(), out, data, k, v, b.EnableSplitting, false)
-		return err == nil // Stop iteration on the first error
-	})
+		if err != nil {
+			break
+		}
+	}
 
 	if err != nil {
 		return err

--- a/binder/query.go
+++ b/binder/query.go
@@ -20,12 +20,14 @@ func (b *QueryBinding) Bind(reqCtx *fasthttp.Request, out any) error {
 	data := make(map[string][]string)
 	var err error
 
-	reqCtx.URI().QueryArgs().All()(func(key, val []byte) bool {
+	for key, val := range reqCtx.URI().QueryArgs().All() {
 		k := utils.UnsafeString(key)
 		v := utils.UnsafeString(val)
 		err = formatBindData(b.Name(), out, data, k, v, b.EnableSplitting, true)
-		return err == nil // Stop iteration on the first error
-	})
+		if err != nil {
+			break
+		}
+	}
 
 	if err != nil {
 		return err

--- a/binder/resp_header.go
+++ b/binder/resp_header.go
@@ -20,12 +20,14 @@ func (b *RespHeaderBinding) Bind(resp *fasthttp.Response, out any) error {
 	data := make(map[string][]string)
 	var err error
 
-	resp.Header.All()(func(key, val []byte) bool {
+	for key, val := range resp.Header.All() {
 		k := utils.UnsafeString(key)
 		v := utils.UnsafeString(val)
 		err = formatBindData(b.Name(), out, data, k, v, b.EnableSplitting, false)
-		return err == nil // Stop iteration on the first error
-	})
+		if err != nil {
+			break
+		}
+	}
 
 	if err != nil {
 		return err

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -830,13 +830,12 @@ func Test_Client_Header(t *testing.T) {
 
 func Test_Client_Header_With_Server(t *testing.T) {
 	handler := func(c fiber.Ctx) error {
-		c.Request().Header.All()(func(key, value []byte) bool {
+		for key, value := range c.Request().Header.All() {
 			if k := string(key); k == "K1" || k == "K2" {
 				_, _ = c.Write(key)   //nolint:errcheck // It is fine to ignore the error here
 				_, _ = c.Write(value) //nolint:errcheck // It is fine to ignore the error here
 			}
-			return true
-		})
+		}
 		return nil
 	}
 
@@ -1614,10 +1613,9 @@ func Test_Client_SetProxyURL(t *testing.T) {
 		req.SetRequestURI(c.BaseURL())
 		req.Header.SetMethod(fasthttp.MethodGet)
 
-		c.Request().Header.All()(func(key, value []byte) bool {
+		for key, value := range c.Request().Header.All() {
 			req.Header.AddBytesKV(key, value)
-			return true
-		})
+		}
 
 		req.Header.Set("isProxy", "true")
 

--- a/client/cookiejar.go
+++ b/client/cookiejar.go
@@ -198,7 +198,7 @@ func (cj *CookieJar) parseCookiesFromResp(host, path []byte, resp *fasthttp.Resp
 	}
 
 	now := time.Now()
-	resp.Header.Cookies()(func(key, value []byte) bool {
+	for key, value := range resp.Header.Cookies() {
 		created := false
 		c := searchCookieByKeyAndPath(key, path, cookies)
 		if c == nil {
@@ -211,8 +211,7 @@ func (cj *CookieJar) parseCookiesFromResp(host, path []byte, resp *fasthttp.Resp
 		} else if created {
 			fasthttp.ReleaseCookie(c)
 		}
-		return true
-	})
+	}
 	cj.hostCookies[hostStr] = cookies
 }
 

--- a/client/request.go
+++ b/client/request.go
@@ -668,12 +668,11 @@ type Header struct {
 func (h *Header) PeekMultiple(key string) []string {
 	var res []string
 	byteKey := []byte(key)
-	h.RequestHeader.All()(func(k, value []byte) bool {
+	for k, value := range h.RequestHeader.All() {
 		if bytes.EqualFold(k, byteKey) {
 			res = append(res, utils.UnsafeString(value))
 		}
-		return true
-	})
+	}
 	return res
 }
 
@@ -702,10 +701,9 @@ type QueryParam struct {
 // Keys returns all keys from the query parameters.
 func (p *QueryParam) Keys() []string {
 	keys := make([]string, 0, p.Len())
-	p.All()(func(key, _ []byte) bool {
+	for key := range p.All() {
 		keys = append(keys, utils.UnsafeString(key))
-		return true
-	})
+	}
 	return slices.Compact(keys)
 }
 
@@ -839,10 +837,9 @@ type FormData struct {
 // Keys returns all keys from the form data.
 func (f *FormData) Keys() []string {
 	keys := make([]string, 0, f.Len())
-	f.All()(func(key, _ []byte) bool {
+	for key := range f.All() {
 		keys = append(keys, utils.UnsafeString(key))
-		return true
-	})
+	}
 	return slices.Compact(keys)
 }
 

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -1046,15 +1046,14 @@ func Test_Request_Patch(t *testing.T) {
 func Test_Request_Header_With_Server(t *testing.T) {
 	t.Parallel()
 	handler := func(c fiber.Ctx) error {
-		c.Request().Header.All()(func(key, value []byte) bool {
+		for key, value := range c.Request().Header.All() {
 			if k := string(key); k == "K1" || k == "K2" {
 				_, err := c.Write(key)
 				require.NoError(t, err)
 				_, err = c.Write(value)
 				require.NoError(t, err)
 			}
-			return true
-		})
+		}
 		return nil
 	}
 

--- a/ctx.go
+++ b/ctx.go
@@ -408,10 +408,9 @@ func (c *DefaultCtx) ClearCookie(key ...string) {
 		}
 		return
 	}
-	c.fasthttp.Request.Header.Cookies()(func(k, _ []byte) bool {
+	for k := range c.fasthttp.Request.Header.Cookies() {
 		c.fasthttp.Response.Header.DelClientCookieBytes(k)
-		return true
-	})
+	}
 }
 
 // RequestCtx returns *fasthttp.RequestCtx that carries a deadline
@@ -767,11 +766,10 @@ func (c *DefaultCtx) GetRespHeader(key string, defaultValue ...string) string {
 // Make copies or use the Immutable setting instead.
 func (c *DefaultCtx) GetRespHeaders() map[string][]string {
 	headers := make(map[string][]string)
-	c.Response().Header.All()(func(k, v []byte) bool {
+	for k, v := range c.Response().Header.All() {
 		key := c.app.getString(k)
 		headers[key] = append(headers[key], c.app.getString(v))
-		return true
-	})
+	}
 	return headers
 }
 
@@ -780,11 +778,10 @@ func (c *DefaultCtx) GetRespHeaders() map[string][]string {
 // Make copies or use the Immutable setting instead.
 func (c *DefaultCtx) GetReqHeaders() map[string][]string {
 	headers := make(map[string][]string)
-	c.Request().Header.All()(func(k, v []byte) bool {
+	for k, v := range c.Request().Header.All() {
 		key := c.app.getString(k)
 		headers[key] = append(headers[key], c.app.getString(v))
-		return true
-	})
+	}
 	return headers
 }
 
@@ -1252,9 +1249,9 @@ func (c *DefaultCtx) Scheme() string {
 
 	scheme := schemeHTTP
 	const lenXHeaderName = 12
-	c.fasthttp.Request.Header.All()(func(key, val []byte) bool {
+	for key, val := range c.fasthttp.Request.Header.All() {
 		if len(key) < lenXHeaderName {
-			return true // Neither "X-Forwarded-" nor "X-Url-Scheme"
+			continue // Neither "X-Forwarded-" nor "X-Url-Scheme"
 		}
 		switch {
 		case bytes.HasPrefix(key, []byte("X-Forwarded-")):
@@ -1274,8 +1271,7 @@ func (c *DefaultCtx) Scheme() string {
 		case bytes.Equal(key, []byte(HeaderXUrlScheme)):
 			scheme = c.app.getString(val)
 		}
-		return true
-	})
+	}
 	return scheme
 }
 
@@ -1316,10 +1312,9 @@ func (c *DefaultCtx) Query(key string, defaultValue ...string) string {
 // Queries()["filters[status]"] == "pending"
 func (c *DefaultCtx) Queries() map[string]string {
 	m := make(map[string]string, c.RequestCtx().QueryArgs().Len())
-	c.RequestCtx().QueryArgs().All()(func(key, value []byte) bool {
+	for key, value := range c.RequestCtx().QueryArgs().All() {
 		m[c.app.getString(key)] = c.app.getString(value)
-		return true
-	})
+	}
 	return m
 }
 

--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -196,10 +196,9 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 		}
 
 		// Convert fasthttp Ctx -> net/http
-		fctx.Response.Header.All()(func(k, v []byte) bool {
+		for k, v := range fctx.Response.Header.All() {
 			w.Header().Add(string(k), string(v))
-			return true
-		})
+		}
 		w.WriteHeader(fctx.Response.StatusCode())
 		_, _ = w.Write(fctx.Response.Body()) //nolint:errcheck // not needed
 	}

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -254,14 +254,13 @@ func New(config ...Config) fiber.Handler {
 		// (more: https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1)
 		if cfg.StoreResponseHeaders {
 			e.headers = make(map[string][]byte)
-			c.Response().Header.All()(func(key, value []byte) bool {
+			for key, value := range c.Response().Header.All() {
 				// create real copy
 				keyS := string(key)
 				if _, ok := ignoreHeaders[keyS]; !ok {
 					e.headers[keyS] = utils.CopyBytes(value)
 				}
-				return true
-			})
+			}
 		}
 
 		// default cache expiration

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -524,12 +524,11 @@ func Test_CORS_AllowOriginHeader_NoMatch(t *testing.T) {
 	handler(ctx)
 
 	var headerExists bool
-	ctx.Response.Header.All()(func(key, _ []byte) bool {
+	for key := range ctx.Response.Header.All() {
 		if string(key) == fiber.HeaderAccessControlAllowOrigin {
 			headerExists = true
 		}
-		return true
-	})
+	}
 	require.False(t, headerExists, "Access-Control-Allow-Origin header should not be set")
 }
 

--- a/middleware/encryptcookie/encryptcookie.go
+++ b/middleware/encryptcookie/encryptcookie.go
@@ -18,7 +18,7 @@ func New(config ...Config) fiber.Handler {
 		}
 
 		// Decrypt request cookies
-		c.Request().Header.Cookies()(func(key, value []byte) bool {
+		for key, value := range c.Request().Header.Cookies() {
 			keyString := string(key)
 			if !isDisabled(keyString, cfg.Except) {
 				decryptedValue, err := cfg.Decryptor(string(value), cfg.Key)
@@ -28,14 +28,13 @@ func New(config ...Config) fiber.Handler {
 					c.Request().Header.SetCookie(string(key), decryptedValue)
 				}
 			}
-			return true
-		})
+		}
 
 		// Continue stack
 		err := c.Next()
 
 		// Encrypt response cookies
-		c.Response().Header.Cookies()(func(key, _ []byte) bool {
+		for key := range c.Response().Header.Cookies() {
 			keyString := string(key)
 			if !isDisabled(keyString, cfg.Except) {
 				cookieValue := fasthttp.Cookie{}
@@ -50,8 +49,7 @@ func New(config ...Config) fiber.Handler {
 					c.Response().Header.SetCookie(&cookieValue)
 				}
 			}
-			return true
-		})
+		}
 
 		return err
 	}


### PR DESCRIPTION
## Summary
- replace fasthttp iterator callbacks with simple `for` loops
- keep early exit behaviour when errors occur

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6863c67370e88326b2ce7ad1f4a61afb