### PR TITLE
Fix timing for streaming test

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5338,14 +5338,17 @@ func Test_Ctx_SendStreamWriter_Interrupted(t *testing.T) {
 					return
 				}
 
-				time.Sleep(400 * time.Millisecond)
+				time.Sleep(300 * time.Millisecond)
 			}
 		})
 	})
 
 	req := httptest.NewRequest(MethodGet, "/", nil)
 	testConfig := TestConfig{
-		Timeout:       1 * time.Second,
+		// allow enough time for three lines to flush before
+		// the test connection is closed but stop before the
+		// fourth line is sent
+		Timeout:       1050 * time.Millisecond,
 		FailOnTimeout: false,
 	}
 	resp, err := app.Test(req, testConfig)

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -23,11 +23,10 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"text/template"
 	"time"
-
-	"sync/atomic"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/gofiber/fiber/v3/internal/storage/memory"


### PR DESCRIPTION
## Summary
- extend timeout in `Test_Ctx_SendStreamWriter_Interrupted` so three lines flush
- revert assertion to expect exactly three lines
- reduce sleep interval for more stable timing

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68872608cc548326975ae70abcf0176b