### PR TITLE
🐛 bug: Fix cookie secure flag with SameSite None

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -425,6 +425,10 @@ func (c *DefaultCtx) Cookie(cookie *Cookie) {
 		cookie.Path = "/"
 	}
 
+	if utils.ToLower(cookie.SameSite) == CookieSameSiteNoneMode && !cookie.Secure {
+		cookie.Secure = true
+	}
+
 	if cookie.SessionOnly {
 		cookie.MaxAge = 0
 		cookie.Expires = time.Time{}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1114,13 +1114,14 @@ func Test_Ctx_Cookie_PartitionedSecure(t *testing.T) {
 
 // go test -run Test_Ctx_Cookie_SameSiteNoneAutoSecure
 func Test_Ctx_Cookie_SameSiteNoneAutoSecure(t *testing.T) {
-	t.Parallel()
 	app := New()
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
-	defer app.ReleaseCtx(c)
+	t.Cleanup(func() {
++		app.ReleaseCtx(c)
++	})
 
 	testCases := []struct {
-		description	string
+		description string
 		sameSite	string
 	}{
 		{
@@ -1139,7 +1140,6 @@ func Test_Ctx_Cookie_SameSiteNoneAutoSecure(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			t.Parallel()
 			// Reset response header for each sub-test to ensure a clean state
 			c.Response().Header.Reset()
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1120,31 +1120,32 @@ func Test_Ctx_Cookie_SameSiteNoneAutoSecure(t *testing.T) {
 	defer app.ReleaseCtx(c)
 
 	testCases := []struct {
-		description string
+		description	string
 		sameSite	string
 	}{
 		{
 			description: "samesite is 'none'",
-			sameSite:	CookieSameSiteNoneMode,
+			sameSite:    CookieSameSiteNoneMode,
 		},
 		{
 			description: "samesite is 'None'",
-			sameSite:	"None",
+			sameSite:    "None",
 		},
 		{
 			description: "samesite is 'NONE'",
-			sameSite:	"NONE",
+			sameSite:    "NONE",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
 			// Reset response header for each sub-test to ensure a clean state
 			c.Response().Header.Reset()
 
 			ck := &Cookie{
-				Name:	 "auto",
-				Value:	"v",
+				Name:     "auto",
+				Value:    "v",
 				SameSite: tc.sameSite,
 			}
 			c.Res().Cookie(ck)

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1117,8 +1117,8 @@ func Test_Ctx_Cookie_SameSiteNoneAutoSecure(t *testing.T) {
 	app := New()
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 	t.Cleanup(func() {
-+		app.ReleaseCtx(c)
-+	})
+		app.ReleaseCtx(c)
+	})
 
 	testCases := []struct {
 		description string

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1096,6 +1096,23 @@ func Test_Ctx_Cookie(t *testing.T) {
 }
 
 // go test -run Test_Ctx_Cookie_PartitionedSecure
+func Test_Ctx_Cookie_PartitionedSecure(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	ck := &Cookie{
+		Name:        "ps",
+		Value:       "v",
+		Secure:      true,
+		SameSite:    CookieSameSiteNoneMode,
+		Partitioned: true,
+	}
+	c.Res().Cookie(ck)
+	require.Equal(t, "ps=v; path=/; secure; SameSite=None; Partitioned", c.Res().Get(HeaderSetCookie))
+}
+
+// go test -run Test_Ctx_Cookie_SameSiteNoneAutoSecure
 func Test_Ctx_Cookie_SameSiteNoneAutoSecure(t *testing.T) {
 	t.Parallel()
 	app := New()
@@ -1199,22 +1216,6 @@ func Test_Ctx_Cookie_MaxAgeOnly(t *testing.T) {
 		"ttl=v; max-age=3600; path=/; SameSite=Lax",
 		c.Res().Get(HeaderSetCookie),
 	)
-}
-
-// go test -run Test_Ctx_Cookie_SameSiteNoneAutoSecure
-func Test_Ctx_Cookie_SameSiteNoneAutoSecure(t *testing.T) {
-	t.Parallel()
-	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{})
-
-	ck := &Cookie{
-		Name:     "auto",
-		Value:    "v",
-		SameSite: CookieSameSiteNoneMode,
-	}
-	c.Res().Cookie(ck)
-
-	require.Equal(t, "auto=v; path=/; secure; SameSite=None", c.Res().Get(HeaderSetCookie))
 }
 
 // go test -run Test_Ctx_Cookie_StrictPartitioned

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1176,6 +1176,22 @@ func Test_Ctx_Cookie_MaxAgeOnly(t *testing.T) {
 	)
 }
 
+// go test -run Test_Ctx_Cookie_SameSiteNoneAutoSecure
+func Test_Ctx_Cookie_SameSiteNoneAutoSecure(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	ck := &Cookie{
+		Name:     "auto",
+		Value:    "v",
+		SameSite: CookieSameSiteNoneMode,
+	}
+	c.Res().Cookie(ck)
+
+	require.Equal(t, "auto=v; path=/; secure; SameSite=None", c.Res().Get(HeaderSetCookie))
+}
+
 // go test -run Test_Ctx_Cookie_StrictPartitioned
 func Test_Ctx_Cookie_StrictPartitioned(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- ensure secure cookies when using `SameSite=None`
- add test verifying secure flag is auto-enabled for `SameSite=None`

Mozilla Docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie?utm_source=chatgpt.com#none

Chrome Docs: https://developers.google.com/search/blog/2020/01/get-ready-for-new-samesitenone-secure