### PR TITLE
Update Copilot docs and setup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,14 @@
+# Copilot Usage
+
+When modifying code, always perform these steps:
+
+1. **Ensure code quality**
+   - `make format` to format the project.
+   - `make lint` for static analysis.
+   - `make test` to run the test suite.
+
+2. **Maintain documentation**
+   Review and update the contents of the `docs` folder if necessary.
+
+3. **Check Markdown**
+   - Finish by running `make markdown` to lint all Markdown files.

--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -1,0 +1,15 @@
+steps:
+  - run: |
+      if [ -d vendor ] || go list -m -mod=readonly all; then
+        echo "Dependencies already present"
+      else
+        go mod tidy && go mod download && go mod vendor
+      fi
+  - run: |
+      go install gotest.tools/gotestsum@latest
+      go install golang.org/x/vuln/cmd/govulncheck@latest
+      go install mvdan.cc/gofumpt@latest
+      go install github.com/tinylib/msgp@latest
+      go install github.com/vburenin/ifacemaker@975a95966976eeb2d4365a7fb236e274c54da64c
+      go install github.com/dkorunic/betteralign/cmd/betteralign@latest
+  - run: go mod tidy


### PR DESCRIPTION
## Summary
- rewrite Copilot instructions in English
- add setup steps for preparing Copilot environment

## Testing
- `make format`
- `make lint` *(fails: unsupported configuration version)*
- `make test`
- `make markdown` *(fails: markdownlint-cli2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68762605150c8326b9d701fbf3d513c6