### PR TITLE
Fix Allow header in envvar 405 responses

### DIFF
--- a/middleware/envvar/envvar.go
+++ b/middleware/envvar/envvar.go
@@ -28,6 +28,7 @@ func New(config ...Config) fiber.Handler {
 
 	return func(c fiber.Ctx) error {
 		if c.Method() != fiber.MethodGet {
+			c.Set(fiber.HeaderAllow, fiber.MethodGet)
 			return fiber.ErrMethodNotAllowed
 		}
 

--- a/middleware/envvar/envvar_test.go
+++ b/middleware/envvar/envvar_test.go
@@ -101,6 +101,7 @@ func Test_EnvVarHandlerMethod(t *testing.T) {
 	resp, err := app.Test(req)
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusMethodNotAllowed, resp.StatusCode)
+	require.Equal(t, fiber.MethodGet, resp.Header.Get(fiber.HeaderAllow))
 }
 
 func Test_EnvVarHandlerSpecialValue(t *testing.T) {


### PR DESCRIPTION
## Summary
- send `Allow: GET` when envvar middleware rejects a request with 405
- check for the Allow header in the envvar middleware tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68707b52c818833395bb19074985c2c4