### PR TITLE
Refactor CSRF configuration removing `KeyLookup`, and remove `FromCookie` `Extractor`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ markdown:
 ## lint: 🚨 Run lint checks
 .PHONY: lint
 lint:
-        golangci-lint run
+	golangci-lint run
 
 ## modernize: 🛠 Run gopls modernize
 .PHONY: modernize

--- a/docs/middleware/csrf.md
+++ b/docs/middleware/csrf.md
@@ -192,17 +192,21 @@ var (
 ### Built-in Extractors
 
 **Secure (Recommended):**
+
 - `csrf.FromHeader("X-Csrf-Token")` - Most secure, preferred for APIs
 - `csrf.FromForm("_csrf")` - Secure for form submissions
 
 **Acceptable:**
+
 - `csrf.FromQuery("csrf_token")` - URL parameters
 - `csrf.FromParam("csrf")` - Route parameters
 
 **Avoid:**
+
 - `csrf.FromCookie("csrf_token")` - Vulnerable to subdomain attacks
 
 #### Using Route-Specific Extractors
+
 There are cases where you might want to use different extractors for different routes:
 
 ```go
@@ -220,6 +224,7 @@ forms.Use(csrf.New(csrf.Config{
 ```
 
 ### Custom Extractor
+
 You can create a custom extractor to handle specific cases:
 
 #### Bearer Token Embedding
@@ -264,11 +269,13 @@ Chaining extractors increases attack surface and complexity. Most applications s
 ## Security Patterns
 
 ### Double Submit Cookie (Default)
+
 - Stores tokens in memory/database
 - Compares cookie value with submitted token
 - No session required
 
 ### Synchronizer Token (with Session)
+
 - Stores tokens in user session
 - More secure, prevents login CSRF
 - Requires session middleware
@@ -312,6 +319,7 @@ app.Use(csrf.New(csrf.Config{
     },
 }))
 ```
+
 ### Custom Storage/Database
 
 You can use any storage from our [storage](https://github.com/gofiber/storage/) package.
@@ -339,7 +347,7 @@ session.Destroy()  // Also deletes CSRF token
 ## Security Features
 
 - **Referer checking** for HTTPS requests
-- **Origin validation** for cross-origin requests  
+- **Origin validation** for cross-origin requests
 - **Token expiration** with configurable timeout
 - **Single-use tokens** for maximum security
 - **BREACH attack protection** recommendations (see note below)
@@ -358,6 +366,7 @@ To mitigate BREACH attacks, ensure your pages are served over HTTPS, disable HTT
 6. **Use `__Host-` cookie prefix** when possible
 
 :::danger Production Requirements
+
 - `CookieSecure: true` (HTTPS only)
 - `CookieSameSite: "Lax"` or `"Strict"`
 - Use `Session` store for better security

--- a/docs/middleware/csrf.md
+++ b/docs/middleware/csrf.md
@@ -177,13 +177,13 @@ const (
 
 ```go
 var (
-    ErrTokenNotFound   = errors.New("csrf token not found")
-    ErrTokenInvalid    = errors.New("csrf token invalid")
-    ErrRefererNotFound = errors.New("referer not supplied")
-    ErrRefererInvalid  = errors.New("referer invalid")
-    ErrRefererNoMatch  = errors.New("referer does not match host")
-    ErrOriginInvalid   = errors.New("origin invalid")
-    ErrOriginNoMatch   = errors.New("origin does not match host")
+    ErrTokenNotFound   = errors.New("csrf: token not found")
+    ErrTokenInvalid    = errors.New("csrf: token invalid")
+    ErrRefererNotFound = errors.New("csrf: referer header missing")
+    ErrRefererInvalid  = errors.New("csrf: referer header invalid")
+    ErrRefererNoMatch  = errors.New("csrf: referer does not match host or trusted origins")
+    ErrOriginInvalid   = errors.New("csrf: origin header invalid")
+    ErrOriginNoMatch   = errors.New("csrf: origin does not match host or trusted origins")
 )
 ```
 

--- a/docs/middleware/csrf.md
+++ b/docs/middleware/csrf.md
@@ -4,179 +4,166 @@ id: csrf
 
 # CSRF
 
-The CSRF middleware for [Fiber](https://github.com/gofiber/fiber) provides protection against [Cross-Site Request Forgery](https://en.wikipedia.org/wiki/Cross-site_request_forgery) (CSRF) attacks. Requests made using methods other than those defined as 'safe' by [RFC9110#section-9.2.1](https://datatracker.ietf.org/doc/html/rfc9110.html#section-9.2.1) (GET, HEAD, OPTIONS, and TRACE) are validated using tokens. If a potential attack is detected, the middleware will return a default 403 Forbidden error.
+The CSRF middleware provides protection against [Cross-Site Request Forgery](https://en.wikipedia.org/wiki/Cross-site_request_forgery) attacks. It validates tokens on unsafe HTTP methods (POST, PUT, DELETE, etc.) and returns 403 Forbidden if an attack is detected.
 
-This middleware offers two [Token Validation Patterns](#token-validation-patterns): the [Double Submit Cookie Pattern (default)](#double-submit-cookie-pattern-default), and the [Synchronizer Token Pattern (with Session)](#synchronizer-token-pattern-with-session).
-
-As a [Defense In Depth](#defense-in-depth) measure, this middleware performs [Referer Checking](#referer-checking) for HTTPS requests.
-
-## How to use Fiber's CSRF Middleware
-
-## Examples
-
-Import the middleware package that is part of the Fiber web framework:
+## Quick Start
 
 ```go
 import (
     "github.com/gofiber/fiber/v3"
     "github.com/gofiber/fiber/v3/middleware/csrf"
 )
