### PR TITLE
🐛 bug: Fix address parsing for leading/trailing spaces

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -634,6 +634,8 @@ func parseAddr(raw string) (string, string) {
 		return "", ""
 	}
 
+	raw = utils.Trim(raw, ' ')
+
 	// Handle IPv6 addresses enclosed in brackets as defined by RFC 3986
 	if strings.HasPrefix(raw, "[") {
 		if end := strings.IndexByte(raw, ']'); end != -1 {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -530,6 +530,7 @@ func Test_Utils_Parse_Address(t *testing.T) {
 		{addr: "[fe80::1%lo0]:1234", host: "[fe80::1%lo0]", port: "1234"},
 		{addr: "[fe80::1%lo0]", host: "[fe80::1%lo0]", port: ""},
 		{addr: ":9090", host: "", port: "9090"},
+		{addr: " 127.0.0.1:8080 ", host: "127.0.0.1", port: "8080"},
 		{addr: "", host: "", port: ""},
 	}
 


### PR DESCRIPTION
## Summary
- trim spaces in `parseAddr`.
- add regression test for addresses with surrounding spaces.