### PR TITLE
Fix static file descriptor leak

### DIFF
--- a/middleware/favicon/favicon.go
+++ b/middleware/favicon/favicon.go
@@ -101,6 +101,9 @@ func New(config ...Config) fiber.Handler {
 			if err != nil {
 				panic(err)
 			}
+			defer func() {
+				_ = f.Close() //nolint:errcheck // not needed
+			}()
 			if iconData, err = io.ReadAll(f); err != nil {
 				panic(err)
 			}

--- a/middleware/static/static.go
+++ b/middleware/static/static.go
@@ -171,11 +171,17 @@ func isFile(root string, filesystem fs.FS) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("static: %w", err)
 		}
+		defer func() {
+			_ = file.Close() //nolint:errcheck // not needed
+		}()
 	} else {
 		file, err = os.Open(filepath.Clean(root))
 		if err != nil {
 			return false, fmt.Errorf("static: %w", err)
 		}
+		defer func() {
+			_ = file.Close() //nolint:errcheck // not needed
+		}()
 	}
 
 	stat, err := file.Stat()


### PR DESCRIPTION
## Summary
- close file descriptor in `isFile` helper
- close favicon file handle when read from filesystem
- suppress linter warnings on closing `fs.File` handles

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6874419e0c0483338a499efe82c68f34