-```
 
-After initializing your Fiber app, you can use the following code to initialize the middleware:
-
-```go
-// Initialize default config
+// Default config (development only)
 app.Use(csrf.New())
 
-// Or extend your config for customization
+// Production config
 app.Use(csrf.New(csrf.Config{
-    KeyLookup:      "header:X-Csrf-Token",
-    CookieName:     "csrf_",
-    CookieSameSite: "Lax",
-    IdleTimeout:    30 * time.Minute,
-    KeyGenerator:   utils.UUIDv4,
-    Extractor:      func(c fiber.Ctx) (string, error) { ... },
+    CookieName:        "__Host-csrf_",
+    CookieSecure:      true,
+    CookieHTTPOnly:    true,  // false for SPAs
+    CookieSameSite:    "Lax",
+    CookieSessionOnly: true,
+    Extractor:         csrf.FromHeader("X-Csrf-Token"),
+    Session:           sessionStore,
 }))
 ```
 
-:::info
-KeyLookup will be ignored if Extractor is explicitly set.
-:::
+## Configuration by Application Type
 
-Getting the CSRF token in a handler:
+### Server-Side Rendered Apps
 
 ```go
-func handler(c fiber.Ctx) error {
-    // Get CSRF token from the context
-    token := csrf.TokenFromContext(c)
-    if token == "" {
-        return c.Status(fiber.StatusInternalServerError)
-    }
-    
-    // Note: Make sure this matches the KeyLookup configured in your middleware
-    // Example: If you configured csrf.Config{KeyLookup: "form:_csrf"}
-    formKey := "_csrf"
-    
-    // Create a form with the CSRF token
-    tmpl := fmt.Sprintf(`<form action="/post" method="POST">
-        <input type="hidden" name="%s" value="%s">
-        <input type="text" name="message">
-        <input type="submit" value="Submit">
-    </form>`, formKey, token)
-    
-    c.Set("Content-Type", "text/html")
-    return c.SendString(tmpl)
-}
+app.Use(csrf.New(csrf.Config{
+    CookieName:        "__Host-csrf_",
+    CookieSecure:      true,
+    CookieHTTPOnly:    true,        // Secure - blocks JavaScript
+    CookieSameSite:    "Lax",
+    CookieSessionOnly: true,
+    Extractor:         csrf.FromForm("_csrf"),
+    Session:           sessionStore,
+}))
 ```
+
+### Single Page Applications (SPAs)
+
+```go
+app.Use(csrf.New(csrf.Config{
+    CookieName:        "__Host-csrf_",
+    CookieSecure:      true,
+    CookieHTTPOnly:    false,       // Required for JavaScript access to tokens
+    CookieSameSite:    "Lax",
+    CookieSessionOnly: true,
+    Extractor:         csrf.FromHeader("X-Csrf-Token"),
+    Session:           sessionStore,
+}))
+```
+
+:::warning SPA Security Trade-off
+SPAs require `CookieHTTPOnly: false` to access tokens via JavaScript. This slightly increases XSS risk but is necessary for SPA functionality.
+:::
 
 ## Recipes for Common Use Cases
 
-There are two basic use cases for the CSRF middleware:
+- **Without Sessions**: [CSRF Recipe](https://github.com/gofiber/recipes/tree/master/csrf) - Simple Double Submit Cookie pattern
+- **With Sessions**: [CSRF with Session Recipe](https://github.com/gofiber/recipes/tree/master/csrf-with-session) - More secure Synchronizer Token pattern
 
-1. **Without Sessions**: This is the simplest way to use the middleware. It uses the Double Submit Cookie Pattern and does not require a user session.
+## Using CSRF Tokens
 
-    - See GoFiber recipe [CSRF](https://github.com/gofiber/recipes/tree/master/csrf) for an example of using the CSRF middleware without a user session.
-
-2. **With Sessions**: This is generally considered more secure. It uses the Synchronizer Token Pattern and requires a user session, and the use of pre-session, which prevents login CSRF attacks.
-
-    - See GoFiber recipe [CSRF with Session](https://github.com/gofiber/recipes/tree/master/csrf-with-session) for an example of using the CSRF middleware with a user session.
-
-## Signatures
+### Server-Side Forms
 
 ```go
