### PR TITLE
🧹 chore: Improve Radix router test coverage

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -122,15 +122,33 @@ func routeConstPrefix(rp routeParser) string {
 		return "/"
 	}
 	var b strings.Builder
-	for _, seg := range rp.segs {
+	idx := 0
+	for i, seg := range rp.segs {
 		if seg.IsParam {
+			// trim trailing slash if the param is optional
+			if seg.IsOptional && strings.HasSuffix(b.String(), "/") {
+				prefix := strings.TrimSuffix(b.String(), "/")
+				if prefix == "" {
+					return "/"
+				}
+				return prefix
+			}
 			break
 		}
 		b.WriteString(seg.Const)
+		idx = i
 	}
 	prefix := b.String()
 	if prefix == "" {
 		return "/"
+	}
+	// special case when first param is optional and no constant prefix
+	if idx+1 < len(rp.segs) && rp.segs[idx+1].IsOptional && strings.HasSuffix(prefix, "/") {
+		trimmed := strings.TrimSuffix(prefix, "/")
+		if trimmed == "" {
+			return "/"
+		}
+		return trimmed
 	}
 	return prefix
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1353,3 +1353,19 @@ func Test_ParamsMatch_InvalidEscape(t *testing.T) {
 	match := paramsMatch(headerParams{"foo": []byte("bar")}, `;foo="bar\\`)
 	require.False(t, match)
 }
+
+func TestRouteConstPrefix(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"/foo/bar":     "/foo/bar",
+		"/foo/:id/bar": "/foo/",
+		"/foo/:id?":    "/foo",
+		"/:id":         "/",
+		"":             "/",
+	}
+	for path, expect := range cases {
+		rp := parseRoute(path)
+		require.Equal(t, expect, routeConstPrefix(rp), path)
+	}
+}

--- a/radix/radix_test.go
+++ b/radix/radix_test.go
@@ -1,6 +1,10 @@
 package radix
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestTreeInsertAndLookup(t *testing.T) {
 	tree := New()
@@ -43,4 +47,94 @@ func TestTreeOverwrite(t *testing.T) {
 	if !ok || v != 2 {
 		t.Fatalf("overwrite failed: %v %v", ok, v)
 	}
+}
+
+func TestLongestPrefixLen(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, 4, longestPrefixLen("/foo", "/foobar"))
+	require.Equal(t, 0, longestPrefixLen("abc", "xyz"))
+	require.Equal(t, 2, longestPrefixLen("abcd", "ab"))
+}
+
+func TestNodeGetSetEdge(t *testing.T) {
+	t.Parallel()
+	n := &node{}
+	child1 := &node{prefix: "a"}
+	n.setEdge('a', child1)
+	require.Equal(t, child1, n.getEdge('a'))
+
+	child2 := &node{prefix: "b"}
+	n.setEdge('a', child2)
+	require.Equal(t, child2, n.getEdge('a'))
+	require.Nil(t, n.getEdge('b'))
+}
+
+func TestTreeInsertSplitAndSearch(t *testing.T) {
+	t.Parallel()
+	tree := New()
+	tree.Insert("", 0) // value on root node
+	tree.Insert("/foo", 1)
+	tree.Insert("/fo", 2) // causes split
+	tree.Insert("/fob", 3)
+	tree.Insert("/fuz", 4)
+
+	p, v, ok := tree.LongestPrefix("/foo")
+	require.True(t, ok)
+	require.Equal(t, "/foo", p)
+	require.Equal(t, 1, v)
+
+	p, v, ok = tree.LongestPrefix("/fo")
+	require.True(t, ok)
+	require.Equal(t, "/fo", p)
+	require.Equal(t, 2, v)
+
+	p, v, ok = tree.LongestPrefix("/fob")
+	require.True(t, ok)
+	require.Equal(t, "/fob", p)
+	require.Equal(t, 3, v)
+
+	p, v, ok = tree.LongestPrefix("/fuz/extra")
+	require.True(t, ok)
+	require.Equal(t, "/fuz", p)
+	require.Equal(t, 4, v)
+
+	p, v, ok = tree.LongestPrefix("/")
+	require.True(t, ok)
+	require.Equal(t, "", p)
+	require.Equal(t, 0, v)
+
+	p, v, ok = tree.LongestPrefix("/unknown")
+	require.True(t, ok)
+	require.Equal(t, "", p)
+	require.Equal(t, 0, v)
+}
+
+func TestTreeLongestPrefixNoMatch(t *testing.T) {
+	t.Parallel()
+	tree := New()
+	tree.Insert("/foo", 1)
+	p, v, ok := tree.LongestPrefix("/bar")
+	require.False(t, ok)
+	require.Equal(t, "", p)
+	require.Nil(t, v)
+}
+
+func TestTreeLongestPrefixNilTree(t *testing.T) {
+	t.Parallel()
+	tree := New()
+	tree.root = nil
+	p, v, ok := tree.LongestPrefix("/foo")
+	require.False(t, ok)
+	require.Equal(t, "", p)
+	require.Nil(t, v)
+}
+
+func TestTreeLongestPrefixEmpty(t *testing.T) {
+	t.Parallel()
+	tree := New()
+	tree.Insert("", 42)
+	p, v, ok := tree.LongestPrefix("")
+	require.True(t, ok)
+	require.Equal(t, "", p)
+	require.Equal(t, 42, v)
 }

