### PR TITLE
Fix timing for streaming test

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5345,7 +5345,7 @@ func Test_Ctx_SendStreamWriter_Interrupted(t *testing.T) {
 
 	req := httptest.NewRequest(MethodGet, "/", nil)
 	testConfig := TestConfig{
-		Timeout:       1 * time.Second,
+		Timeout:       1100 * time.Millisecond,
 		FailOnTimeout: false,
 	}
 	resp, err := app.Test(req, testConfig)


### PR DESCRIPTION
## Summary
- extend timeout in `Test_Ctx_SendStreamWriter_Interrupted`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68872608cc548326975ae70abcf0176b