+func formHandler(c fiber.Ctx) error {
+    token := csrf.TokenFromContext(c)
+    
+    return c.SendString(fmt.Sprintf(`
+        <form method="POST" action="/submit">
+            <input type="hidden" name="_csrf" value="%s">
+            <input type="text" name="message" required>
+            <button type="submit">Submit</button>
+        </form>
+    `, token))
+}
+```
+
+### Single Page Applications
+
+```go
+func apiHandler(c fiber.Ctx) error {
+    token := csrf.TokenFromContext(c)
+    
+    return c.JSON(fiber.Map{
+        "csrf_token": token,
+        "data":       "your data",
+    })
+}
+```
+
+```javascript
+// Get CSRF token from cookie
+function getCsrfToken() {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; __Host-csrf_=`);
+    if (parts.length === 2) return parts.pop().split(';').shift();
+}
+
+// Use with fetch API
+async function makeRequest(url, data) {
+    const csrfToken = getCsrfToken();
+    
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-Csrf-Token': csrfToken
+        },
+        body: JSON.stringify(data)
+    });
+    
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    
+    return response.json();
+}
+```
+
+## Config Properties
+
+| Property          | Type                               | Description                                                                                                                   | Default                      |
+|:------------------|:-----------------------------------|:------------------------------------------------------------------------------------------------------------------------------|:-----------------------------|
+| Next              | `func(fiber.Ctx) bool`             | Skip middleware when returns true                                                                                             | `nil`                        |
+| CookieName        | `string`                           | CSRF cookie name                                                                                                              | `"csrf_"`                    |
+| CookieDomain      | `string`                           | CSRF cookie domain                                                                                                            | `""`                         |
+| CookiePath        | `string`                           | CSRF cookie path                                                                                                              | `""`                         |
+| CookieSecure      | `bool`                             | HTTPS only cookie (**required for production**)                                                                               | `false`                      |
+| CookieHTTPOnly    | `bool`                             | Prevent JavaScript access (**use `false` for SPAs**)                                                                          | `false`                      |
+| CookieSameSite    | `string`                           | SameSite attribute (**use "Lax" or "Strict"**)                                                                                | `"Lax"`                      |
+| CookieSessionOnly | `bool`                             | Session-only cookie (expires on browser close)                                                                                | `false`                      |
+| IdleTimeout       | `time.Duration`                    | Token expiration time                                                                                                         | `30 * time.Minute`           |
+| KeyGenerator      | `func() string`                    | Token generation function                                                                                                     | `utils.UUIDv4`               |
+| ErrorHandler      | `fiber.ErrorHandler`               | Custom error handler                                                                                                          | `defaultErrorHandler`        |
+| Extractor         | `func(fiber.Ctx) (string, error)`  | Token extraction method                                                                                                       | `FromHeader("X-Csrf-Token")` |
+| Session           | `*session.Store`                   | Session store (**recommended for production**)                                                                                | `nil`                        |
+| Storage           | `fiber.Storage`                    | Token storage (overridden by Session)                                                                                         | `nil`                        |
+| TrustedOrigins    | `[]string`                         | Trusted origins for cross-origin requests                                                                                     | `[]`                         |
+| SingleUseToken    | `bool`                             | Generate new token after each use                                                                                             | `false`                      |
+
+## API Reference
+
+```go
+// Create middleware
 func New(config ...Config) fiber.Handler
+
+// Get token from context
 func TokenFromContext(c fiber.Ctx) string
+
+// Get handler from context
 func HandlerFromContext(c fiber.Ctx) *Handler
 
+// Delete token
 func (h *Handler) DeleteToken(c fiber.Ctx) error
 ```
-
-## Config
-
-| Property          | Type                               | Description                                                                                                                                                                                                                                                                                  | Default                      |
-|:------------------|:-----------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------|
-| Next              | `func(fiber.Ctx) bool`             | Next defines a function to skip this middleware when returned true.                                                                                                                                                                                                                          | `nil`                        |
-| KeyLookup         | `string`                           | KeyLookup is a string in the form of "`<source>:<key>`" that is used to create an Extractor that extracts the token from the request. Possible values: "`header:<name>`", "`query:<name>`", "`param:<name>`", "`form:<name>`", "`cookie:<name>`". Ignored if an Extractor is explicitly set. | "header:X-CSRF-Token"        |
-| CookieName        | `string`                           | Name of the csrf cookie. This cookie will store the csrf key.                                                                                                                                                                                                                                | "csrf_"                      |
-| CookieDomain      | `string`                           | Domain of the CSRF cookie.                                                                                                                                                                                                                                                                   | ""                           |
-| CookiePath        | `string`                           | Path of the CSRF cookie.                                                                                                                                                                                                                                                                     | ""                           |
-| CookieSecure      | `bool`                             | Indicates if the CSRF cookie is secure.                                                                                                                                                                                                                                                      | false                        |
-| CookieHTTPOnly    | `bool`                             | Indicates if the CSRF cookie is HTTP-only.                                                                                                                                                                                                                                                   | false                        |
-| CookieSameSite    | `string`                           | Value of SameSite cookie.                                                                                                                                                                                                                                                                    | "Lax"                        |
-| CookieSessionOnly | `bool`                             | Decides whether the cookie should last for only the browser session. (cookie expires on close).                                                                                                                                                                                              | false                        |
-| IdleTimeout       | `time.Duration`                    | IdleTimeout is the duration of inactivity before the CSRF token will expire.                                                                                                                                                                                                                 | 30 * time.Minute             |
-| KeyGenerator      | `func() string`                    | KeyGenerator creates a new CSRF token.                                                                                                                                                                                                                                                       | utils.UUID                   |
-| ErrorHandler      | `fiber.ErrorHandler`               | ErrorHandler is executed when an error is returned from fiber.Handler.                                                                                                                                                                                                                       | DefaultErrorHandler          |
-| Extractor         | `func(fiber.Ctx) (string, error)`  | Extractor returns the CSRF token. If set, this will be used in place of an Extractor based on KeyLookup.                                                                                                                                                                                     | Extractor based on KeyLookup |
-| SingleUseToken    | `bool`                             | SingleUseToken indicates if the CSRF token be destroyed and a new one generated on each use. (See TokenLifecycle)                                                                                                                                                                            | false                        |
-| Storage           | `fiber.Storage`                    | Store is used to store the state of the middleware.                                                                                                                                                                                                                                          | `nil`                        |
-| Session           | `*session.Store`                   | Session is used to store the state of the middleware. Overrides Storage if set.                                                                                                                                                                                                              | `nil`                        |
-| TrustedOrigins    | `[]string`                         | TrustedOrigins is a list of trusted origins for unsafe requests. This supports subdomain matching, so you can use a value like "https://*.example.com" to allow any subdomain of example.com to submit requests.                                                                             | `[]`                         |
-
-### Default Config
-
-```go
-var ConfigDefault = Config{
-    KeyLookup:         "header:" + HeaderName,
-    CookieName:        "csrf_",
-    CookieSameSite:    "Lax",
-    IdleTimeout:       30 * time.Minute,
-    KeyGenerator:      utils.UUIDv4,
-    ErrorHandler:      defaultErrorHandler,
-    Extractor:         FromHeader(HeaderName),
-}
-```
-
-### Recommended Config (with session)
-
-It's recommended to use this middleware with [fiber/middleware/session](https://docs.gofiber.io/api/middleware/session) to store the CSRF token within the session. This is generally more secure than the default configuration.
-
-```go
-var ConfigDefault = Config{
-    KeyLookup:         "header:" + HeaderName,
-    CookieName:        "__Host-csrf_",
-    CookieSameSite:    "Lax",
-    CookieSecure:       true,
-    CookieSessionOnly: true,
-    CookieHTTPOnly:    true,
-    IdleTimeout:       30 * time.Minute,
-    KeyGenerator:      utils.UUIDv4,
-    ErrorHandler:      defaultErrorHandler,
-    Extractor:         FromHeader(HeaderName),
-    Session:           session.Store,
-}
-```
-
-### Trusted Origins
-
-The `TrustedOrigins` option is used to specify a list of trusted origins for unsafe requests. This is useful when you want to allow requests from other origins. This supports matching subdomains at any level. This means you can use a value like `"https://*.example.com"` to allow any subdomain of `example.com` to submit requests, including multiple subdomain levels such as `"https://sub.sub.example.com"`.
-
-To ensure that the provided `TrustedOrigins` origins are correctly formatted, this middleware validates and normalizes them. It checks for valid schemes, i.e., HTTP or HTTPS, and it will automatically remove trailing slashes. If the provided origin is invalid, the middleware will panic.
-
-#### Example with Explicit Origins
-
-In the following example, the CSRF middleware will allow requests from `trusted.example.com`, in addition to the current host.
-
-```go
-app.Use(csrf.New(csrf.Config{
-    TrustedOrigins: []string{"https://trusted.example.com"},
-}))
-```
-
-#### Example with Subdomain Matching
-
-In the following example, the CSRF middleware will allow requests from any subdomain of `example.com`, in addition to the current host.
-
-```go
-app.Use(csrf.New(csrf.Config{
-    TrustedOrigins: []string{"https://*.example.com"},
-}))
-```
-
-:::caution
-When using `TrustedOrigins` with subdomain matching, make sure you control and trust all the subdomains, including all subdomain levels. If not, an attacker could create a subdomain under a trusted origin and use it to send harmful requests.
-:::
 
 ## Constants
 
@@ -186,27 +173,112 @@ const (
 )
 ```
 
-## Sentinel Errors
+## Error Types
 
-The CSRF middleware utilizes a set of sentinel errors to handle various scenarios and communicate errors effectively. These can be used within a [custom error handler](#custom-error-handler) to handle errors returned by the middleware.
+```go
+var (
+    ErrTokenNotFound   = errors.New("csrf token not found")
+    ErrTokenInvalid    = errors.New("csrf token invalid")
+    ErrRefererNotFound = errors.New("referer not supplied")
+    ErrRefererInvalid  = errors.New("referer invalid")
+    ErrRefererNoMatch  = errors.New("referer does not match host")
+    ErrOriginInvalid   = errors.New("origin invalid")
+    ErrOriginNoMatch   = errors.New("origin does not match host")
+)
+```
 
-### Errors Returned to Error Handler
+## Token Extractors
 
-- `ErrTokenNotFound`: Indicates that the CSRF token was not found.
-- `ErrTokenInvalid`: Indicates that the CSRF token is invalid.
-- `ErrRefererNotFound`: Indicates that the referer was not supplied.
-- `ErrRefererInvalid`: Indicates that the referer is invalid.
-- `ErrRefererNoMatch`: Indicates that the referer does not match host and is not a trusted origin.
-- `ErrOriginInvalid`: Indicates that the origin is invalid.
-- `ErrOriginNoMatch`: Indicates that the origin does not match host and is not a trusted origin.
+### Built-in Extractors
 
-If you use the default error handler, the client will receive a 403 Forbidden error without any additional information.
+**Secure (Recommended):**
+- `csrf.FromHeader("X-Csrf-Token")` - Most secure, preferred for APIs
+- `csrf.FromForm("_csrf")` - Secure for form submissions
 
-## Custom Error Handler
+**Acceptable:**
+- `csrf.FromQuery("csrf_token")` - URL parameters
+- `csrf.FromParam("csrf")` - Route parameters
 
-You can use a custom error handler to handle errors returned by the CSRF middleware. The error handler is executed when an error is returned from the middleware. The error handler is passed the error returned from the middleware and the fiber.Ctx.
+**Avoid:**
+- `csrf.FromCookie("csrf_token")` - Vulnerable to subdomain attacks
 
-Example, returning a JSON response for API requests and rendering an error page for other requests:
+### Custom Extractor
+You can create a custom extractor to handle specific cases:
+
+#### Smart Content-Type Extractor
+
+```go
+func SmartExtractor(c fiber.Ctx) (string, error) {
+    contentType := c.Get("Content-Type")
+    
+    // JSON/API requests use header
+    if strings.Contains(contentType, "application/json") {
+        return csrf.FromHeader("X-Csrf-Token")(c)
+    }
+    
+    // Form requests use form field
+    if strings.Contains(contentType, "application/x-www-form-urlencoded") ||
+       strings.Contains(contentType, "multipart/form-data") {
+        return csrf.FromForm("_csrf")(c)
+    }
+    
+    // Default to header
+    return csrf.FromHeader("X-Csrf-Token")(c)
+}
+```
+
+#### Bearer Token Embedding
+
+```go
+func BearerTokenExtractor(c fiber.Ctx) (string, error) {
+    // Extract from "Authorization: Bearer <jwt>:<csrf>"
+    auth := c.Get("Authorization")
+    if !strings.HasPrefix(auth, "Bearer ") {
+        return "", csrf.ErrTokenNotFound
+    }
+    
+    parts := strings.SplitN(strings.TrimPrefix(auth, "Bearer "), ":", 2)
+    if len(parts) != 2 || parts[1] == "" {
+        return "", csrf.ErrTokenNotFound
+    }
+    
+    return parts[1], nil
+}
+```
+
+## Security Patterns
+
+### Double Submit Cookie (Default)
+- Stores tokens in memory/database
+- Compares cookie value with submitted token
+- No session required
+
+### Synchronizer Token (with Session)
+- Stores tokens in user session
+- More secure, prevents login CSRF
+- Requires session middleware
+
+```go
+// Enable synchronizer pattern
+app.Use(csrf.New(csrf.Config{
+    Session: sessionStore,
+}))
+```
+
+## Advanced Configuration
+
+### Trusted Origins
+
+```go
+app.Use(csrf.New(csrf.Config{
+    TrustedOrigins: []string{
+        "https://trusted.example.com",
+        "https://*.example.com", // Wildcard subdomains
+    },
+}))
+```
+
+### Custom Error Handler
 
 ```go
 app.Use(csrf.New(csrf.Config{
@@ -225,8 +297,7 @@ app.Use(csrf.New(csrf.Config{
     },
 }))
 ```
-
-## Custom Storage/Database
+### Custom Storage/Database
 
 You can use any storage from our [storage](https://github.com/gofiber/storage/) package.
 
@@ -237,95 +308,42 @@ app.Use(csrf.New(csrf.Config{
 }))
 ```
 
-## How It Works
-
-### Token Generation
-
-CSRF tokens are generated on 'safe' requests and when the existing token has expired or hasn't been set yet. If `SingleUseToken` is `true`, a new token is generated after each use.  Retrieve the CSRF token using `csrf.TokenFromContext(c)`.
-
-### Security Considerations
-
-This middleware is designed to protect against CSRF attacks but does not protect against other attack vectors, such as XSS. It should be used in combination with other security measures.
-
-:::danger
-Never use 'safe' methods to mutate data, for example, never use a GET request to modify a resource. This middleware will not protect against CSRF attacks on 'safe' methods.
-:::
-
-## Token Validation Patterns
-
-### Double Submit Cookie Pattern (Default)
-
-By default, the middleware generates and stores tokens using the `fiber.Storage` interface. These tokens are not linked to any particular user session, and they are validated using the Double Submit Cookie pattern.  The token is stored in a cookie, and then sent as a header on requests. The middleware compares the cookie value with the header value to validate the token. This is a secure pattern that does not require a user session.
-
-When the authorization status changes, the previously issued token MUST be deleted, and a new one generated. See [Token Lifecycle](#token-lifecycle) [Deleting Tokens](#deleting-tokens) for more information.
-
-:::caution
-When using this pattern, it's important to set the `CookieSameSite` option to `Lax` or `Strict` and ensure that the Extractor is not `FromCookie`, and KeyLookup is not `cookie:<name>`.
-:::
-
-:::note
-When using this pattern, this middleware uses our [Storage](https://github.com/gofiber/storage) package to support various databases through a single interface. The default configuration for Storage saves data to memory. See [Custom Storage/Database](#custom-storagedatabase) for customizing the storage.
-:::
-
-### Synchronizer Token Pattern (with Session)
-
-When using this middleware with a user session, the middleware can be configured to store the token within the session. This method is recommended when using a user session, as it is generally more secure than the Double Submit Cookie Pattern.
-
-When using this pattern it's important to regenerate the session when the authorization status changes, this will also delete the token. See: [Token Lifecycle](#token-lifecycle) for more information.
-
-:::caution
-Pre-sessions are required and will be created automatically if not present. Use a session value to indicate authentication instead of relying on the presence of a session.
-:::
-
-## Defense In Depth
-
-When using this middleware, it's recommended to serve your pages over HTTPS, set the `CookieSecure` option to `true`, and set the `CookieSameSite` option to `Lax` or `Strict`. This ensures that the cookie is only sent over HTTPS and not on requests from external sites.
-
-:::note
-Cookie prefixes `__Host-` and `__Secure-` can be used to further secure the cookie. Note that these prefixes are not supported by all browsers and there are other limitations. See [MDN#Set-Cookie#cookie_prefixes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#cookie_prefixes) for more information.
-
-To use these prefixes, set the `CookieName` option to `__Host-csrf_` or `__Secure-csrf_`.
-:::
-
-## Referer Checking
-
-For HTTPS requests, this middleware performs strict referer checking. Even if a subdomain can set or modify cookies on your domain, it can't force a user to post to your application, since that request won't come from your own exact domain.
-
-:::caution
-When HTTPS requests are protected by CSRF, referer checking is always carried out.
-
-The Referer header is automatically included in requests by all modern browsers, including those made using the JS Fetch API. However, if you're making use of this middleware with a custom client, it's important to ensure that the client sends a valid Referer header.
-:::
-
-## Token Lifecycle
-
-Tokens are valid until they expire or until they are deleted. By default, tokens are valid for 30 minutes, and each subsequent request extends the expiration by the idle timeout. The token only expires if the user doesn't make a request for the duration of the idle timeout.
-
-### Token Reuse
-
-By default, tokens may be used multiple times. If you want to delete the token after it has been used, you can set the `SingleUseToken` option to `true`. This will delete the token after it has been used, and a new token will be generated on the next request.
-
-:::info
-Using `SingleUseToken` comes with usability trade-offs and is not enabled by default. For example, it can interfere with the user experience if the user has multiple tabs open or uses the back button.
-:::
-
-### Deleting Tokens
-
-When the authorization status changes, the CSRF token MUST be deleted, and a new one generated. This can be done by calling `handler.DeleteToken(c)`.
+### Token Management
 
 ```go
-handler := csrf.HandlerFromContext(ctx)
+// Delete token (e.g., on logout)
+handler := csrf.HandlerFromContext(c)
 if handler != nil {
-    if err := handler.DeleteToken(app.AcquireCtx(ctx)); err != nil {
-        // handle error
-    }
+    handler.DeleteToken(c)
 }
+
+// With session middleware
+session.Destroy()  // Also deletes CSRF token
 ```
 
-:::tip
-If you are using this middleware with the fiber session middleware, then you can simply call `session.Destroy()`, `session.Regenerate()`, or `session.Reset()` to delete the session and the token stored therein.
+## Security Features
+
+- **Referer checking** for HTTPS requests
+- **Origin validation** for cross-origin requests  
+- **Token expiration** with configurable timeout
+- **Single-use tokens** for maximum security
+- **BREACH attack protection** recommendations (see note below)
+
+:::note BREACH Protection
+To mitigate BREACH attacks, ensure your pages are served over HTTPS, disable HTTP compression, and implement rate limiting for requests. The CSRF token is sent as a header on every request, so if you include the token in a page that is vulnerable to BREACH, an attacker may be able to extract the token.
 :::
 
-## BREACH
+## Best Practices
 
-It's important to note that the token is sent as a header on every request. If you include the token in a page that is vulnerable to [BREACH](https://en.wikipedia.org/wiki/BREACH), an attacker may be able to extract the token. To mitigate this, ensure your pages are served over HTTPS, disable HTTP compression, and implement rate limiting for requests.
+1. **Always use HTTPS** in production
+2. **Use sessions** for authenticated applications
+3. **Set `CookieSecure: true`** and appropriate SameSite values
+4. **Implement XSS protection** alongside CSRF
+5. **Regenerate tokens** after auth changes
+6. **Use `__Host-` cookie prefix** when possible
+
+:::danger Production Requirements
+- `CookieSecure: true` (HTTPS only)
+- `CookieSameSite: "Lax"` or `"Strict"`
+- Use `Session` store for better security
+:::

--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -8,9 +8,9 @@ import (
 	"github.com/gofiber/utils/v2"
 )
 
-// Config defines the config for middleware.
+// Config defines the config for CSRF middleware.
 type Config struct {
-	// Store is used to store the state of the middleware
+	// Storage is used to store the state of the middleware.
 	//
 	// Optional. Default: memory.New()
 	// Ignored if Session is set.
@@ -21,53 +21,61 @@ type Config struct {
 	// Optional. Default: nil
 	Next func(c fiber.Ctx) bool
 
-	// Session is used to store the state of the middleware
+	// Session is used to store the state of the middleware.
 	//
 	// Optional. Default: nil
-	// If set, the middleware will use the session store instead of the storage
+	// If set, the middleware will use the session store instead of the storage.
 	Session *session.Store
 
-	// KeyGenerator creates a new CSRF token
+	// KeyGenerator creates a new CSRF token.
 	//
-	// Optional. Default: utils.UUID
+	// Optional. Default: utils.UUIDv4
 	KeyGenerator func() string
 
 	// ErrorHandler is executed when an error is returned from fiber.Handler.
 	//
-	// Optional. Default: DefaultErrorHandler
+	// Optional. Default: defaultErrorHandler
 	ErrorHandler fiber.ErrorHandler
 
-	// Extractor returns the csrf token
+	// Extractor returns the CSRF token from the request.
 	//
 	// Optional. Default: FromHeader("X-Csrf-Token")
+	//
 	// Available extractors: FromHeader, FromQuery, FromParam, FromForm
+	//
+	// WARNING: Never create custom extractors that read from cookies with the same
+	// CookieName as this defeats CSRF protection entirely.
 	Extractor func(c fiber.Ctx) (string, error)
 
-	// Name of the session cookie. This cookie will store session key.
-	// Optional. Default value "csrf_".
+	// CookieName is the name of the CSRF cookie.
+	//
+	// Optional. Default: "csrf_"
 	CookieName string
 
-	// Domain of the CSRF cookie.
-	// Optional. Default value "".
+	// CookieDomain is the domain of the CSRF cookie.
+	//
+	// Optional. Default: ""
 	CookieDomain string
 
-	// Path of the CSRF cookie.
-	// Optional. Default value "".
+	// CookiePath is the path of the CSRF cookie.
+	//
+	// Optional. Default: ""
 	CookiePath string
 
-	// Value of SameSite cookie.
-	// Optional. Default value "Lax".
+	// CookieSameSite is the SameSite attribute of the CSRF cookie.
+	//
+	// Optional. Default: "Lax"
 	CookieSameSite string
 
 	// TrustedOrigins is a list of trusted origins for unsafe requests.
 	// For requests that use the Origin header, the origin must match the
 	// Host header or one of the TrustedOrigins.
-	// For secure requests, that do not include the Origin header, the Referer
+	// For secure requests that do not include the Origin header, the Referer
 	// header must match the Host header or one of the TrustedOrigins.
 	//
 	// This supports matching subdomains at any level. This means you can use a value like
-	// `"https://*.example.com"` to allow any subdomain of `example.com` to submit requests,
-	// including multiple subdomain levels such as `"https://sub.sub.example.com"`.
+	// "https://*.example.com" to allow any subdomain of example.com to submit requests,
+	// including multiple subdomain levels such as "https://sub.sub.example.com".
 	//
 	// Optional. Default: []
 	TrustedOrigins []string
@@ -77,28 +85,33 @@ type Config struct {
 	// Optional. Default: 30 * time.Minute
 	IdleTimeout time.Duration
 
-	// Indicates if CSRF cookie is secure.
-	// Optional. Default value false.
+	// CookieSecure indicates if CSRF cookie is secure.
+	//
+	// Optional. Default: false
 	CookieSecure bool
 
-	// Indicates if CSRF cookie is HTTP only.
-	// Optional. Default value false.
+	// CookieHTTPOnly indicates if CSRF cookie is HTTP only.
+	//
+	// Optional. Default: false
 	CookieHTTPOnly bool
 
-	// Decides whether cookie should last for only the browser sesison.
-	// Ignores Expiration if set to true
+	// CookieSessionOnly decides whether cookie should last for only the browser session.
+	// Ignores Expiration if set to true.
+	//
+	// Optional. Default: false
 	CookieSessionOnly bool
 
-	// SingleUseToken indicates if the CSRF token be destroyed
+	// SingleUseToken indicates if the CSRF token should be destroyed
 	// and a new one generated on each use.
 	//
 	// Optional. Default: false
 	SingleUseToken bool
 }
 
+// HeaderName is the default header name for CSRF tokens.
 const HeaderName = "X-Csrf-Token"
 
-// ConfigDefault is the default config
+// ConfigDefault is the default config for CSRF middleware.
 var ConfigDefault = Config{
 	CookieName:     "csrf_",
 	CookieSameSite: "Lax",
@@ -108,12 +121,12 @@ var ConfigDefault = Config{
 	Extractor:      FromHeader(HeaderName),
 }
 
-// default ErrorHandler that process return error from fiber.Handler
+// defaultErrorHandler is the default error handler that processes errors from fiber.Handler.
 func defaultErrorHandler(_ fiber.Ctx, _ error) error {
 	return fiber.ErrForbidden
 }
 
-// Helper function to set default values
+// configDefault is a helper function to set default values.
 func configDefault(config ...Config) Config {
 	// Return default config if nothing provided
 	if len(config) < 1 {

--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/fiber/v3/log"
 	"github.com/gofiber/fiber/v3/middleware/session"
 	"github.com/gofiber/utils/v2"
 )
@@ -41,7 +40,7 @@ type Config struct {
 	// Extractor returns the csrf token
 	//
 	// Optional. Default: FromHeader("X-Csrf-Token")
-	// Available extractors: FromHeader, FromQuery, FromParam, FromForm, FromCookie
+	// Available extractors: FromHeader, FromQuery, FromParam, FromForm
 	Extractor func(c fiber.Ctx) (string, error)
 
 	// Name of the session cookie. This cookie will store session key.
@@ -142,16 +141,6 @@ func configDefault(config ...Config) Config {
 	}
 	if cfg.Extractor == nil {
 		cfg.Extractor = ConfigDefault.Extractor
-	}
-
-	// Validate extractor usage with sessions
-	if isFromCookie(cfg.Extractor) {
-		if cfg.Session == nil {
-			log.Warn("[CSRF] Cookie extractor is not recommended without a session store")
-		}
-		if cfg.CookieSameSite == "None" || (cfg.CookieSameSite != "Lax" && cfg.CookieSameSite != "Strict") {
-			log.Warn("[CSRF] Cookie extractor is only recommended for use with SameSite=Lax or SameSite=Strict")
-		}
 	}
 
 	return cfg

--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -149,7 +149,7 @@ func configDefault(config ...Config) Config {
 		if cfg.Session == nil {
 			log.Warn("[CSRF] Cookie extractor is not recommended without a session store")
 		}
-		if cfg.CookieSameSite == "None" || cfg.CookieSameSite != "Lax" && cfg.CookieSameSite != "Strict" {
+		if cfg.CookieSameSite == "None" || (cfg.CookieSameSite != "Lax" && cfg.CookieSameSite != "Strict") {
 			log.Warn("[CSRF] Cookie extractor is only recommended for use with SameSite=Lax or SameSite=Strict")
 		}
 	}

--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -40,7 +40,7 @@ type Config struct {
 
 	// Extractor returns the csrf token
 	//
-	// Required. Default: FromHeader("X-Csrf-Token")
+	// Optional. Default: FromHeader("X-Csrf-Token")
 	// Available extractors: FromHeader, FromQuery, FromParam, FromForm, FromCookie
 	Extractor func(c fiber.Ctx) (string, error)
 

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -129,7 +129,7 @@ func New(config ...Config) fiber.Handler {
 				return cfg.ErrorHandler(c, err)
 			}
 
-			// Extract token from client request i.e. header, query, param, form or cookie
+			// Extract token from client request i.e. header, query, param, form
 			extractedToken, err := cfg.Extractor(c)
 			if err != nil {
 				return cfg.ErrorHandler(c, err)
@@ -139,10 +139,9 @@ func New(config ...Config) fiber.Handler {
 				return cfg.ErrorHandler(c, ErrTokenNotFound)
 			}
 
-			// If not using FromCookie extractor, check that the token matches the cookie
-			// This is to prevent CSRF attacks by using a Double Submit Cookie method
-			// Useful when we do not have access to the users Session
-			if !isFromCookie(cfg.Extractor) && !compareStrings(extractedToken, c.Cookies(cfg.CookieName)) {
+			// Always check that the extracted token matches the cookie using Double Submit Cookie method
+			// This prevents CSRF attacks by ensuring the token comes from a different source than the cookie
+			if !compareStrings(extractedToken, c.Cookies(cfg.CookieName)) {
 				return cfg.ErrorHandler(c, ErrTokenInvalid)
 			}
 
@@ -271,11 +270,6 @@ func (handler *Handler) DeleteToken(c fiber.Ctx) error {
 	// Expire the cookie
 	expireCSRFCookie(c, handler.config)
 	return nil
-}
-
-// isFromCookie checks if the extractor is created by FromCookie
-func isFromCookie(extractor any) bool {
-	return isCookieExtractor(extractor)
 }
 
 // originMatchesHost checks that the origin header matches the host header

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -139,8 +139,10 @@ func New(config ...Config) fiber.Handler {
 				return cfg.ErrorHandler(c, ErrTokenNotFound)
 			}
 
-			// Always check that the extracted token matches the cookie using Double Submit Cookie method
-			// This prevents CSRF attacks by ensuring the token comes from a different source than the cookie
+			// Double Submit Cookie validation: ensure the extracted token matches the cookie value
+			// This prevents CSRF attacks by requiring attackers to know both the cookie AND submit
+			// the same token through a different channel (header, form, etc.)
+			// WARNING: If using a custom extractor that reads from the same cookie, this provides no protection
 			if !compareStrings(extractedToken, c.Cookies(cfg.CookieName)) {
 				return cfg.ErrorHandler(c, ErrTokenInvalid)
 			}

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -3,7 +3,6 @@ package csrf
 import (
 	"errors"
 	"net/url"
-	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -274,9 +273,9 @@ func (handler *Handler) DeleteToken(c fiber.Ctx) error {
 	return nil
 }
 
-// isFromCookie checks if the extractor is set to ExtractFromCookie
+// isFromCookie checks if the extractor is created by FromCookie
 func isFromCookie(extractor any) bool {
-	return reflect.ValueOf(extractor).Pointer() == reflect.ValueOf(FromCookie).Pointer()
+	return isCookieExtractor(extractor)
 }
 
 // originMatchesHost checks that the origin header matches the host header

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -20,7 +20,8 @@ var (
 	ErrOriginInvalid   = errors.New("origin invalid")
 	ErrOriginNoMatch   = errors.New("origin does not match host and is not a trusted origin")
 	errOriginNotFound  = errors.New("origin not supplied or is null") // internal error, will not be returned to the user
-	dummyValue         = []byte{'+'}
+	dummyValue         = []byte{'+'}                                  // dummyValue is a placeholder value stored in token storage. The actual token validation relies on the key, not this value.
+
 )
 
 // Handler for CSRF middleware

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -572,7 +572,8 @@ func Test_CSRF_From_Cookie(t *testing.T) {
 	app := fiber.New()
 
 	csrfGroup := app.Group("/", New(Config{
-		Extractor: FromCookie("csrf"),
+		Extractor:  FromCookie("csrf"),
+		CookieName: "csrf",
 	}))
 
 	csrfGroup.Post("/", func(c fiber.Ctx) error {
@@ -1589,6 +1590,7 @@ func Test_configDefault_WarnCookieSameSite(t *testing.T) {
 
 	cfg := configDefault(Config{
 		Extractor:      FromCookie("csrf"),
+		CookieName:     "csrf",
 		CookieSameSite: "None",
 	})
 

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -1543,7 +1543,7 @@ func Test_deleteTokenFromStorage(t *testing.T) {
 
 	app := fiber.New()
 	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
-	defer app.ReleaseCtx(ctx)
+	t.Cleanup(func() { app.ReleaseCtx(ctx) })
 
 	token := "token123"
 	dummy := []byte("dummy")
@@ -1715,10 +1715,10 @@ func Test_CSRF_All_Extractors(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name         string
 		extractor    func(c fiber.Ctx) (string, error)
 		setupRequest func(ctx *fasthttp.RequestCtx, token string)
 		expectStatus int
+		name         string
 	}{
 		{
 			name:      "FromHeader",
@@ -1784,6 +1784,7 @@ func Test_CSRF_All_Extractors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			app := fiber.New()
 
 			app.Use(New(Config{Extractor: tc.extractor}))
@@ -1841,6 +1842,7 @@ func Test_CSRF_Param_Extractor(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			app := fiber.New()
 
 			// Only use param-based routing for param extractor tests
@@ -1939,6 +1941,7 @@ func Test_CSRF_Extractors_ErrorTypes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			token, err := tc.extractor(ctx)
 			require.Empty(t, token)
 			require.Equal(t, tc.expected, err)

--- a/middleware/csrf/extractors.go
+++ b/middleware/csrf/extractors.go
@@ -68,3 +68,15 @@ func FromQuery(param string) func(c fiber.Ctx) (string, error) {
 		return token, nil
 	}
 }
+
+// Chain tries multiple extractors in order until one succeeds
+func Chain(extractors ...func(fiber.Ctx) (string, error)) func(fiber.Ctx) (string, error) {
+	return func(c fiber.Ctx) (string, error) {
+		for _, extractor := range extractors {
+			if token, err := extractor(c); err == nil && token != "" {
+				return token, nil
+			}
+		}
+		return "", ErrTokenNotFound
+	}
+}

--- a/middleware/csrf/extractors_test.go
+++ b/middleware/csrf/extractors_test.go
@@ -21,11 +21,6 @@ func Test_Extractors_Missing(t *testing.T) {
 	require.Empty(t, token)
 	require.Equal(t, ErrMissingParam, err)
 
-	// Missing cookie
-	token, err = FromCookie("csrf")(ctx)
-	require.Empty(t, token)
-	require.Equal(t, ErrMissingCookie, err)
-
 	// Missing form
 	token, err = FromForm("csrf")(ctx)
 	require.Empty(t, token)

--- a/middleware/csrf/token.go
+++ b/middleware/csrf/token.go
@@ -4,6 +4,8 @@ import (
 	"time"
 )
 
+// Token represents a CSRF token with expiration metadata.
+// This is used internally for token storage and validation.
 type Token struct {
 	Expiration time.Time `json:"expiration"`
 	Key        string    `json:"key"`


### PR DESCRIPTION
Enhance CSRF configuration by removing the KeyLookup option and implementing a more flexible extractor system. Introduce support for route-specific CSRF extractors, allowing for better customization and usage. Remove `FromCookie` `Extractor` as it is a foot-gun. Improve documentation for clarity.

Supersedes #3589