### PR TITLE
🐛 bug: Fix default configuration of CSRF Middleware

### DIFF
--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -125,7 +125,7 @@ var ConfigDefault = Config{
 	IdleTimeout:    30 * time.Minute,
 	KeyGenerator:   utils.UUIDv4,
 	ErrorHandler:   defaultErrorHandler,
-	Extractor:      FromHeader(HeaderName),
+	Extractor:      nil,
 }
 
 // default ErrorHandler that process return error from fiber.Handler

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -130,12 +130,17 @@ func New(config ...Config) fiber.Handler {
 				return cfg.ErrorHandler(c, err)
 			}
 
+			// Get Extractor
+			extractor := cfg.Extractor
+			if extractor == nil {
+				extractor = FromHeader(HeaderName)
+			}
+
 			// Extract token from client request i.e. header, query, param, form or cookie
-			extractedToken, err := cfg.Extractor(c)
+			extractedToken, err := extractor(c)
 			if err != nil {
 				return cfg.ErrorHandler(c, err)
 			}
-
 			if extractedToken == "" {
 				return cfg.ErrorHandler(c, ErrTokenNotFound)
 			}
@@ -143,7 +148,7 @@ func New(config ...Config) fiber.Handler {
 			// If not using FromCookie extractor, check that the token matches the cookie
 			// This is to prevent CSRF attacks by using a Double Submit Cookie method
 			// Useful when we do not have access to the users Session
-			if !isFromCookie(cfg.Extractor) && !compareStrings(extractedToken, c.Cookies(cfg.CookieName)) {
+			if !isFromCookie(extractor) && !compareStrings(extractedToken, c.Cookies(cfg.CookieName)) {
 				return cfg.ErrorHandler(c, ErrTokenInvalid)
 			}
 


### PR DESCRIPTION
fix: Csrf.ConfigDefault use both 'KeyLookup' and 'Extractor' #3587

Fixes #3587
