### PR TITLE
🔥 feat: Support for disabling response headers in Limiter Middleware

### DIFF
--- a/docs/middleware/limiter.md
+++ b/docs/middleware/limiter.md
@@ -105,7 +105,7 @@ app.Use(limiter.New(limiter.Config{
 | LimitReached           | `fiber.Handler`           | LimitReached is called when a request hits the limit.                                       | A function sending 429 response          |
 | SkipFailedRequests     | `bool`                    | When set to true, requests with StatusCode >= 400 won't be counted.                         | false                                    |
 | SkipSuccessfulRequests | `bool`                    | When set to true, requests with StatusCode < 400 won't be counted.                          | false                                    |
-| DisableHeaders         | `bool`                    | When set to true, the middleware will not include the `X-RateLimit-*` headers in the response. | false                                    |
+| DisableHeaders         | `bool`                    | When set to true, the middleware will not include the rate limit headers (`X-RateLimit-*` and `Retry-After`) in the response. | false                                    |
 | Storage                | `fiber.Storage`           | Store is used to store the state of the middleware.                                         | An in-memory store for this process only |
 | LimiterMiddleware      | `LimiterHandler`          | LimiterMiddleware is the struct that implements a limiter middleware.                       | A new Fixed Window Rate Limiter          |
 

--- a/docs/middleware/limiter.md
+++ b/docs/middleware/limiter.md
@@ -105,6 +105,7 @@ app.Use(limiter.New(limiter.Config{
 | LimitReached           | `fiber.Handler`           | LimitReached is called when a request hits the limit.                                       | A function sending 429 response          |
 | SkipFailedRequests     | `bool`                    | When set to true, requests with StatusCode >= 400 won't be counted.                         | false                                    |
 | SkipSuccessfulRequests | `bool`                    | When set to true, requests with StatusCode < 400 won't be counted.                          | false                                    |
+| DisableHeaders         | `bool`                    | When set to true, the middleware will not include the `X-RateLimit-*` headers in the response. | false                                    |
 | Storage                | `fiber.Storage`           | Store is used to store the state of the middleware.                                         | An in-memory store for this process only |
 | LimiterMiddleware      | `LimiterHandler`          | LimiterMiddleware is the struct that implements a limiter middleware.                       | A new Fixed Window Rate Limiter          |
 
@@ -129,6 +130,7 @@ var ConfigDefault = Config{
     },
     SkipFailedRequests: false,
     SkipSuccessfulRequests: false,
+    DisableHeaders:        false,
     LimiterMiddleware: FixedWindow{},
 }
 ```

--- a/middleware/limiter/config.go
+++ b/middleware/limiter/config.go
@@ -63,7 +63,7 @@ type Config struct {
 	// Default: false
 	SkipSuccessfulRequests bool
 
-	// When set to true, the middleware will not include the X-RateLimit-* headers in the response.
+	// When set to true, the middleware will not include the rate limit headers (X-RateLimit-* and Retry-After) in the response.
 	//
 	// Default: false
 	DisableHeaders bool

--- a/middleware/limiter/config.go
+++ b/middleware/limiter/config.go
@@ -62,6 +62,11 @@ type Config struct {
 	//
 	// Default: false
 	SkipSuccessfulRequests bool
+
+	// When set to true, the middleware will not include the X-RateLimit-* headers in the response.
+	//
+	// Default: false
+	DisableHeaders bool
 }
 
 // ConfigDefault is the default config
@@ -76,6 +81,7 @@ var ConfigDefault = Config{
 	},
 	SkipFailedRequests:     false,
 	SkipSuccessfulRequests: false,
+	DisableHeaders:         false,
 	LimiterMiddleware:      FixedWindow{},
 }
 

--- a/middleware/limiter/limiter_fixed.go
+++ b/middleware/limiter/limiter_fixed.go
@@ -98,9 +98,11 @@ func (FixedWindow) New(cfg Config) fiber.Handler {
 		}
 
 		// We can continue, update RateLimit headers
-		c.Set(xRateLimitLimit, strconv.Itoa(maxRequests))
-		c.Set(xRateLimitRemaining, strconv.Itoa(remaining))
-		c.Set(xRateLimitReset, strconv.FormatUint(resetInSec, 10))
+		if !cfg.DisableHeaders {
+			c.Set(xRateLimitLimit, strconv.Itoa(maxRequests))
+			c.Set(xRateLimitRemaining, strconv.Itoa(remaining))
+			c.Set(xRateLimitReset, strconv.FormatUint(resetInSec, 10))
+		}
 
 		return err
 	}

--- a/middleware/limiter/limiter_fixed.go
+++ b/middleware/limiter/limiter_fixed.go
@@ -74,7 +74,9 @@ func (FixedWindow) New(cfg Config) fiber.Handler {
 		if remaining < 0 {
 			// Return response with Retry-After header
 			// https://tools.ietf.org/html/rfc6584
-			c.Set(fiber.HeaderRetryAfter, strconv.FormatUint(resetInSec, 10))
+			if !cfg.DisableHeaders {
+				c.Set(fiber.HeaderRetryAfter, strconv.FormatUint(resetInSec, 10))
+			}
 
 			// Call LimitReached handler
 			return cfg.LimitReached(c)

--- a/middleware/limiter/limiter_sliding.go
+++ b/middleware/limiter/limiter_sliding.go
@@ -129,9 +129,11 @@ func (SlidingWindow) New(cfg Config) fiber.Handler {
 		}
 
 		// We can continue, update RateLimit headers
-		c.Set(xRateLimitLimit, strconv.Itoa(maxRequests))
-		c.Set(xRateLimitRemaining, strconv.Itoa(remaining))
-		c.Set(xRateLimitReset, strconv.FormatUint(resetInSec, 10))
+		if !cfg.DisableHeaders {
+			c.Set(xRateLimitLimit, strconv.Itoa(maxRequests))
+			c.Set(xRateLimitRemaining, strconv.Itoa(remaining))
+			c.Set(xRateLimitReset, strconv.FormatUint(resetInSec, 10))
+		}
 
 		return err
 	}

--- a/middleware/limiter/limiter_sliding.go
+++ b/middleware/limiter/limiter_sliding.go
@@ -105,7 +105,9 @@ func (SlidingWindow) New(cfg Config) fiber.Handler {
 		if remaining < 0 {
 			// Return response with Retry-After header
 			// https://tools.ietf.org/html/rfc6584
-			c.Set(fiber.HeaderRetryAfter, strconv.FormatUint(resetInSec, 10))
+			if !cfg.DisableHeaders {
+				c.Set(fiber.HeaderRetryAfter, strconv.FormatUint(resetInSec, 10))
+			}
 
 			// Call LimitReached handler
 			return cfg.LimitReached(c)

--- a/middleware/limiter/limiter_test.go
+++ b/middleware/limiter/limiter_test.go
@@ -781,6 +781,8 @@ func Test_Limiter_Disable_Headers(t *testing.T) {
 
 	app.Handler()(fctx)
 
+	require.Equal(t, fiber.StatusOK, fctx.Response.StatusCode())
+	require.Equal(t, "Hello tester!", string(fctx.Response.Body()))
 	require.Equal(t, "", string(fctx.Response.Header.Peek("X-RateLimit-Limit")))
 	require.Equal(t, "", string(fctx.Response.Header.Peek("X-RateLimit-Remaining")))
 	require.Equal(t, "", string(fctx.Response.Header.Peek("X-RateLimit-Reset")))


### PR DESCRIPTION
## Summary
- introduce `DisableHeaders` option for limiter middleware
- set X-RateLimit headers only when not disabled
- document how to disable the headers
- test limiter without headers