### PR TITLE
Fix CookieJar domain logic

### DIFF
--- a/client/cookiejar_test.go
+++ b/client/cookiejar_test.go
@@ -26,14 +26,10 @@ func Test_CookieJarGet(t *testing.T) {
 	t.Parallel()
 
 	url := []byte("http://fasthttp.com/")
-	url1 := []byte("http://fasthttp.com/make")
+	url1 := []byte("http://fasthttp.com/make/")
 	url11 := []byte("http://fasthttp.com/hola")
 	url2 := []byte("http://fasthttp.com/make/fasthttp")
 	url3 := []byte("http://fasthttp.com/make/fasthttp/great")
-	prefix := []byte("/")
-	prefix1 := []byte("/make")
-	prefix2 := []byte("/make/fasthttp")
-	prefix3 := []byte("/make/fasthttp/great")
 	cj := &CookieJar{}
 
 	c1 := &fasthttp.Cookie{}
@@ -69,9 +65,9 @@ func Test_CookieJarGet(t *testing.T) {
 	cj.Set(uri1, c1, c2, c3)
 
 	cookies := cj.Get(uri1)
-	require.Len(t, cookies, 3)
+	require.Len(t, cookies, 1)
 	for _, cookie := range cookies {
-		require.True(t, bytes.HasPrefix(cookie.Path(), prefix1))
+		require.True(t, bytes.HasPrefix(uri1.Path(), cookie.Path()))
 	}
 
 	cookies = cj.Get(uri11)
@@ -80,21 +76,17 @@ func Test_CookieJarGet(t *testing.T) {
 	cookies = cj.Get(uri2)
 	require.Len(t, cookies, 2)
 	for _, cookie := range cookies {
-		require.True(t, bytes.HasPrefix(cookie.Path(), prefix2))
+		require.True(t, bytes.HasPrefix(uri2.Path(), cookie.Path()))
 	}
 
 	cookies = cj.Get(uri3)
-	require.Len(t, cookies, 1)
-
+	require.Len(t, cookies, 3)
 	for _, cookie := range cookies {
-		require.True(t, bytes.HasPrefix(cookie.Path(), prefix3))
+		require.True(t, bytes.HasPrefix(uri3.Path(), cookie.Path()))
 	}
 
 	cookies = cj.Get(uri)
-	require.Len(t, cookies, 3)
-	for _, cookie := range cookies {
-		require.True(t, bytes.HasPrefix(cookie.Path(), prefix))
-	}
+	require.Empty(t, cookies)
 }
 
 func Test_CookieJarGetExpired(t *testing.T) {
@@ -209,4 +201,87 @@ func Test_CookieJarGetFromResponse(t *testing.T) {
 
 	cookies := cj.Get(uri)
 	require.Len(t, cookies, 3)
+	values := map[string]string{"key": "val", "k": "v", "kk": "vv"}
+	for _, c := range cookies {
+		k := string(c.Key())
+		v, ok := values[k]
+		require.True(t, ok)
+		require.Equal(t, v, string(c.Value()))
+		delete(values, k)
+	}
+	require.Empty(t, values)
+}
+
+func Test_CookieJar_HostPort(t *testing.T) {
+	t.Parallel()
+
+	jar := &CookieJar{}
+	uriSet := fasthttp.AcquireURI()
+	require.NoError(t, uriSet.Parse(nil, []byte("http://fasthttp.com:80/path")))
+
+	c := &fasthttp.Cookie{}
+	c.SetKey("k")
+	c.SetValue("v")
+	jar.Set(uriSet, c)
+
+	// retrieve using a different port to ensure port is ignored
+	uriGet := fasthttp.AcquireURI()
+	require.NoError(t, uriGet.Parse(nil, []byte("http://fasthttp.com:8080/path")))
+
+	cookies := jar.Get(uriGet)
+	require.Len(t, cookies, 1)
+	require.Equal(t, "k", string(cookies[0].Key()))
+	require.Equal(t, "v", string(cookies[0].Value()))
+	require.Equal(t, "fasthttp.com", string(cookies[0].Domain()))
+}
+
+func Test_CookieJar_Domain(t *testing.T) {
+	t.Parallel()
+
+	jar := &CookieJar{}
+
+	uri := fasthttp.AcquireURI()
+	require.NoError(t, uri.Parse(nil, []byte("http://sub.example.com/")))
+
+	c := &fasthttp.Cookie{}
+	c.SetKey("k")
+	c.SetValue("v")
+	c.SetDomain("example.com")
+
+	jar.Set(uri, c)
+
+	uri2 := fasthttp.AcquireURI()
+	require.NoError(t, uri2.Parse(nil, []byte("http://other.example.com/")))
+
+	cookies := jar.Get(uri2)
+	require.Len(t, cookies, 1)
+	require.Equal(t, "k", string(cookies[0].Key()))
+	require.Equal(t, "v", string(cookies[0].Value()))
+}
+
+func Test_CookieJar_Secure(t *testing.T) {
+	t.Parallel()
+
+	jar := &CookieJar{}
+
+	uriHTTP := fasthttp.AcquireURI()
+	require.NoError(t, uriHTTP.Parse(nil, []byte("http://example.com/")))
+
+	c := &fasthttp.Cookie{}
+	c.SetKey("k")
+	c.SetValue("v")
+	c.SetSecure(true)
+
+	jar.Set(uriHTTP, c)
+
+	cookies := jar.Get(uriHTTP)
+	require.Empty(t, cookies)
+
+	uriHTTPS := fasthttp.AcquireURI()
+	require.NoError(t, uriHTTPS.Parse(nil, []byte("https://example.com/")))
+
+	cookies = jar.Get(uriHTTPS)
+	require.Len(t, cookies, 1)
+	require.Equal(t, "k", string(cookies[0].Key()))
+	require.Equal(t, "v", string(cookies[0].Value()))
 }


### PR DESCRIPTION
## Summary
- fix path matching for root URLs
- handle expired cookies without leaks
- copy cookies in the correct direction
- adjust regression test for root path behavior
- address revive lint on cookiesForRequest

## Testing
- `go test ./client -run HostPort -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6865b965bc088333af7f9373f582818a