### PR TITLE
🐛 bug: Fix MIME type equality checks

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -220,17 +220,11 @@ func acceptsLanguageOffer(spec, offer string, _ headerParams) bool {
 func acceptsOfferType(spec, offerType string, specParams headerParams) bool {
 	var offerMime, offerParams string
 
-	// Split off any parameters
 	if i := strings.IndexByte(offerType, ';'); i == -1 {
-		offerMime = utils.Trim(offerType, ' ')
+		offerMime = offerType
 	} else {
-		offerMime = utils.Trim(offerType[:i], ' ')
+		offerMime = offerType[:i]
 		offerParams = offerType[i:]
-	}
-
-	// If the OFFER itself is a wildcard, never match
-	if strings.HasSuffix(offerMime, "/*") {
-		return false
 	}
 
 	// Accept: */*
@@ -238,27 +232,24 @@ func acceptsOfferType(spec, offerType string, specParams headerParams) bool {
 		return paramsMatch(specParams, offerParams)
 	}
 
-	// Normalize offerMime (resolve file‑extension → mime)
 	var mimetype string
-	if strings.Contains(offerMime, "/") {
-		mimetype = offerMime
+	if strings.IndexByte(offerMime, '/') != -1 {
+		mimetype = offerMime // MIME type
 	} else {
-		mimetype = utils.GetMIME(offerMime)
+		mimetype = utils.GetMIME(offerMime) // extension
 	}
 
-	// Exact concrete match (neither side has a wildcard subtype)
-	if spec == mimetype && !strings.HasSuffix(spec, "/*") {
+	if spec == mimetype {
+		// Accept: <MIME_type>/<MIME_subtype>
 		return paramsMatch(specParams, offerParams)
 	}
 
-	// Handle spec wildcard on subtype: <type>/*
-	if s := strings.IndexByte(mimetype, '/'); s != -1 {
-		if slash := strings.IndexByte(spec, '/'); slash != -1 {
-			// same major type
-			if utils.EqualFold(spec[:slash], mimetype[:s]) && spec[slash:] == "/*" {
-				// offer must be concrete (we already ruled out offerMime ending in /*)
-				return paramsMatch(specParams, offerParams)
-			}
+	s := strings.IndexByte(mimetype, '/')
+	specSlash := strings.IndexByte(spec, '/')
+	// Accept: <MIME_type>/*
+	if s != -1 && specSlash != -1 {
+		if utils.EqualFold(spec[:specSlash], mimetype[:s]) && (spec[specSlash:] == "/*" || mimetype[s:] == "/*") {
+			return paramsMatch(specParams, offerParams)
 		}
 	}
 

--- a/helpers.go
+++ b/helpers.go
@@ -247,9 +247,9 @@ func acceptsOfferType(spec, offerType string, specParams headerParams) bool {
 	s := strings.IndexByte(mimetype, '/')
 	specSlash := strings.IndexByte(spec, '/')
 	// Accept: <MIME_type>/*
-	if s != -1 && specSlash != -1 {  
-		if utils.EqualFold(spec[:specSlash], mimetype[:s]) && (spec[specSlash:] == "/*" || mimetype[s:] == "/*") {  
-			return paramsMatch(specParams, offerParams)  
+	if s != -1 && specSlash != -1 {
+		if utils.EqualFold(spec[:specSlash], mimetype[:s]) && (spec[specSlash:] == "/*" || mimetype[s:] == "/*") {
+			return paramsMatch(specParams, offerParams)
 		}
 	}
 

--- a/helpers.go
+++ b/helpers.go
@@ -245,8 +245,9 @@ func acceptsOfferType(spec, offerType string, specParams headerParams) bool {
 	}
 
 	s := strings.IndexByte(mimetype, '/')
+	specSlash := strings.IndexByte(spec, '/')
 	// Accept: <MIME_type>/*
-	if strings.HasPrefix(spec, mimetype[:s]) && (spec[s:] == "/*" || mimetype[s:] == "/*") {
+	if specSlash != -1 && utils.EqualFold(spec[:specSlash], mimetype[:s]) && (spec[specSlash:] == "/*" || mimetype[s:] == "/*") {
 		return paramsMatch(specParams, offerParams)
 	}
 

--- a/helpers.go
+++ b/helpers.go
@@ -247,8 +247,10 @@ func acceptsOfferType(spec, offerType string, specParams headerParams) bool {
 	s := strings.IndexByte(mimetype, '/')
 	specSlash := strings.IndexByte(spec, '/')
 	// Accept: <MIME_type>/*
-	if specSlash != -1 && utils.EqualFold(spec[:specSlash], mimetype[:s]) && (spec[specSlash:] == "/*" || mimetype[s:] == "/*") {
-		return paramsMatch(specParams, offerParams)
+	if s != -1 && specSlash != -1 {  
+		if utils.EqualFold(spec[:specSlash], mimetype[:s]) && (spec[specSlash:] == "/*" || mimetype[s:] == "/*") {  
+			return paramsMatch(specParams, offerParams)  
+		}
 	}
 
 	return false

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -244,6 +244,12 @@ func Test_Utils_AcceptsOfferType(t *testing.T) {
 			accepts:     false,
 		},
 		{
+			description: "mismatch with subtype prefix",
+			spec:        "application/json",
+			offerType:   "application/json+xml",
+			accepts:     false,
+		},
+		{
 			description: "params match",
 			spec:        "application/json",
 			specParams:  headerParams{"format": []byte("foo"), "version": []byte("1")},

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -250,12 +250,6 @@ func Test_Utils_AcceptsOfferType(t *testing.T) {
 			accepts:     false,
 		},
 		{
-			description: "unknown offerType extension",
-			spec:        "application/*",
-			offerType:   "unknown",
-			accepts:     false,
-		},
-		{
 			description: "params match",
 			spec:        "application/json",
 			specParams:  headerParams{"format": []byte("foo"), "version": []byte("1")},

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -250,6 +250,12 @@ func Test_Utils_AcceptsOfferType(t *testing.T) {
 			accepts:     false,
 		},
 		{
+			description: "unknown offerType extension",
+			spec:        "application/*",
+			offerType:   "unknown",
+			accepts:     false,
+		},
+		{
 			description: "params match",
 			spec:        "application/json",
 			specParams:  headerParams{"format": []byte("foo"), "version": []byte("1")},


### PR DESCRIPTION
## Summary
- check major MIME type using equality in `acceptsOfferType`
- test mismatch when subtype shares prefix