--- a/router_radix_test.go
+++ b/router_radix_test.go
@@ -129,7 +129,9 @@ require.Equal(t, "2022-08-27", app.getString(body))
 	// escaped colon
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/v1/some/resource/name:customVerb", nil))
 	require.NoError(t, err)
-	body, _ = io.ReadAll(resp.Body)
+body, err = io.ReadAll(resp.Body)
+require.NoError(t, err)
+require.Equal(t, "ok", app.getString(body))
 	require.Equal(t, "ok", app.getString(body))
 
 	// multi wildcard

--- a/router_radix_test.go
+++ b/router_radix_test.go
@@ -102,7 +102,9 @@ require.Equal(t, "john", app.getString(body))
 	// plus parameter
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/user/1/2", nil))
 	require.NoError(t, err)
-	body, _ = io.ReadAll(resp.Body)
+body, err = io.ReadAll(resp.Body)
+require.NoError(t, err)
+require.Equal(t, "1/2", app.getString(body))
 	require.Equal(t, "1/2", app.getString(body))
 
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/user/", nil))

--- a/router_radix_test.go
+++ b/router_radix_test.go
@@ -90,9 +90,9 @@ func Test_Router_Radix_OptionalPlusRegexEscaped(t *testing.T) {
 
 	// optional parameter
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/user", nil))
-	require.NoError(t, err)
-	body, _ := io.ReadAll(resp.Body)
-	require.Equal(t, "", app.getString(body))
+body, err := io.ReadAll(resp.Body)
+require.NoError(t, err)
+require.Equal(t, "", app.getString(body))
 
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/user/john", nil))
 	require.NoError(t, err)

--- a/router_radix_test.go
+++ b/router_radix_test.go
@@ -94,9 +94,9 @@ body, err := io.ReadAll(resp.Body)
 require.NoError(t, err)
 require.Equal(t, "", app.getString(body))
 
-	resp, err = app.Test(httptest.NewRequest(MethodGet, "/user/john", nil))
-	require.NoError(t, err)
-	body, _ = io.ReadAll(resp.Body)
+body, err = io.ReadAll(resp.Body)
+require.NoError(t, err)
+require.Equal(t, "john", app.getString(body))
 	require.Equal(t, "john", app.getString(body))
 
 	// plus parameter

--- a/router_radix_test.go
+++ b/router_radix_test.go
@@ -68,3 +68,67 @@ func Test_Router_Radix_RebuildTree(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, StatusCreated, resp.StatusCode)
 }
+
+func Test_Router_Radix_OptionalPlusRegexEscaped(t *testing.T) {
+	t.Parallel()
+	app := newRadixApp()
+	app.Get("/user/:name?", func(c Ctx) error {
+		return c.SendString(c.Params("name"))
+	})
+	app.Get("/user/+", func(c Ctx) error {
+		return c.SendString(c.Params("+"))
+	})
+	app.Get(`/:date<regex(\d{4}-\d{2}-\d{2})>`, func(c Ctx) error {
+		return c.SendString(c.Params("date"))
+	})
+	app.Get(`/v1/some/resource/name\:customVerb`, func(c Ctx) error {
+		return c.SendString("ok")
+	})
+	app.Get("/v1/*/shop/*", func(c Ctx) error {
+		return c.SendString(c.Params("*1") + "," + c.Params("*2"))
+	})
+
+	// optional parameter
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/user", nil))
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	require.Equal(t, "", app.getString(body))
+
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/user/john", nil))
+	require.NoError(t, err)
+	body, _ = io.ReadAll(resp.Body)
+	require.Equal(t, "john", app.getString(body))
+
+	// plus parameter
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/user/1/2", nil))
+	require.NoError(t, err)
+	body, _ = io.ReadAll(resp.Body)
+	require.Equal(t, "1/2", app.getString(body))
+
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/user/", nil))
+	require.NoError(t, err)
+	body, _ = io.ReadAll(resp.Body)
+	require.Equal(t, "", app.getString(body))
+
+	// regex constraint
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/2022-08-27", nil))
+	require.NoError(t, err)
+	body, _ = io.ReadAll(resp.Body)
+	require.Equal(t, "2022-08-27", app.getString(body))
+
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/125", nil))
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+
+	// escaped colon
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/v1/some/resource/name:customVerb", nil))
+	require.NoError(t, err)
+	body, _ = io.ReadAll(resp.Body)
+	require.Equal(t, "ok", app.getString(body))
+
+	// multi wildcard
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/v1/brand/4/shop/blue/xs", nil))
+	require.NoError(t, err)
+	body, _ = io.ReadAll(resp.Body)
+	require.Equal(t, "brand/4,blue/xs", app.getString(body))
+}

