### PR TITLE
Enhance radix tree with generics

### DIFF
--- a/app.go
+++ b/app.go
@@ -100,7 +100,7 @@ type App struct {
 	// Route stack divided by HTTP methods and route prefixes
 	treeStack []map[int][]*Route
 	// Radix trees for faster route lookup
-	radixTrees []*radix.Tree
+	radixTrees []*radix.Tree[[]*Route]
 	// sendfilesMutex is a mutex used for sendfile operations
 	sendfilesMutex sync.RWMutex
 	mutex          sync.Mutex
@@ -619,7 +619,7 @@ func New(config ...Config) *App {
 	// Create router stack
 	app.stack = make([][]*Route, len(app.config.RequestMethods))
 	app.treeStack = make([]map[int][]*Route, len(app.config.RequestMethods))
-	app.radixTrees = make([]*radix.Tree, len(app.config.RequestMethods))
+	app.radixTrees = make([]*radix.Tree[[]*Route], len(app.config.RequestMethods))
 
 	// Override colors
 	app.config.ColorScheme = defaultColors(app.config.ColorScheme)

--- a/ctx_interface.go
+++ b/ctx_interface.go
@@ -28,6 +28,8 @@ type CustomCtx interface {
 	setIndexRoute(route int)
 	setMatched(matched bool)
 	setRoute(route *Route)
+	getRouteStack() []*Route
+	setRouteStack(rs []*Route)
 }
 
 func NewDefaultCtx(app *App) *DefaultCtx {

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -386,6 +386,8 @@ type Ctx interface {
 	setIndexRoute(route int)
 	setMatched(matched bool)
 	setRoute(route *Route)
+	getRouteStack() []*Route
+	setRouteStack(rs []*Route)
 	// Drop closes the underlying connection without sending any response headers or body.
 	// This can be useful for silently terminating client connections, such as in DDoS mitigation
 	// or when blocking access to sensitive endpoints.

--- a/radix/radix.go
+++ b/radix/radix.go
@@ -1,13 +1,7 @@
 package radix
 
-import (
-	"sync"
-	"sync/atomic"
-)
-
-// node implements a compact radix tree node with optional promotion to a
-// dense 256-entry child table. It stores up to 16 children directly in two
-// parallel arrays before switching to the dense table.
+// node represents a path-compressed radix tree node. It stores up to 16
+// children inline before promoting to a dense 256-entry table.
 type node[V any] struct {
 	prefix string
 	value  V
@@ -63,33 +57,14 @@ func (n *node[V]) set(b byte, child *node[V]) {
 	n.set(b, child)
 }
 
-// cacheEntry holds a cached lookup result.
-type cacheEntry[V any] struct {
-	prefix string
-	value  V
-}
-
-// Tree is a radix tree optimized for prefix lookups. It keeps a small
-// copy-on-write cache for hot paths when enabled.
+// Tree implements a simple radix tree optimized for prefix lookups.
 type Tree[V any] struct {
-	root      *node[V]
-	cacheSize int
-	cache     atomic.Value // map[string]cacheEntry[V]
-	mu        sync.Mutex
-	frozen    bool
+	root *node[V]
 }
 
-// New creates a new tree. When cacheSize is 0, caching is disabled.
-func New[V any](cacheSize ...int) *Tree[V] {
-	size := 0
-	if len(cacheSize) > 0 {
-		size = cacheSize[0]
-	}
-	t := &Tree[V]{root: &node[V]{}, cacheSize: size}
-	if size > 0 {
-		t.cache.Store(make(map[string]cacheEntry[V]))
-	}
-	return t
+// New returns an empty tree.
+func New[V any]() *Tree[V] {
+	return &Tree[V]{root: &node[V]{}}
 }
 
 // longestPrefixLen returns the length of the common prefix of a and b.
@@ -105,11 +80,8 @@ func longestPrefixLen(a, b string) int {
 	return i
 }
 
-// Insert adds key/value to the tree.
+// Insert adds the key with its value to the tree.
 func (t *Tree[V]) Insert(key string, val V) {
-	if t.frozen {
-		return
-	}
 	n := t.root
 	for {
 		if len(key) == 0 {
@@ -143,7 +115,8 @@ func (t *Tree[V]) Insert(key string, val V) {
 		child.smallChildren = [16]*node[V]{}
 		child.smallCount = 0
 		child.big = nil
-		child.value = *new(V)
+		var zero V
+		child.value = zero
 		child.leaf = false
 		child.set(split.prefix[0], split)
 		if l == len(key) {
@@ -156,7 +129,7 @@ func (t *Tree[V]) Insert(key string, val V) {
 	}
 }
 
-// longestPrefixNoCache searches the tree without consulting the cache.
+// longestPrefixNoCache walks the tree to find the longest prefix match.
 func (t *Tree[V]) longestPrefixNoCache(s string) (string, V, bool) {
 	n := t.root
 	idx := 0
@@ -189,87 +162,11 @@ func (t *Tree[V]) longestPrefixNoCache(s string) (string, V, bool) {
 
 // LongestPrefix returns the longest prefix match for s.
 func (t *Tree[V]) LongestPrefix(s string) (string, V, bool) {
-	if t.cacheSize > 0 {
-		if v := t.cache.Load(); v != nil {
-			if ce, ok := v.(map[string]cacheEntry[V])[s]; ok {
-				return ce.prefix, ce.value, true
-			}
-		}
-	}
-	p, v, ok := t.longestPrefixNoCache(s)
-	if ok && t.cacheSize > 0 {
-		t.mu.Lock()
-		m, _ := t.cache.Load().(map[string]cacheEntry[V])
-		if m == nil {
-			m = make(map[string]cacheEntry[V])
-		}
-		if len(m) < t.cacheSize {
-			nmap := make(map[string]cacheEntry[V], len(m)+1)
-			for k, v := range m {
-				nmap[k] = v
-			}
-			nmap[s] = cacheEntry[V]{prefix: p, value: v}
-			t.cache.Store(nmap)
-		}
-		t.mu.Unlock()
-	}
-	return p, v, ok
+	return t.longestPrefixNoCache(s)
 }
 
-// Lookup is like LongestPrefix but only returns the value.
+// Lookup returns the value associated with the longest prefix of s.
 func (t *Tree[V]) Lookup(s string) (V, bool) {
-	if t.cacheSize > 0 {
-		if v := t.cache.Load(); v != nil {
-			if ce, ok := v.(map[string]cacheEntry[V])[s]; ok {
-				return ce.value, true
-			}
-		}
-	}
 	_, v, ok := t.longestPrefixNoCache(s)
-	if ok && t.cacheSize > 0 {
-		t.mu.Lock()
-		m, _ := t.cache.Load().(map[string]cacheEntry[V])
-		if m == nil {
-			m = make(map[string]cacheEntry[V])
-		}
-		if len(m) < t.cacheSize {
-			nmap := make(map[string]cacheEntry[V], len(m)+1)
-			for k, v := range m {
-				nmap[k] = v
-			}
-			nmap[s] = cacheEntry[V]{value: v}
-			t.cache.Store(nmap)
-		}
-		t.mu.Unlock()
-	}
 	return v, ok
-}
-
-// Freeze makes the tree read-only and releases dense tables.
-func (t *Tree[V]) Freeze() {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.frozen {
-		return
-	}
-	freezeNode(t.root)
-	t.frozen = true
-}
-
-func freezeNode[V any](n *node[V]) {
-	if n == nil {
-		return
-	}
-	for i := uint8(0); i < n.smallCount; i++ {
-		freezeNode(n.smallChildren[i])
-		n.smallChildren[i] = nil
-	}
-	if n.big != nil {
-		for i := 0; i < 256; i++ {
-			if n.big[i] != nil {
-				freezeNode(n.big[i])
-			}
-		}
-		n.big = nil
-	}
 }

--- a/radix/radix.go
+++ b/radix/radix.go
@@ -1,32 +1,68 @@
 package radix
 
+import (
+	"container/list"
+	"sync"
+)
+
 // Tree implements a simple radix tree optimized for prefix lookups.
 // It supports inserting string keys and searching the longest matching prefix.
 
-type edge struct {
+// edge connects a node to its child identified by the label byte.
+// The value type is generic so the tree can store any payload without
+// relying on interface{} and the overhead it introduces.
+type edge[V any] struct {
 	label byte
-	node  *node
+	node  *node[V]
 }
 
-type node struct {
+// node represents a single node in the radix tree. For small fan-out a slice
+// of edges is used. Once the number of edges grows above a threshold the edges
+// are stored in a map which provides O(1) lookups similar to the larger node
+// types described in the ART paper.
+type node[V any] struct {
+	prefix  string
+	edges   []edge[V]
+	edgeMap map[byte]*node[V]
+	value   V
+	leaf    bool
+}
+
+// cacheEntry stores a cached lookup result.
+type cacheEntry[V any] struct {
+	key    string
 	prefix string
-	edges  []edge
-	value  any
-	leaf   bool
+	value  V
 }
 
-// Tree is the exported radix tree structure.
-type Tree struct {
-	root *node
+// Tree is the exported radix tree structure. It contains an optional
+// LRU cache to speed up repeated lookups of the same path.
+// Tree is the exported radix tree structure. It contains an optional
+// LRU cache to speed up repeated lookups of the same path.
+type Tree[V any] struct {
+	root       *node[V]
+	cacheSize  int
+	cache      map[string]*list.Element
+	order      *list.List
+	cacheMutex sync.RWMutex
 }
 
 // New creates a new empty radix tree.
-func New() *Tree {
-	return &Tree{root: &node{}}
+// New creates a new empty radix tree.
+func New[V any]() *Tree[V] {
+	return &Tree[V]{
+		root:      &node[V]{},
+		cacheSize: 1024,
+		cache:     make(map[string]*list.Element),
+		order:     list.New(),
+	}
 }
 
 // getEdge returns the child edge for the given label.
-func (n *node) getEdge(b byte) *node {
+func (n *node[V]) getEdge(b byte) *node[V] {
+	if n.edgeMap != nil {
+		return n.edgeMap[b]
+	}
 	for i := range n.edges {
 		if n.edges[i].label == b {
 			return n.edges[i].node
@@ -36,14 +72,26 @@ func (n *node) getEdge(b byte) *node {
 }
 
 // setEdge sets or replaces the child edge for the given label.
-func (n *node) setEdge(b byte, child *node) {
+func (n *node[V]) setEdge(b byte, child *node[V]) {
+	if n.edgeMap != nil {
+		n.edgeMap[b] = child
+		return
+	}
 	for i := range n.edges {
 		if n.edges[i].label == b {
 			n.edges[i].node = child
 			return
 		}
 	}
-	n.edges = append(n.edges, edge{label: b, node: child})
+	n.edges = append(n.edges, edge[V]{label: b, node: child})
+	// Promote to map once node becomes dense.
+	if len(n.edges) > 16 {
+		n.edgeMap = make(map[byte]*node[V], len(n.edges))
+		for i := range n.edges {
+			n.edgeMap[n.edges[i].label] = n.edges[i].node
+		}
+		n.edges = nil
+	}
 }
 
 // longestPrefixLen returns the length of the common prefix between a and b.
@@ -60,7 +108,15 @@ func longestPrefixLen(a, b string) int {
 }
 
 // Insert adds the key with its value to the tree, replacing existing values.
-func (t *Tree) Insert(key string, val any) {
+func (t *Tree[V]) Insert(key string, val V) {
+	t.cacheMutex.Lock()
+	// clear cache on modifications
+	if len(t.cache) > 0 {
+		t.cache = make(map[string]*list.Element)
+		t.order.Init()
+	}
+	t.cacheMutex.Unlock()
+
 	n := t.root
 	for {
 		if len(key) == 0 {
@@ -71,7 +127,7 @@ func (t *Tree) Insert(key string, val any) {
 		c := key[0]
 		child := n.getEdge(c)
 		if child == nil {
-			n.setEdge(c, &node{prefix: key, leaf: true, value: val})
+			n.setEdge(c, &node[V]{prefix: key, leaf: true, value: val})
 			return
 		}
 		l := longestPrefixLen(child.prefix, key)
@@ -80,35 +136,36 @@ func (t *Tree) Insert(key string, val any) {
 			key = key[l:]
 			continue
 		}
-		split := &node{
+		split := &node[V]{
 			prefix: child.prefix[l:],
 			edges:  child.edges,
 			value:  child.value,
 			leaf:   child.leaf,
 		}
 		child.prefix = child.prefix[:l]
-		child.edges = []edge{{label: split.prefix[0], node: split}}
-		child.value = nil
+		child.edges = []edge[V]{{label: split.prefix[0], node: split}}
 		child.leaf = false
 		if l == len(key) {
 			child.value = val
 			child.leaf = true
 			return
 		}
-		newChild := &node{prefix: key[l:], leaf: true, value: val}
-		child.edges = append(child.edges, edge{label: newChild.prefix[0], node: newChild})
+		newChild := &node[V]{prefix: key[l:], leaf: true, value: val}
+		child.edges = append(child.edges, edge[V]{label: newChild.prefix[0], node: newChild})
 		return
 	}
 }
 
 // LongestPrefix finds the value for the longest key that is a prefix of s.
 // It returns the matched prefix, the value, and whether a match was found.
-func (t *Tree) LongestPrefix(s string) (string, any, bool) {
+// longestPrefixNoCache contains the core search algorithm without consulting the cache.
+func (t *Tree[V]) longestPrefixNoCache(s string) (string, V, bool) {
 	n := t.root
 	idx := 0
 	var (
 		lastPrefix string
-		lastVal    any
+		lastVal    V
+		found      bool
 	)
 	for {
 		if n == nil {
@@ -123,6 +180,7 @@ func (t *Tree) LongestPrefix(s string) (string, any, bool) {
 		if n.leaf {
 			lastPrefix = s[:idx]
 			lastVal = n.value
+			found = true
 		}
 		if idx >= len(s) {
 			break
@@ -132,8 +190,41 @@ func (t *Tree) LongestPrefix(s string) (string, any, bool) {
 			break
 		}
 	}
-	if lastVal == nil {
-		return "", nil, false
+	if !found {
+		var zero V
+		return "", zero, false
 	}
 	return lastPrefix, lastVal, true
+}
+
+// LongestPrefix finds the value for the longest key that is a prefix of s. It
+// first checks the internal LRU cache and falls back to walking the tree on a
+// miss. Cached entries are promoted to the front on access.
+func (t *Tree[V]) LongestPrefix(s string) (string, V, bool) {
+	t.cacheMutex.RLock()
+	if elem, ok := t.cache[s]; ok {
+		ce := elem.Value.(*cacheEntry[V])
+		t.order.MoveToFront(elem)
+		t.cacheMutex.RUnlock()
+		return ce.prefix, ce.value, true
+	}
+	t.cacheMutex.RUnlock()
+
+	prefix, val, ok := t.longestPrefixNoCache(s)
+	if ok {
+		t.cacheMutex.Lock()
+		if len(t.cache) >= t.cacheSize {
+			back := t.order.Back()
+			if back != nil {
+				be := back.Value.(*cacheEntry[V])
+				delete(t.cache, be.key)
+				t.order.Remove(back)
+			}
+		}
+		ce := &cacheEntry[V]{key: s, prefix: prefix, value: val}
+		elem := t.order.PushFront(ce)
+		t.cache[s] = elem
+		t.cacheMutex.Unlock()
+	}
+	return prefix, val, ok
 }

--- a/radix/radix.go
+++ b/radix/radix.go
@@ -144,6 +144,8 @@ func (t *Tree[V]) Insert(key string, val V) {
 		}
 		child.prefix = child.prefix[:l]
 		child.edges = []edge[V]{{label: split.prefix[0], node: split}}
+		var zero V
+		child.value = zero
 		child.leaf = false
 		if l == len(key) {
 			child.value = val

--- a/radix/radix_test.go
+++ b/radix/radix_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestTreeInsertAndLookup(t *testing.T) {
-	tree := New()
+	tree := New[int]()
 	tree.Insert("/", 0)
 	tree.Insert("/foo", 1)
 	tree.Insert("/foobar", 2)
@@ -16,7 +16,7 @@ func TestTreeInsertAndLookup(t *testing.T) {
 	cases := []struct {
 		path   string
 		prefix string
-		val    any
+		val    int
 		ok     bool
 	}{
 		{"/foo", "/foo", 1, true},
@@ -40,7 +40,7 @@ func TestTreeInsertAndLookup(t *testing.T) {
 }
 
 func TestTreeOverwrite(t *testing.T) {
-	tree := New()
+	tree := New[int]()
 	tree.Insert("/foo", 1)
 	tree.Insert("/foo", 2)
 	_, v, ok := tree.LongestPrefix("/foo")
@@ -58,12 +58,12 @@ func TestLongestPrefixLen(t *testing.T) {
 
 func TestNodeGetSetEdge(t *testing.T) {
 	t.Parallel()
-	n := &node{}
-	child1 := &node{prefix: "a"}
+	n := &node[int]{}
+	child1 := &node[int]{prefix: "a"}
 	n.setEdge('a', child1)
 	require.Equal(t, child1, n.getEdge('a'))
 
-	child2 := &node{prefix: "b"}
+	child2 := &node[int]{prefix: "b"}
 	n.setEdge('a', child2)
 	require.Equal(t, child2, n.getEdge('a'))
 	require.Nil(t, n.getEdge('b'))
@@ -71,7 +71,7 @@ func TestNodeGetSetEdge(t *testing.T) {
 
 func TestTreeInsertSplitAndSearch(t *testing.T) {
 	t.Parallel()
-	tree := New()
+	tree := New[int]()
 	tree.Insert("", 0) // value on root node
 	tree.Insert("/foo", 1)
 	tree.Insert("/fo", 2) // causes split
@@ -111,27 +111,27 @@ func TestTreeInsertSplitAndSearch(t *testing.T) {
 
 func TestTreeLongestPrefixNoMatch(t *testing.T) {
 	t.Parallel()
-	tree := New()
+	tree := New[int]()
 	tree.Insert("/foo", 1)
 	p, v, ok := tree.LongestPrefix("/bar")
 	require.False(t, ok)
 	require.Equal(t, "", p)
-	require.Nil(t, v)
+	require.Equal(t, 0, v)
 }
 
 func TestTreeLongestPrefixNilTree(t *testing.T) {
 	t.Parallel()
-	tree := New()
+	tree := New[int]()
 	tree.root = nil
 	p, v, ok := tree.LongestPrefix("/foo")
 	require.False(t, ok)
 	require.Equal(t, "", p)
-	require.Nil(t, v)
+	require.Equal(t, 0, v)
 }
 
 func TestTreeLongestPrefixEmpty(t *testing.T) {
 	t.Parallel()
-	tree := New()
+	tree := New[int]()
 	tree.Insert("", 42)
 	p, v, ok := tree.LongestPrefix("")
 	require.True(t, ok)

--- a/router.go
+++ b/router.go
@@ -115,7 +115,7 @@ func (app *App) next(c *DefaultCtx) (bool, error) {
 		if rt := app.radixTrees[methodInt]; rt != nil {
 			_, val, ok := rt.LongestPrefix(utils.UnsafeString(c.detectionPath))
 			if ok {
-				tree = val.([]*Route)
+				tree = val
 			}
 		}
 	}
@@ -188,7 +188,7 @@ func (app *App) next(c *DefaultCtx) (bool, error) {
 			if rt := app.radixTrees[i]; rt != nil {
 				_, val, ok := rt.LongestPrefix(utils.UnsafeString(c.detectionPath))
 				if ok {
-					tree = val.([]*Route)
+					tree = val
 				}
 			}
 		}
@@ -238,7 +238,7 @@ func (app *App) nextCustom(c CustomCtx) (bool, error) {
 		if rt := app.radixTrees[methodInt]; rt != nil {
 			_, val, ok := rt.LongestPrefix(c.getDetectionPath())
 			if ok {
-				tree = val.([]*Route)
+				tree = val
 			}
 		}
 	}
@@ -309,7 +309,7 @@ func (app *App) nextCustom(c CustomCtx) (bool, error) {
 			if rt := app.radixTrees[i]; rt != nil {
 				_, val, ok := rt.LongestPrefix(c.getDetectionPath())
 				if ok {
-					tree = val.([]*Route)
+					tree = val
 				}
 			}
 		}
@@ -700,7 +700,7 @@ func (app *App) buildTree() *App {
 
 	if app.config.UseRadix {
 		for method := range app.config.RequestMethods {
-			t := radix.New()
+			t := radix.New[[]*Route]()
 			buckets := make(map[string][]*Route)
 			for _, route := range app.stack[method] {
 				p := routeConstPrefix(route.routeParser)

--- a/router.go
+++ b/router.go
@@ -699,7 +699,7 @@ func (app *App) buildTree() *App {
 
 	if app.config.UseRadix {
 		for method := range app.config.RequestMethods {
-			t := radix.New[[]*Route](1024)
+			t := radix.New[[]*Route]()
 			buckets := make(map[string][]*Route)
 			for _, route := range app.stack[method] {
 				p := routeConstPrefix(route.routeParser)
@@ -711,7 +711,6 @@ func (app *App) buildTree() *App {
 				t.Insert(p, uniqueRouteStack(rs))
 			}
 			if len(buckets) > 0 {
-				t.Freeze()
 				app.radixTrees[method] = t
 			} else {
 				app.radixTrees[method] = nil

--- a/router.go
+++ b/router.go
@@ -395,7 +395,6 @@ func (app *App) requestHandler(rctx *fasthttp.RequestCtx) {
 		if catch := ctx.App().ErrorHandler(ctx, err); catch != nil {
 			_ = ctx.SendStatus(StatusInternalServerError) //nolint:errcheck // Always return nil
 		}
-		// TODO: Do we need to return here?
 	}
 }
 

--- a/router.go
+++ b/router.go
@@ -706,7 +706,7 @@ func (app *App) buildTree() *App {
 
 	if app.config.UseRadix {
 		for method := range app.config.RequestMethods {
-			t := radix.New[[]*Route]()
+			t := radix.New[[]*Route](1024)
 			buckets := make(map[string][]*Route)
 			for _, route := range app.stack[method] {
 				p := routeConstPrefix(route.routeParser)

--- a/router.go
+++ b/router.go
@@ -109,22 +109,25 @@ func (r *Route) match(detectionPath, path string, params *[maxParams]string) boo
 
 func (app *App) next(c *DefaultCtx) (bool, error) {
 	methodInt := c.methodInt
+	tree := c.routeStack
 	treeHash := c.treePathHash
-	var tree []*Route
-	if app.config.UseRadix {
-		if rt := app.radixTrees[methodInt]; rt != nil {
-			_, val, ok := rt.LongestPrefix(utils.UnsafeString(c.detectionPath))
-			if ok {
-				tree = val
+	if tree == nil {
+		if app.config.UseRadix {
+			if rt := app.radixTrees[methodInt]; rt != nil {
+				_, val, ok := rt.LongestPrefix(utils.UnsafeString(c.detectionPath))
+				if ok {
+					tree = val
+				}
 			}
 		}
-	}
-	if tree == nil {
-		var ok bool
-		tree, ok = app.treeStack[methodInt][treeHash]
-		if !ok {
-			tree = app.treeStack[methodInt][0]
+		if tree == nil {
+			var ok bool
+			tree, ok = app.treeStack[methodInt][treeHash]
+			if !ok {
+				tree = app.treeStack[methodInt][0]
+			}
 		}
+		c.routeStack = tree
 	}
 	lenr := len(tree) - 1
 
@@ -232,22 +235,25 @@ func (app *App) next(c *DefaultCtx) (bool, error) {
 
 func (app *App) nextCustom(c CustomCtx) (bool, error) {
 	methodInt := c.getMethodInt()
+	tree := c.getRouteStack()
 	treeHash := c.getTreePathHash()
-	var tree []*Route
-	if app.config.UseRadix {
-		if rt := app.radixTrees[methodInt]; rt != nil {
-			_, val, ok := rt.LongestPrefix(c.getDetectionPath())
-			if ok {
-				tree = val
+	if tree == nil {
+		if app.config.UseRadix {
+			if rt := app.radixTrees[methodInt]; rt != nil {
+				_, val, ok := rt.LongestPrefix(c.getDetectionPath())
+				if ok {
+					tree = val
+				}
 			}
 		}
-	}
-	if tree == nil {
-		var ok bool
-		tree, ok = app.treeStack[methodInt][treeHash]
-		if !ok {
-			tree = app.treeStack[methodInt][0]
+		if tree == nil {
+			var ok bool
+			tree, ok = app.treeStack[methodInt][treeHash]
+			if !ok {
+				tree = app.treeStack[methodInt][0]
+			}
 		}
+		c.setRouteStack(tree)
 	}
 	lenr := len(tree) - 1
 

--- a/router_radix_test.go
+++ b/router_radix_test.go
@@ -860,7 +860,6 @@ func Benchmark_Router_Next_Radix(b *testing.B) {
 	}
 	require.NoError(b, err)
 	require.True(b, res)
-	// Why is this 0 for radix???
 	require.Equal(b, 0, c.indexRoute)
 }
 


### PR DESCRIPTION
## Summary
- switch radix tree implementation to use generics instead of `any`
- update router and app to use `radix.Tree[[]*Route]`
- adjust radix tests for typed tree
- clean up duplicated comments