### PR TITLE
[Static]: Improve sanitizePath performance

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1384,11 +1384,11 @@ func Test_NewErrorf_Format(t *testing.T) {
 
 	type args []any
 
-	tests := []struct { //nolint:govet // fieldalignment: this struct is already optimally ordered
+	tests := []struct {
 		name string
 		want string
-		code int
 		in   args
+		code int
 	}{
 		{
 			name: "no-args → default text",


### PR DESCRIPTION
before:
```
Benchmark_SanitizePath/nilFS_-_urlencoded_chars
Benchmark_SanitizePath/nilFS_-_urlencoded_chars-12         	 4756809	       234.2 ns/op	     168 B/op	       5 allocs/op
Benchmark_SanitizePath/nilFS_-_urlencoded_chars-12         	 5268462	       228.8 ns/op	     168 B/op	       5 allocs/op
Benchmark_SanitizePath/nilFS_-_urlencoded_chars-12         	 5243587	       228.7 ns/op	     168 B/op	       5 allocs/op
Benchmark_SanitizePath/nilFS_-_urlencoded_chars-12         	 5228282	       228.9 ns/op	     168 B/op	       5 allocs/op
Benchmark_SanitizePath/dirFS_-_urlencoded_chars
Benchmark_SanitizePath/dirFS_-_urlencoded_chars-12         	 4437174	       269.1 ns/op	     192 B/op	       6 allocs/op
Benchmark_SanitizePath/dirFS_-_urlencoded_chars-12         	 4466428	       270.7 ns/op	     192 B/op	       6 allocs/op
Benchmark_SanitizePath/dirFS_-_urlencoded_chars-12         	 4496061	       268.2 ns/op	     192 B/op	       6 allocs/op
Benchmark_SanitizePath/dirFS_-_urlencoded_chars-12         	 4477066	       268.4 ns/op	     192 B/op	       6 allocs/op
Benchmark_SanitizePath/nilFS_-_slashes
Benchmark_SanitizePath/nilFS_-_slashes-12                  	 4411864	       272.8 ns/op	     192 B/op	       6 allocs/op
Benchmark_SanitizePath/nilFS_-_slashes-12                  	 4430572	       269.4 ns/op	     192 B/op	       6 allocs/op
Benchmark_SanitizePath/nilFS_-_slashes-12                  	 4455325	       268.8 ns/op	     192 B/op	       6 allocs/op
Benchmark_SanitizePath/nilFS_-_slashes-12                  	 4445643	       268.4 ns/op	     192 B/op	       6 allocs/op
```

after:
```
Benchmark_SanitizePath/nilFS_-_urlencoded_chars
Benchmark_SanitizePath/nilFS_-_urlencoded_chars-12         	 5381319	       202.2 ns/op	     120 B/op	       4 allocs/op
Benchmark_SanitizePath/nilFS_-_urlencoded_chars-12         	 6024532	       201.0 ns/op	     120 B/op	       4 allocs/op
Benchmark_SanitizePath/nilFS_-_urlencoded_chars-12         	 6059211	       198.1 ns/op	     120 B/op	       4 allocs/op
Benchmark_SanitizePath/nilFS_-_urlencoded_chars-12         	 6072016	       197.9 ns/op	     120 B/op	       4 allocs/op
Benchmark_SanitizePath/dirFS_-_urlencoded_chars
Benchmark_SanitizePath/dirFS_-_urlencoded_chars-12         	 4747710	       241.6 ns/op	     144 B/op	       5 allocs/op
Benchmark_SanitizePath/dirFS_-_urlencoded_chars-12         	 5035154	       238.5 ns/op	     144 B/op	       5 allocs/op
Benchmark_SanitizePath/dirFS_-_urlencoded_chars-12         	 4991553	       239.1 ns/op	     144 B/op	       5 allocs/op
Benchmark_SanitizePath/dirFS_-_urlencoded_chars-12         	 5034110	       238.4 ns/op	     144 B/op	       5 allocs/op
Benchmark_SanitizePath/nilFS_-_slashes
Benchmark_SanitizePath/nilFS_-_slashes-12                  	 5599615	       215.4 ns/op	     160 B/op	       5 allocs/op
Benchmark_SanitizePath/nilFS_-_slashes-12                  	 5578185	       215.0 ns/op	     160 B/op	       5 allocs/op
Benchmark_SanitizePath/nilFS_-_slashes-12                  	 5578350	       216.8 ns/op	     160 B/op	       5 allocs/op
Benchmark_SanitizePath/nilFS_-_slashes-12                  	 5556883	       214.9 ns/op	     160 B/op	       5 allocs/op
```
