### PR TITLE
🐛 bug: Fix multipart boundary for Client per RFC 2046

### DIFF
--- a/client/core.go
+++ b/client/core.go
@@ -14,7 +14,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-var boundary = "--FiberFormBoundary"
+var boundary = "FiberFormBoundary"
 
 // RequestHook is a function invoked before the request is sent.
 // It receives a Client and a Request, allowing you to modify the Request or Client data.

--- a/client/hooks_test.go
+++ b/client/hooks_test.go
@@ -298,7 +298,7 @@ func Test_Parser_Request_Header(t *testing.T) {
 
 		err := parserRequestHeader(client, req)
 		require.NoError(t, err)
-		require.Contains(t, string(req.RawRequest.Header.MultipartFormBoundary()), "--FiberFormBoundary")
+		require.Contains(t, string(req.RawRequest.Header.MultipartFormBoundary()), "FiberFormBoundary")
 		require.Contains(t, string(req.RawRequest.Header.ContentType()), multipartFormData)
 	})
 
@@ -514,7 +514,7 @@ func Test_Parser_Request_Body(t *testing.T) {
 
 		err := parserRequestBody(client, req)
 		require.NoError(t, err)
-		require.Contains(t, string(req.RawRequest.Body()), "----FiberFormBoundary")
+		require.Contains(t, string(req.RawRequest.Body()), "--FiberFormBoundary")
 		require.Contains(t, string(req.RawRequest.Body()), "world")
 	})
 
@@ -527,7 +527,7 @@ func Test_Parser_Request_Body(t *testing.T) {
 
 		err := parserRequestBody(client, req)
 		require.NoError(t, err)
-		require.Contains(t, string(req.RawRequest.Body()), "----FiberFormBoundary")
+		require.Contains(t, string(req.RawRequest.Body()), "--FiberFormBoundary")
 		require.Contains(t, string(req.RawRequest.Body()), "world")
 		require.Contains(t, string(req.RawRequest.Body()), "bar")
 	})

--- a/client/request.go
+++ b/client/request.go
@@ -938,7 +938,7 @@ var requestPool = &sync.Pool{
 			params:     &QueryParam{Args: fasthttp.AcquireArgs()},
 			cookies:    &Cookie{},
 			path:       &PathParam{},
-			boundary:   "--FiberFormBoundary",
+			boundary:   "FiberFormBoundary",
 			formData:   &FormData{Args: fasthttp.AcquireArgs()},
 			files:      make([]*File, 0),
 			RawRequest: fasthttp.AcquireRequest(),

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -1332,7 +1332,7 @@ func Test_Request_Body_With_Server(t *testing.T) {
 
 		app, ln, start := createHelperServer(t)
 		app.Post("/", func(c fiber.Ctx) error {
-			reg := regexp.MustCompile(`multipart/form-data; boundary=[\-\w]{35}`)
+			reg := regexp.MustCompile(`multipart/form-data; boundary=[\-\w]{33}`)
 			require.True(t, reg.MatchString(c.Get(fiber.HeaderContentType)))
 
 			return c.Send(c.Request().Body())


### PR DESCRIPTION
## Summary
- remove leading dashes from default multipart boundary in client
- update tests for new boundary formatting

Related #3383 