### PR TITLE
🔥 feat: Add HeaderLimit option to BasicAuth middleware

### DIFF
--- a/docs/middleware/basicauth.md
+++ b/docs/middleware/basicauth.md
@@ -79,6 +79,7 @@ func handler(c fiber.Ctx) error {
 | Users           | `map[string]string`         | Users defines the allowed credentials.                                                                                                                                | `map[string]string{}` |
 | Realm           | `string`                    | Realm is a string to define the realm attribute of BasicAuth. The realm identifies the system to authenticate against and can be used by clients to save credentials. | `"Restricted"`        |
 | Charset         | `string`                    | Charset sent in the `WWW-Authenticate` header, so clients know how credentials are encoded. | `"UTF-8"` |
+| HeaderLimit     | `int`                       | Maximum allowed length of the `Authorization` header. Requests exceeding this limit are rejected. | `8192` |
 | StorePassword   | `bool`                      | Store the plaintext password in the context and retrieve it via `PasswordFromContext`. | `false` |
 | Authorizer      | `func(string, string) bool` | Authorizer defines a function to check the credentials. It will be called with a username and password and is expected to return true or false to indicate approval.  | `nil`                 |
 | Unauthorized    | `fiber.Handler`             | Unauthorized defines the response body for unauthorized responses.                                                                                                    | `nil`                 |
@@ -91,6 +92,7 @@ var ConfigDefault = Config{
     Users:           map[string]string{},
     Realm:           "Restricted",
     Charset:         "UTF-8",
+    HeaderLimit:     8192,
     StorePassword:   false,
     Authorizer:      nil,
     Unauthorized:    nil,

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1053,7 +1053,7 @@ The adaptor middleware has been significantly optimized for performance and effi
 
 ### BasicAuth
 
-The BasicAuth middleware now validates the `Authorization` header more rigorously and sets security-focused response headers. The default challenge includes the `charset="UTF-8"` parameter and disables caching. Passwords are no longer stored in the request context by default; use the new `StorePassword` option to retain them. A `Charset` option controls the value used in the challenge header.
+The BasicAuth middleware now validates the `Authorization` header more rigorously and sets security-focused response headers. The default challenge includes the `charset="UTF-8"` parameter and disables caching. Passwords are no longer stored in the request context by default; use the new `StorePassword` option to retain them. A `Charset` option controls the value used in the challenge header. A new `HeaderLimit` option restricts the maximum length of the `Authorization` header (default: `8192` bytes).
 
 ### Cache
 

--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -34,7 +34,7 @@ func New(config Config) fiber.Handler {
 
 		// Get authorization header and ensure it matches the Basic scheme
 		auth := utils.Trim(c.Get(fiber.HeaderAuthorization), ' ')
-		if auth == "" {
+		if auth == "" || len(auth) > cfg.HeaderLimit {
 			return cfg.Unauthorized(c)
 		}
 

--- a/middleware/basicauth/basicauth_test.go
+++ b/middleware/basicauth/basicauth_test.go
@@ -185,6 +185,7 @@ func Test_BasicAuth_HeaderLimit(t *testing.T) {
 	creds := base64.StdEncoding.EncodeToString([]byte("john:doe"))
 
 	t.Run("too large", func(t *testing.T) {
+		t.Parallel()
 		app := fiber.New()
 		app.Use(New(Config{Users: map[string]string{"john": "doe"}, HeaderLimit: 10}))
 		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
@@ -195,6 +196,7 @@ func Test_BasicAuth_HeaderLimit(t *testing.T) {
 	})
 
 	t.Run("allowed", func(t *testing.T) {
+		t.Parallel()
 		app := fiber.New()
 		app.Use(New(Config{Users: map[string]string{"john": "doe"}, HeaderLimit: 100}))
 		app.Get("/", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusTeapot) })

--- a/middleware/basicauth/basicauth_test.go
+++ b/middleware/basicauth/basicauth_test.go
@@ -139,6 +139,22 @@ func Test_BasicAuth_InvalidHeader(t *testing.T) {
 	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
 }
 
+func Test_BasicAuth_EmptyAuthorization(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New(Config{Users: map[string]string{"john": "doe"}}))
+
+	cases := []string{"", "   "}
+	for _, h := range cases {
+		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+		req.Header.Set(fiber.HeaderAuthorization, h)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	}
+}
+
 func Test_BasicAuth_WhitespaceHandling(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
@@ -162,6 +178,32 @@ func Test_BasicAuth_WhitespaceHandling(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, fiber.StatusTeapot, resp.StatusCode)
 	}
+}
+
+func Test_BasicAuth_HeaderLimit(t *testing.T) {
+	t.Parallel()
+	creds := base64.StdEncoding.EncodeToString([]byte("john:doe"))
+
+	t.Run("too large", func(t *testing.T) {
+		app := fiber.New()
+		app.Use(New(Config{Users: map[string]string{"john": "doe"}, HeaderLimit: 10}))
+		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+		req.Header.Set(fiber.HeaderAuthorization, "Basic "+creds)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("allowed", func(t *testing.T) {
+		app := fiber.New()
+		app.Use(New(Config{Users: map[string]string{"john": "doe"}, HeaderLimit: 100}))
+		app.Get("/", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusTeapot) })
+		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+		req.Header.Set(fiber.HeaderAuthorization, "Basic "+creds)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, fiber.StatusTeapot, resp.StatusCode)
+	})
 }
 
 // go test -v -run=^$ -bench=Benchmark_Middleware_BasicAuth -benchmem -count=4

--- a/middleware/basicauth/config.go
+++ b/middleware/basicauth/config.go
@@ -49,6 +49,13 @@ type Config struct {
 	// Optional. Default: "UTF-8".
 	Charset string
 
+	// HeaderLimit specifies the maximum allowed length of the
+	// Authorization header. Requests exceeding this limit will
+	// be rejected.
+	//
+	// Optional. Default: 8192.
+	HeaderLimit int
+
 	// StorePassword determines if the plaintext password should be stored
 	// in the context for later retrieval via PasswordFromContext.
 	//
@@ -62,6 +69,7 @@ var ConfigDefault = Config{
 	Users:         map[string]string{},
 	Realm:         "Restricted",
 	Charset:       "UTF-8",
+	HeaderLimit:   8192,
 	StorePassword: false,
 	Authorizer:    nil,
 	Unauthorized:  nil,
@@ -89,6 +97,9 @@ func configDefault(config ...Config) Config {
 	}
 	if cfg.Charset == "" {
 		cfg.Charset = ConfigDefault.Charset
+	}
+	if cfg.HeaderLimit <= 0 {
+		cfg.HeaderLimit = ConfigDefault.HeaderLimit
 	}
 	if cfg.Authorizer == nil {
 		cfg.Authorizer = func(user, pass string) bool {


### PR DESCRIPTION
## Summary
- add `HeaderLimit` option to BasicAuth middleware
- enforce authorization header length in middleware
- document `HeaderLimit` in docs
- note the change in what's new
- test header limit handling
- add unit tests for empty or whitespace-only auth headers