### PR TITLE
🔥 feat: Expand configuration options for Proxy middleware

### DIFF
--- a/docs/middleware/proxy.md
+++ b/docs/middleware/proxy.md
@@ -166,6 +166,27 @@ app.Use(proxy.Balancer(proxy.Config{
 | TLSConfig       | `*tls.Config` (or `*fasthttp.TLSConfig` in v3) | TLS config for the HTTP client.                                                                                                                                                                                                    | `nil`           |
 | DialDualStack   | `bool`                                         | Client will attempt to connect to both IPv4 and IPv6 host addresses if set to true.                                                                                                                                                | `false`         |
 | Client          | `*fasthttp.LBClient`                           | Client is a custom client when client config is complex.                                                                                                                                                                           | `nil`           |
+| Transport       | `fasthttp.RoundTripper`                        | Transport-like wrapper executed for every request and response. | `nil` |
+| DialTimeout     | `fasthttp.DialFuncWithTimeout`                 | Custom dial function with timeout. | `nil` |
+| Dial            | `fasthttp.DialFunc`                            | Custom dial function. | `nil` |
+| RetryIfErr      | `fasthttp.RetryIfErrFunc`                      | Determines retry behavior when errors occur. | `nil` |
+| KeepConnectionHeader | `bool`                                    | Forward the `Connection` header instead of removing it. | `false` |
+| Name            | `string`                                       | Client name used in the `User-Agent` request header. | `""` |
+| MaxConns        | `int`                                          | Maximum number of connections which may be established to the host. | `0` |
+| MaxConnDuration | `time.Duration`                                | Keep-alive connections are closed after this duration. | `0` |
+| MaxIdleConnDuration | `time.Duration`                            | Idle keep-alive connections are closed after this duration. | `0` |
+| MaxIdemponentCallAttempts | `int`                                | Maximum number of attempts for idempotent calls. | `0` |
+| ReadTimeout     | `time.Duration`                                | Maximum duration for full response reading. | `0` |
+| WriteTimeout    | `time.Duration`                                | Maximum duration for full request writing. | `0` |
+| MaxResponseBodySize | `int`                                      | Maximum response body size. | `0` |
+| MaxConnWaitTimeout | `time.Duration`                             | Maximum duration for waiting for a free connection. | `0` |
+| ConnPoolStrategy | `fasthttp.ConnPoolStrategyType`               | Connection pool strategy (LIFO or FIFO). | `0` |
+| NoDefaultUserAgentHeader | `bool`                                | Exclude the default User-Agent header from requests. | `true` |
+| IsTLS           | `bool`                                         | Whether to use TLS for host connections. | `false` |
+| DisableHeaderNamesNormalizing | `bool`                           | Send header names without normalization. | `false` |
+| DisablePathNormalizing | `bool`                                   | Send path values without normalization. | `true` |
+| SecureErrorLogMessage | `bool`                                   | Do not log potentially sensitive content in error logs. | `false` |
+| StreamResponseBody | `bool`                                      | Enable response body streaming. | `false` |
 
 ## Default Config
 
@@ -175,5 +196,8 @@ var ConfigDefault = Config{
     ModifyRequest:  nil,
     ModifyResponse: nil,
     Timeout:        fasthttp.DefaultLBClientTimeout,
+    NoDefaultUserAgentHeader: true,
+    DisablePathNormalizing:   true,
+    KeepConnectionHeader:     false,
 }
 ```

--- a/docs/middleware/proxy.md
+++ b/docs/middleware/proxy.md
@@ -175,7 +175,6 @@ app.Use(proxy.Balancer(proxy.Config{
 | MaxConns        | `int`                                          | Maximum number of connections which may be established to the host. | `0` |
 | MaxConnDuration | `time.Duration`                                | Keep-alive connections are closed after this duration. | `0` |
 | MaxIdleConnDuration | `time.Duration`                            | Idle keep-alive connections are closed after this duration. | `0` |
-| MaxIdemponentCallAttempts | `int`                                | Maximum number of attempts for idempotent calls. | `0` |
 | ReadTimeout     | `time.Duration`                                | Maximum duration for full response reading. | `0` |
 | WriteTimeout    | `time.Duration`                                | Maximum duration for full request writing. | `0` |
 | MaxResponseBodySize | `int`                                      | Maximum response body size. | `0` |
@@ -185,7 +184,6 @@ app.Use(proxy.Balancer(proxy.Config{
 | IsTLS           | `bool`                                         | Whether to use TLS for host connections. | `false` |
 | DisableHeaderNamesNormalizing | `bool`                           | Send header names without normalization. | `false` |
 | DisablePathNormalizing | `bool`                                   | Send path values without normalization. | `true` |
-| SecureErrorLogMessage | `bool`                                   | Do not log potentially sensitive content in error logs. | `false` |
 | StreamResponseBody | `bool`                                      | Enable response body streaming. | `false` |
 
 ## Default Config

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1299,6 +1299,8 @@ Monitor middleware is migrated to the [Contrib package](https://github.com/gofib
 
 The proxy middleware has been updated to improve consistency with Go naming conventions. The `TlsConfig` field in the configuration struct has been renamed to `TLSConfig`. Additionally, the `WithTlsConfig` method has been removed; you should now configure TLS directly via the `TLSConfig` property within the `Config` struct.
 
+The configuration also exposes all [fasthttp `HostClient` options](https://github.com/valyala/fasthttp#hostclient) and introduces `KeepConnectionHeader` to control forwarding of the `Connection` header.
+
 ### Session
 
 The Session middleware has undergone key changes in v3 to improve functionality and flexibility. While v2 methods remain available for backward compatibility, we now recommend using the new middleware handler for session management.

--- a/middleware/proxy/config.go
+++ b/middleware/proxy/config.go
@@ -62,34 +62,177 @@ type Config struct {
 	//
 	// Optional. Default: false
 	DialDualStack bool
+
+	// Transport defines a transport-like mechanism that wraps every request/response.
+	Transport fasthttp.RoundTripper
+
+	// Callback for establishing new connections to hosts with timeout.
+	DialTimeout fasthttp.DialFuncWithTimeout
+
+	// Callback for establishing new connections to hosts.
+	Dial fasthttp.DialFunc
+
+	// When the client encounters an error during a request, the behavior
+	// whether to retry and whether to reset the request timeout should be
+	// determined based on the return value of this field.
+	RetryIfErr fasthttp.RetryIfErrFunc
+
+	// Client name. Used in User-Agent request header.
+	Name string
+
+	// Maximum number of connections which may be established to the host.
+	MaxConns int
+
+	// Keep-alive connections are closed after this duration.
+	MaxConnDuration time.Duration
+
+	// Idle keep-alive connections are closed after this duration.
+	MaxIdleConnDuration time.Duration
+
+	// Maximum number of attempts for idempotent calls.
+	MaxIdemponentCallAttempts int
+
+	// Maximum duration for full response reading (including body).
+	ReadTimeout time.Duration
+
+	// Maximum duration for full request writing (including body).
+	WriteTimeout time.Duration
+
+	// Maximum response body size.
+	MaxResponseBodySize int
+
+	// Maximum duration for waiting for a free connection.
+	MaxConnWaitTimeout time.Duration
+
+	// Connection pool strategy. Can be either LIFO or FIFO (default).
+	ConnPoolStrategy fasthttp.ConnPoolStrategyType
+
+	// NoDefaultUserAgentHeader when set to true, causes the default
+	// User-Agent header to be excluded from the Request.
+	NoDefaultUserAgentHeader bool
+
+	// Whether to use TLS (aka SSL or HTTPS) for host connections.
+	IsTLS bool
+
+	// Header names are passed as-is without normalization if this option is set.
+	DisableHeaderNamesNormalizing bool
+
+	// Path values are sent as-is without normalization.
+	DisablePathNormalizing bool
+
+	// Will not log potentially sensitive content in error logs.
+	SecureErrorLogMessage bool
+
+	// StreamResponseBody enables response body streaming.
+	StreamResponseBody bool
+
+	// KeepConnectionHeader disables the default behavior of stripping
+	// the "Connection" header from proxied requests and responses.
+	// When set to true, the header will be forwarded as-is.
+	KeepConnectionHeader bool
 }
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
-	Next:           nil,
-	ModifyRequest:  nil,
-	ModifyResponse: nil,
-	Timeout:        fasthttp.DefaultLBClientTimeout,
+	Next:                     nil,
+	ModifyRequest:            nil,
+	ModifyResponse:           nil,
+	Timeout:                  fasthttp.DefaultLBClientTimeout,
+	NoDefaultUserAgentHeader: true,
+	DisablePathNormalizing:   true,
+	KeepConnectionHeader:     false,
 }
 
 // configDefault function to set default values
 func configDefault(config ...Config) Config {
-	// Return default config if nothing provided
+	cfg := ConfigDefault
+
 	if len(config) < 1 {
-		return ConfigDefault
+		return cfg
 	}
 
-	// Override default config
-	cfg := config[0]
-
-	// Set default values
-	if cfg.Timeout <= 0 {
-		cfg.Timeout = ConfigDefault.Timeout
+	c := config[0]
+	if c.Next != nil {
+		cfg.Next = c.Next
 	}
+	if c.ModifyRequest != nil {
+		cfg.ModifyRequest = c.ModifyRequest
+	}
+	if c.ModifyResponse != nil {
+		cfg.ModifyResponse = c.ModifyResponse
+	}
+	if c.TLSConfig != nil {
+		cfg.TLSConfig = c.TLSConfig
+	}
+	if c.Client != nil {
+		cfg.Client = c.Client
+	}
+	if len(c.Servers) != 0 {
+		cfg.Servers = c.Servers
+	}
+	if c.Timeout != 0 {
+		cfg.Timeout = c.Timeout
+	}
+	if c.ReadBufferSize != 0 {
+		cfg.ReadBufferSize = c.ReadBufferSize
+	}
+	if c.WriteBufferSize != 0 {
+		cfg.WriteBufferSize = c.WriteBufferSize
+	}
+	cfg.DialDualStack = c.DialDualStack
+	if c.Transport != nil {
+		cfg.Transport = c.Transport
+	}
+	if c.DialTimeout != nil {
+		cfg.DialTimeout = c.DialTimeout
+	}
+	if c.Dial != nil {
+		cfg.Dial = c.Dial
+	}
+	if c.RetryIfErr != nil {
+		cfg.RetryIfErr = c.RetryIfErr
+	}
+	if c.Name != "" {
+		cfg.Name = c.Name
+	}
+	if c.MaxConns != 0 {
+		cfg.MaxConns = c.MaxConns
+	}
+	if c.MaxConnDuration != 0 {
+		cfg.MaxConnDuration = c.MaxConnDuration
+	}
+	if c.MaxIdleConnDuration != 0 {
+		cfg.MaxIdleConnDuration = c.MaxIdleConnDuration
+	}
+	if c.MaxIdemponentCallAttempts != 0 {
+		cfg.MaxIdemponentCallAttempts = c.MaxIdemponentCallAttempts
+	}
+	if c.ReadTimeout != 0 {
+		cfg.ReadTimeout = c.ReadTimeout
+	}
+	if c.WriteTimeout != 0 {
+		cfg.WriteTimeout = c.WriteTimeout
+	}
+	if c.MaxResponseBodySize != 0 {
+		cfg.MaxResponseBodySize = c.MaxResponseBodySize
+	}
+	if c.MaxConnWaitTimeout != 0 {
+		cfg.MaxConnWaitTimeout = c.MaxConnWaitTimeout
+	}
+	if c.ConnPoolStrategy != 0 {
+		cfg.ConnPoolStrategy = c.ConnPoolStrategy
+	}
+	cfg.NoDefaultUserAgentHeader = c.NoDefaultUserAgentHeader
+	cfg.IsTLS = c.IsTLS
+	cfg.DisableHeaderNamesNormalizing = c.DisableHeaderNamesNormalizing
+	cfg.DisablePathNormalizing = c.DisablePathNormalizing
+	cfg.SecureErrorLogMessage = c.SecureErrorLogMessage
+	cfg.StreamResponseBody = c.StreamResponseBody
+	cfg.KeepConnectionHeader = c.KeepConnectionHeader
 
-	// Set default values
 	if len(cfg.Servers) == 0 && cfg.Client == nil {
 		panic("Servers cannot be empty")
 	}
+
 	return cfg
 }

--- a/middleware/proxy/config.go
+++ b/middleware/proxy/config.go
@@ -81,9 +81,6 @@ type Config struct {
 	// Idle keep-alive connections are closed after this duration.
 	MaxIdleConnDuration time.Duration
 
-	// Maximum number of attempts for idempotent calls.
-	MaxIdemponentCallAttempts int
-
 	// Maximum duration for full response reading (including body).
 	ReadTimeout time.Duration
 
@@ -119,9 +116,6 @@ type Config struct {
 
 	// Path values are sent as-is without normalization.
 	DisablePathNormalizing bool
-
-	// Will not log potentially sensitive content in error logs.
-	SecureErrorLogMessage bool
 
 	// StreamResponseBody enables response body streaming.
 	StreamResponseBody bool
@@ -204,9 +198,6 @@ func configDefault(config ...Config) Config {
 	if c.MaxIdleConnDuration != 0 {
 		cfg.MaxIdleConnDuration = c.MaxIdleConnDuration
 	}
-	if c.MaxIdemponentCallAttempts != 0 {
-		cfg.MaxIdemponentCallAttempts = c.MaxIdemponentCallAttempts
-	}
 	if c.ReadTimeout != 0 {
 		cfg.ReadTimeout = c.ReadTimeout
 	}
@@ -226,7 +217,6 @@ func configDefault(config ...Config) Config {
 	cfg.IsTLS = c.IsTLS
 	cfg.DisableHeaderNamesNormalizing = c.DisableHeaderNamesNormalizing
 	cfg.DisablePathNormalizing = c.DisablePathNormalizing
-	cfg.SecureErrorLogMessage = c.SecureErrorLogMessage
 	cfg.StreamResponseBody = c.StreamResponseBody
 	cfg.KeepConnectionHeader = c.KeepConnectionHeader
 

--- a/middleware/proxy/config.go
+++ b/middleware/proxy/config.go
@@ -10,6 +10,9 @@ import (
 
 // Config defines the config for middleware.
 type Config struct {
+	// Transport defines a transport-like mechanism that wraps every request/response.
+	Transport fasthttp.RoundTripper
+
 	// Next defines a function to skip this middleware when returned true.
 	//
 	// Optional. Default: nil
@@ -33,6 +36,20 @@ type Config struct {
 	// and DialDualStack will not be used if the client are set.
 	Client *fasthttp.LBClient
 
+	// Callback for establishing new connections to hosts with timeout.
+	DialTimeout fasthttp.DialFuncWithTimeout
+
+	// Callback for establishing new connections to hosts.
+	Dial fasthttp.DialFunc
+
+	// When the client encounters an error during a request, the behavior
+	// whether to retry and whether to reset the request timeout should be
+	// determined based on the return value of this field.
+	RetryIfErr fasthttp.RetryIfErrFunc
+
+	// Client name. Used in User-Agent request header.
+	Name string
+
 	// Servers defines a list of <scheme>://<host> HTTP servers,
 	//
 	// which are used in a round-robin manner.
@@ -54,31 +71,6 @@ type Config struct {
 
 	// Per-connection buffer size for responses' writing.
 	WriteBufferSize int
-
-	// Attempt to connect to both ipv4 and ipv6 host addresses if set to true.
-	//
-	// By default client connects only to ipv4 addresses, since unfortunately ipv6
-	// remains broken in many networks worldwide :)
-	//
-	// Optional. Default: false
-	DialDualStack bool
-
-	// Transport defines a transport-like mechanism that wraps every request/response.
-	Transport fasthttp.RoundTripper
-
-	// Callback for establishing new connections to hosts with timeout.
-	DialTimeout fasthttp.DialFuncWithTimeout
-
-	// Callback for establishing new connections to hosts.
-	Dial fasthttp.DialFunc
-
-	// When the client encounters an error during a request, the behavior
-	// whether to retry and whether to reset the request timeout should be
-	// determined based on the return value of this field.
-	RetryIfErr fasthttp.RetryIfErrFunc
-
-	// Client name. Used in User-Agent request header.
-	Name string
 
 	// Maximum number of connections which may be established to the host.
 	MaxConns int
@@ -106,6 +98,14 @@ type Config struct {
 
 	// Connection pool strategy. Can be either LIFO or FIFO (default).
 	ConnPoolStrategy fasthttp.ConnPoolStrategyType
+
+	// Attempt to connect to both ipv4 and ipv6 host addresses if set to true.
+	//
+	// By default client connects only to ipv4 addresses, since unfortunately ipv6
+	// remains broken in many networks worldwide :)
+	//
+	// Optional. Default: false
+	DialDualStack bool
 
 	// NoDefaultUserAgentHeader when set to true, causes the default
 	// User-Agent header to be excluded from the Request.

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -20,8 +20,8 @@ func Balancer(config Config) fiber.Handler {
 
 	// Load balanced client
 	lbc := &fasthttp.LBClient{}
-	// Note that Servers, Timeout, WriteBufferSize, ReadBufferSize, TLSConfig and DialDualStack
-	// will not be used if the client are set.
+	// Note that Servers, Timeout, WriteBufferSize, ReadBufferSize, TLSConfig, DialDualStack,
+	// MaxConnsPerHost, MaxIdleConnDuration, and ReadTimeout will not be used if the client is set.
 	if cfg.Client == nil {
 		// Set timeout
 		lbc.Timeout = cfg.Timeout

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -47,10 +47,10 @@ func Balancer(config Config) fiber.Handler {
 
 				TLSConfig: cfg.TLSConfig,
 
-				Name:                      cfg.Name,
-				MaxConns:                  cfg.MaxConns,
-				MaxConnDuration:           cfg.MaxConnDuration,
-				MaxIdleConnDuration:       cfg.MaxIdleConnDuration,
+				Name:                cfg.Name,
+				MaxConns:            cfg.MaxConns,
+				MaxConnDuration:     cfg.MaxConnDuration,
+				MaxIdleConnDuration: cfg.MaxIdleConnDuration,
 
 				ReadBufferSize:  cfg.ReadBufferSize,
 				WriteBufferSize: cfg.WriteBufferSize,

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -51,7 +51,6 @@ func Balancer(config Config) fiber.Handler {
 				MaxConns:                  cfg.MaxConns,
 				MaxConnDuration:           cfg.MaxConnDuration,
 				MaxIdleConnDuration:       cfg.MaxIdleConnDuration,
-				MaxIdemponentCallAttempts: cfg.MaxIdemponentCallAttempts,
 
 				ReadBufferSize:  cfg.ReadBufferSize,
 				WriteBufferSize: cfg.WriteBufferSize,
@@ -67,7 +66,6 @@ func Balancer(config Config) fiber.Handler {
 				IsTLS:                         cfg.IsTLS,
 				DisableHeaderNamesNormalizing: cfg.DisableHeaderNamesNormalizing,
 				DisablePathNormalizing:        cfg.DisablePathNormalizing,
-				SecureErrorLogMessage:         cfg.SecureErrorLogMessage,
 				StreamResponseBody:            cfg.StreamResponseBody,
 			}
 


### PR DESCRIPTION
## Summary
- expose new KeepConnectionHeader field and host client options in proxy config
- document all new options in proxy middleware docs
- mention feature in What's New
- add tests for client Name, custom Dial and Connection header behaviour

Fixes #2700 