--- a/router_radix_test.go
+++ b/router_radix_test.go
@@ -90,36 +90,35 @@ func Test_Router_Radix_OptionalPlusRegexEscaped(t *testing.T) {
 
 	// optional parameter
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/user", nil))
-body, err := io.ReadAll(resp.Body)
-require.NoError(t, err)
-require.Equal(t, "", app.getString(body))
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "", app.getString(body))
 
-body, err = io.ReadAll(resp.Body)
-require.NoError(t, err)
-require.Equal(t, "john", app.getString(body))
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/user/john", nil))
+	require.NoError(t, err)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
 	require.Equal(t, "john", app.getString(body))
 
 	// plus parameter
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/user/1/2", nil))
 	require.NoError(t, err)
-body, err = io.ReadAll(resp.Body)
-require.NoError(t, err)
-require.Equal(t, "1/2", app.getString(body))
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
 	require.Equal(t, "1/2", app.getString(body))
 
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/user/", nil))
 	require.NoError(t, err)
-body, err = io.ReadAll(resp.Body)
-require.NoError(t, err)
-require.Equal(t, "", app.getString(body))
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
 	require.Equal(t, "", app.getString(body))
 
 	// regex constraint
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/2022-08-27", nil))
 	require.NoError(t, err)
-body, err = io.ReadAll(resp.Body)
-require.NoError(t, err)
-require.Equal(t, "2022-08-27", app.getString(body))
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
 	require.Equal(t, "2022-08-27", app.getString(body))
 
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/125", nil))
@@ -129,14 +128,14 @@ require.Equal(t, "2022-08-27", app.getString(body))
 	// escaped colon
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/v1/some/resource/name:customVerb", nil))
 	require.NoError(t, err)
-body, err = io.ReadAll(resp.Body)
-require.NoError(t, err)
-require.Equal(t, "ok", app.getString(body))
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
 	require.Equal(t, "ok", app.getString(body))
 
 	// multi wildcard
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/v1/brand/4/shop/blue/xs", nil))
 	require.NoError(t, err)
-	body, _ = io.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
 	require.Equal(t, "brand/4,blue/xs", app.getString(body))
 }

--- a/router_radix_test.go
+++ b/router_radix_test.go
@@ -109,7 +109,9 @@ require.Equal(t, "1/2", app.getString(body))
 
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/user/", nil))
 	require.NoError(t, err)
-	body, _ = io.ReadAll(resp.Body)
+body, err = io.ReadAll(resp.Body)
+require.NoError(t, err)
+require.Equal(t, "", app.getString(body))
 	require.Equal(t, "", app.getString(body))
 
 	// regex constraint

--- a/router_radix_test.go
+++ b/router_radix_test.go
@@ -117,7 +117,9 @@ require.Equal(t, "", app.getString(body))
 	// regex constraint
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/2022-08-27", nil))
 	require.NoError(t, err)
-	body, _ = io.ReadAll(resp.Body)
+body, err = io.ReadAll(resp.Body)
+require.NoError(t, err)
+require.Equal(t, "2022-08-27", app.getString(body))
 	require.Equal(t, "2022-08-27", app.getString(body))
 
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/125", nil))


### PR DESCRIPTION
## Summary
- ensure `routeConstPrefix` handles optional parameters without trailing slashes
- cover radix tree implementation with additional tests
- test router features while `UseRadix` is enabled
- add tests for constant prefix helper

This PR is to enhance #3591 