### PR TITLE
feat(middleware/session): Introduce Extractor pattern for session ID retrieval

### DIFF
--- a/docs/middleware/session.md
+++ b/docs/middleware/session.md
@@ -367,10 +367,10 @@ session.Chain(
 You can create custom extractors by returning a `session.Extractor` struct that defines how to extract the session ID from the request and how the middleware should handle responses.
 
 The `Source` field is crucial as it controls whether the middleware sets response values:
-- `SourceCookie`: Sets cookies in the response
-- `SourceHeader`: Sets headers in the response  
-- `SourceOther`: Read-only, no response values set
 
+- `SourceCookie`: Sets cookies in the response
+- `SourceHeader`: Sets headers in the response
+- `SourceOther`: Read-only, no response values set
 
 ```go
 // Custom extractor for Authorization Bearer tokens

--- a/docs/middleware/session.md
+++ b/docs/middleware/session.md
@@ -96,6 +96,7 @@ app.Post("/login", func(c fiber.Ctx) error {
 ```
 
 **Benefits:**
+
 - Automatic session saving
 - Automatic resource cleanup
 - No manual lifecycle management
@@ -133,6 +134,7 @@ func backgroundTask(sessionID string) {
 ```
 
 **Requirements:**
+
 - Must call `sess.Release()` when done
 - Must call `sess.Save()` to persist changes
 - Handle errors manually
@@ -221,6 +223,7 @@ app.Post("/login", func(c fiber.Ctx) error {
 ### Common Security Mistakes
 
 ❌ **Session Fixation Vulnerability:**
+
 ```go
 // DANGEROUS: Keeping same session ID after login
 app.Post("/login", func(c fiber.Ctx) error {
@@ -232,6 +235,7 @@ app.Post("/login", func(c fiber.Ctx) error {
 ```
 
 ✅ **Secure Implementation:**
+
 ```go
 // SECURE: Always regenerate session ID after authentication
 app.Post("/login", func(c fiber.Ctx) error {
@@ -282,6 +286,7 @@ app.Use(session.New(session.Config{
 ```
 
 **How it works:**
+
 - `IdleTimeout`: Storage automatically removes sessions after inactivity period
   - Any route that uses the middleware will reset the idle timer
   - Calling `sess.Save()` will also reset the idle timer
@@ -332,7 +337,7 @@ app.Use(session.New(session.Config{
 The session middleware intelligently sets response values based on the extractors in your chain:
 
 - **Cookie + Header extractors**: Both cookie and header are set in the response
-- **Only Cookie extractors**: Only cookie is set in the response  
+- **Only Cookie extractors**: Only cookie is set in the response
 - **Only Header extractors**: Only header is set in the response
 - **Only Query/Form/Param extractors**: No response values are set (read-only)
 - **Mixed extractors**: Only cookie and header extractors set response values
@@ -525,6 +530,7 @@ if ok {
 ```
 
 **Important Notes:**
+
 - Custom types must be registered before using them in sessions
 - Registration must happen during application startup
 - All instances of the application must register the same types
@@ -535,13 +541,14 @@ if ok {
 ### v2 to v3 Breaking Changes
 
 1. **Function Signature**: `session.New()` now returns middleware handler, not store
-2. **Session ID Extraction**: `KeyLookup` replaced with `Extractor` functions  
+2. **Session ID Extraction**: `KeyLookup` replaced with `Extractor` functions
 3. **Lifecycle Management**: Manual `Release()` required for store pattern
 4. **Timeout Handling**: `Expiration` split into `IdleTimeout` and `AbsoluteTimeout`
 
 ### Migration Examples
 
 **v2 Code:**
+
 ```go
 store := session.New(session.Config{
     KeyLookup: "cookie:session_id",
@@ -559,6 +566,7 @@ app.Get("/", func(c fiber.Ctx) error {
 ```
 
 **v3 Middleware Pattern (Recommended):**
+
 ```go
 app.Use(session.New(session.Config{
     Extractor: session.FromCookie("session_id"),
@@ -573,6 +581,7 @@ app.Get("/", func(c fiber.Ctx) error {
 ```
 
 **v3 Store Pattern (Advanced):**
+
 ```go
 store := session.NewStore(session.Config{
     Extractor: session.FromCookie("session_id"),

--- a/docs/middleware/session.md
+++ b/docs/middleware/session.md
@@ -38,9 +38,13 @@ app.Get("/", func(c fiber.Ctx) error {
     }
     
     // Set session data  
-    sess.Set("visits", visits.(int)+1)
+    newVisits := 1
+    if visits != nil {
+        newVisits = visits.(int) + 1
+    }
+    sess.Set("visits", newVisits)
     
-    return c.SendString(fmt.Sprintf("Visits: %d", visits))
+    return c.SendString(fmt.Sprintf("Visits: %d", newVisits))
 })
 ```
 

--- a/docs/middleware/session.md
+++ b/docs/middleware/session.md
@@ -4,481 +4,674 @@ id: session
 
 # Session
 
-The `session` middleware provides session management for Fiber applications, utilizing the [Storage](https://github.com/gofiber/storage) package for multi-database support via a unified interface. By default, session data is stored in memory, but custom storage options are easily configurable (see examples below).
-
-As of v3, we recommend using the middleware handler for session management. However, for backward compatibility, v2's session methods are still available, allowing you to continue using the session management techniques from earlier versions of Fiber. Both methods are demonstrated in the examples.
+The Session middleware provides robust session management for Fiber applications, utilizing the [Storage](https://github.com/gofiber/storage) package for multi-database support via a unified interface. By default, session data is stored in memory, but custom storage options are easily configurable.
 
 ## Table of Contents
 
+- [Quick Start](#quick-start)
+- [Usage Patterns](#usage-patterns)
+- [Session Security](#session-security)
+- [Session ID Extractors](#session-id-extractors)
+- [Configuration](#configuration)
 - [Migration Guide](#migration-guide)
-  - [v2 to v3](#v2-to-v3)
-- [Types](#types)
-  - [Config](#config)
-  - [Middleware](#middleware)
-  - [Session](#session)
-  - [Store](#store)
-- [Signatures](#signatures)
-  - [Session Package Functions](#session-package-functions)
-  - [Config Methods](#config-methods)
-  - [Middleware Methods](#middleware-methods)
-  - [Session Methods](#session-methods)
-  - [Store Methods](#store-methods)
-- [Examples](#examples)
-  - [Middleware Handler (Recommended)](#middleware-handler-recommended)
-  - [Custom Storage Example](#custom-storage-example)
-  - [Session Without Middleware Handler](#session-without-middleware-handler)
-  - [Custom Types in Session Data](#custom-types-in-session-data)
-- [Config](#config)
-- [Default Config](#default-config)
+- [API Reference](#api-reference)
 
-## Migration Guide
-
-### v2 to v3
-
-- **Function Signature Change**: In v3, the `New` function now returns a middleware handler instead of a `*Store`. To access the store, use the `Store` method on `*Middleware` (obtained from `session.FromContext(c)` in a handler) or use `NewStore` or `NewWithStore`.
-
-- **Session Lifecycle Management**: The `*Store.Save` method no longer releases the instance automatically. You must manually call `sess.Release()` after using the session to manage its lifecycle properly.
-
-- **Expiration Handling**: Previously, the `Expiration` field represented the maximum session duration before expiration. However, it would extend every time the session was saved, making its behavior a mix between session duration and session idle timeout. The `Expiration` field has been removed and replaced with `IdleTimeout` and `AbsoluteTimeout` fields, which explicitly defines the session's idle and absolute timeout periods.
-
-  - **Idle Timeout**: The new `IdleTimeout`, handles session inactivity. If the session is idle for the specified duration, it will expire. The idle timeout is updated when the session is saved. If you are using the middleware handler, the idle timeout will be updated automatically.
-
-  - **Absolute Timeout**: The `AbsoluteTimeout` field has been added. If you need to set an absolute session timeout, you can use this field to define the duration. The session will expire after the specified duration, regardless of activity.
-
-For more details about Fiber v3, see [What’s New](https://github.com/gofiber/fiber/blob/main/docs/whats_new.md).
-
-### Migrating v2 to v3 Example (Legacy Approach)
-
-To convert a v2 example to use the v3 legacy approach, follow these steps:
-
-1. **Initialize with Store**: Use `session.NewStore()` to obtain a store.
-2. **Retrieve Session**: Access the session store using the `store.Get(c)` method.
-3. **Release Session**: Ensure that you call `sess.Release()` after you are done with the session to manage its lifecycle.
-
-:::note
-When using the legacy approach, the IdleTimeout will be updated when the session is saved.
-:::
-
-#### Example Conversion
-
-**v2 Example:**
+## Quick Start
 
 ```go
-store := session.New()
+import (
+    "fmt"
+    "github.com/gofiber/fiber/v3"
+    "github.com/gofiber/fiber/v3/middleware/session"
+)
 
-app.Get("/", func(c *fiber.Ctx) error {
-    sess, err := store.Get(c)
-    if err != nil {
-        return err
+// Basic usage
+app.Use(session.New())
+
+app.Get("/", func(c fiber.Ctx) error {
+    sess := session.FromContext(c)
+    
+    // Get session data
+    visits := sess.Get("visits")
+    if visits == nil {
+        visits = 0
     }
-
-    key, ok := sess.Get("key").(string)
-    if !ok {
-        return c.SendStatus(fiber.StatusInternalServerError)
-    }
-
-    sess.Set("key", "value")
-
-    err = sess.Save()
-    if err != nil {
-        return c.SendStatus(fiber.StatusInternalServerError)
-    }
-
-    return nil
+    
+    // Set session data  
+    sess.Set("visits", visits.(int)+1)
+    
+    return c.SendString(fmt.Sprintf("Visits: %d", visits))
 })
 ```
 
-**v3 Legacy Approach:**
+### Production Configuration
 
 ```go
+import (
+    "time"
+    "github.com/gofiber/storage/redis"
+)
+
+storage := redis.New(redis.Config{
+    Host: "localhost",
+    Port: 6379,
+})
+
+app.Use(session.New(session.Config{
+    Storage:           storage,
+    CookieSecure:      true,              // HTTPS only
+    CookieHTTPOnly:    true,              // Prevent XSS
+    CookieSameSite:    "Lax",             // CSRF protection
+    IdleTimeout:       30 * time.Minute,  // Session timeout
+    AbsoluteTimeout:   24 * time.Hour,    // Maximum session life
+    Extractor:         session.FromCookie("__Host-session_id"),
+}))
+```
+
+## Usage Patterns
+
+### Middleware Pattern (Recommended)
+
+The middleware pattern automatically manages session lifecycle and is the recommended approach for most applications.
+
+```go
+// Setup middleware
+app.Use(session.New())
+
+// Use in handlers
+app.Post("/login", func(c fiber.Ctx) error {
+    sess := session.FromContext(c)
+    
+    // Session is automatically saved when handler returns
+    sess.Set("user_id", 123)
+    sess.Set("authenticated", true)
+    
+    return c.Redirect("/dashboard")
+})
+```
+
+**Benefits:**
+- Automatic session saving
+- Automatic resource cleanup
+- No manual lifecycle management
+- Thread-safe operations
+
+### Store Pattern (Advanced)
+
+Use the store pattern for background tasks or when you need direct session access.
+
+```go
+import (
+    "context"
+    "log"
+    "time"
+)
+
 store := session.NewStore()
+
+// In background tasks
+func backgroundTask(sessionID string) {
+    sess, err := store.GetByID(context.Background(), sessionID)
+    if err != nil {
+        return
+    }
+    defer sess.Release() // Important: Manual cleanup required
+    
+    // Modify session
+    sess.Set("last_task", time.Now())
+    
+    // Manual save required
+    if err := sess.Save(); err != nil {
+        log.Error("Failed to save session:", err)
+    }
+}
+```
+
+**Requirements:**
+- Must call `sess.Release()` when done
+- Must call `sess.Save()` to persist changes
+- Handle errors manually
+
+## Session Security
+
+### Authentication Flow
+
+Understanding session lifecycle during authentication is crucial for security.
+
+#### Basic Login/Logout
+
+```go
+app.Post("/login", func(c fiber.Ctx) error {
+    sess := session.FromContext(c)
+    
+    email := c.FormValue("email")
+    password := c.FormValue("password")
+    
+    // Simple credential validation (use proper authentication in production)
+    if email == "admin@example.com" && password == "secret" {
+        // CRITICAL: Regenerate session ID to prevent session fixation
+        // This changes the session ID while preserving existing data
+        if err := sess.Regenerate(); err != nil {
+            return c.Status(500).SendString("Session error")
+        }
+        
+        // Add authentication data to existing session
+        sess.Set("user_id", 1)
+        sess.Set("authenticated", true)
+        
+        return c.Redirect("/dashboard")
+    }
+    
+    return c.Status(401).SendString("Invalid credentials")
+})
+
+app.Post("/logout", func(c fiber.Ctx) error {
+    sess := session.FromContext(c)
+    
+    // Complete session reset (clears all data + new session ID)
+    if err := sess.Reset(); err != nil {
+        return c.Status(500).SendString("Session error")
+    }
+    
+    return c.Redirect("/")
+})
+```
+
+#### Cart Preservation During Login
+
+```go
+app.Post("/login", func(c fiber.Ctx) error {
+    sess := session.FromContext(c)
+    
+    // Validate credentials (implement your own validation)
+    email := c.FormValue("email")
+    password := c.FormValue("password")
+    if !isValidUser(email, password) {
+        return c.Status(401).JSON(fiber.Map{"error": "Invalid credentials"})
+    }
+    
+    // CRITICAL: Regenerate session ID to prevent session fixation
+    // This changes the session ID while preserving existing data
+    if err := sess.Regenerate(); err != nil {
+        return c.Status(500).JSON(fiber.Map{"error": "Session error"})
+    }
+    
+    // Add authentication data to existing session
+    sess.Set("user_id", getUserID(email))
+    sess.Set("authenticated", true)
+    sess.Set("login_time", time.Now())
+    
+    return c.JSON(fiber.Map{"status": "logged in"})
+})
+```
+
+### Security Methods Comparison
+
+| Method | Session ID | Session Data | Use Case |
+|--------|------------|--------------|----------|
+| `Regenerate()` | ✅ Changes | ✅ Preserved | Login, privilege escalation |
+| `Reset()` | ✅ Changes | ❌ Cleared | Logout, security breach |
+| `Destroy()` | ⚪ Unchanged | ❌ Cleared | Clear data only |
+
+### Common Security Mistakes
+
+❌ **Session Fixation Vulnerability:**
+```go
+// DANGEROUS: Keeping same session ID after login
+app.Post("/login", func(c fiber.Ctx) error {
+    sess := session.FromContext(c)
+    // Validate user...
+    sess.Set("user_id", userID) // Attacker can hijack this session!
+    return c.Redirect("/dashboard")
+})
+```
+
+✅ **Secure Implementation:**
+```go
+// SECURE: Always regenerate session ID after authentication
+app.Post("/login", func(c fiber.Ctx) error {
+    sess := session.FromContext(c)
+    // Validate user...
+    if err := sess.Regenerate(); err != nil { // Prevents session fixation
+        return err
+    }
+    sess.Set("user_id", userID)
+    return c.Redirect("/dashboard")
+})
+```
+
+### Authentication Middleware
+
+This is a basic example of an authentication middleware that checks if a user is logged in before accessing protected routes.
+
+```go
+// Authentication check middleware
+func RequireAuth(c fiber.Ctx) error {
+    sess := session.FromContext(c)
+    if sess == nil {
+        return c.Redirect("/login")
+    }
+    
+    // Check if user is authenticated
+    if sess.Get("authenticated") != true {
+        return c.Redirect("/login")
+    }
+    
+    return c.Next()
+}
+
+// Usage
+app.Use("/dashboard", RequireAuth)
+app.Use("/admin", RequireAuth)
+```
+
+### Automatic Session Expiration
+
+Sessions automatically expire based on your configuration:
+
+```go
+app.Use(session.New(session.Config{
+    IdleTimeout:     30 * time.Minute, // Auto-expire after 30 min of inactivity
+    AbsoluteTimeout: 24 * time.Hour,   // Force expire after 24 hours regardless of activity
+}))
+```
+
+**How it works:**
+- `IdleTimeout`: Storage automatically removes sessions after inactivity period
+  - Any route that uses the middleware will reset the idle timer
+  - Calling `sess.Save()` will also reset the idle timer
+- `AbsoluteTimeout`: Sessions are forcibly expired after maximum duration
+- No manual cleanup required - the storage layer handles this
+
+## Session ID Extractors
+
+### Built-in Extractors
+
+```go
+// Cookie-based (recommended for web apps)
+session.FromCookie("session_id")
+
+// Header-based (recommended for APIs)  
+session.FromHeader("X-Session-ID")
+
+// Form data
+session.FromForm("session_id")
+
+// URL query parameter
+session.FromQuery("session_id")
+
+// URL path parameter
+session.FromParam("id")
+```
+
+### Multiple Sources with Fallback
+
+```go
+app.Use(session.New(session.Config{
+    Extractor: session.Chain(
+        session.FromCookie("session_id"),    // Try cookie first
+        session.FromHeader("X-Session-ID"),  // Then header
+        session.FromQuery("session_id"),     // Finally query
+    ),
+}))
+```
+
+### Custom Extractor
+
+```go
+import "strings"
+
+func CustomExtractor(c fiber.Ctx) (string, error) {
+    // Try Authorization header
+    auth := c.Get("Authorization")
+    if strings.HasPrefix(auth, "Bearer ") {
+        sessionID := strings.TrimPrefix(auth, "Bearer ")
+        if sessionID != "" {
+            return sessionID, nil
+        }
+    }
+    
+    // Return empty string to generate new session
+    return "", nil
+}
+
+app.Use(session.New(session.Config{
+    Extractor: CustomExtractor,
+}))
+```
+
+## Configuration
+
+### Storage Options
+
+```go
+import (
+    "github.com/gofiber/storage/redis"
+    "github.com/gofiber/storage/postgres"
+)
+
+// Redis (recommended for production)
+redisStorage := redis.New(redis.Config{
+    Host:     "localhost",
+    Port:     6379,
+    Password: "",
+    Database: 0,
+})
+
+// PostgreSQL
+pgStorage := postgres.New(postgres.Config{
+    Host:     "localhost",
+    Port:     5432,
+    Database: "sessions",
+    Username: "user",
+    Password: "pass",
+})
+
+app.Use(session.New(session.Config{
+    Storage: redisStorage,
+}))
+```
+
+### Production Security Settings
+
+```go
+import (
+    "log"
+    "time"
+    "github.com/gofiber/utils/v2"
+)
+
+app.Use(session.New(session.Config{
+    // Storage
+    Storage: redisStorage,
+    
+    // Security
+    CookieSecure:      true,    // HTTPS only (required in production)
+    CookieHTTPOnly:    true,    // No JavaScript access (prevents XSS)
+    CookieSameSite:    "Lax",   // CSRF protection
+    
+    // Session Management
+    IdleTimeout:       30 * time.Minute,  // Inactivity timeout
+    AbsoluteTimeout:   24 * time.Hour,    // Maximum session duration
+    
+    // Cookie Settings
+    CookiePath:        "/",
+    CookieDomain:      "example.com",
+    CookieSessionOnly: false,   // Persist across browser restarts
+    
+    // Session ID
+    Extractor:         session.FromCookie("__Host-session_id"),
+    KeyGenerator:      utils.UUIDv4,
+    
+    // Error Handling
+    ErrorHandler: func(c fiber.Ctx, err error) {
+        log.Printf("Session error: %v", err)
+    },
+}))
+```
+
+### Custom Types
+
+Session data supports basic Go types by default:
+
+- `string`, `int`, `int8`, `int16`, `int32`, `int64`
+- `uint`, `uint8`, `uint16`, `uint32`, `uint64`
+- `bool`, `float32`, `float64`
+- `[]byte`, `complex64`, `complex128`
+- `interface{}`
+
+For custom types (structs, maps, slices), you must register them for encoding/decoding:
+
+```go
+import "fmt"
+
+type User struct {
+    ID   int    `json:"id"`
+    Name string `json:"name"`
+    Role string `json:"role"`
+}
+
+// Method 1: Using NewWithStore
+func main() {
+    app := fiber.New()
+    
+    sessionMiddleware, store := session.NewWithStore()
+    store.RegisterType(User{}) // Register custom type
+    
+    app.Use(sessionMiddleware)
+    
+    app.Get("/", func(c fiber.Ctx) error {
+        sess := session.FromContext(c)
+        
+        // Set custom type
+        sess.Set("user", User{ID: 123, Name: "John", Role: "admin"})
+        
+        // Get custom type
+        user, ok := sess.Get("user").(User)
+        if ok {
+            return c.SendString(fmt.Sprintf("User: %s (Role: %s)", user.Name, user.Role))
+        }
+        
+        return c.SendString("No user found")
+    })
+    
+    app.Listen(":3000")
+}
+```
+
+```go
+// Method 2: Using separate store
+store := session.NewStore()
+store.RegisterType(User{})
+
+app.Use(session.New(session.Config{
+    Store: store,
+}))
+
+// Usage in handlers
+sess.Set("user", User{ID: 123, Name: "John", Role: "admin"})
+user, ok := sess.Get("user").(User)
+if ok {
+    fmt.Printf("User: %s (Role: %s)", user.Name, user.Role)
+}
+```
+
+**Important Notes:**
+- Custom types must be registered before using them in sessions
+- Registration must happen during application startup
+- All instances of the application must register the same types
+- Types are encoded using Go's `gob` package
+
+## Migration Guide
+
+### v2 to v3 Breaking Changes
+
+1. **Function Signature**: `session.New()` now returns middleware handler, not store
+2. **Session ID Extraction**: `KeyLookup` replaced with `Extractor` functions  
+3. **Lifecycle Management**: Manual `Release()` required for store pattern
+4. **Timeout Handling**: `Expiration` split into `IdleTimeout` and `AbsoluteTimeout`
+
+### Migration Examples
+
+**v2 Code:**
+```go
+store := session.New(session.Config{
+    KeyLookup: "cookie:session_id",
+})
 
 app.Get("/", func(c fiber.Ctx) error {
     sess, err := store.Get(c)
     if err != nil {
         return err
     }
-    defer sess.Release() // Important: Release the session
-
-    key, ok := sess.Get("key").(string)
-    if !ok {
-        return c.SendStatus(fiber.StatusInternalServerError)
-    }
-
+    // Session automatically saved and released
     sess.Set("key", "value")
-
-    err = sess.Save()
-    if err != nil {
-        return c.SendStatus(fiber.StatusInternalServerError)
-    }
-
     return nil
 })
 ```
 
-### v3 Example (Recommended Middleware Handler)
-
-Do not call `sess.Release()` when using the middleware handler. `sess.Save()` is also not required, as the middleware automatically saves the session data.
-
-For the recommended approach, use the middleware handler. See the [Middleware Handler (Recommended)](#middleware-handler-recommended) section for details.
-
-## Types
-
-### Config
-
-Defines the configuration options for the session middleware.
-
+**v3 Middleware Pattern (Recommended):**
 ```go
-type Config struct {
-    Storage           fiber.Storage
-    Next              func(fiber.Ctx) bool
-    Store             *Store
-    ErrorHandler      func(fiber.Ctx, error)
-    KeyGenerator      func() string
-    KeyLookup         string
-    CookieDomain      string
-    CookiePath        string
-    CookieSameSite    string
-    IdleTimeout       time.Duration
-    AbsoluteTimeout   time.Duration
-    CookieSecure      bool
-    CookieHTTPOnly    bool
-    CookieSessionOnly bool
-}
+app.Use(session.New(session.Config{
+    Extractor: session.FromCookie("session_id"),
+}))
+
+app.Get("/", func(c fiber.Ctx) error {
+    sess := session.FromContext(c)
+    // Session automatically saved and released
+    sess.Set("key", "value")
+    return nil
+})
 ```
 
-### Middleware
-
-The `Middleware` struct encapsulates the session middleware configuration and storage, created via `New` or `NewWithStore`.
-
+**v3 Store Pattern (Advanced):**
 ```go
-type Middleware struct {
-    Session *Session
-}
+store := session.NewStore(session.Config{
+    Extractor: session.FromCookie("session_id"),
+})
+
+app.Get("/", func(c fiber.Ctx) error {
+    sess, err := store.Get(c)
+    if err != nil {
+        return err
+    }
+    defer sess.Release() // Manual cleanup required
+    
+    sess.Set("key", "value")
+    return sess.Save() // Manual save required
+})
 ```
 
-### Session
+## API Reference
 
-Represents a user session, accessible through `FromContext` or `Store.Get`.
+### Middleware Methods (Recommended)
 
 ```go
-type Session struct {}
+sess := session.FromContext(c)
+
+// Data operations
+sess.Get(key any) any
+sess.Set(key, value any)
+sess.Delete(key any)
+sess.Keys() []any
+
+// Session management
+sess.ID() string
+sess.Fresh() bool
+sess.Regenerate() error  // Change ID, keep data
+sess.Reset() error       // Change ID, clear data
+sess.Destroy() error     // Keep ID, clear data
+
+// Store access
+sess.Store() *session.Store
 ```
 
-### Store
-
-Handles session data management and is created using `NewStore`, `NewWithStore` or by accessing the `Store` method of a middleware instance.
+### Session Methods (Store Pattern)
 
 ```go
-type Store struct {
-    Config
-}
+sess, err := store.Get(c)
+defer sess.Release() // Required!
+
+// Same methods as middleware, plus:
+sess.Save() error              // Manual save required
+sess.SetIdleTimeout(duration)  // Per-session timeout
+sess.Release()                 // Manual cleanup required
 ```
 
-## Signatures
+### Config Properties
 
-### Session Package Functions
+| Property | Type | Description | Default |
+|----------|------|-------------|---------|
+| `Storage` | `fiber.Storage` | Session storage backend | `memory.New()` |
+| `Extractor` | `func(fiber.Ctx) (string, error)` | Session ID extraction | `FromCookie("session_id")` |
+| `KeyGenerator` | `func() string` | Session ID generator | `utils.UUIDv4` |
+| `IdleTimeout` | `time.Duration` | Inactivity timeout | `30 * time.Minute` |
+| `AbsoluteTimeout` | `time.Duration` | Maximum session duration | `0` (unlimited) |
+| `CookieSecure` | `bool` | HTTPS only | `false` |
+| `CookieHTTPOnly` | `bool` | No JavaScript access | `false` |
+| `CookieSameSite` | `string` | SameSite attribute | `"Lax"` |
+| `ErrorHandler` | `func(fiber.Ctx, error)` | Error callback | `DefaultErrorHandler` |
 
-```go
-func New(config ...Config) *Middleware
-func NewWithStore(config ...Config) (fiber.Handler, *Store)
-func FromContext(c fiber.Ctx) *Middleware
-```
+## Complete Examples
 
-### Config Methods
-
-```go
-func DefaultErrorHandler(fiber.Ctx, err error)
-```
-
-### Middleware Methods
-
-```go
-func (m *Middleware) Set(key any, value any)
-func (m *Middleware) Get(key any) any
-func (m *Middleware) Delete(key any)
-func (m *Middleware) Keys() []any
-func (m *Middleware) Destroy() error
-func (m *Middleware) Reset() error
-func (m *Middleware) Store() *Store
-```
-
-### Session Methods
+### E-commerce with Cart Persistence
 
 ```go
-func (s *Session) Fresh() bool
-func (s *Session) ID() string
-func (s *Session) Get(key any) any
-func (s *Session) Set(key any, val any)
-func (s *Session) Delete(key any)
-func (s *Session) Keys() []any
-func (s *Session) Destroy() error
-func (s *Session) Regenerate() error
-func (s *Session) Release()
-func (s *Session) Reset() error
-func (s *Session) Save() error
-func (s *Session) SetIdleTimeout(idleTimeout time.Duration)
-```
-
-### Store Methods
-
-```go
-func (*Store) RegisterType(i any)
-func (s *Store) Get(c fiber.Ctx) (*Session, error)
-func (s *Store) GetByID(id string) (*Session, error)
-func (s *Store) Reset() error
-func (s *Store) Delete(id string) error
-```
-
-:::note
-
-#### `GetByID` Method
-
-The `GetByID` method retrieves a session from storage using its session ID. Unlike `Get`, which ties the session to a `fiber.Ctx` (request-response cycle), `GetByID` operates independently of any HTTP context. This makes it ideal for scenarios such as background processing, scheduled tasks, or non-HTTP-related session management.
-
-##### Key Features
-
-- **Context Independence**: Sessions retrieved via `GetByID` are not bound to `fiber.Ctx`. This means the session can be manipulated in contexts that aren't tied to an active HTTP request-response cycle.
-- **Background Task Suitability**: Use this method when you need to manage sessions outside of the standard HTTP workflow, such as in scheduled jobs, background tasks, or any non-HTTP context where session data needs to be accessed or modified.
-
-##### Usage Considerations
-
-- **Manual Persistence**: Since there is no associated `fiber.Ctx`, changes made to the session (e.g., modifying data) will **not** automatically be saved to storage. You **must** call `session.Save()` explicitly to persist any updates to storage.
-- **No Automatic Cookie Handling**: Any updates made to the session will **not** affect the client-side cookies. If the session changes need to be reflected in the client (e.g., in a future HTTP response), you will need to handle this manually by setting the cookies via other methods.
-- **Resource Management**: After using a session retrieved by `GetByID`, you should call `session.Release()` to properly release the session back to the pool and free up resources.
-
-##### Example Use Cases
-
-- **Scheduled Jobs**: Retrieve and update session data periodically without triggering an HTTP request.
-- **Background Processing**: Manage sessions for tasks running in the background, such as user inactivity checks or batch processing.
-
-:::
-
-## Examples
-
-:::note
-**Security Notice**: For robust security, especially during sensitive operations like account changes or transactions, consider using CSRF protection. Fiber provides a [CSRF Middleware](https://docs.gofiber.io/api/middleware/csrf) that can be used with sessions to prevent CSRF attacks.
-:::
-
-:::note
-**Middleware Order**: The order of middleware matters. The session middleware should come before any handler or middleware that uses the session (for example, the CSRF middleware).
-:::
-
-### Middleware Handler (Recommended)
-
-```go
-package main
-
 import (
+    "time"
     "github.com/gofiber/fiber/v3"
-    "github.com/gofiber/fiber/v3/middleware/csrf"
     "github.com/gofiber/fiber/v3/middleware/session"
+    "github.com/gofiber/storage/redis"
 )
 
 func main() {
     app := fiber.New()
-
-    sessionMiddleware, sessionStore := session.NewWithStore()
-
-    app.Use(sessionMiddleware)
-    app.Use(csrf.New(csrf.Config{
-        Session: sessionStore,
+    
+    // Session middleware
+    app.Use(session.New(session.Config{
+        Storage:           redis.New(),
+        CookieSecure:      true,
+        CookieHTTPOnly:    true,
+        CookieSameSite:    "Lax",
+        IdleTimeout:       30 * time.Minute,
+        AbsoluteTimeout:   24 * time.Hour,
+        Extractor:         session.FromCookie("__Host-cart_session"),
     }))
-
-    app.Get("/", func(c fiber.Ctx) error {
+    
+    // Add to cart (anonymous user)
+    app.Post("/cart/add", func(c fiber.Ctx) error {
         sess := session.FromContext(c)
-        if sess == nil {
-            return c.SendStatus(fiber.StatusInternalServerError)
-        }
-
-        name, ok := sess.Get("name").(string)
-        if !ok {
-            return c.SendString("Welcome anonymous user!")
-        }
-
-        return c.SendString("Welcome " + name)
+        
+        cart, _ := sess.Get("cart").([]string)
+        cart = append(cart, c.FormValue("item_id"))
+        sess.Set("cart", cart)
+        
+        return c.JSON(fiber.Map{"items": len(cart)})
     })
-
-    app.Listen(":3000")
-}
-```
-
-### Custom Storage Example
-
-```go
-package main
-
-import (
-    "github.com/gofiber/fiber/v3"
-    "github.com/gofiber/storage/sqlite3"
-    "github.com/gofiber/fiber/v3/middleware/csrf"
-    "github.com/gofiber/fiber/v3/middleware/session"
-)
-
-func main() {
-    app := fiber.New()
-
-    storage := sqlite3.New()
-    sessionMiddleware, sessionStore := session.NewWithStore(session.Config{
-        Storage: storage,
-    })
-
-    app.Use(sessionMiddleware)
-    app.Use(csrf.New(csrf.Config{
-        Session: sessionStore,
-    }))
-
-    app.Listen(":3000")
-}
-```
-
-### Session Without Middleware Handler
-
-```go
-package main
-
-import (
-    "github.com/gofiber/fiber/v3"
-    "github.com/gofiber/fiber/v3/middleware/csrf"
-    "github.com/gofiber/fiber/v3/middleware/session"
-)
-
-func main() {
-    app := fiber.New()
-
-    sessionStore := session.NewStore()
-
-    app.Use(csrf.New(csrf.Config{
-        Session: sessionStore,
-    }))
-
-    app.Get("/", func(c fiber.Ctx) error {
-        sess, err := sessionStore.Get(c)
-        if err != nil {
-            return c.SendStatus(fiber.StatusInternalServerError)
-        }
-        defer sess.Release()
-
-        name, ok := sess.Get("name").(string)
-        if !ok {
-            return c.SendString("Welcome anonymous user!")
-        }
-
-        return c.SendString("Welcome " + name)
-    })
-
+    
+    // Login (preserve session data)
     app.Post("/login", func(c fiber.Ctx) error {
-        sess, err := sessionStore.Get(c)
-        if err != nil {
-            return c.SendStatus(fiber.StatusInternalServerError)
+        sess := session.FromContext(c)
+        
+        // Simple validation (implement proper authentication)
+        email := c.FormValue("email")
+        password := c.FormValue("password")
+        if email != "user@example.com" || password != "password" {
+            return c.Status(401).JSON(fiber.Map{"error": "Invalid credentials"})
         }
-        defer sess.Release()
-
-        if !sess.Fresh() {
-            if err := sess.Regenerate(); err != nil {
-                return c.SendStatus(fiber.StatusInternalServerError)
-            }
+        
+        // Regenerate session ID for security
+        // This changes the session ID while preserving existing data
+        if err := sess.Regenerate(); err != nil {
+            return c.Status(500).JSON(fiber.Map{"error": "Session error"})
         }
-
-        sess.Set("name", "John Doe")
-
-        err = sess.Save()
-        if err != nil {
-            return c.SendStatus(fiber.StatusInternalServerError)
-        }
-
-        return c.SendString("Logged in!")
+        
+        sess.Set("user_id", 1)
+        sess.Set("authenticated", true)
+        
+        return c.JSON(fiber.Map{"status": "logged in"})
     })
-
+    
+    // Logout (clear everything)
+    app.Post("/logout", func(c fiber.Ctx) error {
+        sess := session.FromContext(c)
+        
+        if err := sess.Reset(); err != nil {
+            return c.Status(500).JSON(fiber.Map{"error": "Session error"})
+        }
+        
+        return c.JSON(fiber.Map{"status": "logged out"})
+    })
+    
     app.Listen(":3000")
 }
-```
 
-### Custom Types in Session Data
-
-Session data can only be of the following types by default:
-
-- `string`
-- `int`
-- `int8`
-- `int16`
-- `int32`
-- `int64`
-- `uint`
-- `uint8`
-- `uint16`
-- `uint32`
-- `uint64`
-- `bool`
-- `float32`
-- `float64`
-- `[]byte`
-- `complex64`
-- `complex128`
-- `interface{}`
-
-To support other types in session data, you can register custom types. Here is an example of how to register a custom type:
-
-```go
-package main
-
-import (
-    "github.com/gofiber/fiber/v3"
-    "github.com/gofiber/fiber/v3/middleware/session"
-)
-
-type User struct {
-    Name string
-    Age  int
+// Helper functions (implement these properly in production)
+func isValidUser(email, password string) bool {
+    return email == "user@example.com" && password == "password"
 }
 
-func main() {
-    app := fiber.New()
-
-    sessionMiddleware, sessionStore := session.NewWithStore()
-    sessionStore.RegisterType(User{})
-
-    app.Use(sessionMiddleware)
-
-    app.Listen(":3000")
-}
-```
-
-## Config
-
-| Property              | Type                           | Description                                                                                | Default                   |
-|-----------------------|--------------------------------|--------------------------------------------------------------------------------------------|---------------------------|
-| **Storage**           | `fiber.Storage`                | Defines where session data is stored.                                                      | `nil` (in-memory storage) |
-| **Next**              | `func(c fiber.Ctx) bool`       | Function to skip this middleware under certain conditions.                                 | `nil`                     |
-| **ErrorHandler**      | `func(c fiber.Ctx, err error)` | Custom error handler for session middleware errors.                                        | `nil`                     |
-| **KeyGenerator**      | `func() string`                | Function to generate session IDs.                                                          | `UUID()`                  |
-| **KeyLookup**         | `string`                       | Key used to store session ID in cookie or header.                                          | `"cookie:session_id"`     |
-| **CookieDomain**      | `string`                       | The domain scope of the session cookie.                                                    | `""`                      |
-| **CookiePath**        | `string`                       | The path scope of the session cookie.                                                      | `"/"`                     |
-| **CookieSameSite**    | `string`                       | The SameSite attribute of the session cookie.                                              | `"Lax"`                   |
-| **IdleTimeout**       | `time.Duration`                | Maximum duration of inactivity before session expires.                                     | `30 * time.Minute`        |
-| **AbsoluteTimeout**   | `time.Duration`                | Maximum duration before session expires.                                                   | `0` (no expiration)       |
-| **CookieSecure**      | `bool`                         | Ensures session cookie is only sent over HTTPS.                                            | `false`                   |
-| **CookieHTTPOnly**    | `bool`                         | Ensures session cookie is not accessible to JavaScript (HTTP only).                        | `true`                    |
-| **CookieSessionOnly** | `bool`                         | Prevents session cookie from being saved after the session ends (cookie expires on close). | `false`                   |
-
-## Default Config
-
-```go
-session.Config{
-    Storage:           memory.New(),
-    Next:              nil,
-    Store:             nil,
-    ErrorHandler:      nil,
-    KeyGenerator:      utils.UUIDv4,
-    KeyLookup:         "cookie:session_id",
-    CookieDomain:      "",
-    CookiePath:        "",
-    CookieSameSite:    "Lax",
-    IdleTimeout:       30 * time.Minute,
-    AbsoluteTimeout:   0,
-    CookieSecure:      false,
-    CookieHTTPOnly:    false,
-    CookieSessionOnly: false,
+func getUserID(email string) int {
+    return 1 // Return actual user ID from database
 }
 ```

--- a/docs/middleware/session.md
+++ b/docs/middleware/session.md
@@ -32,20 +32,17 @@ app.Use(session.New())
 app.Get("/", func(c fiber.Ctx) error {
     sess := session.FromContext(c)
     
-    // Get session data
-    visits := sess.Get("visits")
-    if visits == nil {
-        visits = 0
+    // Get and update visits count
+    var visits int
+    if v := sess.Get("visits"); v != nil {
+        // Use type assertion with an ok check to prevent a panic
+        if vInt, ok := v.(int); ok {
+            visits = vInt
+        }
     }
-    
-    // Set session data  
-    newVisits := 1
-    if visits != nil {
-        newVisits = visits.(int) + 1
-    }
-    sess.Set("visits", newVisits)
-    
-    return c.SendString(fmt.Sprintf("Visits: %d", newVisits))
+    visits++
+    sess.Set("visits", visits)
+    return c.SendString(fmt.Sprintf("Visits: %d", visits))
 })
 ```
 

--- a/docs/middleware/session.md
+++ b/docs/middleware/session.md
@@ -126,7 +126,7 @@ func backgroundTask(sessionID string) {
     
     // Manual save required
     if err := sess.Save(); err != nil {
-        log.Error("Failed to save session:", err)
+        log.Printf("Failed to save session: %v", err)
     }
 }
 ```

--- a/docs/middleware/session.md
+++ b/docs/middleware/session.md
@@ -15,7 +15,7 @@ The Session middleware provides robust session management for Fiber applications
 - [Configuration](#configuration)
 - [Migration Guide](#migration-guide)
 - [API Reference](#api-reference)
-- [Complete Examples](#complete-examples)
+- [Examples](#examples)
 
 ## Quick Start
 
@@ -676,22 +676,22 @@ session.Chain(extractors ...session.Extractor) session.Extractor
 
 ### Config Properties
 
-| Property | Type | Description | Default |
-|----------|------|-------------|---------|
-| `Storage` | `fiber.Storage` | Session storage backend | `memory.New()` |
-| `Extractor` | `session.Extractor` | Session ID extraction | `FromCookie("session_id")` |
-| `KeyGenerator` | `func() string` | Session ID generator | `utils.UUIDv4` |
-| `IdleTimeout` | `time.Duration` | Inactivity timeout | `30 * time.Minute` |
-| `AbsoluteTimeout` | `time.Duration` | Maximum session duration | `0` (unlimited) |
-| `CookieSecure` | `bool` | HTTPS only | `false` |
-| `CookieHTTPOnly` | `bool` | No JavaScript access | `false` |
-| `CookieSameSite` | `string` | SameSite attribute | `"Lax"` |
-| `CookiePath` | `string` | Cookie path | `""` |
-| `CookieDomain` | `string` | Cookie domain | `""` |
-| `CookieSessionOnly` | `bool` | Session cookie | `false` |
-| `ErrorHandler` | `func(fiber.Ctx, error)` | Error callback | `DefaultErrorHandler` |
+| Property            | Type                        | Description                 | Default                   |
+|---------------------|-----------------------------|-----------------------------|---------------------------|
+| `Storage`           | `fiber.Storage`             | Session storage backend     | `memory.New()`            |
+| `Extractor`         | `session.Extractor`         | Session ID extraction       | `FromCookie("session_id")`|
+| `KeyGenerator`      | `func() string`             | Session ID generator        | `utils.UUIDv4`            |
+| `IdleTimeout`       | `time.Duration`             | Inactivity timeout          | `30 * time.Minute`        |
+| `AbsoluteTimeout`   | `time.Duration`             | Maximum session duration    | `0` (unlimited)           |
+| `CookieSecure`      | `bool`                      | HTTPS only                  | `false`                   |
+| `CookieHTTPOnly`    | `bool`                      | No JavaScript access        | `false`                   |
+| `CookieSameSite`    | `string`                    | SameSite attribute          | `"Lax"`                   |
+| `CookiePath`        | `string`                    | Cookie path                 | `""`                      |
+| `CookieDomain`      | `string`                    | Cookie domain               | `""`                      |
+| `CookieSessionOnly` | `bool`                      | Session cookie              | `false`                   |
+| `ErrorHandler`      | `func(fiber.Ctx, error)`    | Error callback              | `DefaultErrorHandler`     |
 
-## Complete Examples
+## Examples
 
 ### E-commerce with Cart Persistence
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1314,7 +1314,7 @@ The session middleware has undergone significant improvements in v3, focusing on
 
 #### Key Changes
 
-**Extractor Pattern**: The string-based `KeyLookup` configuration has been replaced with a more flexible and type-safe `Extractor` function pattern, similar to the CSRF middleware.
+**Extractor Pattern**: The string-based `KeyLookup` configuration has been replaced with a more flexible and type-safe `Extractor` function pattern.
 
 - **New Middleware Handler**: The `New` function now returns a middleware handler instead of a `*Store`. To access the session store, use the `Store` method on the middleware, or opt for `NewStore` or `NewWithStore` for custom store integration.
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1306,6 +1306,14 @@ The Session middleware has undergone key changes in v3 to improve functionality 
 
 #### Key Updates
 
+### Session
+
+The session middleware has undergone significant improvements in v3, focusing on type safety, flexibility, and better developer experience.
+
+#### Key Changes
+
+**Extractor Pattern**: The string-based `KeyLookup` configuration has been replaced with a more flexible and type-safe `Extractor` function pattern, similar to the CSRF middleware.
+
 - **New Middleware Handler**: The `New` function now returns a middleware handler instead of a `*Store`. To access the session store, use the `Store` method on the middleware, or opt for `NewStore` or `NewWithStore` for custom store integration.
 
 - **Manual Session Release**: Session instances are no longer automatically released after being saved. To ensure proper lifecycle management, you must manually call `sess.Release()`.

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -76,7 +76,7 @@ func Test_CSRF_WithSession(t *testing.T) {
 
 	// session store
 	store := session.NewStore(session.Config{
-		KeyLookup: "cookie:_session",
+		Extractor: session.FromCookie("_session"),
 	})
 
 	// fiber instance
@@ -274,7 +274,7 @@ func Test_CSRF_ExpiredToken_WithSession(t *testing.T) {
 
 	// session store
 	store := session.NewStore(session.Config{
-		KeyLookup: "cookie:_session",
+		Extractor: session.FromCookie("_session"),
 	})
 
 	// fiber instance
@@ -1090,7 +1090,7 @@ func Test_CSRF_DeleteToken_WithSession(t *testing.T) {
 
 	// session store
 	store := session.NewStore(session.Config{
-		KeyLookup: "cookie:_session",
+		Extractor: session.FromCookie("_session"),
 	})
 
 	// fiber instance

--- a/middleware/session/config.go
+++ b/middleware/session/config.go
@@ -55,7 +55,7 @@ type Config struct {
 	CookieSameSite string
 
 	// sessionName is the name of the session for cookie/header setting.
-	// This is extracted from the Extractor configuration or defaults to "session_id".
+	// This is used when setting the session cookie and should match the extractor's key if it's cookie-based.
 	sessionName string
 
 	// IdleTimeout defines the maximum duration of inactivity before the session expires.

--- a/middleware/session/config.go
+++ b/middleware/session/config.go
@@ -10,7 +10,6 @@ import (
 
 // Config defines the configuration for the session middleware.
 type Config struct {
-
 	// Storage interface for storing session data.
 	//
 	// Optional. Default: memory.New()

--- a/middleware/session/config_test.go
+++ b/middleware/session/config_test.go
@@ -13,25 +13,25 @@ func TestConfigDefault(t *testing.T) {
 	// Test default config
 	cfg := configDefault()
 	require.Equal(t, 30*time.Minute, cfg.IdleTimeout)
-	require.Equal(t, "cookie:session_id", cfg.KeyLookup)
 	require.NotNil(t, cfg.KeyGenerator)
-	require.Equal(t, SourceCookie, cfg.source)
+	require.NotNil(t, cfg.Extractor)
 	require.Equal(t, "session_id", cfg.sessionName)
+	require.Equal(t, "Lax", cfg.CookieSameSite)
 }
 
 func TestConfigDefaultWithCustomConfig(t *testing.T) {
 	// Test custom config
 	customConfig := Config{
 		IdleTimeout:  48 * time.Hour,
-		KeyLookup:    "header:custom_session_id",
+		Extractor:    FromHeader("X-Custom-Session"),
 		KeyGenerator: func() string { return "custom_key" },
+		sessionName:  "custom_session",
 	}
 	cfg := configDefault(customConfig)
 	require.Equal(t, 48*time.Hour, cfg.IdleTimeout)
-	require.Equal(t, "header:custom_session_id", cfg.KeyLookup)
 	require.NotNil(t, cfg.KeyGenerator)
-	require.Equal(t, SourceHeader, cfg.source)
-	require.Equal(t, "custom_session_id", cfg.sessionName)
+	require.NotNil(t, cfg.Extractor)
+	require.Equal(t, "custom_session", cfg.sessionName)
 }
 
 func TestDefaultErrorHandler(t *testing.T) {
@@ -46,14 +46,11 @@ func TestDefaultErrorHandler(t *testing.T) {
 	require.Equal(t, fiber.StatusInternalServerError, ctx.Response().StatusCode())
 }
 
-func TestInvalidKeyLookupFormat(t *testing.T) {
-	require.PanicsWithValue(t, "[session] KeyLookup must be in the format '<source>:<name>'", func() {
-		configDefault(Config{KeyLookup: "invalid_format"})
-	})
-}
-
-func TestUnsupportedSource(t *testing.T) {
-	require.PanicsWithValue(t, "[session] unsupported source in KeyLookup", func() {
-		configDefault(Config{KeyLookup: "unsupported:session_id"})
+func TestAbsoluteTimeoutValidation(t *testing.T) {
+	require.PanicsWithValue(t, "[session] AbsoluteTimeout must be greater than or equal to IdleTimeout", func() {
+		configDefault(Config{
+			IdleTimeout:     30 * time.Minute,
+			AbsoluteTimeout: 15 * time.Minute, // Less than IdleTimeout
+		})
 	})
 }

--- a/middleware/session/config_test.go
+++ b/middleware/session/config_test.go
@@ -15,7 +15,7 @@ func TestConfigDefault(t *testing.T) {
 	require.Equal(t, 30*time.Minute, cfg.IdleTimeout)
 	require.NotNil(t, cfg.KeyGenerator)
 	require.NotNil(t, cfg.Extractor)
-	require.Equal(t, "session_id", cfg.sessionName)
+	require.Equal(t, "session_id", cfg.Extractor.Key)
 	require.Equal(t, "Lax", cfg.CookieSameSite)
 }
 
@@ -25,13 +25,12 @@ func TestConfigDefaultWithCustomConfig(t *testing.T) {
 		IdleTimeout:  48 * time.Hour,
 		Extractor:    FromHeader("X-Custom-Session"),
 		KeyGenerator: func() string { return "custom_key" },
-		sessionName:  "custom_session",
 	}
 	cfg := configDefault(customConfig)
 	require.Equal(t, 48*time.Hour, cfg.IdleTimeout)
 	require.NotNil(t, cfg.KeyGenerator)
 	require.NotNil(t, cfg.Extractor)
-	require.Equal(t, "custom_session", cfg.sessionName)
+	require.Equal(t, "X-Custom-Session", cfg.Extractor.Key)
 }
 
 func TestDefaultErrorHandler(t *testing.T) {

--- a/middleware/session/extractors.go
+++ b/middleware/session/extractors.go
@@ -100,4 +100,3 @@ func Chain(extractors ...func(fiber.Ctx) (string, error)) func(fiber.Ctx) (strin
 		return "", ErrMissingSessionID
 	}
 }
-}

--- a/middleware/session/extractors.go
+++ b/middleware/session/extractors.go
@@ -7,6 +7,7 @@ import (
 )
 
 var (
+	ErrMissingSessionID         = errors.New("missing session id")
 	ErrMissingSessionIDInHeader = errors.New("missing session id in header")
 	ErrMissingSessionIDInQuery  = errors.New("missing session id in query")
 	ErrMissingSessionIDInParam  = errors.New("missing session id in param")
@@ -74,7 +75,7 @@ func FromQuery(param string) func(c fiber.Ctx) (string, error) {
 func Chain(extractors ...func(fiber.Ctx) (string, error)) func(fiber.Ctx) (string, error) {
 	if len(extractors) == 0 {
 		return func(fiber.Ctx) (string, error) {
-			return "", ErrMissingSessionIDInCookie // Default fallback error
+			return "", ErrMissingSessionID // Default fallback error
 		}
 	}
 
@@ -93,10 +94,10 @@ func Chain(extractors ...func(fiber.Ctx) (string, error)) func(fiber.Ctx) (strin
 				lastErr = err
 			}
 		}
-
 		if lastErr != nil {
 			return "", lastErr
 		}
-		return "", ErrMissingSessionIDInCookie
+		return "", ErrMissingSessionID
 	}
+}
 }

--- a/middleware/session/extractors.go
+++ b/middleware/session/extractors.go
@@ -72,6 +72,8 @@ func FromQuery(param string) func(c fiber.Ctx) (string, error) {
 
 // Chain tries multiple extractors in order until one succeeds.
 // Returns the first successful extraction or the last error encountered.
+// If no extractors are provided, the returned function always fails with ErrMissingSessionID.
+// otherwise, returns ErrMissingSessionID if all extractors returned empty strings without errors.
 func Chain(extractors ...func(fiber.Ctx) (string, error)) func(fiber.Ctx) (string, error) {
 	if len(extractors) == 0 {
 		return func(fiber.Ctx) (string, error) {

--- a/middleware/session/extractors.go
+++ b/middleware/session/extractors.go
@@ -1,0 +1,102 @@
+package session
+
+import (
+	"errors"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+var (
+	ErrMissingSessionIDInHeader = errors.New("missing session id in header")
+	ErrMissingSessionIDInQuery  = errors.New("missing session id in query")
+	ErrMissingSessionIDInParam  = errors.New("missing session id in param")
+	ErrMissingSessionIDInForm   = errors.New("missing session id in form")
+	ErrMissingSessionIDInCookie = errors.New("missing session id in cookie")
+)
+
+// FromCookie returns a function that extracts session ID from the request cookie.
+func FromCookie(key string) func(c fiber.Ctx) (string, error) {
+	return func(c fiber.Ctx) (string, error) {
+		sessionID := c.Cookies(key)
+		if sessionID == "" {
+			return "", ErrMissingSessionIDInCookie
+		}
+		return sessionID, nil
+	}
+}
+
+// FromParam returns a function that extracts session ID from the url param string.
+func FromParam(param string) func(c fiber.Ctx) (string, error) {
+	return func(c fiber.Ctx) (string, error) {
+		sessionID := c.Params(param)
+		if sessionID == "" {
+			return "", ErrMissingSessionIDInParam
+		}
+		return sessionID, nil
+	}
+}
+
+// FromForm returns a function that extracts session ID from a multipart-form.
+func FromForm(param string) func(c fiber.Ctx) (string, error) {
+	return func(c fiber.Ctx) (string, error) {
+		sessionID := c.FormValue(param)
+		if sessionID == "" {
+			return "", ErrMissingSessionIDInForm
+		}
+		return sessionID, nil
+	}
+}
+
+// FromHeader returns a function that extracts session ID from the request header.
+func FromHeader(param string) func(c fiber.Ctx) (string, error) {
+	return func(c fiber.Ctx) (string, error) {
+		sessionID := c.Get(param)
+		if sessionID == "" {
+			return "", ErrMissingSessionIDInHeader
+		}
+		return sessionID, nil
+	}
+}
+
+// FromQuery returns a function that extracts session ID from the query string.
+func FromQuery(param string) func(c fiber.Ctx) (string, error) {
+	return func(c fiber.Ctx) (string, error) {
+		sessionID := fiber.Query[string](c, param)
+		if sessionID == "" {
+			return "", ErrMissingSessionIDInQuery
+		}
+		return sessionID, nil
+	}
+}
+
+// Chain tries multiple extractors in order until one succeeds.
+// Returns the first successful extraction or the last error encountered.
+func Chain(extractors ...func(fiber.Ctx) (string, error)) func(fiber.Ctx) (string, error) {
+	if len(extractors) == 0 {
+		return func(fiber.Ctx) (string, error) {
+			return "", ErrMissingSessionIDInCookie // Default fallback error
+		}
+	}
+
+	return func(c fiber.Ctx) (string, error) {
+		var lastErr error
+
+		for _, extractor := range extractors {
+			sessionID, err := extractor(c)
+
+			if err == nil && sessionID != "" {
+				return sessionID, nil
+			}
+
+			// Only update lastErr if we got an actual error
+			if err != nil {
+				lastErr = err
+			}
+		}
+
+		if lastErr != nil {
+			return "", lastErr
+		}
+		return "", ErrMissingSessionIDInCookie
+	}
+}

--- a/middleware/session/extractors.go
+++ b/middleware/session/extractors.go
@@ -6,6 +6,21 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
+type Source int
+
+const (
+	SourceCookie Source = iota
+	SourceHeader
+	SourceOther // For query, form, param, or custom extractors
+)
+
+type Extractor struct {
+	Extract func(fiber.Ctx) (string, error)
+	Key     string
+	Chain   []Extractor // For chaining multiple extractors
+	Source  Source
+}
+
 var (
 	ErrMissingSessionID         = errors.New("missing session id")
 	ErrMissingSessionIDInHeader = errors.New("missing session id in header")
@@ -15,90 +30,123 @@ var (
 	ErrMissingSessionIDInCookie = errors.New("missing session id in cookie")
 )
 
-// FromCookie returns a function that extracts session ID from the request cookie.
-func FromCookie(key string) func(c fiber.Ctx) (string, error) {
-	return func(c fiber.Ctx) (string, error) {
-		sessionID := c.Cookies(key)
-		if sessionID == "" {
-			return "", ErrMissingSessionIDInCookie
-		}
-		return sessionID, nil
+// FromCookie returns an extractor that extracts session ID from the request cookie.
+func FromCookie(key string) Extractor {
+	return Extractor{
+		Extract: func(c fiber.Ctx) (string, error) {
+			sessionID := c.Cookies(key)
+			if sessionID == "" {
+				return "", ErrMissingSessionIDInCookie
+			}
+			return sessionID, nil
+		},
+		Source: SourceCookie,
+		Key:    key,
 	}
 }
 
-// FromParam returns a function that extracts session ID from the url param string.
-func FromParam(param string) func(c fiber.Ctx) (string, error) {
-	return func(c fiber.Ctx) (string, error) {
-		sessionID := c.Params(param)
-		if sessionID == "" {
-			return "", ErrMissingSessionIDInParam
-		}
-		return sessionID, nil
+// FromParam returns an extractor that extracts session ID from the url param string.
+func FromParam(param string) Extractor {
+	return Extractor{
+		Extract: func(c fiber.Ctx) (string, error) {
+			sessionID := c.Params(param)
+			if sessionID == "" {
+				return "", ErrMissingSessionIDInParam
+			}
+			return sessionID, nil
+		},
+		Source: SourceOther,
+		Key:    param,
 	}
 }
 
-// FromForm returns a function that extracts session ID from a multipart-form.
-func FromForm(param string) func(c fiber.Ctx) (string, error) {
-	return func(c fiber.Ctx) (string, error) {
-		sessionID := c.FormValue(param)
-		if sessionID == "" {
-			return "", ErrMissingSessionIDInForm
-		}
-		return sessionID, nil
+// FromForm returns an extractor that extracts session ID from a multipart-form.
+func FromForm(param string) Extractor {
+	return Extractor{
+		Extract: func(c fiber.Ctx) (string, error) {
+			sessionID := c.FormValue(param)
+			if sessionID == "" {
+				return "", ErrMissingSessionIDInForm
+			}
+			return sessionID, nil
+		},
+		Source: SourceOther,
+		Key:    param,
 	}
 }
 
-// FromHeader returns a function that extracts session ID from the request header.
-func FromHeader(param string) func(c fiber.Ctx) (string, error) {
-	return func(c fiber.Ctx) (string, error) {
-		sessionID := c.Get(param)
-		if sessionID == "" {
-			return "", ErrMissingSessionIDInHeader
-		}
-		return sessionID, nil
+// FromHeader returns an extractor that extracts session ID from the request header.
+func FromHeader(param string) Extractor {
+	return Extractor{
+		Extract: func(c fiber.Ctx) (string, error) {
+			sessionID := c.Get(param)
+			if sessionID == "" {
+				return "", ErrMissingSessionIDInHeader
+			}
+			return sessionID, nil
+		},
+		Source: SourceHeader,
+		Key:    param,
 	}
 }
 
-// FromQuery returns a function that extracts session ID from the query string.
-func FromQuery(param string) func(c fiber.Ctx) (string, error) {
-	return func(c fiber.Ctx) (string, error) {
-		sessionID := fiber.Query[string](c, param)
-		if sessionID == "" {
-			return "", ErrMissingSessionIDInQuery
-		}
-		return sessionID, nil
+// FromQuery returns an extractor that extracts session ID from the query string.
+func FromQuery(param string) Extractor {
+	return Extractor{
+		Extract: func(c fiber.Ctx) (string, error) {
+			sessionID := fiber.Query[string](c, param)
+			if sessionID == "" {
+				return "", ErrMissingSessionIDInQuery
+			}
+			return sessionID, nil
+		},
+		Source: SourceOther,
+		Key:    param,
 	}
 }
 
 // Chain tries multiple extractors in order until one succeeds.
 // Returns the first successful extraction or the last error encountered.
-// If no extractors are provided, the returned function always fails with ErrMissingSessionID.
-// otherwise, returns ErrMissingSessionID if all extractors returned empty strings without errors.
-func Chain(extractors ...func(fiber.Ctx) (string, error)) func(fiber.Ctx) (string, error) {
+// If no extractors are provided, the returned extractor always fails with ErrMissingSessionID.
+func Chain(extractors ...Extractor) Extractor {
 	if len(extractors) == 0 {
-		return func(fiber.Ctx) (string, error) {
-			return "", ErrMissingSessionID // Default fallback error
+		return Extractor{
+			Extract: func(fiber.Ctx) (string, error) {
+				return "", ErrMissingSessionID
+			},
+			Source: SourceOther,
+			Key:    "",
+			Chain:  []Extractor{},
 		}
 	}
 
-	return func(c fiber.Ctx) (string, error) {
-		var lastErr error
+	// Use the source and key from the first extractor as the primary
+	primarySource := extractors[0].Source
+	primaryKey := extractors[0].Key
 
-		for _, extractor := range extractors {
-			sessionID, err := extractor(c)
+	return Extractor{
+		Extract: func(c fiber.Ctx) (string, error) {
+			var lastErr error
 
-			if err == nil && sessionID != "" {
-				return sessionID, nil
+			for _, extractor := range extractors {
+				sessionID, err := extractor.Extract(c)
+
+				if err == nil && sessionID != "" {
+					return sessionID, nil
+				}
+
+				// Only update lastErr if we got an actual error
+				if err != nil {
+					lastErr = err
+				}
 			}
-
-			// Only update lastErr if we got an actual error
-			if err != nil {
-				lastErr = err
+			if lastErr != nil {
+				return "", lastErr
 			}
-		}
-		if lastErr != nil {
-			return "", lastErr
-		}
-		return "", ErrMissingSessionID
+			return "", ErrMissingSessionID
+		},
+		Source: primarySource,
+		Key:    primaryKey,
+		Chain:  extractors,
 	}
 }

--- a/middleware/session/extractors_test.go
+++ b/middleware/session/extractors_test.go
@@ -31,7 +31,7 @@ func TestFromCookie(t *testing.T) {
 
 		ctx.Request().Header.SetCookie("session_id", "test-session-id")
 
-		sessionID, err := extractor(ctx)
+		sessionID, err := extractor.Extract(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "test-session-id", sessionID)
 	})
@@ -41,7 +41,7 @@ func TestFromCookie(t *testing.T) {
 		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
 		defer app.ReleaseCtx(ctx)
 
-		sessionID, err := extractor(ctx)
+		sessionID, err := extractor.Extract(ctx)
 		require.Error(t, err)
 		require.Equal(t, ErrMissingSessionIDInCookie, err)
 		require.Empty(t, sessionID)
@@ -60,7 +60,7 @@ func TestFromHeader(t *testing.T) {
 
 		ctx.Request().Header.Set("X-Session-ID", "test-session-id")
 
-		sessionID, err := extractor(ctx)
+		sessionID, err := extractor.Extract(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "test-session-id", sessionID)
 	})
@@ -70,7 +70,7 @@ func TestFromHeader(t *testing.T) {
 		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
 		defer app.ReleaseCtx(ctx)
 
-		sessionID, err := extractor(ctx)
+		sessionID, err := extractor.Extract(ctx)
 		require.Error(t, err)
 		require.Equal(t, ErrMissingSessionIDInHeader, err)
 		require.Empty(t, sessionID)
@@ -89,7 +89,7 @@ func TestFromQuery(t *testing.T) {
 
 		ctx.Request().SetRequestURI("/test?session_id=test-session-id")
 
-		sessionID, err := extractor(ctx)
+		sessionID, err := extractor.Extract(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "test-session-id", sessionID)
 	})
@@ -101,7 +101,7 @@ func TestFromQuery(t *testing.T) {
 
 		ctx.Request().SetRequestURI("/test")
 
-		sessionID, err := extractor(ctx)
+		sessionID, err := extractor.Extract(ctx)
 		require.Error(t, err)
 		require.Equal(t, ErrMissingSessionIDInQuery, err)
 		require.Empty(t, sessionID)
@@ -122,7 +122,7 @@ func TestFromForm(t *testing.T) {
 		ctx.Request().Header.SetContentType("application/x-www-form-urlencoded")
 		ctx.Request().SetBodyString("session_id=test-session-id")
 
-		sessionID, err := extractor(ctx)
+		sessionID, err := extractor.Extract(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "test-session-id", sessionID)
 	})
@@ -136,7 +136,7 @@ func TestFromForm(t *testing.T) {
 		ctx.Request().Header.SetContentType("application/x-www-form-urlencoded")
 		ctx.Request().SetBodyString("other_field=value")
 
-		sessionID, err := extractor(ctx)
+		sessionID, err := extractor.Extract(ctx)
 		require.Error(t, err)
 		require.Equal(t, ErrMissingSessionIDInForm, err)
 		require.Empty(t, sessionID)
@@ -149,7 +149,7 @@ func TestFromParam(t *testing.T) {
 
 	// FromParam
 	app.Get("/test/:csrf", func(c fiber.Ctx) error {
-		token, err := FromParam("csrf")(c)
+		token, err := FromParam("csrf").Extract(c)
 		require.NoError(t, err)
 		require.Equal(t, "token_from_param", token)
 		return nil
@@ -181,7 +181,7 @@ func TestChain(t *testing.T) {
 			FromHeader("X-Session-ID"),
 		)
 
-		sessionID, err := extractor(ctx)
+		sessionID, err := extractor.Extract(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "cookie-session-id", sessionID) // First extractor wins
 	})
@@ -198,7 +198,7 @@ func TestChain(t *testing.T) {
 			FromHeader("X-Session-ID"),
 		)
 
-		sessionID, err := extractor(ctx)
+		sessionID, err := extractor.Extract(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "header-session-id", sessionID)
 	})
@@ -213,7 +213,7 @@ func TestChain(t *testing.T) {
 			FromHeader("X-Session-ID"),
 		)
 
-		sessionID, err := extractor(ctx)
+		sessionID, err := extractor.Extract(ctx)
 		require.Error(t, err)
 		require.Empty(t, sessionID)
 	})
@@ -225,7 +225,7 @@ func TestChain(t *testing.T) {
 
 		extractor := Chain()
 
-		sessionID, err := extractor(ctx)
+		sessionID, err := extractor.Extract(ctx)
 		require.Error(t, err)
 		require.Equal(t, ErrMissingSessionID, err)
 		require.Empty(t, sessionID)

--- a/middleware/session/extractors_test.go
+++ b/middleware/session/extractors_test.go
@@ -109,38 +109,38 @@ func TestFromQuery(t *testing.T) {
 }
 
 func TestFromForm(t *testing.T) {
-    t.Parallel()
-    app := fiber.New()
-    extractor := FromForm("session_id")
+	t.Parallel()
+	app := fiber.New()
+	extractor := FromForm("session_id")
 
-    t.Run("success", func(t *testing.T) {
-        t.Parallel()
-        ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
-        defer app.ReleaseCtx(ctx)
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
 
-        ctx.Request().Header.SetMethod("POST")
-        ctx.Request().Header.SetContentType("application/x-www-form-urlencoded")
-        ctx.Request().SetBodyString("session_id=test-session-id")
+		ctx.Request().Header.SetMethod("POST")
+		ctx.Request().Header.SetContentType("application/x-www-form-urlencoded")
+		ctx.Request().SetBodyString("session_id=test-session-id")
 
-        sessionID, err := extractor(ctx)
-        require.NoError(t, err)
-        require.Equal(t, "test-session-id", sessionID)
-    })
+		sessionID, err := extractor(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "test-session-id", sessionID)
+	})
 
-    t.Run("missing form field", func(t *testing.T) {
-        t.Parallel()
-        ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
-        defer app.ReleaseCtx(ctx)
+	t.Run("missing form field", func(t *testing.T) {
+		t.Parallel()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
 
-        ctx.Request().Header.SetMethod("POST")
-        ctx.Request().Header.SetContentType("application/x-www-form-urlencoded")
-        ctx.Request().SetBodyString("other_field=value")
+		ctx.Request().Header.SetMethod("POST")
+		ctx.Request().Header.SetContentType("application/x-www-form-urlencoded")
+		ctx.Request().SetBodyString("other_field=value")
 
-        sessionID, err := extractor(ctx)
-        require.Error(t, err)
-        require.Equal(t, ErrMissingSessionIDInForm, err)
-        require.Empty(t, sessionID)
-    })
+		sessionID, err := extractor(ctx)
+		require.Error(t, err)
+		require.Equal(t, ErrMissingSessionIDInForm, err)
+		require.Empty(t, sessionID)
+	})
 }
 
 func TestFromParam(t *testing.T) {

--- a/middleware/session/extractors_test.go
+++ b/middleware/session/extractors_test.go
@@ -1,0 +1,218 @@
+package session
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// newRequest creates a new *http.Request for Fiber's app.Test
+func newRequest(method, target string) *http.Request {
+	req, err := http.NewRequestWithContext(context.Background(), method, target, nil)
+	if err != nil {
+		panic(err)
+	}
+	return req
+}
+
+func TestFromCookie(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	extractor := FromCookie("session_id")
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		ctx.Request().Header.SetCookie("session_id", "test-session-id")
+
+		sessionID, err := extractor(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "test-session-id", sessionID)
+	})
+
+	t.Run("missing cookie", func(t *testing.T) {
+		t.Parallel()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		sessionID, err := extractor(ctx)
+		require.Error(t, err)
+		require.Equal(t, ErrMissingSessionIDInCookie, err)
+		require.Empty(t, sessionID)
+	})
+}
+
+func TestFromHeader(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	extractor := FromHeader("X-Session-ID")
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		ctx.Request().Header.Set("X-Session-ID", "test-session-id")
+
+		sessionID, err := extractor(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "test-session-id", sessionID)
+	})
+
+	t.Run("missing header", func(t *testing.T) {
+		t.Parallel()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		sessionID, err := extractor(ctx)
+		require.Error(t, err)
+		require.Equal(t, ErrMissingSessionIDInHeader, err)
+		require.Empty(t, sessionID)
+	})
+}
+
+func TestFromQuery(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	extractor := FromQuery("session_id")
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		ctx.Request().SetRequestURI("/test?session_id=test-session-id")
+
+		sessionID, err := extractor(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "test-session-id", sessionID)
+	})
+
+	t.Run("missing query param", func(t *testing.T) {
+		t.Parallel()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		ctx.Request().SetRequestURI("/test")
+
+		sessionID, err := extractor(ctx)
+		require.Error(t, err)
+		require.Equal(t, ErrMissingSessionIDInQuery, err)
+		require.Empty(t, sessionID)
+	})
+}
+
+func TestFromForm(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	extractor := FromForm("session_id")
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		ctx.Request().Header.SetMethod("POST")
+		ctx.Request().Header.SetContentType("application/x-www-form-urlencoded")
+		ctx.Request().SetBodyString("session_id=test-session-id")
+
+		sessionID, err := extractor(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "test-session-id", sessionID)
+	})
+}
+
+func TestFromParam(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	// FromParam
+	app.Get("/test/:csrf", func(c fiber.Ctx) error {
+		token, err := FromParam("csrf")(c)
+		require.NoError(t, err)
+		require.Equal(t, "token_from_param", token)
+		return nil
+	})
+
+	// Note: This test is more complex as it requires route setup
+	// In a real scenario, you'd set up a route with parameters
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		_, err := app.Test(newRequest(fiber.MethodGet, "/test/token_from_param"))
+		require.NoError(t, err)
+	})
+}
+
+func TestChain(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	t.Run("first extractor succeeds", func(t *testing.T) {
+		t.Parallel()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		ctx.Request().Header.SetCookie("session_id", "cookie-session-id")
+		ctx.Request().Header.Set("X-Session-ID", "header-session-id")
+
+		extractor := Chain(
+			FromCookie("session_id"),
+			FromHeader("X-Session-ID"),
+		)
+
+		sessionID, err := extractor(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "cookie-session-id", sessionID) // First extractor wins
+	})
+
+	t.Run("second extractor succeeds", func(t *testing.T) {
+		t.Parallel()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		ctx.Request().Header.Set("X-Session-ID", "header-session-id")
+
+		extractor := Chain(
+			FromCookie("session_id"),
+			FromHeader("X-Session-ID"),
+		)
+
+		sessionID, err := extractor(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "header-session-id", sessionID)
+	})
+
+	t.Run("all extractors fail", func(t *testing.T) {
+		t.Parallel()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		extractor := Chain(
+			FromCookie("session_id"),
+			FromHeader("X-Session-ID"),
+		)
+
+		sessionID, err := extractor(ctx)
+		require.Error(t, err)
+		require.Empty(t, sessionID)
+	})
+
+	t.Run("empty chain", func(t *testing.T) {
+		t.Parallel()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		extractor := Chain()
+
+		sessionID, err := extractor(ctx)
+		require.Error(t, err)
+		require.Equal(t, ErrMissingSessionIDInCookie, err)
+		require.Empty(t, sessionID)
+	})
+}

--- a/middleware/session/extractors_test.go
+++ b/middleware/session/extractors_test.go
@@ -109,23 +109,38 @@ func TestFromQuery(t *testing.T) {
 }
 
 func TestFromForm(t *testing.T) {
-	t.Parallel()
-	app := fiber.New()
-	extractor := FromForm("session_id")
+    t.Parallel()
+    app := fiber.New()
+    extractor := FromForm("session_id")
 
-	t.Run("success", func(t *testing.T) {
-		t.Parallel()
-		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
-		defer app.ReleaseCtx(ctx)
+    t.Run("success", func(t *testing.T) {
+        t.Parallel()
+        ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+        defer app.ReleaseCtx(ctx)
 
-		ctx.Request().Header.SetMethod("POST")
-		ctx.Request().Header.SetContentType("application/x-www-form-urlencoded")
-		ctx.Request().SetBodyString("session_id=test-session-id")
+        ctx.Request().Header.SetMethod("POST")
+        ctx.Request().Header.SetContentType("application/x-www-form-urlencoded")
+        ctx.Request().SetBodyString("session_id=test-session-id")
 
-		sessionID, err := extractor(ctx)
-		require.NoError(t, err)
-		require.Equal(t, "test-session-id", sessionID)
-	})
+        sessionID, err := extractor(ctx)
+        require.NoError(t, err)
+        require.Equal(t, "test-session-id", sessionID)
+    })
+
+    t.Run("missing form field", func(t *testing.T) {
+        t.Parallel()
+        ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+        defer app.ReleaseCtx(ctx)
+
+        ctx.Request().Header.SetMethod("POST")
+        ctx.Request().Header.SetContentType("application/x-www-form-urlencoded")
+        ctx.Request().SetBodyString("other_field=value")
+
+        sessionID, err := extractor(ctx)
+        require.Error(t, err)
+        require.Equal(t, ErrMissingSessionIDInForm, err)
+        require.Empty(t, sessionID)
+    })
 }
 
 func TestFromParam(t *testing.T) {

--- a/middleware/session/extractors_test.go
+++ b/middleware/session/extractors_test.go
@@ -212,7 +212,7 @@ func TestChain(t *testing.T) {
 
 		sessionID, err := extractor(ctx)
 		require.Error(t, err)
-		require.Equal(t, ErrMissingSessionIDInCookie, err)
+		require.Equal(t, ErrMissingSessionID, err)
 		require.Empty(t, sessionID)
 	})
 }

--- a/middleware/session/middleware.go
+++ b/middleware/session/middleware.go
@@ -303,6 +303,24 @@ func (m *Middleware) Reset() error {
 	return m.Session.Reset()
 }
 
+// Regenerate generates a new session ID while preserving session data.
+//
+// This method is commonly used after authentication to prevent session fixation attacks.
+// Unlike Reset(), this method preserves all existing session data.
+//
+// Returns:
+//   - error: An error if the regeneration fails.
+//
+// Usage:
+//
+//	err := m.Regenerate()
+func (m *Middleware) Regenerate() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.Session.Regenerate()
+}
+
 // Store returns the session store.
 //
 // Returns:

--- a/middleware/session/middleware_test.go
+++ b/middleware/session/middleware_test.go
@@ -56,7 +56,41 @@ func Test_Session_Middleware(t *testing.T) {
 		if sess == nil {
 			return c.SendStatus(fiber.StatusInternalServerError)
 		}
+
+		// Set a value to ensure it is cleared after reset
+		sess.Set("key", "value")
+
 		if err := sess.Reset(); err != nil {
+			return c.SendStatus(fiber.StatusInternalServerError)
+		}
+		// Ensure value is cleared
+		value, ok := sess.Get("key").(string)
+		if ok || value != "" {
+			return c.SendStatus(fiber.StatusInternalServerError)
+		}
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	app.Post("/regenerate", func(c fiber.Ctx) error {
+		sess := FromContext(c)
+		if sess == nil {
+			return c.SendStatus(fiber.StatusInternalServerError)
+		}
+		// Set a value to ensure it is preserved after regeneration
+		sess.Set("key", "value")
+
+		// Regenerate the session ID
+		if err := sess.Regenerate(); err != nil {
+			return c.SendStatus(fiber.StatusInternalServerError)
+		}
+		// Ensure the session ID has changed but session data is preserved
+		newID := sess.ID()
+		if newID == "" {
+			return c.SendStatus(fiber.StatusInternalServerError)
+		}
+		// Check if the session data is still accessible
+		value, ok := sess.Get("key").(string)
+		if !ok || value != "value" {
 			return c.SendStatus(fiber.StatusInternalServerError)
 		}
 		return c.SendStatus(fiber.StatusOK)
@@ -123,7 +157,7 @@ func Test_Session_Middleware(t *testing.T) {
 		return c.SendString("keys=" + strings.Join(strKeys, ","))
 	})
 
-	// Test GET, SET, DELETE, RESET, DESTROY by sending requests to the respective routes
+	// Test GET, SET, DELETE, RESET, REGENERATE, DESTROY by sending requests to the respective routes
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fiber.MethodGet)
 	ctx.Request.SetRequestURI("/get")
@@ -189,6 +223,23 @@ func Test_Session_Middleware(t *testing.T) {
 	newToken := string(ctx.Response.Header.Peek(fiber.HeaderSetCookie))
 	require.NotEmpty(t, newToken, "Expected Set-Cookie header to be present")
 	newTokenParts := strings.SplitN(strings.SplitN(newToken, ";", 2)[0], "=", 2)
+	require.Len(t, newTokenParts, 2, "Expected Set-Cookie header to contain a token")
+	newToken = newTokenParts[1]
+	require.NotEqual(t, token, newToken)
+	token = newToken
+
+	// Test POST /regenerate to regenerate the session ID
+	ctx.Request.Reset()
+	ctx.Response.Reset()
+	ctx.Request.Header.SetMethod(fiber.MethodPost)
+	ctx.Request.SetRequestURI("/regenerate")
+	ctx.Request.Header.SetCookie("session_id", token)
+	h(ctx)
+	require.Equal(t, fiber.StatusOK, ctx.Response.StatusCode())
+	// verify we have a new session token
+	newToken = string(ctx.Response.Header.Peek(fiber.HeaderSetCookie))
+	require.NotEmpty(t, newToken, "Expected Set-Cookie header to be present")
+	newTokenParts = strings.SplitN(strings.SplitN(newToken, ";", 2)[0], "=", 2)
 	require.Len(t, newTokenParts, 2, "Expected Set-Cookie header to contain a token")
 	newToken = newTokenParts[1]
 	require.NotEqual(t, token, newToken)
@@ -338,11 +389,10 @@ func Test_Session_WithConfig(t *testing.T) {
 			return c.Get("key") == "value"
 		},
 		IdleTimeout: 1 * time.Second,
-		KeyLookup:   "cookie:session_id_test",
+		Extractor:   FromCookie("session_id_test"),
 		KeyGenerator: func() string {
 			return "test"
 		},
-		source:      "cookie_test",
 		sessionName: "session_id_test",
 	}))
 

--- a/middleware/session/middleware_test.go
+++ b/middleware/session/middleware_test.go
@@ -393,7 +393,6 @@ func Test_Session_WithConfig(t *testing.T) {
 		KeyGenerator: func() string {
 			return "test"
 		},
-		sessionName: "session_id_test",
 	}))
 
 	app.Get("/", func(c fiber.Ctx) error {

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -384,11 +384,9 @@ func (s *Session) getExtractorInfo() []Extractor {
 				relevantExtractors = append(relevantExtractors, chainExtractor)
 			}
 		}
-	} else {
+	} else if extractor.Source == SourceCookie || extractor.Source == SourceHeader {
 		// Single extractor - only include if it's cookie or header
-		if extractor.Source == SourceCookie || extractor.Source == SourceHeader {
-			relevantExtractors = append(relevantExtractors, extractor)
-		}
+		relevantExtractors = append(relevantExtractors, extractor)
 	}
 
 	// If no cookie/header extractors found and the config has a store but no explicit cookie/header extractors,
@@ -453,7 +451,6 @@ func (s *Session) delSession() {
 			s.ctx.Response().Header.DelCookie(ext.Key)
 
 			fcookie := fasthttp.AcquireCookie()
-			defer fasthttp.ReleaseCookie(fcookie)
 
 			fcookie.SetKey(ext.Key)
 			fcookie.SetPath(s.config.CookiePath)
@@ -463,6 +460,7 @@ func (s *Session) delSession() {
 
 			s.setCookieAttributes(fcookie)
 			s.ctx.Response().Header.SetCookie(fcookie)
+			fasthttp.ReleaseCookie(fcookie)
 		case SourceOther:
 			// No action required for SourceOther
 		}

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -373,7 +373,7 @@ func (s *Session) setSession() {
 		return
 	}
 
-	// Always set the cookie, but also check if we need to set headers
+	// Always set the cookie.
 	// This is a simplified approach - for more complex scenarios,
 	// users can implement custom logic after session save
 	fcookie := fasthttp.AcquireCookie()

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -373,9 +373,10 @@ func (s *Session) setSession() {
 		return
 	}
 
-	// Always set the cookie.
-	// This is a simplified approach - for more complex scenarios,
-	// users can implement custom logic after session save
+	// Always set the cookie, even for sessions extracted from headers or other sources.
+	// This means a session will result in cookie creation regardless of how it was obtained,
+	// which may be unexpected for some use cases. For more complex scenarios,
+	// users can implement custom logic after session save.
 	fcookie := fasthttp.AcquireCookie()
 	fcookie.SetKey(s.config.sessionName)
 	fcookie.SetValue(s.id)

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -532,7 +532,7 @@ func Test_Session_Save(t *testing.T) {
 		t.Parallel()
 		// session store
 		store := NewStore(Config{
-			KeyLookup: "header:session_id",
+			Extractor: FromHeader("session_id"),
 		})
 		// fiber instance
 		app := fiber.New()
@@ -550,7 +550,6 @@ func Test_Session_Save(t *testing.T) {
 		err = sess.Save()
 		require.NoError(t, err)
 		require.Equal(t, store.getSessionID(ctx), string(ctx.Response().Header.Peek(store.sessionName)))
-		require.Equal(t, store.getSessionID(ctx), string(ctx.Request().Header.Peek(store.sessionName)))
 		sess.Release()
 	})
 }
@@ -728,7 +727,7 @@ func Test_Session_Destroy(t *testing.T) {
 		t.Parallel()
 		// session store
 		store := NewStore(Config{
-			KeyLookup: "header:session_id",
+			Extractor: FromHeader("session_id"),
 		})
 		// fiber instance
 		app := fiber.New()
@@ -759,7 +758,6 @@ func Test_Session_Destroy(t *testing.T) {
 		err = sess.Destroy()
 		require.NoError(t, err)
 		require.Equal(t, "", string(ctx.Response().Header.Peek(store.sessionName)))
-		require.Equal(t, "", string(ctx.Request().Header.Peek(store.sessionName)))
 	})
 }
 

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -38,8 +38,8 @@ func Test_Session(t *testing.T) {
 	app.ReleaseCtx(ctx)
 	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 
-	// set session
-	ctx.Request().Header.SetCookie(store.sessionName, token)
+	// set session using default cookie extractor
+	ctx.Request().Header.SetCookie("session_id", token)
 
 	// get session
 	sess, err = store.Get(ctx)
@@ -107,7 +107,7 @@ func Test_Session(t *testing.T) {
 	defer app.ReleaseCtx(ctx)
 
 	// request the server with the old session
-	ctx.Request().Header.SetCookie(store.sessionName, id)
+	ctx.Request().Header.SetCookie("session_id", id)
 	sess, err = store.Get(ctx)
 	defer sess.Release()
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func Test_Session_Types(t *testing.T) {
 	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
 
 	// set cookie
-	ctx.Request().Header.SetCookie(store.sessionName, "123")
+	ctx.Request().Header.SetCookie("session_id", "123")
 
 	// get session
 	sess, err := store.Get(ctx)
@@ -198,7 +198,7 @@ func Test_Session_Types(t *testing.T) {
 	app.ReleaseCtx(ctx)
 	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 
-	ctx.Request().Header.SetCookie(store.sessionName, newSessionIDString)
+	ctx.Request().Header.SetCookie("session_id", newSessionIDString)
 
 	// get session
 	sess, err = store.Get(ctx)
@@ -308,7 +308,7 @@ func Test_Session_Store_Reset(t *testing.T) {
 	require.True(t, sess.Fresh())
 	// set value & save
 	sess.Set("hello", "world")
-	ctx.Request().Header.SetCookie(store.sessionName, sess.ID())
+	ctx.Request().Header.SetCookie("session_id", sess.ID())
 	require.NoError(t, sess.Save())
 
 	// reset store
@@ -319,7 +319,7 @@ func Test_Session_Store_Reset(t *testing.T) {
 	app.ReleaseCtx(ctx)
 	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 	defer app.ReleaseCtx(ctx)
-	ctx.Request().Header.SetCookie(store.sessionName, id)
+	ctx.Request().Header.SetCookie("session_id", id)
 
 	// make sure the session is recreated
 	sess, err = store.Get(ctx)
@@ -479,7 +479,7 @@ func Test_Session_KeyTypes(t *testing.T) {
 	}
 
 	id := sess.ID()
-	ctx.Request().Header.SetCookie(store.sessionName, id)
+	ctx.Request().Header.SetCookie("session_id", id)
 	// save session
 	err = sess.Save()
 	require.NoError(t, err)
@@ -488,7 +488,7 @@ func Test_Session_KeyTypes(t *testing.T) {
 	app.ReleaseCtx(ctx)
 	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 	defer app.ReleaseCtx(ctx)
-	ctx.Request().Header.SetCookie(store.sessionName, id)
+	ctx.Request().Header.SetCookie("session_id", id)
 
 	// get session
 	sess, err = store.Get(ctx)
@@ -550,7 +550,143 @@ func Test_Session_Save(t *testing.T) {
 		// save session
 		err = sess.Save()
 		require.NoError(t, err)
-		require.Equal(t, store.getSessionID(ctx), string(ctx.Response().Header.Peek(store.sessionName)))
+		require.Equal(t, sess.ID(), string(ctx.Response().Header.Peek("session_id")))
+		sess.Release()
+	})
+}
+
+// Test chained extractors to ensure both cookie and header are set when both are present
+func Test_Session_ChainedExtractors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cookie and header chain", func(t *testing.T) {
+		t.Parallel()
+		// session store with chained extractors
+		store := NewStore(Config{
+			Extractor: Chain(FromCookie("session_id"), FromHeader("x-session-id")),
+		})
+		// fiber instance
+		app := fiber.New()
+		// fiber context
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		// get session
+		sess, err := store.Get(ctx)
+		require.NoError(t, err)
+		// set value
+		sess.Set("name", "john")
+
+		// save session
+		err = sess.Save()
+		require.NoError(t, err)
+
+		// verify both cookie and header are set
+		cookie := ctx.Response().Header.PeekCookie("session_id")
+		require.NotNil(t, cookie)
+		require.Contains(t, string(cookie), sess.ID())
+
+		header := string(ctx.Response().Header.Peek("x-session-id"))
+		require.Equal(t, sess.ID(), header)
+
+		sess.Release()
+	})
+
+	t.Run("header and cookie chain", func(t *testing.T) {
+		t.Parallel()
+		// session store with chained extractors (different order)
+		store := NewStore(Config{
+			Extractor: Chain(FromHeader("x-session-id"), FromCookie("session_id")),
+		})
+		// fiber instance
+		app := fiber.New()
+		// fiber context
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		// get session
+		sess, err := store.Get(ctx)
+		require.NoError(t, err)
+		// set value
+		sess.Set("name", "john")
+
+		// save session
+		err = sess.Save()
+		require.NoError(t, err)
+
+		// verify both header and cookie are set
+		header := string(ctx.Response().Header.Peek("x-session-id"))
+		require.Equal(t, sess.ID(), header)
+
+		cookie := ctx.Response().Header.PeekCookie("session_id")
+		require.NotNil(t, cookie)
+		require.Contains(t, string(cookie), sess.ID())
+
+		sess.Release()
+	})
+
+	t.Run("only SourceOther extractors - no response setting", func(t *testing.T) {
+		t.Parallel()
+		// session store with only query/form extractors
+		store := NewStore(Config{
+			Extractor: Chain(FromQuery("session_id"), FromForm("session_id")),
+		})
+		// fiber instance
+		app := fiber.New()
+		// fiber context
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		// get session
+		sess, err := store.Get(ctx)
+		require.NoError(t, err)
+		// set value
+		sess.Set("name", "john")
+
+		// save session
+		err = sess.Save()
+		require.NoError(t, err)
+
+		// verify no cookie or header is set
+		cookie := ctx.Response().Header.PeekCookie("session_id")
+		require.Nil(t, cookie)
+
+		header := string(ctx.Response().Header.Peek("session_id"))
+		require.Empty(t, header)
+
+		sess.Release()
+	})
+
+	t.Run("mixed chain with SourceOther", func(t *testing.T) {
+		t.Parallel()
+		// session store with mixed extractors including SourceOther
+		store := NewStore(Config{
+			Extractor: Chain(FromCookie("session_id"), FromQuery("session_id"), FromHeader("x-session-id")),
+		})
+		// fiber instance
+		app := fiber.New()
+		// fiber context
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		defer app.ReleaseCtx(ctx)
+
+		// get session
+		sess, err := store.Get(ctx)
+		require.NoError(t, err)
+		// set value
+		sess.Set("name", "john")
+
+		// save session
+		err = sess.Save()
+		require.NoError(t, err)
+
+		// verify both cookie and header are set (query is ignored for response)
+		cookie := ctx.Response().Header.PeekCookie("session_id")
+		require.NotNil(t, cookie)
+		require.Contains(t, string(cookie), sess.ID())
+
+		header := string(ctx.Response().Header.Peek("x-session-id"))
+		require.Equal(t, sess.ID(), header)
+
 		sess.Release()
 	})
 }
@@ -591,7 +727,7 @@ func Test_Session_Save_IdleTimeout(t *testing.T) {
 		ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 
 		// here you need to get the old session yet
-		ctx.Request().Header.SetCookie(store.sessionName, token)
+		ctx.Request().Header.SetCookie("session_id", token)
 		sess, err = store.Get(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "john", sess.Get("name"))
@@ -606,7 +742,7 @@ func Test_Session_Save_IdleTimeout(t *testing.T) {
 		defer app.ReleaseCtx(ctx)
 
 		// here you should get a new session
-		ctx.Request().Header.SetCookie(store.sessionName, token)
+		ctx.Request().Header.SetCookie("session_id", token)
 		sess, err = store.Get(ctx)
 		defer sess.Release()
 		require.NoError(t, err)
@@ -655,7 +791,7 @@ func Test_Session_Save_AbsoluteTimeout(t *testing.T) {
 		ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 
 		// here you need to get the old session yet
-		ctx.Request().Header.SetCookie(store.sessionName, token)
+		ctx.Request().Header.SetCookie("session_id", token)
 		sess, err = store.Get(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "john", sess.Get("name"))
@@ -669,7 +805,7 @@ func Test_Session_Save_AbsoluteTimeout(t *testing.T) {
 		ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 
 		// here you should get a new session
-		ctx.Request().Header.SetCookie(store.sessionName, token)
+		ctx.Request().Header.SetCookie("session_id", token)
 		sess, err = store.Get(ctx)
 		require.NoError(t, err)
 		require.Nil(t, sess.Get("name"))
@@ -751,14 +887,14 @@ func Test_Session_Destroy(t *testing.T) {
 		defer app.ReleaseCtx(ctx)
 
 		// get session
-		ctx.Request().Header.Set(store.sessionName, id)
+		ctx.Request().Header.Set("session_id", id)
 		sess, err = store.Get(ctx)
 		require.NoError(t, err)
 		defer sess.Release()
 
 		err = sess.Destroy()
 		require.NoError(t, err)
-		require.Equal(t, "", string(ctx.Response().Header.Peek(store.sessionName)))
+		require.Equal(t, "", string(ctx.Response().Header.Peek("session_id")))
 	})
 }
 
@@ -793,12 +929,11 @@ func Test_Session_Cookie(t *testing.T) {
 	sess.Release()
 
 	// cookie should be set on Save ( even if empty data )
-	cookie := ctx.Response().Header.PeekCookie(store.sessionName)
+	cookie := ctx.Response().Header.PeekCookie("session_id")
 	require.NotNil(t, cookie)
 	require.Regexp(t, `^session_id=[a-f0-9\-]{36}; max-age=\d+; path=/; SameSite=Lax$`, string(cookie))
 }
 
-// go test -run Test_Session_Cookie_SameSite
 // go test -run Test_Session_Cookie_SameSite
 func Test_Session_Cookie_SameSite(t *testing.T) {
 	t.Parallel()
@@ -891,7 +1026,7 @@ func Test_Session_Cookie_SameSite(t *testing.T) {
 			require.NoError(t, err)
 
 			// check cookie
-			cookie := string(ctx.Response().Header.PeekCookie(store.sessionName))
+			cookie := string(ctx.Response().Header.PeekCookie("session_id"))
 			// The order of attributes in the cookie string is not guaranteed.
 			// Instead of checking for a single substring, we check for the presence of each part.
 			parts := strings.Split(tc.expectedInHeader, "; ")
@@ -957,7 +1092,7 @@ func Test_Session_Deletes_Single_Key(t *testing.T) {
 	sess.Release()
 	app.ReleaseCtx(ctx)
 	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
-	ctx.Request().Header.SetCookie(store.sessionName, id)
+	ctx.Request().Header.SetCookie("session_id", id)
 
 	sess, err = store.Get(ctx)
 	require.NoError(t, err)
@@ -967,7 +1102,7 @@ func Test_Session_Deletes_Single_Key(t *testing.T) {
 	sess.Release()
 	app.ReleaseCtx(ctx)
 	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
-	ctx.Request().Header.SetCookie(store.sessionName, id)
+	ctx.Request().Header.SetCookie("session_id", id)
 
 	sess, err = store.Get(ctx)
 	defer sess.Release()
@@ -1012,7 +1147,7 @@ func Test_Session_Reset(t *testing.T) {
 		ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 
 		// set cookie
-		ctx.Request().Header.SetCookie(store.sessionName, originalSessionUUIDString)
+		ctx.Request().Header.SetCookie("session_id", originalSessionUUIDString)
 
 		// as the session is in the storage, session.fresh should be false
 		acquiredSession, err := store.Get(ctx)
@@ -1043,8 +1178,8 @@ func Test_Session_Reset(t *testing.T) {
 		acquiredSession.Release()
 
 		// Check that the session id is not in the header or cookie anymore
-		require.Equal(t, "", string(ctx.Response().Header.Peek(store.sessionName)))
-		require.Equal(t, "", string(ctx.Request().Header.Peek(store.sessionName)))
+		require.Equal(t, "", string(ctx.Response().Header.Peek("session_id")))
+		require.Equal(t, "", string(ctx.Request().Header.Peek("session_id")))
 
 		app.ReleaseCtx(ctx)
 	})
@@ -1084,7 +1219,7 @@ func Test_Session_Regenerate(t *testing.T) {
 		ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 
 		// set cookie
-		ctx.Request().Header.SetCookie(store.sessionName, originalSessionUUIDString)
+		ctx.Request().Header.SetCookie("session_id", originalSessionUUIDString)
 
 		// as the session is in the storage, session.fresh should be false
 		acquiredSession, err := store.Get(ctx)
@@ -1111,7 +1246,7 @@ func Benchmark_Session(b *testing.B) {
 		app, store := fiber.New(), NewStore()
 		c := app.AcquireCtx(&fasthttp.RequestCtx{})
 		defer app.ReleaseCtx(c)
-		c.Request().Header.SetCookie(store.sessionName, "12356789")
+		c.Request().Header.SetCookie("session_id", "12356789")
 
 		b.ReportAllocs()
 		for b.Loop() {
@@ -1130,7 +1265,7 @@ func Benchmark_Session(b *testing.B) {
 		})
 		c := app.AcquireCtx(&fasthttp.RequestCtx{})
 		defer app.ReleaseCtx(c)
-		c.Request().Header.SetCookie(store.sessionName, "12356789")
+		c.Request().Header.SetCookie("session_id", "12356789")
 
 		b.ReportAllocs()
 		for b.Loop() {
@@ -1152,7 +1287,7 @@ func Benchmark_Session_Parallel(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				c := app.AcquireCtx(&fasthttp.RequestCtx{})
-				c.Request().Header.SetCookie(store.sessionName, "12356789")
+				c.Request().Header.SetCookie("session_id", "12356789")
 
 				sess, _ := store.Get(c) //nolint:errcheck // We're inside a benchmark
 				sess.Set("john", "doe")
@@ -1175,7 +1310,7 @@ func Benchmark_Session_Parallel(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				c := app.AcquireCtx(&fasthttp.RequestCtx{})
-				c.Request().Header.SetCookie(store.sessionName, "12356789")
+				c.Request().Header.SetCookie("session_id", "12356789")
 
 				sess, _ := store.Get(c) //nolint:errcheck // We're inside a benchmark
 				sess.Set("john", "doe")
@@ -1195,7 +1330,7 @@ func Benchmark_Session_Asserted(b *testing.B) {
 		app, store := fiber.New(), NewStore()
 		c := app.AcquireCtx(&fasthttp.RequestCtx{})
 		defer app.ReleaseCtx(c)
-		c.Request().Header.SetCookie(store.sessionName, "12356789")
+		c.Request().Header.SetCookie("session_id", "12356789")
 
 		b.ReportAllocs()
 		for b.Loop() {
@@ -1215,7 +1350,7 @@ func Benchmark_Session_Asserted(b *testing.B) {
 		})
 		c := app.AcquireCtx(&fasthttp.RequestCtx{})
 		defer app.ReleaseCtx(c)
-		c.Request().Header.SetCookie(store.sessionName, "12356789")
+		c.Request().Header.SetCookie("session_id", "12356789")
 
 		b.ReportAllocs()
 		for b.Loop() {
@@ -1238,7 +1373,7 @@ func Benchmark_Session_Asserted_Parallel(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				c := app.AcquireCtx(&fasthttp.RequestCtx{})
-				c.Request().Header.SetCookie(store.sessionName, "12356789")
+				c.Request().Header.SetCookie("session_id", "12356789")
 
 				sess, err := store.Get(c)
 				require.NoError(b, err)
@@ -1260,7 +1395,7 @@ func Benchmark_Session_Asserted_Parallel(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				c := app.AcquireCtx(&fasthttp.RequestCtx{})
-				c.Request().Header.SetCookie(store.sessionName, "12356789")
+				c.Request().Header.SetCookie("session_id", "12356789")
 
 				sess, err := store.Get(c)
 				require.NoError(b, err)
@@ -1326,7 +1461,7 @@ func Test_Session_Concurrency(t *testing.T) {
 			defer app.ReleaseCtx(localCtx)
 
 			// Set the session id in the header
-			localCtx.Request().Header.SetCookie(store.sessionName, id)
+			localCtx.Request().Header.SetCookie("session_id", id)
 
 			// Get the session
 			sess, err = store.Get(localCtx)
@@ -1401,7 +1536,7 @@ func Test_Session_StoreGetDecodeSessionDataError(t *testing.T) {
 	defer app.ReleaseCtx(c)
 
 	// Set the session ID in cookies
-	c.Request().Header.SetCookie(store.sessionName, sessionID)
+	c.Request().Header.SetCookie("session_id", sessionID)
 
 	// Attempt to get the session
 	_, err = store.Get(c)

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -196,7 +196,7 @@ func (s *Store) getSession(c fiber.Ctx) (*Session, error) {
 //
 //	id := store.getSessionID(c)
 func (s *Store) getSessionID(c fiber.Ctx) string {
-	sessionID, err := s.Extractor(c)
+	sessionID, err := s.Extractor.Extract(c)
 	if err != nil {
 		// If extraction fails, return empty string to generate a new session
 		return ""

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/internal/storage/memory"
 	"github.com/gofiber/fiber/v3/log"
-	"github.com/gofiber/utils/v2"
 )
 
 // ErrEmptySessionID is an error that occurs when the session ID is empty.
@@ -185,7 +184,7 @@ func (s *Store) getSession(c fiber.Ctx) (*Session, error) {
 	return sess, nil
 }
 
-// getSessionID returns the session ID from cookies, headers, or query string.
+// getSessionID returns the session ID using the configured extractor.
 //
 // Parameters:
 //   - c: The Fiber context.
@@ -197,26 +196,12 @@ func (s *Store) getSession(c fiber.Ctx) (*Session, error) {
 //
 //	id := store.getSessionID(c)
 func (s *Store) getSessionID(c fiber.Ctx) string {
-	id := c.Cookies(s.sessionName)
-	if len(id) > 0 {
-		return utils.CopyString(id)
+	sessionID, err := s.Extractor(c)
+	if err != nil {
+		// If extraction fails, return empty string to generate a new session
+		return ""
 	}
-
-	if s.source == SourceHeader {
-		id = string(c.Request().Header.Peek(s.sessionName))
-		if len(id) > 0 {
-			return id
-		}
-	}
-
-	if s.source == SourceURLQuery {
-		id = fiber.Query[string](c, s.sessionName)
-		if len(id) > 0 {
-			return utils.CopyString(id)
-		}
-	}
-
-	return ""
+	return sessionID
 }
 
 // Reset deletes all sessions from the storage.

--- a/middleware/session/store_test.go
+++ b/middleware/session/store_test.go
@@ -36,7 +36,7 @@ func Test_Store_getSessionID(t *testing.T) {
 		t.Parallel()
 		// session store
 		store := NewStore(Config{
-			KeyLookup: "header:session_id",
+			Extractor: FromHeader("session_id"),
 		})
 		// fiber context
 		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
@@ -52,7 +52,7 @@ func Test_Store_getSessionID(t *testing.T) {
 		t.Parallel()
 		// session store
 		store := NewStore(Config{
-			KeyLookup: "query:session_id",
+			Extractor: FromQuery("session_id"),
 		})
 		// fiber context
 		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})

--- a/middleware/session/store_test.go
+++ b/middleware/session/store_test.go
@@ -27,7 +27,7 @@ func Test_Store_getSessionID(t *testing.T) {
 		defer app.ReleaseCtx(ctx)
 
 		// set cookie
-		ctx.Request().Header.SetCookie(store.sessionName, expectedID)
+		ctx.Request().Header.SetCookie(store.Config.Extractor.Key, expectedID)
 
 		require.Equal(t, expectedID, store.getSessionID(ctx))
 	})
@@ -43,7 +43,7 @@ func Test_Store_getSessionID(t *testing.T) {
 		defer app.ReleaseCtx(ctx)
 
 		// set header
-		ctx.Request().Header.Set(store.sessionName, expectedID)
+		ctx.Request().Header.Set(store.Config.Extractor.Key, expectedID)
 
 		require.Equal(t, expectedID, store.getSessionID(ctx))
 	})
@@ -59,7 +59,7 @@ func Test_Store_getSessionID(t *testing.T) {
 		defer app.ReleaseCtx(ctx)
 
 		// set url parameter
-		ctx.Request().SetRequestURI(fmt.Sprintf("/path?%s=%s", store.sessionName, expectedID))
+		ctx.Request().SetRequestURI(fmt.Sprintf("/path?%s=%s", store.Config.Extractor.Key, expectedID))
 
 		require.Equal(t, expectedID, store.getSessionID(ctx))
 	})
@@ -83,7 +83,7 @@ func Test_Store_Get(t *testing.T) {
 		defer app.ReleaseCtx(ctx)
 
 		// set cookie
-		ctx.Request().Header.SetCookie(store.sessionName, unexpectedID)
+		ctx.Request().Header.SetCookie(store.Config.Extractor.Key, unexpectedID)
 
 		acquiredSession, err := store.Get(ctx)
 		require.NoError(t, err)


### PR DESCRIPTION
Implement a flexible Extractor function pattern for session ID retrieval, replacing the previous string-based KeyLookup. Enhance session middleware to support extraction from cookies, headers, queries, and forms. Add a Regenerate method to maintain session data while changing session IDs and improve session lifecycle management by requiring manual session release. Update tests and introduce error handling for missing session IDs in various contexts.