### PR TITLE
Support hashed BasicAuth passwords

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
   go install golang.org/x/vuln/cmd/govulncheck@latest      # vulnerability scanner
   go install mvdan.cc/gofumpt@latest                       # code formatter
   go install github.com/tinylib/msgp@latest                # msgp codegen
-  go install github.com/vburenin/ifacemaker@975a95966976eeb2d4365a7fb236e274c54da64c  # interface impls
+  go install github.com/vburenin/ifacemaker@f30b6f9bdbed4b5c4804ec9ba4a04a999525c202  # interface impls
   go install github.com/dkorunic/betteralign/cmd/betteralign@latest  # struct alignment
   go mod tidy                                              # clean up go.mod & go.sum
   ```

--- a/Makefile
+++ b/Makefile
@@ -73,5 +73,5 @@ betteralign:
 .PHONY: generate
 generate:
 	go install github.com/tinylib/msgp@latest
-	go install github.com/vburenin/ifacemaker@975a95966976eeb2d4365a7fb236e274c54da64c
+	go install github.com/vburenin/ifacemaker@f30b6f9bdbed4b5c4804ec9ba4a04a999525c202
 	go generate ./...

--- a/ctx.go
+++ b/ctx.go
@@ -5,26 +5,14 @@
 package fiber
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"mime/multipart"
-	"net"
-	"net/http"
-	"net/url"
-	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
-	"text/template"
 	"time"
-
-	"golang.org/x/net/idna"
 
 	"github.com/gofiber/utils/v2"
 	"github.com/valyala/bytebufferpool"
@@ -52,18 +40,18 @@ var (
 type contextKey int //nolint:unused // need for future (nolintlint)
 
 // DefaultCtx is the default implementation of the Ctx interface
-// generation tool `go install github.com/vburenin/ifacemaker@975a95966976eeb2d4365a7fb236e274c54da64c`
-// https://github.com/vburenin/ifacemaker/blob/975a95966976eeb2d4365a7fb236e274c54da64c/ifacemaker.go#L14-L30
+// generation tool `go install github.com/vburenin/ifacemaker@f30b6f9bdbed4b5c4804ec9ba4a04a999525c202`
+// https://github.com/vburenin/ifacemaker/blob/f30b6f9bdbed4b5c4804ec9ba4a04a999525c202/ifacemaker.go#L14-L31
 //
-//go:generate ifacemaker --file ctx.go --struct DefaultCtx --iface Ctx --pkg fiber --output ctx_interface_gen.go --not-exported true --iface-comment "Ctx represents the Context which hold the HTTP request and response.\nIt has methods for the request query string, parameters, body, HTTP headers and so on."
+//go:generate ifacemaker --file ctx.go --file req.go --file res.go --struct DefaultCtx --iface Ctx --pkg fiber --promoted --output ctx_interface_gen.go --not-exported true --iface-comment "Ctx represents the Context which hold the HTTP request and response.\nIt has methods for the request query string, parameters, body, HTTP headers and so on."
 type DefaultCtx struct {
+	DefaultReq                         // Default request api
+	DefaultRes                         // Default response api
 	app           *App                 // Reference to *App
 	route         *Route               // Reference to *Route
 	fasthttp      *fasthttp.RequestCtx // Reference to *fasthttp.RequestCtx
 	bind          *Bind                // Default bind reference
 	redirect      *Redirect            // Default redirect reference
-	req           *DefaultReq          // Default request api reference
-	res           *DefaultRes          // Default response api reference
 	values        [maxParams]string    // Route parameter values
 	viewBindMap   sync.Map             // Default view map to bind template engine
 	baseURI       string               // HTTP base uri
@@ -76,84 +64,6 @@ type DefaultCtx struct {
 	indexHandler  int                  // Index of the current handler
 	methodInt     int                  // HTTP method INT equivalent
 	matched       bool                 // Non use route matched
-}
-
-// SendFile defines configuration options when to transfer file with SendFile.
-type SendFile struct {
-	// FS is the file system to serve the static files from.
-	// You can use interfaces compatible with fs.FS like embed.FS, os.DirFS etc.
-	//
-	// Optional. Default: nil
-	FS fs.FS
-
-	// When set to true, the server tries minimizing CPU usage by caching compressed files.
-	// This works differently than the github.com/gofiber/compression middleware.
-	// You have to set Content-Encoding header to compress the file.
-	// Available compression methods are gzip, br, and zstd.
-	//
-	// Optional. Default: false
-	Compress bool `json:"compress"`
-
-	// When set to true, enables byte range requests.
-	//
-	// Optional. Default: false
-	ByteRange bool `json:"byte_range"`
-
-	// When set to true, enables direct download.
-	//
-	// Optional. Default: false
-	Download bool `json:"download"`
-
-	// Expiration duration for inactive file handlers.
-	// Use a negative time.Duration to disable it.
-	//
-	// Optional. Default: 10 * time.Second
-	CacheDuration time.Duration `json:"cache_duration"`
-
-	// The value for the Cache-Control HTTP-header
-	// that is set on the file response. MaxAge is defined in seconds.
-	//
-	// Optional. Default: 0
-	MaxAge int `json:"max_age"`
-}
-
-// sendFileStore is used to keep the SendFile configuration and the handler.
-type sendFileStore struct {
-	handler           fasthttp.RequestHandler
-	cacheControlValue string
-	config            SendFile
-}
-
-// compareConfig compares the current SendFile config with the new one
-// and returns true if they are different.
-//
-// Here we don't use reflect.DeepEqual because it is quite slow compared to manual comparison.
-func (sf *sendFileStore) compareConfig(cfg SendFile) bool {
-	if sf.config.FS != cfg.FS {
-		return false
-	}
-
-	if sf.config.Compress != cfg.Compress {
-		return false
-	}
-
-	if sf.config.ByteRange != cfg.ByteRange {
-		return false
-	}
-
-	if sf.config.Download != cfg.Download {
-		return false
-	}
-
-	if sf.config.CacheDuration != cfg.CacheDuration {
-		return false
-	}
-
-	if sf.config.MaxAge != cfg.MaxAge {
-		return false
-	}
-
-	return true
 }
 
 // TLSHandler object
@@ -169,114 +79,15 @@ func (t *TLSHandler) GetClientInfo(info *tls.ClientHelloInfo) (*tls.Certificate,
 	return nil, nil //nolint:nilnil // Not returning anything useful here is probably fine
 }
 
-// Range data for c.Range
-type Range struct {
-	Type   string
-	Ranges []RangeSet
-}
-
-// RangeSet represents a single content range from a request.
-type RangeSet struct {
-	Start int
-	End   int
-}
-
-// Cookie data for c.Cookie
-type Cookie struct {
-	Expires     time.Time `json:"expires"`      // The expiration date of the cookie
-	Name        string    `json:"name"`         // The name of the cookie
-	Value       string    `json:"value"`        // The value of the cookie
-	Path        string    `json:"path"`         // Specifies a URL path which is allowed to receive the cookie
-	Domain      string    `json:"domain"`       // Specifies the domain which is allowed to receive the cookie
-	SameSite    string    `json:"same_site"`    // Controls whether or not a cookie is sent with cross-site requests
-	MaxAge      int       `json:"max_age"`      // The maximum age (in seconds) of the cookie
-	Secure      bool      `json:"secure"`       // Indicates that the cookie should only be transmitted over a secure HTTPS connection
-	HTTPOnly    bool      `json:"http_only"`    // Indicates that the cookie is accessible only through the HTTP protocol
-	Partitioned bool      `json:"partitioned"`  // Indicates if the cookie is stored in a partitioned cookie jar
-	SessionOnly bool      `json:"session_only"` // Indicates if the cookie is a session-only cookie
-}
-
 // Views is the interface that wraps the Render function.
 type Views interface {
 	Load() error
 	Render(out io.Writer, name string, binding any, layout ...string) error
 }
 
-// ResFmt associates a Content Type to a fiber.Handler for c.Format
-type ResFmt struct {
-	Handler   func(Ctx) error
-	MediaType string
-}
-
-// Accepts checks if the specified extensions or content types are acceptable.
-func (c *DefaultCtx) Accepts(offers ...string) string {
-	header := joinHeaderValues(c.fasthttp.Request.Header.PeekAll(HeaderAccept))
-	return getOffer(header, acceptsOfferType, offers...)
-}
-
-// AcceptsCharsets checks if the specified charset is acceptable.
-func (c *DefaultCtx) AcceptsCharsets(offers ...string) string {
-	header := joinHeaderValues(c.fasthttp.Request.Header.PeekAll(HeaderAcceptCharset))
-	return getOffer(header, acceptsOffer, offers...)
-}
-
-// AcceptsEncodings checks if the specified encoding is acceptable.
-func (c *DefaultCtx) AcceptsEncodings(offers ...string) string {
-	header := joinHeaderValues(c.fasthttp.Request.Header.PeekAll(HeaderAcceptEncoding))
-	return getOffer(header, acceptsOffer, offers...)
-}
-
-// AcceptsLanguages checks if the specified language is acceptable.
-func (c *DefaultCtx) AcceptsLanguages(offers ...string) string {
-	header := joinHeaderValues(c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage))
-	return getOffer(header, acceptsLanguageOffer, offers...)
-}
-
 // App returns the *App reference to the instance of the Fiber application
 func (c *DefaultCtx) App() *App {
 	return c.app
-}
-
-// Append the specified value to the HTTP response header field.
-// If the header is not already set, it creates the header with the specified value.
-func (c *DefaultCtx) Append(field string, values ...string) {
-	if len(values) == 0 {
-		return
-	}
-	h := c.app.getString(c.fasthttp.Response.Header.Peek(field))
-	originalH := h
-	for _, value := range values {
-		if len(h) == 0 {
-			h = value
-		} else if h != value && !strings.HasPrefix(h, value+",") && !strings.HasSuffix(h, " "+value) &&
-			!strings.Contains(h, " "+value+",") {
-			h += ", " + value
-		}
-	}
-	if originalH != h {
-		c.Set(field, h)
-	}
-}
-
-// Attachment sets the HTTP response Content-Disposition header field to attachment.
-func (c *DefaultCtx) Attachment(filename ...string) {
-	if len(filename) > 0 {
-		fname := filepath.Base(filename[0])
-		c.Type(filepath.Ext(fname))
-		var quoted string
-		if c.app.isASCII(fname) {
-			quoted = c.app.quoteString(fname)
-		} else {
-			quoted = c.app.quoteRawString(fname)
-		}
-		disp := `attachment; filename="` + quoted + `"`
-		if !c.app.isASCII(fname) {
-			disp += `; filename*=UTF-8''` + url.PathEscape(fname)
-		}
-		c.setCanonical(HeaderContentDisposition, disp)
-		return
-	}
-	c.setCanonical(HeaderContentDisposition, "attachment")
 }
 
 // BaseURL returns (protocol + host + base path).
@@ -290,215 +101,10 @@ func (c *DefaultCtx) BaseURL() string {
 	return c.baseURI
 }
 
-// BodyRaw contains the raw body submitted in a POST request.
-// Returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting instead.
-func (c *DefaultCtx) BodyRaw() []byte {
-	return c.getBody()
-}
-
-func (c *DefaultCtx) tryDecodeBodyInOrder(
-	originalBody *[]byte,
-	encodings []string,
-) ([]byte, uint8, error) {
-	var (
-		err             error
-		body            []byte
-		decodesRealized uint8
-	)
-
-	for idx := range encodings {
-		i := len(encodings) - 1 - idx
-		encoding := encodings[i]
-		decodesRealized++
-		switch encoding {
-		case StrGzip, "x-gzip":
-			body, err = c.fasthttp.Request.BodyGunzip()
-		case StrBr, StrBrotli:
-			body, err = c.fasthttp.Request.BodyUnbrotli()
-		case StrDeflate:
-			body, err = c.fasthttp.Request.BodyInflate()
-		case StrZstd:
-			body, err = c.fasthttp.Request.BodyUnzstd()
-		case StrIdentity:
-			body = c.fasthttp.Request.Body()
-		case StrCompress, "x-compress":
-			return nil, decodesRealized - 1, ErrNotImplemented
-		default:
-			return nil, decodesRealized - 1, ErrUnsupportedMediaType
-		}
-
-		if err != nil {
-			return nil, decodesRealized, err
-		}
-
-		if i > 0 && decodesRealized > 0 {
-			if i == len(encodings)-1 {
-				tempBody := c.fasthttp.Request.Body()
-				*originalBody = make([]byte, len(tempBody))
-				copy(*originalBody, tempBody)
-			}
-			c.fasthttp.Request.SetBodyRaw(body)
-		}
-	}
-
-	return body, decodesRealized, nil
-}
-
-// Body contains the raw body submitted in a POST request.
-// This method will decompress the body if the 'Content-Encoding' header is provided.
-// It returns the original (or decompressed) body data which is valid only within the handler.
-// Don't store direct references to the returned data.
-// If you need to keep the body's data later, make a copy or use the Immutable option.
-func (c *DefaultCtx) Body() []byte {
-	var (
-		err                error
-		body, originalBody []byte
-		headerEncoding     string
-		encodingOrder      = []string{"", "", ""}
-	)
-
-	// Get Content-Encoding header
-	headerEncoding = utils.ToLower(utils.UnsafeString(c.Request().Header.ContentEncoding()))
-
-	// If no encoding is provided, return the original body
-	if len(headerEncoding) == 0 {
-		return c.getBody()
-	}
-
-	// Split and get the encodings list, in order to attend the
-	// rule defined at: https://www.rfc-editor.org/rfc/rfc9110#section-8.4-5
-	encodingOrder = getSplicedStrList(headerEncoding, encodingOrder)
-	for i := range encodingOrder {
-		encodingOrder[i] = utils.ToLower(encodingOrder[i])
-	}
-	if len(encodingOrder) == 0 {
-		return c.getBody()
-	}
-
-	var decodesRealized uint8
-	body, decodesRealized, err = c.tryDecodeBodyInOrder(&originalBody, encodingOrder)
-
-	// Ensure that the body will be the original
-	if originalBody != nil && decodesRealized > 0 {
-		c.fasthttp.Request.SetBodyRaw(originalBody)
-	}
-	if err != nil {
-		switch {
-		case errors.Is(err, ErrUnsupportedMediaType):
-			_ = c.SendStatus(StatusUnsupportedMediaType) //nolint:errcheck // It is fine to ignore the error
-		case errors.Is(err, ErrNotImplemented):
-			_ = c.SendStatus(StatusNotImplemented) //nolint:errcheck // It is fine to ignore the error
-		}
-		return []byte(err.Error())
-	}
-
-	if c.app.config.Immutable {
-		return utils.CopyBytes(body)
-	}
-	return body
-}
-
-// ClearCookie expires a specific cookie by key on the client side.
-// If no key is provided it expires all cookies that came with the request.
-func (c *DefaultCtx) ClearCookie(key ...string) {
-	if len(key) > 0 {
-		for i := range key {
-			c.fasthttp.Response.Header.DelClientCookie(key[i])
-		}
-		return
-	}
-	for k := range c.fasthttp.Request.Header.Cookies() {
-		c.fasthttp.Response.Header.DelClientCookieBytes(k)
-	}
-}
-
 // RequestCtx returns *fasthttp.RequestCtx that carries a deadline
 // a cancellation signal, and other values across API boundaries.
 func (c *DefaultCtx) RequestCtx() *fasthttp.RequestCtx {
 	return c.fasthttp
-}
-
-// Cookie sets a cookie by passing a cookie struct.
-func (c *DefaultCtx) Cookie(cookie *Cookie) {
-	if cookie.Path == "" {
-		cookie.Path = "/"
-	}
-
-	if cookie.SessionOnly {
-		cookie.MaxAge = 0
-		cookie.Expires = time.Time{}
-	}
-
-	var sameSite http.SameSite
-
-	switch {
-	case utils.EqualFold(cookie.SameSite, CookieSameSiteStrictMode):
-		sameSite = http.SameSiteStrictMode
-	case utils.EqualFold(cookie.SameSite, CookieSameSiteNoneMode):
-		sameSite = http.SameSiteNoneMode
-		// SameSite=None requires Secure=true per RFC and browser requirements
-		cookie.Secure = true
-	case utils.EqualFold(cookie.SameSite, CookieSameSiteDisabled):
-		sameSite = 0
-	case utils.EqualFold(cookie.SameSite, CookieSameSiteLaxMode):
-		sameSite = http.SameSiteLaxMode
-	default:
-		sameSite = http.SameSiteLaxMode
-	}
-
-	// create/validate cookie using net/http
-	hc := &http.Cookie{
-		Name:        cookie.Name,
-		Value:       cookie.Value,
-		Path:        cookie.Path,
-		Domain:      cookie.Domain,
-		Expires:     cookie.Expires,
-		MaxAge:      cookie.MaxAge,
-		Secure:      cookie.Secure,
-		HttpOnly:    cookie.HTTPOnly,
-		SameSite:    sameSite,
-		Partitioned: cookie.Partitioned,
-	}
-
-	if err := hc.Valid(); err != nil {
-		// invalid cookies are ignored, same approach as net/http
-		return
-	}
-
-	// create fasthttp cookie
-	fcookie := fasthttp.AcquireCookie()
-	fcookie.SetKey(hc.Name)
-	fcookie.SetValue(hc.Value)
-	fcookie.SetPath(hc.Path)
-	fcookie.SetDomain(hc.Domain)
-
-	if !cookie.SessionOnly {
-		fcookie.SetMaxAge(hc.MaxAge)
-		fcookie.SetExpire(hc.Expires)
-	}
-
-	fcookie.SetSecure(hc.Secure)
-	fcookie.SetHTTPOnly(hc.HttpOnly)
-
-	switch sameSite {
-	case http.SameSiteLaxMode:
-		fcookie.SetSameSite(fasthttp.CookieSameSiteLaxMode)
-	case http.SameSiteStrictMode:
-		fcookie.SetSameSite(fasthttp.CookieSameSiteStrictMode)
-	case http.SameSiteNoneMode:
-		fcookie.SetSameSite(fasthttp.CookieSameSiteNoneMode)
-	case http.SameSiteDefaultMode:
-		fcookie.SetSameSite(fasthttp.CookieSameSiteDefaultMode)
-	default:
-		fcookie.SetSameSite(fasthttp.CookieSameSiteDisabled)
-	}
-
-	fcookie.SetPartitioned(hc.Partitioned)
-
-	// Set resp header
-	c.fasthttp.Response.Header.SetCookie(fcookie)
-	fasthttp.ReleaseCookie(fcookie)
 }
 
 // Deadline returns the time when work done on behalf of this context
@@ -521,40 +127,6 @@ func (*DefaultCtx) Deadline() (time.Time, bool) {
 // See: https://github.com/valyala/fasthttp/issues/965#issuecomment-777268945
 func (*DefaultCtx) Done() <-chan struct{} {
 	return nil
-}
-
-// Cookies are used for getting a cookie value by key.
-// Defaults to the empty string "" if the cookie doesn't exist.
-// If a default value is given, it will return that value if the cookie doesn't exist.
-// The returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting to use the value outside the Handler.
-func (c *DefaultCtx) Cookies(key string, defaultValue ...string) string {
-	return defaultString(c.app.getString(c.fasthttp.Request.Header.Cookie(key)), defaultValue)
-}
-
-// Download transfers the file from path as an attachment.
-// Typically, browsers will prompt the user for download.
-// By default, the Content-Disposition header filename= parameter is the filepath (this typically appears in the browser dialog).
-// Override this default with the filename parameter.
-func (c *DefaultCtx) Download(file string, filename ...string) error {
-	var fname string
-	if len(filename) > 0 {
-		fname = filename[0]
-	} else {
-		fname = filepath.Base(file)
-	}
-	var quoted string
-	if c.app.isASCII(fname) {
-		quoted = c.app.quoteString(fname)
-	} else {
-		quoted = c.app.quoteRawString(fname)
-	}
-	disp := `attachment; filename="` + quoted + `"`
-	if !c.app.isASCII(fname) {
-		disp += `; filename*=UTF-8''` + url.PathEscape(fname)
-	}
-	c.setCanonical(HeaderContentDisposition, disp)
-	return c.SendFile(file)
 }
 
 // If Done is not yet closed, Err returns nil.
@@ -583,178 +155,26 @@ func (c *DefaultCtx) Response() *fasthttp.Response {
 	return &c.fasthttp.Response
 }
 
-// Format performs content-negotiation on the Accept HTTP header.
-// It uses Accepts to select a proper format and calls the matching
-// user-provided handler function.
-// If no accepted format is found, and a format with MediaType "default" is given,
-// that default handler is called. If no format is found and no default is given,
-// StatusNotAcceptable is sent.
-func (c *DefaultCtx) Format(handlers ...ResFmt) error {
-	if len(handlers) == 0 {
-		return ErrNoHandlers
-	}
-
-	c.Vary(HeaderAccept)
-
-	if c.Get(HeaderAccept) == "" {
-		c.Response().Header.SetContentType(handlers[0].MediaType)
-		return handlers[0].Handler(c)
-	}
-
-	// Using an int literal as the slice capacity allows for the slice to be
-	// allocated on the stack. The number was chosen arbitrarily as an
-	// approximation of the maximum number of content types a user might handle.
-	// If the user goes over, it just causes allocations, so it's not a problem.
-	types := make([]string, 0, 8)
-	var defaultHandler Handler
-	for _, h := range handlers {
-		if h.MediaType == "default" {
-			defaultHandler = h.Handler
-			continue
-		}
-		types = append(types, h.MediaType)
-	}
-	accept := c.Accepts(types...)
-
-	if accept == "" {
-		if defaultHandler == nil {
-			return c.SendStatus(StatusNotAcceptable)
-		}
-		return defaultHandler(c)
-	}
-
-	for _, h := range handlers {
-		if h.MediaType == accept {
-			c.Response().Header.SetContentType(h.MediaType)
-			return h.Handler(c)
-		}
-	}
-
-	return fmt.Errorf("%w: format: an Accept was found but no handler was called", errUnreachable)
-}
-
-// AutoFormat performs content-negotiation on the Accept HTTP header.
-// It uses Accepts to select a proper format.
-// The supported content types are text/html, text/plain, application/json, and application/xml.
-// For more flexible content negotiation, use Format.
-// If the header is not specified or there is no proper format, text/plain is used.
-func (c *DefaultCtx) AutoFormat(body any) error {
-	// Get accepted content type
-	accept := c.Accepts("html", "json", "txt", "xml", "msgpack")
-	// Set accepted content type
-	c.Type(accept)
-	// Type convert provided body
-	var b string
-	switch val := body.(type) {
-	case string:
-		b = val
-	case []byte:
-		b = c.app.getString(val)
-	default:
-		b = fmt.Sprintf("%v", val)
-	}
-
-	// Format based on the accept content type
-	switch accept {
-	case "html":
-		return c.SendString("<p>" + b + "</p>")
-	case "json":
-		return c.JSON(body)
-	case "msgpack":
-		return c.MsgPack(body)
-	case "txt":
-		return c.SendString(b)
-	case "xml":
-		return c.XML(body)
-	}
-	return c.SendString(b)
-}
-
-// FormFile returns the first file by key from a MultipartForm.
-func (c *DefaultCtx) FormFile(key string) (*multipart.FileHeader, error) {
-	return c.fasthttp.FormFile(key)
-}
-
-// FormValue returns the first value by key from a MultipartForm.
-// Search is performed in QueryArgs, PostArgs, MultipartForm and FormFile in this particular order.
-// Defaults to the empty string "" if the form value doesn't exist.
-// If a default value is given, it will return that value if the form value does not exist.
-// Returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting instead.
-func (c *DefaultCtx) FormValue(key string, defaultValue ...string) string {
-	return defaultString(c.app.getString(c.fasthttp.FormValue(key)), defaultValue)
-}
-
-// Fresh returns true when the response is still “fresh” in the client's cache,
-// otherwise false is returned to indicate that the client cache is now stale
-// and the full response should be sent.
-// When a client sends the Cache-Control: no-cache request header to indicate an end-to-end
-// reload request, this module will return false to make handling these requests transparent.
-// https://github.com/jshttp/fresh/blob/master/index.js#L33
-func (c *DefaultCtx) Fresh() bool {
-	// fields
-	modifiedSince := c.Get(HeaderIfModifiedSince)
-	noneMatch := c.Get(HeaderIfNoneMatch)
-
-	// unconditional request
-	if modifiedSince == "" && noneMatch == "" {
-		return false
-	}
-
-	// Always return stale when Cache-Control: no-cache
-	// to support end-to-end reload requests
-	// https://www.rfc-editor.org/rfc/rfc9111#section-5.2.1.4
-	cacheControl := c.Get(HeaderCacheControl)
-	if cacheControl != "" && isNoCache(cacheControl) {
-		return false
-	}
-
-	// if-none-match
-	if noneMatch != "" && noneMatch != "*" {
-		etag := c.app.getString(c.fasthttp.Response.Header.Peek(HeaderETag))
-		if etag == "" {
-			return false
-		}
-		if c.app.isEtagStale(etag, c.app.getBytes(noneMatch)) {
-			return false
-		}
-
-		if modifiedSince != "" {
-			lastModified := c.app.getString(c.fasthttp.Response.Header.Peek(HeaderLastModified))
-			if lastModified != "" {
-				lastModifiedTime, err := http.ParseTime(lastModified)
-				if err != nil {
-					return false
-				}
-				modifiedSinceTime, err := http.ParseTime(modifiedSince)
-				if err != nil {
-					return false
-				}
-				return lastModifiedTime.Compare(modifiedSinceTime) != 1
-			}
-		}
-	}
-	return true
-}
-
 // Get returns the HTTP request header specified by field.
 // Field names are case-insensitive
 // Returned value is only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting instead.
 func (c *DefaultCtx) Get(key string, defaultValue ...string) string {
-	return GetReqHeader(c, key, defaultValue...)
+	return c.DefaultReq.Get(key, defaultValue...)
 }
 
-// GetReqHeader returns the HTTP request header specified by filed.
-// This function is generic and can handle different headers type values.
-// If the generic type cannot be matched to a supported type, the function
-// returns the default value (if provided) or the zero value of type V.
-func GetReqHeader[V GenericType](c Ctx, key string, defaultValue ...V) V {
-	v, err := genericParseType[V](c.App().getString(c.Request().Header.Peek(key)))
-	if err != nil && len(defaultValue) > 0 {
-		return defaultValue[0]
-	}
-	return v
+// GetHeaders returns the HTTP request headers.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting instead.
+func (c *DefaultCtx) GetHeaders() map[string][]string {
+	return c.DefaultReq.GetHeaders()
+}
+
+// GetReqHeaders returns the HTTP request headers.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting instead.
+func (c *DefaultCtx) GetReqHeaders() map[string][]string {
+	return c.DefaultReq.GetHeaders()
 }
 
 // GetRespHeader returns the HTTP response header specified by field.
@@ -762,395 +182,14 @@ func GetReqHeader[V GenericType](c Ctx, key string, defaultValue ...V) V {
 // Returned value is only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting instead.
 func (c *DefaultCtx) GetRespHeader(key string, defaultValue ...string) string {
-	return defaultString(c.app.getString(c.fasthttp.Response.Header.Peek(key)), defaultValue)
+	return c.DefaultRes.Get(key, defaultValue...)
 }
 
 // GetRespHeaders returns the HTTP response headers.
 // Returned value is only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting instead.
 func (c *DefaultCtx) GetRespHeaders() map[string][]string {
-	headers := make(map[string][]string)
-	for k, v := range c.Response().Header.All() {
-		key := c.app.getString(k)
-		headers[key] = append(headers[key], c.app.getString(v))
-	}
-	return headers
-}
-
-// GetReqHeaders returns the HTTP request headers.
-// Returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting instead.
-func (c *DefaultCtx) GetReqHeaders() map[string][]string {
-	headers := make(map[string][]string)
-	for k, v := range c.Request().Header.All() {
-		key := c.app.getString(k)
-		headers[key] = append(headers[key], c.app.getString(v))
-	}
-	return headers
-}
-
-// Host contains the host derived from the X-Forwarded-Host or Host HTTP header.
-// Returned value is only valid within the handler. Do not store any references.
-// In a network context, `Host` refers to the combination of a hostname and potentially a port number used for connecting,
-// while `Hostname` refers specifically to the name assigned to a device on a network, excluding any port information.
-// Example: URL: https://example.com:8080 -> Host: example.com:8080
-// Make copies or use the Immutable setting instead.
-// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
-func (c *DefaultCtx) Host() string {
-	if c.IsProxyTrusted() {
-		if host := c.Get(HeaderXForwardedHost); len(host) > 0 {
-			commaPos := strings.Index(host, ",")
-			if commaPos != -1 {
-				return host[:commaPos]
-			}
-			return host
-		}
-	}
-	return c.app.getString(c.fasthttp.Request.URI().Host())
-}
-
-// Hostname contains the hostname derived from the X-Forwarded-Host or Host HTTP header using the c.Host() method.
-// Returned value is only valid within the handler. Do not store any references.
-// Example: URL: https://example.com:8080 -> Hostname: example.com
-// Make copies or use the Immutable setting instead.
-// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
-func (c *DefaultCtx) Hostname() string {
-	addr, _ := parseAddr(c.Host())
-
-	return addr
-}
-
-// Port returns the remote port of the request.
-func (c *DefaultCtx) Port() string {
-	tcpaddr, ok := c.fasthttp.RemoteAddr().(*net.TCPAddr)
-	if !ok {
-		panic(errors.New("failed to type-assert to *net.TCPAddr"))
-	}
-	return strconv.Itoa(tcpaddr.Port)
-}
-
-// IP returns the remote IP address of the request.
-// If ProxyHeader and IP Validation is configured, it will parse that header and return the first valid IP address.
-// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
-func (c *DefaultCtx) IP() string {
-	if c.IsProxyTrusted() && len(c.app.config.ProxyHeader) > 0 {
-		return c.extractIPFromHeader(c.app.config.ProxyHeader)
-	}
-
-	return c.fasthttp.RemoteIP().String()
-}
-
-// extractIPsFromHeader will return a slice of IPs it found given a header name in the order they appear.
-// When IP validation is enabled, any invalid IPs will be omitted.
-func (c *DefaultCtx) extractIPsFromHeader(header string) []string {
-	// TODO: Reuse the c.extractIPFromHeader func somehow in here
-
-	headerValue := c.Get(header)
-
-	// We can't know how many IPs we will return, but we will try to guess with this constant division.
-	// Counting ',' makes function slower for about 50ns in general case.
-	const maxEstimatedCount = 8
-	estimatedCount := min(len(headerValue)/maxEstimatedCount,
-		// Avoid big allocation on big header
-		maxEstimatedCount)
-
-	ipsFound := make([]string, 0, estimatedCount)
-
-	i := 0
-	j := -1
-
-iploop:
-	for {
-		var v4, v6 bool
-
-		// Manually splitting string without allocating slice, working with parts directly
-		i, j = j+1, j+2
-
-		if j > len(headerValue) {
-			break
-		}
-
-		for j < len(headerValue) && headerValue[j] != ',' {
-			switch headerValue[j] {
-			case ':':
-				v6 = true
-			case '.':
-				v4 = true
-			}
-			j++
-		}
-
-		for i < j && (headerValue[i] == ' ' || headerValue[i] == ',') {
-			i++
-		}
-
-		s := utils.TrimRight(headerValue[i:j], ' ')
-
-		if c.app.config.EnableIPValidation {
-			// Skip validation if IP is clearly not IPv4/IPv6, otherwise validate without allocations
-			if (!v6 && !v4) || (v6 && !utils.IsIPv6(s)) || (v4 && !utils.IsIPv4(s)) {
-				continue iploop
-			}
-		}
-
-		ipsFound = append(ipsFound, s)
-	}
-
-	return ipsFound
-}
-
-// extractIPFromHeader will attempt to pull the real client IP from the given header when IP validation is enabled.
-// currently, it will return the first valid IP address in header.
-// when IP validation is disabled, it will simply return the value of the header without any inspection.
-// Implementation is almost the same as in extractIPsFromHeader, but without allocation of []string.
-func (c *DefaultCtx) extractIPFromHeader(header string) string {
-	if c.app.config.EnableIPValidation {
-		headerValue := c.Get(header)
-
-		i := 0
-		j := -1
-
-	iploop:
-		for {
-			var v4, v6 bool
-
-			// Manually splitting string without allocating slice, working with parts directly
-			i, j = j+1, j+2
-
-			if j > len(headerValue) {
-				break
-			}
-
-			for j < len(headerValue) && headerValue[j] != ',' {
-				switch headerValue[j] {
-				case ':':
-					v6 = true
-				case '.':
-					v4 = true
-				}
-				j++
-			}
-
-			for i < j && headerValue[i] == ' ' {
-				i++
-			}
-
-			s := utils.TrimRight(headerValue[i:j], ' ')
-
-			if c.app.config.EnableIPValidation {
-				if (!v6 && !v4) || (v6 && !utils.IsIPv6(s)) || (v4 && !utils.IsIPv4(s)) {
-					continue iploop
-				}
-			}
-
-			return s
-		}
-
-		return c.fasthttp.RemoteIP().String()
-	}
-
-	// default behavior if IP validation is not enabled is just to return whatever value is
-	// in the proxy header. Even if it is empty or invalid
-	return c.Get(c.app.config.ProxyHeader)
-}
-
-// IPs returns a string slice of IP addresses specified in the X-Forwarded-For request header.
-// When IP validation is enabled, only valid IPs are returned.
-func (c *DefaultCtx) IPs() []string {
-	return c.extractIPsFromHeader(HeaderXForwardedFor)
-}
-
-// Is returns the matching content type,
-// if the incoming request's Content-Type HTTP header field matches the MIME type specified by the type parameter
-func (c *DefaultCtx) Is(extension string) bool {
-	extensionHeader := utils.GetMIME(extension)
-	if extensionHeader == "" {
-		return false
-	}
-
-	ct := c.app.getString(c.fasthttp.Request.Header.ContentType())
-	if i := strings.IndexByte(ct, ';'); i != -1 {
-		ct = ct[:i]
-	}
-	ct = utils.Trim(ct, ' ')
-	return utils.EqualFold(ct, extensionHeader)
-}
-
-// JSON converts any interface or string to JSON.
-// Array and slice values encode as JSON arrays,
-// except that []byte encodes as a base64-encoded string,
-// and a nil slice encodes as the null JSON value.
-// If the ctype parameter is given, this method will set the
-// Content-Type header equal to ctype. If ctype is not given,
-// The Content-Type header will be set to application/json; charset=utf-8.
-func (c *DefaultCtx) JSON(data any, ctype ...string) error {
-	raw, err := c.app.config.JSONEncoder(data)
-	if err != nil {
-		return err
-	}
-	c.fasthttp.Response.SetBodyRaw(raw)
-	if len(ctype) > 0 {
-		c.fasthttp.Response.Header.SetContentType(ctype[0])
-	} else {
-		c.fasthttp.Response.Header.SetContentType(MIMEApplicationJSONCharsetUTF8)
-	}
-	return nil
-}
-
-// MsgPack converts any interface or string to MessagePack encoded bytes.
-// If the ctype parameter is given, this method will set the
-// Content-Type header equal to ctype. If ctype is not given,
-// The Content-Type header will be set to application/vnd.msgpack.
-func (c *DefaultCtx) MsgPack(data any, ctype ...string) error {
-	raw, err := c.app.config.MsgPackEncoder(data)
-	if err != nil {
-		return err
-	}
-	c.fasthttp.Response.SetBodyRaw(raw)
-	if len(ctype) > 0 {
-		c.fasthttp.Response.Header.SetContentType(ctype[0])
-	} else {
-		c.fasthttp.Response.Header.SetContentType(MIMEApplicationMsgPack)
-	}
-	return nil
-}
-
-// CBOR converts any interface or string to CBOR encoded bytes.
-// If the ctype parameter is given, this method will set the
-// Content-Type header equal to ctype. If ctype is not given,
-// The Content-Type header will be set to application/cbor.
-func (c *DefaultCtx) CBOR(data any, ctype ...string) error {
-	raw, err := c.app.config.CBOREncoder(data)
-	if err != nil {
-		return err
-	}
-	c.fasthttp.Response.SetBodyRaw(raw)
-	if len(ctype) > 0 {
-		c.fasthttp.Response.Header.SetContentType(ctype[0])
-	} else {
-		c.fasthttp.Response.Header.SetContentType(MIMEApplicationCBOR)
-	}
-	return nil
-}
-
-// JSONP sends a JSON response with JSONP support.
-// This method is identical to JSON, except that it opts-in to JSONP callback support.
-// By default, the callback name is simply callback.
-func (c *DefaultCtx) JSONP(data any, callback ...string) error {
-	raw, err := c.app.config.JSONEncoder(data)
-	if err != nil {
-		return err
-	}
-
-	var result, cb string
-
-	if len(callback) > 0 {
-		cb = callback[0]
-	} else {
-		cb = "callback"
-	}
-
-	result = cb + "(" + c.app.getString(raw) + ");"
-
-	c.setCanonical(HeaderXContentTypeOptions, "nosniff")
-	c.fasthttp.Response.Header.SetContentType(MIMETextJavaScriptCharsetUTF8)
-	return c.SendString(result)
-}
-
-// XML converts any interface or string to XML.
-// This method also sets the content header to application/xml; charset=utf-8.
-func (c *DefaultCtx) XML(data any) error {
-	raw, err := c.app.config.XMLEncoder(data)
-	if err != nil {
-		return err
-	}
-	c.fasthttp.Response.SetBodyRaw(raw)
-	c.fasthttp.Response.Header.SetContentType(MIMEApplicationXMLCharsetUTF8)
-	return nil
-}
-
-// Links joins the links followed by the property to populate the response's Link HTTP header field.
-func (c *DefaultCtx) Links(link ...string) {
-	if len(link) == 0 {
-		return
-	}
-	bb := bytebufferpool.Get()
-	for i := range link {
-		if i%2 == 0 {
-			bb.WriteByte('<')
-			bb.WriteString(link[i])
-			bb.WriteByte('>')
-		} else {
-			bb.WriteString(`; rel="` + link[i] + `",`)
-		}
-	}
-	c.setCanonical(HeaderLink, utils.TrimRight(c.app.getString(bb.Bytes()), ','))
-	bytebufferpool.Put(bb)
-}
-
-// Locals makes it possible to pass any values under keys scoped to the request
-// and therefore available to all following routes that match the request.
-//
-// All the values are removed from ctx after returning from the top
-// RequestHandler. Additionally, Close method is called on each value
-// implementing io.Closer before removing the value from ctx.
-func (c *DefaultCtx) Locals(key any, value ...any) any {
-	if len(value) == 0 {
-		return c.fasthttp.UserValue(key)
-	}
-	c.fasthttp.SetUserValue(key, value[0])
-	return value[0]
-}
-
-// Locals function utilizing Go's generics feature.
-// This function allows for manipulating and retrieving local values within a
-// request context with a more specific data type.
-//
-// All the values are removed from ctx after returning from the top
-// RequestHandler. Additionally, Close method is called on each value
-// implementing io.Closer before removing the value from ctx.
-func Locals[V any](c Ctx, key any, value ...V) V {
-	var v V
-	var ok bool
-	if len(value) == 0 {
-		v, ok = c.Locals(key).(V)
-	} else {
-		v, ok = c.Locals(key, value[0]).(V)
-	}
-	if !ok {
-		return v // return zero of type V
-	}
-	return v
-}
-
-// Location sets the response Location HTTP header to the specified path parameter.
-func (c *DefaultCtx) Location(path string) {
-	c.setCanonical(HeaderLocation, path)
-}
-
-// Method returns the HTTP request method for the context, optionally overridden by the provided argument.
-// If no override is given or if the provided override is not a valid HTTP method, it returns the current method from the context.
-// Otherwise, it updates the context's method and returns the overridden method as a string.
-func (c *DefaultCtx) Method(override ...string) string {
-	if len(override) == 0 {
-		// Nothing to override, just return current method from context
-		return c.app.method(c.methodInt)
-	}
-
-	method := utils.ToUpper(override[0])
-	methodInt := c.app.methodInt(method)
-	if methodInt == -1 {
-		// Provided override does not valid HTTP method, no override, return current method
-		return c.app.method(c.methodInt)
-	}
-	c.methodInt = methodInt
-	return method
-}
-
-// MultipartForm parse form entries from binary.
-// This returns a map[string][]string, so given a key the value will be a string slice.
-func (c *DefaultCtx) MultipartForm() (*multipart.Form, error) {
-	return c.fasthttp.MultipartForm()
+	return c.DefaultRes.GetHeaders()
 }
 
 // ClientHelloInfo return CHI from context
@@ -1195,55 +234,6 @@ func (c *DefaultCtx) OriginalURL() string {
 	return c.app.getString(c.fasthttp.Request.Header.RequestURI())
 }
 
-// Params is used to get the route parameters.
-// Defaults to empty string "" if the param doesn't exist.
-// If a default value is given, it will return that value if the param doesn't exist.
-// Returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting to use the value outside the Handler.
-func (c *DefaultCtx) Params(key string, defaultValue ...string) string {
-	if key == "*" || key == "+" {
-		key += "1"
-	}
-
-	route := c.Route()
-	for i := range route.Params {
-		if len(key) != len(c.route.Params[i]) {
-			continue
-		}
-		if route.Params[i] == key || (!c.app.config.CaseSensitive && utils.EqualFold(route.Params[i], key)) {
-			// in case values are not here
-			if len(c.values) <= i || len(c.values[i]) == 0 {
-				break
-			}
-			return c.values[i]
-		}
-	}
-	return defaultString("", defaultValue)
-}
-
-// Params is used to get the route parameters.
-// This function is generic and can handle different route parameters type values.
-// If the generic type cannot be matched to a supported type, the function
-// returns the default value (if provided) or the zero value of type V.
-//
-// Example:
-//
-// http://example.com/user/:user -> http://example.com/user/john
-// Params[string](c, "user") -> returns john
-//
-// http://example.com/id/:id -> http://example.com/user/114
-// Params[int](c, "id") ->  returns 114 as integer.
-//
-// http://example.com/id/:number -> http://example.com/id/john
-// Params[int](c, "number", 0) -> returns 0 because can't parse 'john' as integer.
-func Params[V GenericType](c Ctx, key string, defaultValue ...V) V {
-	v, err := genericParseType[V](c.Params(key))
-	if err != nil && len(defaultValue) > 0 {
-		return defaultValue[0]
-	}
-	return v
-}
-
 // Path returns the path part of the request URL.
 // Optionally, you could override the path.
 // Make copies or use the Immutable setting to use the value outside the Handler.
@@ -1260,189 +250,16 @@ func (c *DefaultCtx) Path(override ...string) string {
 	return c.app.getString(c.path)
 }
 
-// Scheme contains the request protocol string: http or https for TLS requests.
-// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
-func (c *DefaultCtx) Scheme() string {
-	if c.fasthttp.IsTLS() {
-		return schemeHTTPS
-	}
-	if !c.IsProxyTrusted() {
-		return schemeHTTP
-	}
-
-	scheme := schemeHTTP
-	const lenXHeaderName = 12
-	for key, val := range c.fasthttp.Request.Header.All() {
-		if len(key) < lenXHeaderName {
-			continue // Neither "X-Forwarded-" nor "X-Url-Scheme"
-		}
-		switch {
-		case bytes.HasPrefix(key, []byte("X-Forwarded-")):
-			if bytes.Equal(key, []byte(HeaderXForwardedProto)) ||
-				bytes.Equal(key, []byte(HeaderXForwardedProtocol)) {
-				v := c.app.getString(val)
-				commaPos := strings.Index(v, ",")
-				if commaPos != -1 {
-					scheme = v[:commaPos]
-				} else {
-					scheme = v
-				}
-			} else if bytes.Equal(key, []byte(HeaderXForwardedSsl)) && bytes.Equal(val, []byte("on")) {
-				scheme = schemeHTTPS
-			}
-
-		case bytes.Equal(key, []byte(HeaderXUrlScheme)):
-			scheme = c.app.getString(val)
-		}
-	}
-	return scheme
+// Req returns a convenience type whose API is limited to operations
+// on the incoming request.
+func (c *DefaultCtx) Req() Req {
+	return &c.DefaultReq
 }
 
-// Protocol returns the HTTP protocol of request: HTTP/1.1 and HTTP/2.
-func (c *DefaultCtx) Protocol() string {
-	return utils.UnsafeString(c.fasthttp.Request.Header.Protocol())
-}
-
-// Query returns the query string parameter in the url.
-// Defaults to empty string "" if the query doesn't exist.
-// If a default value is given, it will return that value if the query doesn't exist.
-// Returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting to use the value outside the Handler.
-func (c *DefaultCtx) Query(key string, defaultValue ...string) string {
-	return Query(c, key, defaultValue...)
-}
-
-// Queries returns a map of query parameters and their values.
-//
-// GET /?name=alex&wanna_cake=2&id=
-// Queries()["name"] == "alex"
-// Queries()["wanna_cake"] == "2"
-// Queries()["id"] == ""
-//
-// GET /?field1=value1&field1=value2&field2=value3
-// Queries()["field1"] == "value2"
-// Queries()["field2"] == "value3"
-//
-// GET /?list_a=1&list_a=2&list_a=3&list_b[]=1&list_b[]=2&list_b[]=3&list_c=1,2,3
-// Queries()["list_a"] == "3"
-// Queries()["list_b[]"] == "3"
-// Queries()["list_c"] == "1,2,3"
-//
-// GET /api/search?filters.author.name=John&filters.category.name=Technology&filters[customer][name]=Alice&filters[status]=pending
-// Queries()["filters.author.name"] == "John"
-// Queries()["filters.category.name"] == "Technology"
-// Queries()["filters[customer][name]"] == "Alice"
-// Queries()["filters[status]"] == "pending"
-func (c *DefaultCtx) Queries() map[string]string {
-	m := make(map[string]string, c.RequestCtx().QueryArgs().Len())
-	for key, value := range c.RequestCtx().QueryArgs().All() {
-		m[c.app.getString(key)] = c.app.getString(value)
-	}
-	return m
-}
-
-// Query Retrieves the value of a query parameter from the request's URI.
-// The function is generic and can handle query parameter values of different types.
-// It takes the following parameters:
-// - c: The context object representing the current request.
-// - key: The name of the query parameter.
-// - defaultValue: (Optional) The default value to return in case the query parameter is not found or cannot be parsed.
-// The function performs the following steps:
-//  1. Type-asserts the context object to *DefaultCtx.
-//  2. Retrieves the raw query parameter value from the request's URI.
-//  3. Parses the raw value into the appropriate type based on the generic type parameter V.
-//     If parsing fails, the function checks if a default value is provided. If so, it returns the default value.
-//  4. Returns the parsed value.
-//
-// If the generic type cannot be matched to a supported type, the function returns the default value (if provided) or the zero value of type V.
-//
-// Example usage:
-//
-//	GET /?search=john&age=8
-//	name := Query[string](c, "search") // Returns "john"
-//	age := Query[int](c, "age") // Returns 8
-//	unknown := Query[string](c, "unknown", "default") // Returns "default" since the query parameter "unknown" is not found
-func Query[V GenericType](c Ctx, key string, defaultValue ...V) V {
-	q := c.App().getString(c.RequestCtx().QueryArgs().Peek(key))
-	v, err := genericParseType[V](q)
-	if err != nil && len(defaultValue) > 0 {
-		return defaultValue[0]
-	}
-	return v
-}
-
-// Range returns a struct containing the type and a slice of ranges.
-func (c *DefaultCtx) Range(size int) (Range, error) {
-	var (
-		rangeData Range
-		ranges    string
-	)
-	rangeStr := utils.Trim(c.Get(HeaderRange), ' ')
-
-	i := strings.IndexByte(rangeStr, '=')
-	if i == -1 || strings.Contains(rangeStr[i+1:], "=") {
-		return rangeData, ErrRangeMalformed
-	}
-	rangeData.Type = utils.ToLower(utils.Trim(rangeStr[:i], ' '))
-	if rangeData.Type != "bytes" {
-		return rangeData, ErrRangeMalformed
-	}
-	ranges = utils.Trim(rangeStr[i+1:], ' ')
-
-	var (
-		singleRange string
-		moreRanges  = ranges
-	)
-	for moreRanges != "" {
-		singleRange = moreRanges
-		if i := strings.IndexByte(moreRanges, ','); i >= 0 {
-			singleRange = moreRanges[:i]
-			moreRanges = utils.Trim(moreRanges[i+1:], ' ')
-		} else {
-			moreRanges = ""
-		}
-
-		singleRange = utils.Trim(singleRange, ' ')
-
-		var (
-			startStr, endStr string
-			i                int
-		)
-		if i = strings.IndexByte(singleRange, '-'); i == -1 {
-			return rangeData, ErrRangeMalformed
-		}
-		startStr = utils.Trim(singleRange[:i], ' ')
-		endStr = utils.Trim(singleRange[i+1:], ' ')
-
-		start, startErr := fasthttp.ParseUint(utils.UnsafeBytes(startStr))
-		end, endErr := fasthttp.ParseUint(utils.UnsafeBytes(endStr))
-		if startErr != nil { // -nnn
-			start = size - end
-			end = size - 1
-		} else if endErr != nil { // nnn-
-			end = size - 1
-		}
-		if end > size-1 { // limit last-byte-pos to current length
-			end = size - 1
-		}
-		if start > end || start < 0 {
-			continue
-		}
-		rangeData.Ranges = append(rangeData.Ranges, struct {
-			Start int
-			End   int
-		}{
-			Start: start,
-			End:   end,
-		})
-	}
-	if len(rangeData.Ranges) < 1 {
-		c.Status(StatusRequestedRangeNotSatisfiable)
-		c.Set(HeaderContentRange, "bytes */"+strconv.Itoa(size))
-		return rangeData, ErrRequestedRangeNotSatisfiable
-	}
-
-	return rangeData, nil
+// Res returns a convenience type whose API is limited to operations
+// on the outgoing response.
+func (c *DefaultCtx) Res() Res {
+	return &c.DefaultRes
 }
 
 // Redirect returns the Redirect reference.
@@ -1466,148 +283,6 @@ func (c *DefaultCtx) ViewBind(vars Map) error {
 		c.viewBindMap.Store(k, v)
 	}
 	return nil
-}
-
-// getLocationFromRoute get URL location from route using parameters
-func (c *DefaultCtx) getLocationFromRoute(route Route, params Map) (string, error) {
-	buf := bytebufferpool.Get()
-	for _, segment := range route.routeParser.segs {
-		if !segment.IsParam {
-			_, err := buf.WriteString(segment.Const)
-			if err != nil {
-				return "", fmt.Errorf("failed to write string: %w", err)
-			}
-			continue
-		}
-
-		for key, val := range params {
-			isSame := key == segment.ParamName || (!c.app.config.CaseSensitive && utils.EqualFold(key, segment.ParamName))
-			isGreedy := segment.IsGreedy && len(key) == 1 && bytes.IndexByte(greedyParameters, key[0]) != -1
-			if isSame || isGreedy {
-				_, err := buf.WriteString(utils.ToString(val))
-				if err != nil {
-					return "", fmt.Errorf("failed to write string: %w", err)
-				}
-			}
-		}
-	}
-	location := buf.String()
-	// release buffer
-	bytebufferpool.Put(buf)
-	return location, nil
-}
-
-// GetRouteURL generates URLs to named routes, with parameters. URLs are relative, for example: "/user/1831"
-func (c *DefaultCtx) GetRouteURL(routeName string, params Map) (string, error) {
-	return c.getLocationFromRoute(c.App().GetRoute(routeName), params)
-}
-
-// Render a template with data and sends a text/html response.
-// We support the following engines: https://github.com/gofiber/template
-func (c *DefaultCtx) Render(name string, bind any, layouts ...string) error {
-	// Get new buffer from pool
-	buf := bytebufferpool.Get()
-	defer bytebufferpool.Put(buf)
-
-	// Initialize empty bind map if bind is nil
-	if bind == nil {
-		bind = make(Map)
-	}
-
-	// Pass-locals-to-views, bind, appListKeys
-	c.renderExtensions(bind)
-
-	var rendered bool
-	for i := len(c.app.mountFields.appListKeys) - 1; i >= 0; i-- {
-		prefix := c.app.mountFields.appListKeys[i]
-		app := c.app.mountFields.appList[prefix]
-		if prefix == "" || strings.Contains(c.OriginalURL(), prefix) {
-			if len(layouts) == 0 && app.config.ViewsLayout != "" {
-				layouts = []string{
-					app.config.ViewsLayout,
-				}
-			}
-
-			// Render template from Views
-			if app.config.Views != nil {
-				if err := app.config.Views.Render(buf, name, bind, layouts...); err != nil {
-					return fmt.Errorf("failed to render: %w", err)
-				}
-
-				rendered = true
-				break
-			}
-		}
-	}
-
-	if !rendered {
-		// Render raw template using 'name' as filepath if no engine is set
-		var tmpl *template.Template
-		if _, err := readContent(buf, name); err != nil {
-			return err
-		}
-		// Parse template
-		tmpl, err := template.New("").Parse(c.app.getString(buf.Bytes()))
-		if err != nil {
-			return fmt.Errorf("failed to parse: %w", err)
-		}
-		buf.Reset()
-		// Render template
-		if err := tmpl.Execute(buf, bind); err != nil {
-			return fmt.Errorf("failed to execute: %w", err)
-		}
-	}
-
-	// Set Content-Type to text/html
-	c.fasthttp.Response.Header.SetContentType(MIMETextHTMLCharsetUTF8)
-	// Set rendered template to body
-	c.fasthttp.Response.SetBody(buf.Bytes())
-
-	return nil
-}
-
-func (c *DefaultCtx) renderExtensions(bind any) {
-	if bindMap, ok := bind.(Map); ok {
-		// Bind view map
-		c.viewBindMap.Range(func(key, value any) bool {
-			keyValue, ok := key.(string)
-			if !ok {
-				return true
-			}
-			if _, ok := bindMap[keyValue]; !ok {
-				bindMap[keyValue] = value
-			}
-			return true
-		})
-
-		// Check if the PassLocalsToViews option is enabled (by default it is disabled)
-		if c.app.config.PassLocalsToViews {
-			// Loop through each local and set it in the map
-			c.fasthttp.VisitUserValues(func(key []byte, val any) {
-				// check if bindMap doesn't contain the key
-				if _, ok := bindMap[c.app.getString(key)]; !ok {
-					// Set the key and value in the bindMap
-					bindMap[c.app.getString(key)] = val
-				}
-			})
-		}
-	}
-
-	if len(c.app.mountFields.appListKeys) == 0 {
-		c.app.generateAppListKeys()
-	}
-}
-
-// Req returns a convenience type whose API is limited to operations
-// on the incoming request.
-func (c *DefaultCtx) Req() Req {
-	return c.req
-}
-
-// Res returns a convenience type whose API is limited to operations
-// on the outgoing response.
-func (c *DefaultCtx) Res() Res {
-	return c.res
 }
 
 // Route returns the matched Route struct.
@@ -1653,263 +328,6 @@ func (c *DefaultCtx) SaveFileToStorage(fileheader *multipart.FileHeader, path st
 // Secure returns whether a secure connection was established.
 func (c *DefaultCtx) Secure() bool {
 	return c.Protocol() == schemeHTTPS
-}
-
-// Send sets the HTTP response body without copying it.
-// From this point onward the body argument must not be changed.
-func (c *DefaultCtx) Send(body []byte) error {
-	// Write response body
-	c.fasthttp.Response.SetBodyRaw(body)
-	return nil
-}
-
-// SendFile transfers the file from the specified path.
-// By default, the file is not compressed. To enable compression, set SendFile.Compress to true.
-// The Content-Type response HTTP header field is set based on the file's extension.
-// If the file extension is missing or invalid, the Content-Type is detected from the file's format.
-func (c *DefaultCtx) SendFile(file string, config ...SendFile) error {
-	// Save the filename, we will need it in the error message if the file isn't found
-	filename := file
-
-	var cfg SendFile
-	if len(config) > 0 {
-		cfg = config[0]
-	}
-
-	if cfg.CacheDuration == 0 {
-		cfg.CacheDuration = 10 * time.Second
-	}
-
-	var fsHandler fasthttp.RequestHandler
-	var cacheControlValue string
-
-	c.app.sendfilesMutex.RLock()
-	for _, sf := range c.app.sendfiles {
-		if sf.compareConfig(cfg) {
-			fsHandler = sf.handler
-			cacheControlValue = sf.cacheControlValue
-			break
-		}
-	}
-	c.app.sendfilesMutex.RUnlock()
-
-	if fsHandler == nil {
-		fasthttpFS := &fasthttp.FS{
-			Root:                   "",
-			FS:                     cfg.FS,
-			AllowEmptyRoot:         true,
-			GenerateIndexPages:     false,
-			AcceptByteRange:        cfg.ByteRange,
-			Compress:               cfg.Compress,
-			CompressBrotli:         cfg.Compress,
-			CompressZstd:           cfg.Compress,
-			CompressedFileSuffixes: c.app.config.CompressedFileSuffixes,
-			CacheDuration:          cfg.CacheDuration,
-			SkipCache:              cfg.CacheDuration < 0,
-			IndexNames:             []string{"index.html"},
-			PathNotFound: func(ctx *fasthttp.RequestCtx) {
-				ctx.Response.SetStatusCode(StatusNotFound)
-			},
-		}
-
-		if cfg.FS != nil {
-			fasthttpFS.Root = "."
-		}
-
-		sf := &sendFileStore{
-			config:  cfg,
-			handler: fasthttpFS.NewRequestHandler(),
-		}
-
-		maxAge := cfg.MaxAge
-		if maxAge > 0 {
-			sf.cacheControlValue = "public, max-age=" + strconv.Itoa(maxAge)
-		}
-
-		// set vars
-		fsHandler = sf.handler
-		cacheControlValue = sf.cacheControlValue
-
-		c.app.sendfilesMutex.Lock()
-		c.app.sendfiles = append(c.app.sendfiles, sf)
-		c.app.sendfilesMutex.Unlock()
-	}
-
-	// Keep original path for mutable params
-	c.pathOriginal = utils.CopyString(c.pathOriginal)
-
-	// Delete the Accept-Encoding header if compression is disabled
-	if !cfg.Compress {
-		// https://github.com/valyala/fasthttp/blob/7cc6f4c513f9e0d3686142e0a1a5aa2f76b3194a/fs.go#L55
-		c.fasthttp.Request.Header.Del(HeaderAcceptEncoding)
-	}
-
-	// copy of https://github.com/valyala/fasthttp/blob/7cc6f4c513f9e0d3686142e0a1a5aa2f76b3194a/fs.go#L103-L121 with small adjustments
-	if len(file) == 0 || (!filepath.IsAbs(file) && cfg.FS == nil) {
-		// extend relative path to absolute path
-		hasTrailingSlash := len(file) > 0 && (file[len(file)-1] == '/' || file[len(file)-1] == '\\')
-
-		var err error
-		file = filepath.FromSlash(file)
-		if file, err = filepath.Abs(file); err != nil {
-			return fmt.Errorf("failed to determine abs file path: %w", err)
-		}
-		if hasTrailingSlash {
-			file += "/"
-		}
-	}
-
-	// convert the path to forward slashes regardless the OS in order to set the URI properly
-	// the handler will convert back to OS path separator before opening the file
-	file = filepath.ToSlash(file)
-
-	// Restore the original requested URL
-	originalURL := utils.CopyString(c.OriginalURL())
-	defer c.fasthttp.Request.SetRequestURI(originalURL)
-
-	// Set new URI for fileHandler
-	c.fasthttp.Request.SetRequestURI(file)
-
-	// Save status code
-	status := c.fasthttp.Response.StatusCode()
-
-	// Serve file
-	fsHandler(c.fasthttp)
-
-	// Sets the response Content-Disposition header to attachment if the Download option is true
-	if cfg.Download {
-		c.Attachment()
-	}
-
-	// Get the status code which is set by fasthttp
-	fsStatus := c.fasthttp.Response.StatusCode()
-
-	// Check for error
-	if status != StatusNotFound && fsStatus == StatusNotFound {
-		return NewError(StatusNotFound, fmt.Sprintf("sendfile: file %s not found", filename))
-	}
-
-	// Set the status code set by the user if it is different from the fasthttp status code and 200
-	if status != fsStatus && status != StatusOK {
-		c.Status(status)
-	}
-
-	// Apply cache control header
-	if status != StatusNotFound && status != StatusForbidden {
-		if len(cacheControlValue) > 0 {
-			c.RequestCtx().Response.Header.Set(HeaderCacheControl, cacheControlValue)
-		}
-
-		return nil
-	}
-
-	return nil
-}
-
-// SendStatus sets the HTTP status code and if the response body is empty,
-// it sets the correct status message in the body.
-func (c *DefaultCtx) SendStatus(status int) error {
-	c.Status(status)
-
-	// Only set status body when there is no response body
-	if len(c.fasthttp.Response.Body()) == 0 {
-		return c.SendString(utils.StatusMessage(status))
-	}
-
-	return nil
-}
-
-// SendString sets the HTTP response body for string types.
-// This means no type assertion, recommended for faster performance
-func (c *DefaultCtx) SendString(body string) error {
-	c.fasthttp.Response.SetBodyString(body)
-
-	return nil
-}
-
-// SendStream sets response body stream and optional body size.
-func (c *DefaultCtx) SendStream(stream io.Reader, size ...int) error {
-	if len(size) > 0 && size[0] >= 0 {
-		c.fasthttp.Response.SetBodyStream(stream, size[0])
-	} else {
-		c.fasthttp.Response.SetBodyStream(stream, -1)
-	}
-
-	return nil
-}
-
-// SendStreamWriter sets response body stream writer
-func (c *DefaultCtx) SendStreamWriter(streamWriter func(*bufio.Writer)) error {
-	c.fasthttp.Response.SetBodyStreamWriter(fasthttp.StreamWriter(streamWriter))
-
-	return nil
-}
-
-// Set sets the response's HTTP header field to the specified key, value.
-func (c *DefaultCtx) Set(key, val string) {
-	c.fasthttp.Response.Header.Set(key, val)
-}
-
-func (c *DefaultCtx) setCanonical(key, val string) {
-	c.fasthttp.Response.Header.SetCanonical(utils.UnsafeBytes(key), utils.UnsafeBytes(val))
-}
-
-// Subdomains returns a slice of subdomains from the host, excluding the last `offset` components.
-// If the offset is negative or exceeds the number of subdomains, an empty slice is returned.
-// If the offset is zero every label (no trimming) is returned.
-func (c *DefaultCtx) Subdomains(offset ...int) []string {
-	o := 2
-	if len(offset) > 0 {
-		o = offset[0]
-	}
-
-	// Negative offset, return nothing.
-	if o < 0 {
-		return []string{}
-	}
-
-	// Normalize host according to RFC 3986
-	host := c.Hostname()
-	// Trim the trailing dot of a fully-qualified domain
-	if strings.HasSuffix(host, ".") {
-		host = utils.TrimRight(host, '.')
-	}
-	host = utils.ToLower(host)
-
-	// Decode punycode labels only when necessary
-	if strings.Contains(host, "xn--") {
-		if u, err := idna.Lookup.ToUnicode(host); err == nil {
-			host = utils.ToLower(u)
-		}
-	}
-
-	// Return nothing for IP addresses
-	ip := host
-	if strings.HasPrefix(ip, "[") && strings.HasSuffix(ip, "]") {
-		ip = ip[1 : len(ip)-1]
-	}
-	if utils.IsIPv4(ip) || utils.IsIPv6(ip) {
-		return []string{}
-	}
-
-	parts := strings.Split(host, ".")
-
-	// offset == 0, caller wants everything.
-	if o == 0 {
-		return parts
-	}
-
-	// If we trim away the whole slice (or more), nothing remains.
-	if o >= len(parts) {
-		return []string{}
-	}
-
-	return parts[:len(parts)-o]
-}
-
-// Stale returns the inverse of Fresh, indicating if the client's cached response is considered stale.
-func (c *DefaultCtx) Stale() bool {
-	return !c.Fresh()
 }
 
 // Status sets the HTTP status for the response.
@@ -1958,74 +376,10 @@ func (c *DefaultCtx) String() string {
 	return str
 }
 
-// Type sets the Content-Type HTTP header to the MIME type specified by the file extension.
-func (c *DefaultCtx) Type(extension string, charset ...string) Ctx {
-	mimeType := utils.GetMIME(extension)
-
-	if len(charset) > 0 {
-		c.fasthttp.Response.Header.SetContentType(mimeType + "; charset=" + charset[0])
-	} else {
-		// Automatically add UTF-8 charset for text-based MIME types
-		if shouldIncludeCharset(mimeType) {
-			c.fasthttp.Response.Header.SetContentType(mimeType + "; charset=utf-8")
-		} else {
-			c.fasthttp.Response.Header.SetContentType(mimeType)
-		}
-	}
-	return c
-}
-
-// shouldIncludeCharset determines if a MIME type should include UTF-8 charset by default
-func shouldIncludeCharset(mimeType string) bool {
-	// Everything under text/ gets UTF-8 by default.
-	if strings.HasPrefix(mimeType, "text/") {
-		return true
-	}
-
-	// Explicit application types that should default to UTF-8.
-	switch mimeType {
-	case MIMEApplicationJSON,
-		MIMEApplicationJavaScript,
-		MIMEApplicationXML:
-		return true
-	}
-
-	// Any application/*+json or application/*+xml.
-	if strings.HasSuffix(mimeType, "+json") || strings.HasSuffix(mimeType, "+xml") {
-		return true
-	}
-
-	return false
-}
-
-// Vary adds the given header field to the Vary response header.
-// This will append the header, if not already listed, otherwise leaves it listed in the current location.
-func (c *DefaultCtx) Vary(fields ...string) {
-	c.Append(HeaderVary, fields...)
-}
-
 // Value makes it possible to retrieve values (Locals) under keys scoped to the request
 // and therefore available to all following routes that match the request.
 func (c *DefaultCtx) Value(key any) any {
 	return c.fasthttp.UserValue(key)
-}
-
-// Write appends p into response body.
-func (c *DefaultCtx) Write(p []byte) (int, error) {
-	c.fasthttp.Response.AppendBody(p)
-	return len(p), nil
-}
-
-// Writef appends f & a into response body writer.
-func (c *DefaultCtx) Writef(f string, a ...any) (int, error) {
-	//nolint:wrapcheck // This must not be wrapped
-	return fmt.Fprintf(c.fasthttp.Response.BodyWriter(), f, a...)
-}
-
-// WriteString appends s to response body.
-func (c *DefaultCtx) WriteString(s string) (int, error) {
-	c.fasthttp.Response.AppendBodyString(s)
-	return len(s), nil
 }
 
 // XHR returns a Boolean property, that is true, if the request's X-Requested-With header field is XMLHttpRequest,
@@ -2065,53 +419,6 @@ func (c *DefaultCtx) configDependentPaths() {
 	}
 }
 
-// IsProxyTrusted checks trustworthiness of remote ip.
-// If Config.TrustProxy false, it returns true
-// IsProxyTrusted can check remote ip by proxy ranges and ip map.
-func (c *DefaultCtx) IsProxyTrusted() bool {
-	if !c.app.config.TrustProxy {
-		return true
-	}
-
-	ip := c.fasthttp.RemoteIP()
-
-	if (c.app.config.TrustProxyConfig.Loopback && ip.IsLoopback()) ||
-		(c.app.config.TrustProxyConfig.Private && ip.IsPrivate()) ||
-		(c.app.config.TrustProxyConfig.LinkLocal && ip.IsLinkLocalUnicast()) {
-		return true
-	}
-
-	if _, trusted := c.app.config.TrustProxyConfig.ips[ip.String()]; trusted {
-		return true
-	}
-
-	for _, ipNet := range c.app.config.TrustProxyConfig.ranges {
-		if ipNet.Contains(ip) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// IsFromLocal will return true if request came from local.
-func (c *DefaultCtx) IsFromLocal() bool {
-	return c.fasthttp.RemoteIP().IsLoopback()
-}
-
-// Bind You can bind body, cookie, headers etc. into the map, map slice, struct easily by using Binding method.
-// It gives custom binding support, detailed binding options and more.
-// Replacement of: BodyParser, ParamsParser, GetReqHeaders, GetRespHeaders, AllParams, QueryParser, ReqHeaderParser
-func (c *DefaultCtx) Bind() *Bind {
-	if c.bind == nil {
-		c.bind = &Bind{
-			ctx:            c,
-			dontHandleErrs: true,
-		}
-	}
-	return c.bind
-}
-
 // Reset is a method to reset context fields by given request when to use server handlers.
 func (c *DefaultCtx) Reset(fctx *fasthttp.RequestCtx) {
 	// Reset route and handler index
@@ -2129,6 +436,9 @@ func (c *DefaultCtx) Reset(fctx *fasthttp.RequestCtx) {
 	c.baseURI = ""
 	// Prettify path
 	c.configDependentPaths()
+
+	c.DefaultReq.c = c
+	c.DefaultRes.c = c
 }
 
 // Release is a method to reset context fields when to use ReleaseCtx()
@@ -2142,19 +452,62 @@ func (c *DefaultCtx) release() {
 		ReleaseRedirect(c.redirect)
 		c.redirect = nil
 	}
+	c.DefaultReq.release()
+	c.DefaultRes.release()
 }
 
-func (c *DefaultCtx) getBody() []byte {
-	if c.app.config.Immutable {
-		return utils.CopyBytes(c.fasthttp.Request.Body())
+func (c *DefaultCtx) renderExtensions(bind any) {
+	if bindMap, ok := bind.(Map); ok {
+		// Bind view map
+		c.viewBindMap.Range(func(key, value any) bool {
+			keyValue, ok := key.(string)
+			if !ok {
+				return true
+			}
+			if _, ok := bindMap[keyValue]; !ok {
+				bindMap[keyValue] = value
+			}
+			return true
+		})
+
+		// Check if the PassLocalsToViews option is enabled (by default it is disabled)
+		if c.app.config.PassLocalsToViews {
+			// Loop through each local and set it in the map
+			c.fasthttp.VisitUserValues(func(key []byte, val any) {
+				// check if bindMap doesn't contain the key
+				if _, ok := bindMap[c.app.getString(key)]; !ok {
+					// Set the key and value in the bindMap
+					bindMap[c.app.getString(key)] = val
+				}
+			})
+		}
 	}
 
-	return c.fasthttp.Request.Body()
+	if len(c.app.mountFields.appListKeys) == 0 {
+		c.app.generateAppListKeys()
+	}
+}
+
+// Bind You can bind body, cookie, headers etc. into the map, map slice, struct easily by using Binding method.
+// It gives custom binding support, detailed binding options and more.
+// Replacement of: BodyParser, ParamsParser, GetReqHeaders, GetRespHeaders, AllParams, QueryParser, ReqHeaderParser
+func (c *DefaultCtx) Bind() *Bind {
+	if c.bind == nil {
+		c.bind = &Bind{
+			ctx:            c,
+			dontHandleErrs: true,
+		}
+	}
+	return c.bind
 }
 
 // Methods to use with next stack.
 func (c *DefaultCtx) getMethodInt() int {
 	return c.methodInt
+}
+
+func (c *DefaultCtx) setMethodInt(methodInt int) {
+	c.methodInt = methodInt
 }
 
 func (c *DefaultCtx) getIndexRoute() int {
@@ -2167,10 +520,6 @@ func (c *DefaultCtx) getTreePathHash() int {
 
 func (c *DefaultCtx) getDetectionPath() string {
 	return c.app.getString(c.detectionPath)
-}
-
-func (c *DefaultCtx) getPathOriginal() string {
-	return c.pathOriginal
 }
 
 func (c *DefaultCtx) getValues() *[maxParams]string {
@@ -2197,27 +546,10 @@ func (c *DefaultCtx) setRoute(route *Route) {
 	c.route = route
 }
 
-// Drop closes the underlying connection without sending any response headers or body.
-// This can be useful for silently terminating client connections, such as in DDoS mitigation
-// or when blocking access to sensitive endpoints.
-func (c *DefaultCtx) Drop() error {
-	//nolint:wrapcheck // error wrapping is avoided to keep the operation lightweight and focused on connection closure.
-	return c.RequestCtx().Conn().Close()
+func (c *DefaultCtx) keepOriginalPath() {
+	c.pathOriginal = utils.CopyString(c.pathOriginal)
 }
 
-// End immediately flushes the current response and closes the underlying connection.
-func (c *DefaultCtx) End() error {
-	ctx := c.RequestCtx()
-	conn := ctx.Conn()
-
-	bw := bufio.NewWriter(conn)
-	if err := ctx.Response.Write(bw); err != nil {
-		return err
-	}
-
-	if err := bw.Flush(); err != nil {
-		return err //nolint:wrapcheck // unnecessary to wrap it
-	}
-
-	return conn.Close() //nolint:wrapcheck // unnecessary to wrap it
+func (c *DefaultCtx) getPathOriginal() string {
+	return c.pathOriginal
 }

--- a/ctx_interface.go
+++ b/ctx_interface.go
@@ -36,8 +36,8 @@ func NewDefaultCtx(app *App) *DefaultCtx {
 		// Set app reference
 		app: app,
 	}
-	ctx.req = &DefaultReq{ctx: ctx}
-	ctx.res = &DefaultRes{ctx: ctx}
+	ctx.DefaultReq.c = ctx
+	ctx.DefaultRes.c = ctx
 
 	return ctx
 }

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -15,42 +15,13 @@ import (
 // Ctx represents the Context which hold the HTTP request and response.
 // It has methods for the request query string, parameters, body, HTTP headers and so on.
 type Ctx interface {
-	// Accepts checks if the specified extensions or content types are acceptable.
-	Accepts(offers ...string) string
-	// AcceptsCharsets checks if the specified charset is acceptable.
-	AcceptsCharsets(offers ...string) string
-	// AcceptsEncodings checks if the specified encoding is acceptable.
-	AcceptsEncodings(offers ...string) string
-	// AcceptsLanguages checks if the specified language is acceptable.
-	AcceptsLanguages(offers ...string) string
 	// App returns the *App reference to the instance of the Fiber application
 	App() *App
-	// Append the specified value to the HTTP response header field.
-	// If the header is not already set, it creates the header with the specified value.
-	Append(field string, values ...string)
-	// Attachment sets the HTTP response Content-Disposition header field to attachment.
-	Attachment(filename ...string)
 	// BaseURL returns (protocol + host + base path).
 	BaseURL() string
-	// BodyRaw contains the raw body submitted in a POST request.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
-	BodyRaw() []byte
-	tryDecodeBodyInOrder(originalBody *[]byte, encodings []string) ([]byte, uint8, error)
-	// Body contains the raw body submitted in a POST request.
-	// This method will decompress the body if the 'Content-Encoding' header is provided.
-	// It returns the original (or decompressed) body data which is valid only within the handler.
-	// Don't store direct references to the returned data.
-	// If you need to keep the body's data later, make a copy or use the Immutable option.
-	Body() []byte
-	// ClearCookie expires a specific cookie by key on the client side.
-	// If no key is provided it expires all cookies that came with the request.
-	ClearCookie(key ...string)
 	// RequestCtx returns *fasthttp.RequestCtx that carries a deadline
 	// a cancellation signal, and other values across API boundaries.
 	RequestCtx() *fasthttp.RequestCtx
-	// Cookie sets a cookie by passing a cookie struct.
-	Cookie(cookie *Cookie)
 	// Deadline returns the time when work done on behalf of this context
 	// should be canceled. Deadline returns ok==false when no deadline is
 	// set. Successive calls to Deadline return the same results.
@@ -67,17 +38,6 @@ type Ctx interface {
 	// Due to current limitations in how fasthttp works, Done operates as a nop.
 	// See: https://github.com/valyala/fasthttp/issues/965#issuecomment-777268945
 	Done() <-chan struct{}
-	// Cookies are used for getting a cookie value by key.
-	// Defaults to the empty string "" if the cookie doesn't exist.
-	// If a default value is given, it will return that value if the cookie doesn't exist.
-	// The returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the value outside the Handler.
-	Cookies(key string, defaultValue ...string) string
-	// Download transfers the file from path as an attachment.
-	// Typically, browsers will prompt the user for download.
-	// By default, the Content-Disposition header filename= parameter is the filepath (this typically appears in the browser dialog).
-	// Override this default with the filename parameter.
-	Download(file string, filename ...string) error
 	// If Done is not yet closed, Err returns nil.
 	// If Done is closed, Err returns a non-nil error explaining why:
 	// context.DeadlineExceeded if the context's deadline passed,
@@ -95,19 +55,129 @@ type Ctx interface {
 	// This allows you to use all fasthttp response methods
 	// https://godoc.org/github.com/valyala/fasthttp#Response
 	Response() *fasthttp.Response
-	// Format performs content-negotiation on the Accept HTTP header.
-	// It uses Accepts to select a proper format and calls the matching
-	// user-provided handler function.
-	// If no accepted format is found, and a format with MediaType "default" is given,
-	// that default handler is called. If no format is found and no default is given,
-	// StatusNotAcceptable is sent.
-	Format(handlers ...ResFmt) error
-	// AutoFormat performs content-negotiation on the Accept HTTP header.
-	// It uses Accepts to select a proper format.
-	// The supported content types are text/html, text/plain, application/json, and application/xml.
-	// For more flexible content negotiation, use Format.
-	// If the header is not specified or there is no proper format, text/plain is used.
-	AutoFormat(body any) error
+	// Get returns the HTTP request header specified by field.
+	// Field names are case-insensitive
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
+	Get(key string, defaultValue ...string) string
+	// GetHeaders returns the HTTP request headers.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
+	GetHeaders() map[string][]string
+	// GetReqHeaders returns the HTTP request headers.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
+	GetReqHeaders() map[string][]string
+	// GetRespHeader returns the HTTP response header specified by field.
+	// Field names are case-insensitive
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
+	GetRespHeader(key string, defaultValue ...string) string
+	// GetRespHeaders returns the HTTP response headers.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
+	GetRespHeaders() map[string][]string
+	// ClientHelloInfo return CHI from context
+	ClientHelloInfo() *tls.ClientHelloInfo
+	// Next executes the next method in the stack that matches the current route.
+	Next() error
+	// RestartRouting instead of going to the next handler. This may be useful after
+	// changing the request path. Note that handlers might be executed again.
+	RestartRouting() error
+	// OriginalURL contains the original request URL.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
+	OriginalURL() string
+	// Path returns the path part of the request URL.
+	// Optionally, you could override the path.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
+	Path(override ...string) string
+	// Req returns a convenience type whose API is limited to operations
+	// on the incoming request.
+	Req() Req
+	// Res returns a convenience type whose API is limited to operations
+	// on the outgoing response.
+	Res() Res
+	// Redirect returns the Redirect reference.
+	// Use Redirect().Status() to set custom redirection status code.
+	// If status is not specified, status defaults to 303 See Other.
+	// You can use Redirect().To(), Redirect().Route() and Redirect().Back() for redirection.
+	Redirect() *Redirect
+	// ViewBind Add vars to default view var map binding to template engine.
+	// Variables are read by the Render method and may be overwritten.
+	ViewBind(vars Map) error
+	// Route returns the matched Route struct.
+	Route() *Route
+	// SaveFile saves any multipart file to disk.
+	SaveFile(fileheader *multipart.FileHeader, path string) error
+	// SaveFileToStorage saves any multipart file to an external storage system.
+	SaveFileToStorage(fileheader *multipart.FileHeader, path string, storage Storage) error
+	// Secure returns whether a secure connection was established.
+	Secure() bool
+	// Status sets the HTTP status for the response.
+	// This method is chainable.
+	Status(status int) Ctx
+	// String returns unique string representation of the ctx.
+	//
+	// The returned value may be useful for logging.
+	String() string
+	// Value makes it possible to retrieve values (Locals) under keys scoped to the request
+	// and therefore available to all following routes that match the request.
+	Value(key any) any
+	// XHR returns a Boolean property, that is true, if the request's X-Requested-With header field is XMLHttpRequest,
+	// indicating that the request was issued by a client library (such as jQuery).
+	XHR() bool
+	// configDependentPaths set paths for route recognition and prepared paths for the user,
+	// here the features for caseSensitive, decoded paths, strict paths are evaluated
+	configDependentPaths()
+	// Reset is a method to reset context fields by given request when to use server handlers.
+	Reset(fctx *fasthttp.RequestCtx)
+	// Release is a method to reset context fields when to use ReleaseCtx()
+	release()
+	renderExtensions(bind any)
+	// Bind You can bind body, cookie, headers etc. into the map, map slice, struct easily by using Binding method.
+	// It gives custom binding support, detailed binding options and more.
+	// Replacement of: BodyParser, ParamsParser, GetReqHeaders, GetRespHeaders, AllParams, QueryParser, ReqHeaderParser
+	Bind() *Bind
+	// Methods to use with next stack.
+	getMethodInt() int
+	setMethodInt(methodInt int)
+	getIndexRoute() int
+	getTreePathHash() int
+	getDetectionPath() string
+	getValues() *[maxParams]string
+	getMatched() bool
+	setIndexHandler(handler int)
+	setIndexRoute(route int)
+	setMatched(matched bool)
+	setRoute(route *Route)
+	keepOriginalPath()
+	getPathOriginal() string
+	// Accepts checks if the specified extensions or content types are acceptable.
+	Accepts(offers ...string) string
+	// AcceptsCharsets checks if the specified charset is acceptable.
+	AcceptsCharsets(offers ...string) string
+	// AcceptsEncodings checks if the specified encoding is acceptable.
+	AcceptsEncodings(offers ...string) string
+	// AcceptsLanguages checks if the specified language is acceptable.
+	AcceptsLanguages(offers ...string) string
+	// BodyRaw contains the raw body submitted in a POST request.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
+	BodyRaw() []byte
+	tryDecodeBodyInOrder(originalBody *[]byte, encodings []string) ([]byte, uint8, error)
+	// Body contains the raw body submitted in a POST request.
+	// This method will decompress the body if the 'Content-Encoding' header is provided.
+	// It returns the original (or decompressed) body data which is valid only within the handler.
+	// Don't store direct references to the returned data.
+	// If you need to keep the body's data later, make a copy or use the Immutable option.
+	Body() []byte
+	// Cookies are used for getting a cookie value by key.
+	// Defaults to the empty string "" if the cookie doesn't exist.
+	// If a default value is given, it will return that value if the cookie doesn't exist.
+	// The returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
+	Cookies(key string, defaultValue ...string) string
 	// FormFile returns the first file by key from a MultipartForm.
 	FormFile(key string) (*multipart.FileHeader, error)
 	// FormValue returns the first value by key from a MultipartForm.
@@ -122,26 +192,8 @@ type Ctx interface {
 	// and the full response should be sent.
 	// When a client sends the Cache-Control: no-cache request header to indicate an end-to-end
 	// reload request, this module will return false to make handling these requests transparent.
-	// https://github.com/jshttp/fresh/blob/10e0471669dbbfbfd8de65bc6efac2ddd0bfa057/index.js#L33
+	// https://github.com/jshttp/fresh/blob/master/index.js#L33
 	Fresh() bool
-	// Get returns the HTTP request header specified by field.
-	// Field names are case-insensitive
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
-	Get(key string, defaultValue ...string) string
-	// GetRespHeader returns the HTTP response header specified by field.
-	// Field names are case-insensitive
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
-	GetRespHeader(key string, defaultValue ...string) string
-	// GetRespHeaders returns the HTTP response headers.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
-	GetRespHeaders() map[string][]string
-	// GetReqHeaders returns the HTTP request headers.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
-	GetReqHeaders() map[string][]string
 	// Host contains the host derived from the X-Forwarded-Host or Host HTTP header.
 	// Returned value is only valid within the handler. Do not store any references.
 	// In a network context, `Host` refers to the combination of a hostname and potentially a port number used for connecting,
@@ -176,33 +228,6 @@ type Ctx interface {
 	// Is returns the matching content type,
 	// if the incoming request's Content-Type HTTP header field matches the MIME type specified by the type parameter
 	Is(extension string) bool
-	// JSON converts any interface or string to JSON.
-	// Array and slice values encode as JSON arrays,
-	// except that []byte encodes as a base64-encoded string,
-	// and a nil slice encodes as the null JSON value.
-	// If the ctype parameter is given, this method will set the
-	// Content-Type header equal to ctype. If ctype is not given,
-	// The Content-Type header will be set to application/json.
-	JSON(data any, ctype ...string) error
-	// MsgPack converts any interface or string to MessagePack encoded bytes.
-	// If the ctype parameter is given, this method will set the
-	// Content-Type header equal to ctype. If ctype is not given,
-	// The Content-Type header will be set to application/vnd.msgpack.
-	MsgPack(data any, ctype ...string) error
-	// CBOR converts any interface or string to CBOR encoded bytes.
-	// If the ctype parameter is given, this method will set the
-	// Content-Type header equal to ctype. If ctype is not given,
-	// The Content-Type header will be set to application/cbor.
-	CBOR(data any, ctype ...string) error
-	// JSONP sends a JSON response with JSONP support.
-	// This method is identical to JSON, except that it opts-in to JSONP callback support.
-	// By default, the callback name is simply callback.
-	JSONP(data any, callback ...string) error
-	// XML converts any interface or string to XML.
-	// This method also sets the content header to application/xml; charset=utf-8.
-	XML(data any) error
-	// Links joins the links followed by the property to populate the response's Link HTTP header field.
-	Links(link ...string)
 	// Locals makes it possible to pass any values under keys scoped to the request
 	// and therefore available to all following routes that match the request.
 	//
@@ -210,8 +235,6 @@ type Ctx interface {
 	// RequestHandler. Additionally, Close method is called on each value
 	// implementing io.Closer before removing the value from ctx.
 	Locals(key any, value ...any) any
-	// Location sets the response Location HTTP header to the specified path parameter.
-	Location(path string)
 	// Method returns the HTTP request method for the context, optionally overridden by the provided argument.
 	// If no override is given or if the provided override is not a valid HTTP method, it returns the current method from the context.
 	// Otherwise, it updates the context's method and returns the overridden method as a string.
@@ -219,27 +242,12 @@ type Ctx interface {
 	// MultipartForm parse form entries from binary.
 	// This returns a map[string][]string, so given a key the value will be a string slice.
 	MultipartForm() (*multipart.Form, error)
-	// ClientHelloInfo return CHI from context
-	ClientHelloInfo() *tls.ClientHelloInfo
-	// Next executes the next method in the stack that matches the current route.
-	Next() error
-	// RestartRouting instead of going to the next handler. This may be useful after
-	// changing the request path. Note that handlers might be executed again.
-	RestartRouting() error
-	// OriginalURL contains the original request URL.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the value outside the Handler.
-	OriginalURL() string
 	// Params is used to get the route parameters.
 	// Defaults to empty string "" if the param doesn't exist.
 	// If a default value is given, it will return that value if the param doesn't exist.
 	// Returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Params(key string, defaultValue ...string) string
-	// Path returns the path part of the request URL.
-	// Optionally, you could override the path.
-	// Make copies or use the Immutable setting to use the value outside the Handler.
-	Path(override ...string) string
 	// Scheme contains the request protocol string: http or https for TLS requests.
 	// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
 	Scheme() string
@@ -275,14 +283,76 @@ type Ctx interface {
 	Queries() map[string]string
 	// Range returns a struct containing the type and a slice of ranges.
 	Range(size int) (Range, error)
-	// Redirect returns the Redirect reference.
-	// Use Redirect().Status() to set custom redirection status code.
-	// If status is not specified, status defaults to 303 See Other.
-	// You can use Redirect().To(), Redirect().Route() and Redirect().Back() for redirection.
-	Redirect() *Redirect
-	// ViewBind Add vars to default view var map binding to template engine.
-	// Variables are read by the Render method and may be overwritten.
-	ViewBind(vars Map) error
+	// Subdomains returns a slice of subdomains from the host, excluding the last `offset` components.
+	// If the offset is negative or exceeds the number of subdomains, an empty slice is returned.
+	// If the offset is zero every label (no trimming) is returned.
+	Subdomains(offset ...int) []string
+	// Stale returns the inverse of Fresh, indicating if the client's cached response is considered stale.
+	Stale() bool
+	// IsProxyTrusted checks trustworthiness of remote ip.
+	// If Config.TrustProxy false, it returns true
+	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
+	IsProxyTrusted() bool
+	// IsFromLocal will return true if request came from local.
+	IsFromLocal() bool
+	getBody() []byte
+	// Append the specified value to the HTTP response header field.
+	// If the header is not already set, it creates the header with the specified value.
+	Append(field string, values ...string)
+	// Attachment sets the HTTP response Content-Disposition header field to attachment.
+	Attachment(filename ...string)
+	// ClearCookie expires a specific cookie by key on the client side.
+	// If no key is provided it expires all cookies that came with the request.
+	ClearCookie(key ...string)
+	// Cookie sets a cookie by passing a cookie struct.
+	Cookie(cookie *Cookie)
+	// Download transfers the file from path as an attachment.
+	// Typically, browsers will prompt the user for download.
+	// By default, the Content-Disposition header filename= parameter is the filepath (this typically appears in the browser dialog).
+	// Override this default with the filename parameter.
+	Download(file string, filename ...string) error
+	// Format performs content-negotiation on the Accept HTTP header.
+	// It uses Accepts to select a proper format and calls the matching
+	// user-provided handler function.
+	// If no accepted format is found, and a format with MediaType "default" is given,
+	// that default handler is called. If no format is found and no default is given,
+	// StatusNotAcceptable is sent.
+	Format(handlers ...ResFmt) error
+	// AutoFormat performs content-negotiation on the Accept HTTP header.
+	// It uses Accepts to select a proper format.
+	// The supported content types are text/html, text/plain, application/json, and application/xml.
+	// For more flexible content negotiation, use Format.
+	// If the header is not specified or there is no proper format, text/plain is used.
+	AutoFormat(body any) error
+	// JSON converts any interface or string to JSON.
+	// Array and slice values encode as JSON arrays,
+	// except that []byte encodes as a base64-encoded string,
+	// and a nil slice encodes as the null JSON value.
+	// If the ctype parameter is given, this method will set the
+	// Content-Type header equal to ctype. If ctype is not given,
+	// The Content-Type header will be set to application/json; charset=utf-8.
+	JSON(data any, ctype ...string) error
+	// MsgPack converts any interface or string to MessagePack encoded bytes.
+	// If the ctype parameter is given, this method will set the
+	// Content-Type header equal to ctype. If ctype is not given,
+	// The Content-Type header will be set to application/vnd.msgpack.
+	MsgPack(data any, ctype ...string) error
+	// CBOR converts any interface or string to CBOR encoded bytes.
+	// If the ctype parameter is given, this method will set the
+	// Content-Type header equal to ctype. If ctype is not given,
+	// The Content-Type header will be set to application/cbor.
+	CBOR(data any, ctype ...string) error
+	// JSONP sends a JSON response with JSONP support.
+	// This method is identical to JSON, except that it opts-in to JSONP callback support.
+	// By default, the callback name is simply callback.
+	JSONP(data any, callback ...string) error
+	// XML converts any interface or string to XML.
+	// This method also sets the content header to application/xml; charset=utf-8.
+	XML(data any) error
+	// Links joins the links followed by the property to populate the response's Link HTTP header field.
+	Links(link ...string)
+	// Location sets the response Location HTTP header to the specified path parameter.
+	Location(path string)
 	// getLocationFromRoute get URL location from route using parameters
 	getLocationFromRoute(route Route, params Map) (string, error)
 	// GetRouteURL generates URLs to named routes, with parameters. URLs are relative, for example: "/user/1831"
@@ -290,21 +360,6 @@ type Ctx interface {
 	// Render a template with data and sends a text/html response.
 	// We support the following engines: https://github.com/gofiber/template
 	Render(name string, bind any, layouts ...string) error
-	renderExtensions(bind any)
-	// Req returns a convenience type whose API is limited to operations
-	// on the incoming request.
-	Req() Req
-	// Res returns a convenience type whose API is limited to operations
-	// on the outgoing response.
-	Res() Res
-	// Route returns the matched Route struct.
-	Route() *Route
-	// SaveFile saves any multipart file to disk.
-	SaveFile(fileheader *multipart.FileHeader, path string) error
-	// SaveFileToStorage saves any multipart file to an external storage system.
-	SaveFileToStorage(fileheader *multipart.FileHeader, path string, storage Storage) error
-	// Secure returns whether a secure connection was established.
-	Secure() bool
 	// Send sets the HTTP response body without copying it.
 	// From this point onward the body argument must not be changed.
 	Send(body []byte) error
@@ -326,66 +381,17 @@ type Ctx interface {
 	// Set sets the response's HTTP header field to the specified key, value.
 	Set(key, val string)
 	setCanonical(key, val string)
-	// Subdomains returns a slice of subdomains from the host, excluding the last `offset` components.
-	// If the offset is negative or exceeds the number of subdomains, an empty slice is returned.
-	// If the offset is zero every label (no trimming) is returned.
-	Subdomains(offset ...int) []string
-	// Stale returns the inverse of Fresh, indicating if the client's cached response is considered stale.
-	Stale() bool
-	// Status sets the HTTP status for the response.
-	// This method is chainable.
-	Status(status int) Ctx
-	// String returns unique string representation of the ctx.
-	//
-	// The returned value may be useful for logging.
-	String() string
 	// Type sets the Content-Type HTTP header to the MIME type specified by the file extension.
 	Type(extension string, charset ...string) Ctx
 	// Vary adds the given header field to the Vary response header.
 	// This will append the header, if not already listed, otherwise leaves it listed in the current location.
 	Vary(fields ...string)
-	// Value makes it possible to retrieve values (Locals) under keys scoped to the request
-	// and therefore available to all following routes that match the request.
-	Value(key any) any
 	// Write appends p into response body.
 	Write(p []byte) (int, error)
 	// Writef appends f & a into response body writer.
 	Writef(f string, a ...any) (int, error)
 	// WriteString appends s to response body.
 	WriteString(s string) (int, error)
-	// XHR returns a Boolean property, that is true, if the request's X-Requested-With header field is XMLHttpRequest,
-	// indicating that the request was issued by a client library (such as jQuery).
-	XHR() bool
-	// configDependentPaths set paths for route recognition and prepared paths for the user,
-	// here the features for caseSensitive, decoded paths, strict paths are evaluated
-	configDependentPaths()
-	// IsProxyTrusted checks trustworthiness of remote ip.
-	// If Config.TrustProxy false, it returns true
-	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
-	IsProxyTrusted() bool
-	// IsFromLocal will return true if request came from local.
-	IsFromLocal() bool
-	// Bind You can bind body, cookie, headers etc. into the map, map slice, struct easily by using Binding method.
-	// It gives custom binding support, detailed binding options and more.
-	// Replacement of: BodyParser, ParamsParser, GetReqHeaders, GetRespHeaders, AllParams, QueryParser, ReqHeaderParser
-	Bind() *Bind
-	// Reset is a method to reset context fields by given request when to use server handlers.
-	Reset(fctx *fasthttp.RequestCtx)
-	// Release is a method to reset context fields when to use ReleaseCtx()
-	release()
-	getBody() []byte
-	// Methods to use with next stack.
-	getMethodInt() int
-	getIndexRoute() int
-	getTreePathHash() int
-	getDetectionPath() string
-	getPathOriginal() string
-	getValues() *[maxParams]string
-	getMatched() bool
-	setIndexHandler(handler int)
-	setIndexRoute(route int)
-	setMatched(matched bool)
-	setRoute(route *Route)
 	// Drop closes the underlying connection without sending any response headers or body.
 	// This can be useful for silently terminating client connections, such as in DDoS mitigation
 	// or when blocking access to sensitive endpoints.

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1409,12 +1409,14 @@ func Test_Ctx_Format(t *testing.T) {
 	err := c.Res().Format(formatHandlers("application/xhtml+xml", "application/xml", "foo/bar")...)
 	require.Equal(t, "application/xhtml+xml", accepted)
 	require.Equal(t, "application/xhtml+xml", c.GetRespHeader(HeaderContentType))
+	require.Equal(t, "application/xhtml+xml", c.Res().Get(HeaderContentType))
 	require.NoError(t, err)
 	require.NotEqual(t, StatusNotAcceptable, c.Response().StatusCode())
 
 	err = c.Res().Format(formatHandlers("foo/bar;a=b")...)
 	require.Equal(t, "foo/bar;a=b", accepted)
 	require.Equal(t, "foo/bar;a=b", c.GetRespHeader(HeaderContentType))
+	require.Equal(t, "foo/bar;a=b", c.Res().Get(HeaderContentType))
 	require.NoError(t, err)
 	require.NotEqual(t, StatusNotAcceptable, c.Response().StatusCode())
 
@@ -1435,6 +1437,7 @@ func Test_Ctx_Format(t *testing.T) {
 	err = c.Format(formatHandlers("text/html", "default")...)
 	require.Equal(t, "default", accepted)
 	require.Equal(t, "text/html", c.GetRespHeader(HeaderContentType))
+	require.Equal(t, "text/html", c.Res().Get(HeaderContentType))
 	require.NoError(t, err)
 
 	err = c.Format()
@@ -3081,9 +3084,12 @@ func Test_Ctx_Path(t *testing.T) {
 	app := New(Config{UnescapePath: true})
 	app.Get("/test/:user", func(c Ctx) error {
 		require.Equal(t, "/Test/John", c.Path())
+		require.Equal(t, "/Test/John", string(c.Request().URI().Path()))
 		// not strict && case insensitive
 		require.Equal(t, "/ABC/", c.Path("/ABC/"))
+		require.Equal(t, "/ABC/", string(c.Request().URI().Path()))
 		require.Equal(t, "/test/john/", c.Path("/test/john/"))
+		require.Equal(t, "/test/john/", string(c.Request().URI().Path()))
 		return nil
 	})
 
@@ -3092,6 +3098,7 @@ func Test_Ctx_Path(t *testing.T) {
 		require.Equal(t, "/specialChars/créer", c.Path())
 		// unescape is also working if you set the path afterwards
 		require.Equal(t, "/اختبار/", c.Path("/%D8%A7%D8%AE%D8%AA%D8%A8%D8%A7%D8%B1/"))
+		require.Equal(t, "/اختبار/", string(c.Request().URI().Path()))
 		return nil
 	})
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/specialChars/cr%C3%A9er", nil))
@@ -4751,7 +4758,7 @@ func Test_Ctx_RenderWithoutLocals(t *testing.T) {
 
 	err := c.Render("./.github/testdata/index.tmpl", Map{})
 	require.NoError(t, err)
-	require.Equal(t, "<h1><no value></h1>", string(c.Response().Body()))
+	require.Equal(t, "<h1></h1>", string(c.Response().Body()))
 }
 
 func Test_Ctx_RenderWithLocals(t *testing.T) {
@@ -5961,6 +5968,12 @@ func Test_Ctx_GetRespHeaders(t *testing.T) {
 		"Multi":        {"one", "two"},
 		"Test":         {"Hello, World 👋!"},
 	}, c.GetRespHeaders())
+	require.Equal(t, map[string][]string{
+		"Content-Type": {"application/json"},
+		"Foo":          {"bar"},
+		"Multi":        {"one", "two"},
+		"Test":         {"Hello, World 👋!"},
+	}, c.Res().GetHeaders())
 }
 
 func Benchmark_Ctx_GetRespHeaders(b *testing.B) {
@@ -6003,6 +6016,12 @@ func Test_Ctx_GetReqHeaders(t *testing.T) {
 		"Test":         {"Hello, World 👋!"},
 		"Multi":        {"one", "two"},
 	}, c.GetReqHeaders())
+	require.Equal(t, map[string][]string{
+		"Content-Type": {"application/json"},
+		"Foo":          {"bar"},
+		"Test":         {"Hello, World 👋!"},
+		"Multi":        {"one", "two"},
+	}, c.GetHeaders())
 }
 
 func Test_Ctx_Set_SanitizeHeaderValue(t *testing.T) {

--- a/docs/middleware/basicauth.md
+++ b/docs/middleware/basicauth.md
@@ -24,6 +24,7 @@ Import the middleware package that is part of the Fiber web framework
 import (
     "github.com/gofiber/fiber/v3"
     "github.com/gofiber/fiber/v3/middleware/basicauth"
+    "golang.org/x/crypto/bcrypt"
 )
 ```
 
@@ -33,26 +34,32 @@ After you initiate your Fiber app, you can use the following possibilities:
 // Provide a minimal config
 app.Use(basicauth.New(basicauth.Config{
     Users: map[string]string{
-        "john":  "doe",
-        "admin": "123456",
+        // "doe" hashed using SHA-256
+        "john":  "{SHA256}eZ75KhGvkY4/t0HfQpNPO1aO0tk6wd908bjUGieTKm8=",
+        // "123456" hashed using bcrypt
+        "admin": "$2a$10$gTYwCN66/tBRoCr3.TXa1.v1iyvwIF7GRBqxzv7G.AHLMt/owXrp.",
     },
 }))
 
 // Or extend your config for customization
 app.Use(basicauth.New(basicauth.Config{
     Users: map[string]string{
-        "john":  "doe",
-        "admin": "123456",
+        // "doe" hashed using SHA-256
+        "john":  "{SHA256}eZ75KhGvkY4/t0HfQpNPO1aO0tk6wd908bjUGieTKm8=",
+        // "123456" hashed using bcrypt
+        "admin": "$2a$10$gTYwCN66/tBRoCr3.TXa1.v1iyvwIF7GRBqxzv7G.AHLMt/owXrp.",
     },
     Realm: "Forbidden",
     Authorizer: func(user, pass string, c fiber.Ctx) bool {
-        if user == "john" && pass == "doe" {
-            return true
+        // example: validate against a custom store and restrict by IP
+        hash, err := userStore.Lookup(user)
+        if err != nil {
+            return false
         }
-        if user == "admin" && pass == "123456" {
-            return true
+        if bcrypt.CompareHashAndPassword([]byte(hash), []byte(pass)) != nil {
+            return false
         }
-        return false
+        return c.IP() == "127.0.0.1"
     },
     Unauthorized: func(c fiber.Ctx) error {
         return c.SendFile("./unauthorized.html")
@@ -61,6 +68,17 @@ app.Use(basicauth.New(basicauth.Config{
 ```
 
 Getting the username and password
+
+### Password hashes
+
+Passwords must be supplied in pre-hashed form. The middleware detects the
+hashing algorithm from a prefix:
+
+- `"{SHA512}"` or `"{SHA256}"` followed by a base64 encoded digest
+- standard bcrypt strings beginning with `$2`
+
+If no prefix is present the value is interpreted as a SHA-256 digest encoded in
+hex or base64. Plaintext passwords are rejected.
 
 ```go
 func handler(c fiber.Ctx) error {
@@ -76,7 +94,7 @@ func handler(c fiber.Ctx) error {
 | Property        | Type                        | Description                                                                                                                                                           | Default               |
 |:----------------|:----------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------|
 | Next            | `func(fiber.Ctx) bool`     | Next defines a function to skip this middleware when returned true.                                                                                                   | `nil`                 |
-| Users           | `map[string]string`         | Users defines the allowed credentials.                                                                                                                                | `map[string]string{}` |
+| Users           | `map[string]string`         | Users maps usernames to **hashed** passwords (e.g. bcrypt, `{SHA256}`). | `map[string]string{}` |
 | Realm           | `string`                    | Realm is a string to define the realm attribute of BasicAuth. The realm identifies the system to authenticate against and can be used by clients to save credentials. | `"Restricted"`        |
 | Charset         | `string`                    | Charset sent in the `WWW-Authenticate` header, so clients know how credentials are encoded. | `"UTF-8"` |
 | HeaderLimit     | `int`                       | Maximum allowed length of the `Authorization` header. Requests exceeding this limit are rejected. | `8192` |

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1054,7 +1054,7 @@ The adaptor middleware has been significantly optimized for performance and effi
 
 ### BasicAuth
 
-The BasicAuth middleware now validates the `Authorization` header more rigorously and sets security-focused response headers. The default challenge includes the `charset="UTF-8"` parameter and disables caching. Passwords are no longer stored in the request context by default; use the new `StorePassword` option to retain them. A `Charset` option controls the value used in the challenge header.
+The BasicAuth middleware now validates the `Authorization` header more rigorously and sets security-focused response headers. Passwords must be provided in **hashed** form (e.g. SHA-256 or bcrypt) rather than plaintext. The default challenge includes the `charset="UTF-8"` parameter and disables caching. Passwords are no longer stored in the request context by default; use the new `StorePassword` option to retain them. A `Charset` option controls the value used in the challenge header.
 A new `HeaderLimit` option restricts the maximum length of the `Authorization` header (default: `8192` bytes).
 The `Authorizer` function now receives the current `fiber.Ctx` as a third argument, allowing credential checks to incorporate request context.
 
@@ -1946,6 +1946,8 @@ Authorizer: func(user, pass string, _ fiber.Ctx) bool {
     return user == "admin" && pass == "secret"
 }
 ```
+
+Passwords configured for BasicAuth must now be pre-hashed. If no prefix is supplied the middleware expects a SHA-256 digest encoded in hex. Common prefixes like `{SHA256}`, `{SHA512}` and bcrypt strings are also supported. Plaintext passwords are no longer accepted.
 
 You can also set the optional `HeaderLimit`, `StorePassword`, and `Charset`
 options to further control authentication behavior.

--- a/middleware/basicauth/basicauth_test.go
+++ b/middleware/basicauth/basicauth_test.go
@@ -1,7 +1,10 @@
 package basicauth
 
 import (
+	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http/httptest"
@@ -10,7 +13,18 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
+	"golang.org/x/crypto/bcrypt"
 )
+
+func sha256Hash(p string) string {
+	sum := sha256.Sum256([]byte(p))
+	return "{SHA256}" + base64.StdEncoding.EncodeToString(sum[:])
+}
+
+func sha512Hash(p string) string {
+	sum := sha512.Sum512([]byte(p))
+	return "{SHA512}" + base64.StdEncoding.EncodeToString(sum[:])
+}
 
 // go test -run Test_BasicAuth_Next
 func Test_BasicAuth_Next(t *testing.T) {
@@ -31,10 +45,14 @@ func Test_Middleware_BasicAuth(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
 
+	hashedJohn := sha256Hash("doe")
+	hashedAdmin, err := bcrypt.GenerateFromPassword([]byte("123456"), bcrypt.MinCost)
+	require.NoError(t, err)
+
 	app.Use(New(Config{
 		Users: map[string]string{
-			"john":  "doe",
-			"admin": "123456",
+			"john":  hashedJohn,
+			"admin": string(hashedAdmin),
 		},
 		StorePassword: true,
 	}))
@@ -96,8 +114,10 @@ func Test_BasicAuth_NoStorePassword(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
 
+	hashedJohn := sha256Hash("doe")
+
 	app.Use(New(Config{
-		Users: map[string]string{"john": "doe"},
+		Users: map[string]string{"john": hashedJohn},
 	}))
 
 	app.Get("/", func(c fiber.Ctx) error {
@@ -143,7 +163,8 @@ func Test_BasicAuth_WWWAuthenticateHeader(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
 
-	app.Use(New(Config{Users: map[string]string{"john": "doe"}}))
+	hashedJohn := sha256Hash("doe")
+	app.Use(New(Config{Users: map[string]string{"john": hashedJohn}}))
 
 	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
 	require.NoError(t, err)
@@ -155,7 +176,8 @@ func Test_BasicAuth_InvalidHeader(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
 
-	app.Use(New(Config{Users: map[string]string{"john": "doe"}}))
+	hashedJohn := sha256Hash("doe")
+	app.Use(New(Config{Users: map[string]string{"john": hashedJohn}}))
 
 	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
 	req.Header.Set(fiber.HeaderAuthorization, "Basic notbase64")
@@ -169,7 +191,8 @@ func Test_BasicAuth_EmptyAuthorization(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
 
-	app.Use(New(Config{Users: map[string]string{"john": "doe"}}))
+	hashedJohn := sha256Hash("doe")
+	app.Use(New(Config{Users: map[string]string{"john": hashedJohn}}))
 
 	cases := []string{"", "   "}
 	for _, h := range cases {
@@ -185,7 +208,8 @@ func Test_BasicAuth_WhitespaceHandling(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
 
-	app.Use(New(Config{Users: map[string]string{"john": "doe"}}))
+	hashedJohn := sha256Hash("doe")
+	app.Use(New(Config{Users: map[string]string{"john": hashedJohn}}))
 	app.Get("/", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusTeapot) })
 
 	creds := base64.StdEncoding.EncodeToString([]byte("john:doe"))
@@ -209,11 +233,12 @@ func Test_BasicAuth_WhitespaceHandling(t *testing.T) {
 func Test_BasicAuth_HeaderLimit(t *testing.T) {
 	t.Parallel()
 	creds := base64.StdEncoding.EncodeToString([]byte("john:doe"))
+	hashedJohn := sha256Hash("doe")
 
 	t.Run("too large", func(t *testing.T) {
 		t.Parallel()
 		app := fiber.New()
-		app.Use(New(Config{Users: map[string]string{"john": "doe"}, HeaderLimit: 10}))
+		app.Use(New(Config{Users: map[string]string{"john": hashedJohn}, HeaderLimit: 10}))
 		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
 		req.Header.Set(fiber.HeaderAuthorization, "Basic "+creds)
 		resp, err := app.Test(req)
@@ -224,7 +249,7 @@ func Test_BasicAuth_HeaderLimit(t *testing.T) {
 	t.Run("allowed", func(t *testing.T) {
 		t.Parallel()
 		app := fiber.New()
-		app.Use(New(Config{Users: map[string]string{"john": "doe"}, HeaderLimit: 100}))
+		app.Use(New(Config{Users: map[string]string{"john": hashedJohn}, HeaderLimit: 100}))
 		app.Get("/", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusTeapot) })
 		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
 		req.Header.Set(fiber.HeaderAuthorization, "Basic "+creds)
@@ -238,9 +263,11 @@ func Test_BasicAuth_HeaderLimit(t *testing.T) {
 func Benchmark_Middleware_BasicAuth(b *testing.B) {
 	app := fiber.New()
 
+	hashedJohn := sha256Hash("doe")
+
 	app.Use(New(Config{
 		Users: map[string]string{
-			"john": "doe",
+			"john": hashedJohn,
 		},
 	}))
 	app.Get("/", func(c fiber.Ctx) error {
@@ -267,9 +294,11 @@ func Benchmark_Middleware_BasicAuth(b *testing.B) {
 func Benchmark_Middleware_BasicAuth_Upper(b *testing.B) {
 	app := fiber.New()
 
+	hashedJohn := sha256Hash("doe")
+
 	app.Use(New(Config{
 		Users: map[string]string{
-			"john": "doe",
+			"john": hashedJohn,
 		},
 	}))
 	app.Get("/", func(c fiber.Ctx) error {
@@ -296,7 +325,8 @@ func Test_BasicAuth_Immutable(t *testing.T) {
 	t.Parallel()
 	app := fiber.New(fiber.Config{Immutable: true})
 
-	app.Use(New(Config{Users: map[string]string{"john": "doe"}}))
+	hashedJohn := sha256Hash("doe")
+	app.Use(New(Config{Users: map[string]string{"john": hashedJohn}}))
 	app.Get("/", func(c fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusTeapot)
 	})
@@ -308,4 +338,94 @@ func Test_BasicAuth_Immutable(t *testing.T) {
 	resp, err := app.Test(req)
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusTeapot, resp.StatusCode)
+}
+
+func Test_parseHashedPassword(t *testing.T) {
+	t.Parallel()
+	pass := "secret"
+	sha := sha256.Sum256([]byte(pass))
+	b64 := base64.StdEncoding.EncodeToString(sha[:])
+	hexDigest := hex.EncodeToString(sha[:])
+	bcryptHash, err := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name   string
+		hashed string
+	}{
+		{"bcrypt", string(bcryptHash)},
+		{"sha512", sha512Hash(pass)},
+		{"sha256", sha256Hash(pass)},
+		{"sha256-hex", hexDigest},
+		{"sha256-b64", b64},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			verify, err := parseHashedPassword(tt.hashed)
+			require.NoError(t, err)
+			require.True(t, verify(pass))
+			require.False(t, verify("wrong"))
+		})
+	}
+}
+
+func Test_BasicAuth_HashVariants(t *testing.T) {
+	t.Parallel()
+	pass := "doe"
+	bcryptHash, err := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.MinCost)
+	require.NoError(t, err)
+	cases := []struct {
+		name   string
+		hashed string
+	}{
+		{"bcrypt", string(bcryptHash)},
+		{"sha512", sha512Hash(pass)},
+		{"sha256", sha256Hash(pass)},
+		{"sha256-hex", func() string { h := sha256.Sum256([]byte(pass)); return hex.EncodeToString(h[:]) }()},
+	}
+
+	for _, tt := range cases {
+		app := fiber.New()
+		app.Use(New(Config{Users: map[string]string{"john": tt.hashed}}))
+		app.Get("/", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusTeapot) })
+
+		creds := base64.StdEncoding.EncodeToString([]byte("john:" + pass))
+		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+		req.Header.Set(fiber.HeaderAuthorization, "Basic "+creds)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, fiber.StatusTeapot, resp.StatusCode)
+	}
+}
+
+func Test_BasicAuth_HashVariants_Invalid(t *testing.T) {
+	t.Parallel()
+	pass := "doe"
+	wrong := "wrong"
+	bcryptHash, err := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.MinCost)
+	require.NoError(t, err)
+	cases := []struct {
+		name   string
+		hashed string
+	}{
+		{"bcrypt", string(bcryptHash)},
+		{"sha512", sha512Hash(pass)},
+		{"sha256", sha256Hash(pass)},
+		{"sha256-hex", func() string { h := sha256.Sum256([]byte(pass)); return hex.EncodeToString(h[:]) }()},
+	}
+
+	for _, tt := range cases {
+		app := fiber.New()
+		app.Use(New(Config{Users: map[string]string{"john": tt.hashed}}))
+		app.Get("/", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusTeapot) })
+
+		creds := base64.StdEncoding.EncodeToString([]byte("john:" + wrong))
+		req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+		req.Header.Set(fiber.HeaderAuthorization, "Basic "+creds)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	}
 }

--- a/middleware/basicauth/config.go
+++ b/middleware/basicauth/config.go
@@ -1,11 +1,18 @@
 package basicauth
 
 import (
+	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/utils/v2"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // Config defines the config for middleware.
@@ -103,9 +110,17 @@ func configDefault(config ...Config) Config {
 		cfg.HeaderLimit = ConfigDefault.HeaderLimit
 	}
 	if cfg.Authorizer == nil {
+		verifiers := make(map[string]func(string) bool, len(cfg.Users))
+		for u, hpw := range cfg.Users {
+			v, err := parseHashedPassword(hpw)
+			if err != nil {
+				panic(err)
+			}
+			verifiers[u] = v
+		}
 		cfg.Authorizer = func(user, pass string, _ fiber.Ctx) bool {
-			userPwd, exist := cfg.Users[user]
-			return exist && subtle.ConstantTimeCompare(utils.UnsafeBytes(userPwd), utils.UnsafeBytes(pass)) == 1
+			verify, ok := verifiers[user]
+			return ok && verify(pass)
 		}
 	}
 	if cfg.Unauthorized == nil {
@@ -121,4 +136,46 @@ func configDefault(config ...Config) Config {
 		}
 	}
 	return cfg
+}
+
+func parseHashedPassword(h string) (func(string) bool, error) {
+	switch {
+	case strings.HasPrefix(h, "$2"):
+		hash := []byte(h)
+		return func(p string) bool {
+			return bcrypt.CompareHashAndPassword(hash, []byte(p)) == nil
+		}, nil
+	case strings.HasPrefix(h, "{SHA512}"):
+		b, err := base64.StdEncoding.DecodeString(h[len("{SHA512}"):])
+		if err != nil {
+			return nil, fmt.Errorf("decode SHA512 password: %w", err)
+		}
+		return func(p string) bool {
+			sum := sha512.Sum512([]byte(p))
+			return subtle.ConstantTimeCompare(sum[:], b) == 1
+		}, nil
+	case strings.HasPrefix(h, "{SHA256}"):
+		b, err := base64.StdEncoding.DecodeString(h[len("{SHA256}"):])
+		if err != nil {
+			return nil, fmt.Errorf("decode SHA256 password: %w", err)
+		}
+		return func(p string) bool {
+			sum := sha256.Sum256([]byte(p))
+			return subtle.ConstantTimeCompare(sum[:], b) == 1
+		}, nil
+	default:
+		b, err := hex.DecodeString(h)
+		if err != nil || len(b) != sha256.Size {
+			if b, err = base64.StdEncoding.DecodeString(h); err != nil {
+				return nil, fmt.Errorf("decode SHA256 password: %w", err)
+			}
+			if len(b) != sha256.Size {
+				return nil, errors.New("decode SHA256 password: invalid length")
+			}
+		}
+		return func(p string) bool {
+			sum := sha256.Sum256([]byte(p))
+			return subtle.ConstantTimeCompare(sum[:], b) == 1
+		}, nil
+	}
 }

--- a/req.go
+++ b/req.go
@@ -1,159 +1,911 @@
 package fiber
 
 import (
-	"crypto/tls"
+	"bytes"
+	"errors"
 	"mime/multipart"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gofiber/utils/v2"
+	"github.com/valyala/fasthttp"
+	"golang.org/x/net/idna"
 )
 
-//go:generate ifacemaker --file req.go --struct DefaultReq --iface Req --pkg fiber --output req_interface_gen.go --not-exported true --iface-comment "Req"
+// Range data for c.Range
+type Range struct {
+	Type   string
+	Ranges []RangeSet
+}
+
+// RangeSet represents a single content range from a request.
+type RangeSet struct {
+	Start int
+	End   int
+}
+
+//go:generate ifacemaker --file req.go --struct DefaultReq --iface Req --pkg fiber --output req_interface_gen.go --not-exported true --iface-comment "Req is an interface for request-related Ctx methods."
 type DefaultReq struct {
-	ctx *DefaultCtx
+	c Ctx
 }
 
+// Accepts checks if the specified extensions or content types are acceptable.
 func (r *DefaultReq) Accepts(offers ...string) string {
-	return r.ctx.Accepts(offers...)
+	header := joinHeaderValues(r.Request().Header.PeekAll(HeaderAccept))
+	return getOffer(header, acceptsOfferType, offers...)
 }
 
+// AcceptsCharsets checks if the specified charset is acceptable.
 func (r *DefaultReq) AcceptsCharsets(offers ...string) string {
-	return r.ctx.AcceptsCharsets(offers...)
+	header := joinHeaderValues(r.Request().Header.PeekAll(HeaderAcceptCharset))
+	return getOffer(header, acceptsOffer, offers...)
 }
 
+// AcceptsEncodings checks if the specified encoding is acceptable.
 func (r *DefaultReq) AcceptsEncodings(offers ...string) string {
-	return r.ctx.AcceptsEncodings(offers...)
+	header := joinHeaderValues(r.Request().Header.PeekAll(HeaderAcceptEncoding))
+	return getOffer(header, acceptsOffer, offers...)
 }
 
+// AcceptsLanguages checks if the specified language is acceptable.
 func (r *DefaultReq) AcceptsLanguages(offers ...string) string {
-	return r.ctx.AcceptsLanguages(offers...)
+	header := joinHeaderValues(r.Request().Header.PeekAll(HeaderAcceptLanguage))
+	return getOffer(header, acceptsLanguageOffer, offers...)
 }
 
+// App returns the *App reference to the instance of the Fiber application
+func (r *DefaultReq) App() *App {
+	return r.c.App()
+}
+
+// BaseURL returns (protocol + host + base path).
 func (r *DefaultReq) BaseURL() string {
-	return r.ctx.BaseURL()
+	return r.c.BaseURL()
 }
 
-func (r *DefaultReq) Body() []byte {
-	return r.ctx.Body()
-}
-
+// BodyRaw contains the raw body submitted in a POST request.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting instead.
 func (r *DefaultReq) BodyRaw() []byte {
-	return r.ctx.BodyRaw()
+	return r.getBody()
 }
 
-func (r *DefaultReq) ClientHelloInfo() *tls.ClientHelloInfo {
-	return r.ctx.ClientHelloInfo()
+func (r *DefaultReq) tryDecodeBodyInOrder(
+	originalBody *[]byte,
+	encodings []string,
+) ([]byte, uint8, error) {
+	var (
+		err             error
+		body            []byte
+		decodesRealized uint8
+	)
+
+	request := r.Request()
+	for idx := range encodings {
+		i := len(encodings) - 1 - idx
+		encoding := encodings[i]
+		decodesRealized++
+		switch encoding {
+		case StrGzip, "x-gzip":
+			body, err = request.BodyGunzip()
+		case StrBr, StrBrotli:
+			body, err = request.BodyUnbrotli()
+		case StrDeflate:
+			body, err = request.BodyInflate()
+		case StrZstd:
+			body, err = request.BodyUnzstd()
+		case StrIdentity:
+			body = request.Body()
+		case StrCompress, "x-compress":
+			return nil, decodesRealized - 1, ErrNotImplemented
+		default:
+			return nil, decodesRealized - 1, ErrUnsupportedMediaType
+		}
+
+		if err != nil {
+			return nil, decodesRealized, err
+		}
+
+		if i > 0 && decodesRealized > 0 {
+			if i == len(encodings)-1 {
+				tempBody := request.Body()
+				*originalBody = make([]byte, len(tempBody))
+				copy(*originalBody, tempBody)
+			}
+			request.SetBodyRaw(body)
+		}
+	}
+
+	return body, decodesRealized, nil
 }
 
+// Body contains the raw body submitted in a POST request.
+// This method will decompress the body if the 'Content-Encoding' header is provided.
+// It returns the original (or decompressed) body data which is valid only within the handler.
+// Don't store direct references to the returned data.
+// If you need to keep the body's data later, make a copy or use the Immutable option.
+func (r *DefaultReq) Body() []byte {
+	var (
+		err                error
+		body, originalBody []byte
+		headerEncoding     string
+		encodingOrder      = []string{"", "", ""}
+	)
+
+	request := r.Request()
+
+	// Get Content-Encoding header
+	headerEncoding = utils.ToLower(utils.UnsafeString(request.Header.ContentEncoding()))
+
+	// If no encoding is provided, return the original body
+	if len(headerEncoding) == 0 {
+		return r.getBody()
+	}
+
+	// Split and get the encodings list, in order to attend the
+	// rule defined at: https://www.rfc-editor.org/rfc/rfc9110#section-8.4-5
+	encodingOrder = getSplicedStrList(headerEncoding, encodingOrder)
+	for i := range encodingOrder {
+		encodingOrder[i] = utils.ToLower(encodingOrder[i])
+	}
+	if len(encodingOrder) == 0 {
+		return r.getBody()
+	}
+
+	var decodesRealized uint8
+	body, decodesRealized, err = r.tryDecodeBodyInOrder(&originalBody, encodingOrder)
+
+	// Ensure that the body will be the original
+	if originalBody != nil && decodesRealized > 0 {
+		request.SetBodyRaw(originalBody)
+	}
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrUnsupportedMediaType):
+			_ = r.c.SendStatus(StatusUnsupportedMediaType) //nolint:errcheck // It is fine to ignore the error
+		case errors.Is(err, ErrNotImplemented):
+			_ = r.c.SendStatus(StatusNotImplemented) //nolint:errcheck // It is fine to ignore the error
+		}
+		return []byte(err.Error())
+	}
+
+	if r.App().config.Immutable {
+		return utils.CopyBytes(body)
+	}
+	return body
+}
+
+// RequestCtx returns *fasthttp.RequestCtx that carries a deadline
+// a cancellation signal, and other values across API boundaries.
+func (r *DefaultReq) RequestCtx() *fasthttp.RequestCtx {
+	return r.c.RequestCtx()
+}
+
+// Cookies are used for getting a cookie value by key.
+// Defaults to the empty string "" if the cookie doesn't exist.
+// If a default value is given, it will return that value if the cookie doesn't exist.
+// The returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting to use the value outside the Handler.
 func (r *DefaultReq) Cookies(key string, defaultValue ...string) string {
-	return r.ctx.Cookies(key, defaultValue...)
+	return defaultString(r.App().getString(r.Request().Header.Cookie(key)), defaultValue)
 }
 
+// Request return the *fasthttp.Request object
+// This allows you to use all fasthttp request methods
+// https://godoc.org/github.com/valyala/fasthttp#Request
+func (r *DefaultReq) Request() *fasthttp.Request {
+	return r.c.Request()
+}
+
+// FormFile returns the first file by key from a MultipartForm.
 func (r *DefaultReq) FormFile(key string) (*multipart.FileHeader, error) {
-	return r.ctx.FormFile(key)
+	return r.RequestCtx().FormFile(key)
 }
 
+// FormValue returns the first value by key from a MultipartForm.
+// Search is performed in QueryArgs, PostArgs, MultipartForm and FormFile in this particular order.
+// Defaults to the empty string "" if the form value doesn't exist.
+// If a default value is given, it will return that value if the form value does not exist.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting instead.
 func (r *DefaultReq) FormValue(key string, defaultValue ...string) string {
-	return r.ctx.FormValue(key, defaultValue...)
+	return defaultString(r.App().getString(r.RequestCtx().FormValue(key)), defaultValue)
 }
 
+// Fresh returns true when the response is still “fresh” in the client's cache,
+// otherwise false is returned to indicate that the client cache is now stale
+// and the full response should be sent.
+// When a client sends the Cache-Control: no-cache request header to indicate an end-to-end
+// reload request, this module will return false to make handling these requests transparent.
+// https://github.com/jshttp/fresh/blob/master/index.js#L33
 func (r *DefaultReq) Fresh() bool {
-	return r.ctx.Fresh()
+	// fields
+	modifiedSince := r.Get(HeaderIfModifiedSince)
+	noneMatch := r.Get(HeaderIfNoneMatch)
+
+	// unconditional request
+	if modifiedSince == "" && noneMatch == "" {
+		return false
+	}
+
+	// Always return stale when Cache-Control: no-cache
+	// to support end-to-end reload requests
+	// https://www.rfc-editor.org/rfc/rfc9111#section-5.2.1.4
+	cacheControl := r.Get(HeaderCacheControl)
+	if cacheControl != "" && isNoCache(cacheControl) {
+		return false
+	}
+
+	app := r.App()
+	// if-none-match
+	if noneMatch != "" && noneMatch != "*" {
+		response := r.c.Response()
+		etag := app.getString(response.Header.Peek(HeaderETag))
+		if etag == "" {
+			return false
+		}
+		if app.isEtagStale(etag, app.getBytes(noneMatch)) {
+			return false
+		}
+
+		if modifiedSince != "" {
+			lastModified := app.getString(response.Header.Peek(HeaderLastModified))
+			if lastModified != "" {
+				lastModifiedTime, err := http.ParseTime(lastModified)
+				if err != nil {
+					return false
+				}
+				modifiedSinceTime, err := http.ParseTime(modifiedSince)
+				if err != nil {
+					return false
+				}
+				return lastModifiedTime.Compare(modifiedSinceTime) != 1
+			}
+		}
+	}
+	return true
 }
 
+// Get returns the HTTP request header specified by field.
+// Field names are case-insensitive
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting instead.
 func (r *DefaultReq) Get(key string, defaultValue ...string) string {
-	return r.ctx.Get(key, defaultValue...)
+	return GetReqHeader(r.c, key, defaultValue...)
 }
 
+// GetReqHeader returns the HTTP request header specified by filed.
+// This function is generic and can handle different headers type values.
+// If the generic type cannot be matched to a supported type, the function
+// returns the default value (if provided) or the zero value of type V.
+func GetReqHeader[V GenericType](c Ctx, key string, defaultValue ...V) V {
+	v, err := genericParseType[V](c.App().getString(c.Request().Header.Peek(key)))
+	if err != nil && len(defaultValue) > 0 {
+		return defaultValue[0]
+	}
+	return v
+}
+
+// GetHeaders (a.k.a GetReqHeaders) returns the HTTP request headers.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting instead.
+func (r *DefaultReq) GetHeaders() map[string][]string {
+	app := r.App()
+	headers := make(map[string][]string)
+	for k, v := range r.Request().Header.All() {
+		key := app.getString(k)
+		headers[key] = append(headers[key], app.getString(v))
+	}
+	return headers
+}
+
+// Host contains the host derived from the X-Forwarded-Host or Host HTTP header.
+// Returned value is only valid within the handler. Do not store any references.
+// In a network context, `Host` refers to the combination of a hostname and potentially a port number used for connecting,
+// while `Hostname` refers specifically to the name assigned to a device on a network, excluding any port information.
+// Example: URL: https://example.com:8080 -> Host: example.com:8080
+// Make copies or use the Immutable setting instead.
+// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
 func (r *DefaultReq) Host() string {
-	return r.ctx.Host()
+	if r.IsProxyTrusted() {
+		if host := r.Get(HeaderXForwardedHost); len(host) > 0 {
+			commaPos := strings.Index(host, ",")
+			if commaPos != -1 {
+				return host[:commaPos]
+			}
+			return host
+		}
+	}
+	return r.App().getString(r.Request().URI().Host())
 }
 
+// Hostname contains the hostname derived from the X-Forwarded-Host or Host HTTP header using the c.Host() method.
+// Returned value is only valid within the handler. Do not store any references.
+// Example: URL: https://example.com:8080 -> Hostname: example.com
+// Make copies or use the Immutable setting instead.
+// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
 func (r *DefaultReq) Hostname() string {
-	return r.ctx.Hostname()
+	addr, _ := parseAddr(r.Host())
+
+	return addr
 }
 
-func (r *DefaultReq) IP() string {
-	return r.ctx.IP()
-}
-
-func (r *DefaultReq) IPs() []string {
-	return r.ctx.IPs()
-}
-
-func (r *DefaultReq) Is(extension string) bool {
-	return r.ctx.Is(extension)
-}
-
-func (r *DefaultReq) IsFromLocal() bool {
-	return r.ctx.IsFromLocal()
-}
-
-func (r *DefaultReq) IsProxyTrusted() bool {
-	return r.ctx.IsProxyTrusted()
-}
-
-func (r *DefaultReq) Method(override ...string) string {
-	return r.ctx.Method(override...)
-}
-
-func (r *DefaultReq) MultipartForm() (*multipart.Form, error) {
-	return r.ctx.MultipartForm()
-}
-
-func (r *DefaultReq) OriginalURL() string {
-	return r.ctx.OriginalURL()
-}
-
-func (r *DefaultReq) Params(key string, defaultValue ...string) string {
-	return r.ctx.Params(key, defaultValue...)
-}
-
-func (r *DefaultReq) Path(override ...string) string {
-	return r.ctx.Path(override...)
-}
-
+// Port returns the remote port of the request.
 func (r *DefaultReq) Port() string {
-	return r.ctx.Port()
+	tcpaddr, ok := r.RequestCtx().RemoteAddr().(*net.TCPAddr)
+	if !ok {
+		panic(errors.New("failed to type-assert to *net.TCPAddr"))
+	}
+	return strconv.Itoa(tcpaddr.Port)
 }
 
+// IP returns the remote IP address of the request.
+// If ProxyHeader and IP Validation is configured, it will parse that header and return the first valid IP address.
+// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
+func (r *DefaultReq) IP() string {
+	app := r.App()
+	if r.IsProxyTrusted() && len(app.config.ProxyHeader) > 0 {
+		return r.extractIPFromHeader(app.config.ProxyHeader)
+	}
+
+	return r.RequestCtx().RemoteIP().String()
+}
+
+// extractIPsFromHeader will return a slice of IPs it found given a header name in the order they appear.
+// When IP validation is enabled, any invalid IPs will be omitted.
+func (r *DefaultReq) extractIPsFromHeader(header string) []string {
+	// TODO: Reuse the c.extractIPFromHeader func somehow in here
+
+	headerValue := r.Get(header)
+
+	// We can't know how many IPs we will return, but we will try to guess with this constant division.
+	// Counting ',' makes function slower for about 50ns in general case.
+	const maxEstimatedCount = 8
+	estimatedCount := min(len(headerValue)/maxEstimatedCount,
+		// Avoid big allocation on big header
+		maxEstimatedCount)
+
+	ipsFound := make([]string, 0, estimatedCount)
+
+	i := 0
+	j := -1
+
+iploop:
+	for {
+		var v4, v6 bool
+
+		// Manually splitting string without allocating slice, working with parts directly
+		i, j = j+1, j+2
+
+		if j > len(headerValue) {
+			break
+		}
+
+		for j < len(headerValue) && headerValue[j] != ',' {
+			switch headerValue[j] {
+			case ':':
+				v6 = true
+			case '.':
+				v4 = true
+			}
+			j++
+		}
+
+		for i < j && (headerValue[i] == ' ' || headerValue[i] == ',') {
+			i++
+		}
+
+		s := utils.TrimRight(headerValue[i:j], ' ')
+
+		if r.App().config.EnableIPValidation {
+			// Skip validation if IP is clearly not IPv4/IPv6, otherwise validate without allocations
+			if (!v6 && !v4) || (v6 && !utils.IsIPv6(s)) || (v4 && !utils.IsIPv4(s)) {
+				continue iploop
+			}
+		}
+
+		ipsFound = append(ipsFound, s)
+	}
+
+	return ipsFound
+}
+
+// extractIPFromHeader will attempt to pull the real client IP from the given header when IP validation is enabled.
+// currently, it will return the first valid IP address in header.
+// when IP validation is disabled, it will simply return the value of the header without any inspection.
+// Implementation is almost the same as in extractIPsFromHeader, but without allocation of []string.
+func (r *DefaultReq) extractIPFromHeader(header string) string {
+	app := r.App()
+	if app.config.EnableIPValidation {
+		headerValue := r.Get(header)
+
+		i := 0
+		j := -1
+
+	iploop:
+		for {
+			var v4, v6 bool
+
+			// Manually splitting string without allocating slice, working with parts directly
+			i, j = j+1, j+2
+
+			if j > len(headerValue) {
+				break
+			}
+
+			for j < len(headerValue) && headerValue[j] != ',' {
+				switch headerValue[j] {
+				case ':':
+					v6 = true
+				case '.':
+					v4 = true
+				}
+				j++
+			}
+
+			for i < j && headerValue[i] == ' ' {
+				i++
+			}
+
+			s := utils.TrimRight(headerValue[i:j], ' ')
+
+			if app.config.EnableIPValidation {
+				if (!v6 && !v4) || (v6 && !utils.IsIPv6(s)) || (v4 && !utils.IsIPv4(s)) {
+					continue iploop
+				}
+			}
+
+			return s
+		}
+
+		return r.RequestCtx().RemoteIP().String()
+	}
+
+	// default behavior if IP validation is not enabled is just to return whatever value is
+	// in the proxy header. Even if it is empty or invalid
+	return r.Get(app.config.ProxyHeader)
+}
+
+// IPs returns a string slice of IP addresses specified in the X-Forwarded-For request header.
+// When IP validation is enabled, only valid IPs are returned.
+func (r *DefaultReq) IPs() []string {
+	return r.extractIPsFromHeader(HeaderXForwardedFor)
+}
+
+// Is returns the matching content type,
+// if the incoming request's Content-Type HTTP header field matches the MIME type specified by the type parameter
+func (r *DefaultReq) Is(extension string) bool {
+	extensionHeader := utils.GetMIME(extension)
+	if extensionHeader == "" {
+		return false
+	}
+
+	ct := r.App().getString(r.Request().Header.ContentType())
+	if i := strings.IndexByte(ct, ';'); i != -1 {
+		ct = ct[:i]
+	}
+	ct = utils.Trim(ct, ' ')
+	return utils.EqualFold(ct, extensionHeader)
+}
+
+// Locals makes it possible to pass any values under keys scoped to the request
+// and therefore available to all following routes that match the request.
+//
+// All the values are removed from ctx after returning from the top
+// RequestHandler. Additionally, Close method is called on each value
+// implementing io.Closer before removing the value from ctx.
+func (r *DefaultReq) Locals(key any, value ...any) any {
+	if len(value) == 0 {
+		return r.RequestCtx().UserValue(key)
+	}
+	r.RequestCtx().SetUserValue(key, value[0])
+	return value[0]
+}
+
+// Locals function utilizing Go's generics feature.
+// This function allows for manipulating and retrieving local values within a
+// request context with a more specific data type.
+//
+// All the values are removed from ctx after returning from the top
+// RequestHandler. Additionally, Close method is called on each value
+// implementing io.Closer before removing the value from ctx.
+func Locals[V any](c Ctx, key any, value ...V) V {
+	var v V
+	var ok bool
+	if len(value) == 0 {
+		v, ok = c.Locals(key).(V)
+	} else {
+		v, ok = c.Locals(key, value[0]).(V)
+	}
+	if !ok {
+		return v // return zero of type V
+	}
+	return v
+}
+
+// Method returns the HTTP request method for the context, optionally overridden by the provided argument.
+// If no override is given or if the provided override is not a valid HTTP method, it returns the current method from the context.
+// Otherwise, it updates the context's method and returns the overridden method as a string.
+func (r *DefaultReq) Method(override ...string) string {
+	app := r.App()
+	if len(override) == 0 {
+		// Nothing to override, just return current method from context
+		return app.method(r.c.getMethodInt())
+	}
+
+	method := utils.ToUpper(override[0])
+	methodInt := app.methodInt(method)
+	if methodInt == -1 {
+		// Provided override does not valid HTTP method, no override, return current method
+		return app.method(r.c.getMethodInt())
+	}
+	r.c.setMethodInt(methodInt)
+	return method
+}
+
+// MultipartForm parse form entries from binary.
+// This returns a map[string][]string, so given a key the value will be a string slice.
+func (r *DefaultReq) MultipartForm() (*multipart.Form, error) {
+	return r.RequestCtx().MultipartForm()
+}
+
+// OriginalURL contains the original request URL.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting to use the value outside the Handler.
+func (r *DefaultReq) OriginalURL() string {
+	return r.App().getString(r.Request().Header.RequestURI())
+}
+
+// Params is used to get the route parameters.
+// Defaults to empty string "" if the param doesn't exist.
+// If a default value is given, it will return that value if the param doesn't exist.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting to use the value outside the Handler.
+func (r *DefaultReq) Params(key string, defaultValue ...string) string {
+	if key == "*" || key == "+" {
+		key += "1"
+	}
+
+	app := r.App()
+	route := r.Route()
+	values := r.c.getValues()
+	for i := range route.Params {
+		if len(key) != len(route.Params[i]) {
+			continue
+		}
+		if route.Params[i] == key || (!app.config.CaseSensitive && utils.EqualFold(route.Params[i], key)) {
+			// in case values are not here
+			if len(values) <= i || len(values[i]) == 0 {
+				break
+			}
+			return values[i]
+		}
+	}
+	return defaultString("", defaultValue)
+}
+
+// Params is used to get the route parameters.
+// This function is generic and can handle different route parameters type values.
+// If the generic type cannot be matched to a supported type, the function
+// returns the default value (if provided) or the zero value of type V.
+//
+// Example:
+//
+// http://example.com/user/:user -> http://example.com/user/john
+// Params[string](c, "user") -> returns john
+//
+// http://example.com/id/:id -> http://example.com/user/114
+// Params[int](c, "id") ->  returns 114 as integer.
+//
+// http://example.com/id/:number -> http://example.com/id/john
+// Params[int](c, "number", 0) -> returns 0 because can't parse 'john' as integer.
+func Params[V GenericType](c Ctx, key string, defaultValue ...V) V {
+	v, err := genericParseType[V](c.Params(key))
+	if err != nil && len(defaultValue) > 0 {
+		return defaultValue[0]
+	}
+	return v
+}
+
+// Scheme contains the request protocol string: http or https for TLS requests.
+// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
+func (r *DefaultReq) Scheme() string {
+	ctx := r.RequestCtx()
+	if ctx.IsTLS() {
+		return schemeHTTPS
+	}
+	if !r.IsProxyTrusted() {
+		return schemeHTTP
+	}
+
+	app := r.App()
+	scheme := schemeHTTP
+	const lenXHeaderName = 12
+	for key, val := range ctx.Request.Header.All() {
+		if len(key) < lenXHeaderName {
+			continue // Neither "X-Forwarded-" nor "X-Url-Scheme"
+		}
+		switch {
+		case bytes.HasPrefix(key, []byte("X-Forwarded-")):
+			if bytes.Equal(key, []byte(HeaderXForwardedProto)) ||
+				bytes.Equal(key, []byte(HeaderXForwardedProtocol)) {
+				v := app.getString(val)
+				commaPos := strings.Index(v, ",")
+				if commaPos != -1 {
+					scheme = v[:commaPos]
+				} else {
+					scheme = v
+				}
+			} else if bytes.Equal(key, []byte(HeaderXForwardedSsl)) && bytes.Equal(val, []byte("on")) {
+				scheme = schemeHTTPS
+			}
+
+		case bytes.Equal(key, []byte(HeaderXUrlScheme)):
+			scheme = app.getString(val)
+		}
+	}
+	return scheme
+}
+
+// Protocol returns the HTTP protocol of request: HTTP/1.1 and HTTP/2.
 func (r *DefaultReq) Protocol() string {
-	return r.ctx.Protocol()
+	return utils.UnsafeString(r.Request().Header.Protocol())
 }
 
-func (r *DefaultReq) Queries() map[string]string {
-	return r.ctx.Queries()
-}
-
+// Query returns the query string parameter in the url.
+// Defaults to empty string "" if the query doesn't exist.
+// If a default value is given, it will return that value if the query doesn't exist.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting to use the value outside the Handler.
 func (r *DefaultReq) Query(key string, defaultValue ...string) string {
-	return r.ctx.Query(key, defaultValue...)
+	return Query(r.c, key, defaultValue...)
 }
 
+// Queries returns a map of query parameters and their values.
+//
+// GET /?name=alex&wanna_cake=2&id=
+// Queries()["name"] == "alex"
+// Queries()["wanna_cake"] == "2"
+// Queries()["id"] == ""
+//
+// GET /?field1=value1&field1=value2&field2=value3
+// Queries()["field1"] == "value2"
+// Queries()["field2"] == "value3"
+//
+// GET /?list_a=1&list_a=2&list_a=3&list_b[]=1&list_b[]=2&list_b[]=3&list_c=1,2,3
+// Queries()["list_a"] == "3"
+// Queries()["list_b[]"] == "3"
+// Queries()["list_c"] == "1,2,3"
+//
+// GET /api/search?filters.author.name=John&filters.category.name=Technology&filters[customer][name]=Alice&filters[status]=pending
+// Queries()["filters.author.name"] == "John"
+// Queries()["filters.category.name"] == "Technology"
+// Queries()["filters[customer][name]"] == "Alice"
+// Queries()["filters[status]"] == "pending"
+func (r *DefaultReq) Queries() map[string]string {
+	app := r.App()
+	queryArgs := r.RequestCtx().QueryArgs()
+
+	m := make(map[string]string, queryArgs.Len())
+	for key, value := range queryArgs.All() {
+		m[app.getString(key)] = app.getString(value)
+	}
+	return m
+}
+
+// Query Retrieves the value of a query parameter from the request's URI.
+// The function is generic and can handle query parameter values of different types.
+// It takes the following parameters:
+// - c: The context object representing the current request.
+// - key: The name of the query parameter.
+// - defaultValue: (Optional) The default value to return in case the query parameter is not found or cannot be parsed.
+// The function performs the following steps:
+//  1. Type-asserts the context object to *DefaultCtx.
+//  2. Retrieves the raw query parameter value from the request's URI.
+//  3. Parses the raw value into the appropriate type based on the generic type parameter V.
+//     If parsing fails, the function checks if a default value is provided. If so, it returns the default value.
+//  4. Returns the parsed value.
+//
+// If the generic type cannot be matched to a supported type, the function returns the default value (if provided) or the zero value of type V.
+//
+// Example usage:
+//
+//	GET /?search=john&age=8
+//	name := Query[string](c, "search") // Returns "john"
+//	age := Query[int](c, "age") // Returns 8
+//	unknown := Query[string](c, "unknown", "default") // Returns "default" since the query parameter "unknown" is not found
+func Query[V GenericType](c Ctx, key string, defaultValue ...V) V {
+	q := c.App().getString(c.RequestCtx().QueryArgs().Peek(key))
+	v, err := genericParseType[V](q)
+	if err != nil && len(defaultValue) > 0 {
+		return defaultValue[0]
+	}
+	return v
+}
+
+// Range returns a struct containing the type and a slice of ranges.
 func (r *DefaultReq) Range(size int) (Range, error) {
-	return r.ctx.Range(size)
+	var (
+		rangeData Range
+		ranges    string
+	)
+	rangeStr := utils.Trim(r.Get(HeaderRange), ' ')
+
+	i := strings.IndexByte(rangeStr, '=')
+	if i == -1 || strings.Contains(rangeStr[i+1:], "=") {
+		return rangeData, ErrRangeMalformed
+	}
+	rangeData.Type = utils.ToLower(utils.Trim(rangeStr[:i], ' '))
+	if rangeData.Type != "bytes" {
+		return rangeData, ErrRangeMalformed
+	}
+	ranges = utils.Trim(rangeStr[i+1:], ' ')
+
+	var (
+		singleRange string
+		moreRanges  = ranges
+	)
+	for moreRanges != "" {
+		singleRange = moreRanges
+		if i := strings.IndexByte(moreRanges, ','); i >= 0 {
+			singleRange = moreRanges[:i]
+			moreRanges = utils.Trim(moreRanges[i+1:], ' ')
+		} else {
+			moreRanges = ""
+		}
+
+		singleRange = utils.Trim(singleRange, ' ')
+
+		var (
+			startStr, endStr string
+			i                int
+		)
+		if i = strings.IndexByte(singleRange, '-'); i == -1 {
+			return rangeData, ErrRangeMalformed
+		}
+		startStr = utils.Trim(singleRange[:i], ' ')
+		endStr = utils.Trim(singleRange[i+1:], ' ')
+
+		start, startErr := fasthttp.ParseUint(utils.UnsafeBytes(startStr))
+		end, endErr := fasthttp.ParseUint(utils.UnsafeBytes(endStr))
+		if startErr != nil { // -nnn
+			start = size - end
+			end = size - 1
+		} else if endErr != nil { // nnn-
+			end = size - 1
+		}
+		if end > size-1 { // limit last-byte-pos to current length
+			end = size - 1
+		}
+		if start > end || start < 0 {
+			continue
+		}
+		rangeData.Ranges = append(rangeData.Ranges, struct {
+			Start int
+			End   int
+		}{
+			Start: start,
+			End:   end,
+		})
+	}
+	if len(rangeData.Ranges) < 1 {
+		r.c.Status(StatusRequestedRangeNotSatisfiable)
+		r.c.Set(HeaderContentRange, "bytes */"+strconv.Itoa(size))
+		return rangeData, ErrRequestedRangeNotSatisfiable
+	}
+
+	return rangeData, nil
 }
 
+// Route returns the matched Route struct.
 func (r *DefaultReq) Route() *Route {
-	return r.ctx.Route()
+	return r.c.Route()
 }
 
-func (r *DefaultReq) SaveFile(fileheader *multipart.FileHeader, path string) error {
-	return r.ctx.SaveFile(fileheader, path)
-}
-
-func (r *DefaultReq) SaveFileToStorage(fileheader *multipart.FileHeader, path string, storage Storage) error {
-	return r.ctx.SaveFileToStorage(fileheader, path, storage)
-}
-
-func (r *DefaultReq) Secure() bool {
-	return r.ctx.Secure()
-}
-
-func (r *DefaultReq) Stale() bool {
-	return r.ctx.Stale()
-}
-
+// Subdomains returns a slice of subdomains from the host, excluding the last `offset` components.
+// If the offset is negative or exceeds the number of subdomains, an empty slice is returned.
+// If the offset is zero every label (no trimming) is returned.
 func (r *DefaultReq) Subdomains(offset ...int) []string {
-	return r.ctx.Subdomains(offset...)
+	o := 2
+	if len(offset) > 0 {
+		o = offset[0]
+	}
+
+	// Negative offset, return nothing.
+	if o < 0 {
+		return []string{}
+	}
+
+	// Normalize host according to RFC 3986
+	host := r.Hostname()
+	// Trim the trailing dot of a fully-qualified domain
+	if strings.HasSuffix(host, ".") {
+		host = utils.TrimRight(host, '.')
+	}
+	host = utils.ToLower(host)
+
+	// Decode punycode labels only when necessary
+	if strings.Contains(host, "xn--") {
+		if u, err := idna.Lookup.ToUnicode(host); err == nil {
+			host = utils.ToLower(u)
+		}
+	}
+
+	// Return nothing for IP addresses
+	ip := host
+	if strings.HasPrefix(ip, "[") && strings.HasSuffix(ip, "]") {
+		ip = ip[1 : len(ip)-1]
+	}
+	if utils.IsIPv4(ip) || utils.IsIPv6(ip) {
+		return []string{}
+	}
+
+	parts := strings.Split(host, ".")
+
+	// offset == 0, caller wants everything.
+	if o == 0 {
+		return parts
+	}
+
+	// If we trim away the whole slice (or more), nothing remains.
+	if o >= len(parts) {
+		return []string{}
+	}
+
+	return parts[:len(parts)-o]
 }
 
-func (r *DefaultReq) XHR() bool {
-	return r.ctx.XHR()
+// Stale returns the inverse of Fresh, indicating if the client's cached response is considered stale.
+func (r *DefaultReq) Stale() bool {
+	return !r.Fresh()
+}
+
+// IsProxyTrusted checks trustworthiness of remote ip.
+// If Config.TrustProxy false, it returns true
+// IsProxyTrusted can check remote ip by proxy ranges and ip map.
+func (r *DefaultReq) IsProxyTrusted() bool {
+	config := r.App().config
+	if !config.TrustProxy {
+		return true
+	}
+
+	ip := r.RequestCtx().RemoteIP()
+
+	if (config.TrustProxyConfig.Loopback && ip.IsLoopback()) ||
+		(config.TrustProxyConfig.Private && ip.IsPrivate()) ||
+		(config.TrustProxyConfig.LinkLocal && ip.IsLinkLocalUnicast()) {
+		return true
+	}
+
+	if _, trusted := config.TrustProxyConfig.ips[ip.String()]; trusted {
+		return true
+	}
+
+	for _, ipNet := range config.TrustProxyConfig.ranges {
+		if ipNet.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsFromLocal will return true if request came from local.
+func (r *DefaultReq) IsFromLocal() bool {
+	return r.RequestCtx().RemoteIP().IsLoopback()
+}
+
+// Release is a method to reset Req fields when to use ReleaseCtx()
+func (r *DefaultReq) release() {
+	r.c = nil
+}
+
+func (r *DefaultReq) getBody() []byte {
+	if r.App().config.Immutable {
+		return utils.CopyBytes(r.Request().Body())
+	}
+
+	return r.Request().Body()
 }

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -3,47 +3,182 @@
 package fiber
 
 import (
-	"crypto/tls"
 	"mime/multipart"
+
+	"github.com/valyala/fasthttp"
 )
 
-// Req
+// Req is an interface for request-related Ctx methods.
 type Req interface {
+	// Accepts checks if the specified extensions or content types are acceptable.
 	Accepts(offers ...string) string
+	// AcceptsCharsets checks if the specified charset is acceptable.
 	AcceptsCharsets(offers ...string) string
+	// AcceptsEncodings checks if the specified encoding is acceptable.
 	AcceptsEncodings(offers ...string) string
+	// AcceptsLanguages checks if the specified language is acceptable.
 	AcceptsLanguages(offers ...string) string
+	// App returns the *App reference to the instance of the Fiber application
+	App() *App
+	// BaseURL returns (protocol + host + base path).
 	BaseURL() string
-	Body() []byte
+	// BodyRaw contains the raw body submitted in a POST request.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
 	BodyRaw() []byte
-	ClientHelloInfo() *tls.ClientHelloInfo
+	tryDecodeBodyInOrder(originalBody *[]byte, encodings []string) ([]byte, uint8, error)
+	// Body contains the raw body submitted in a POST request.
+	// This method will decompress the body if the 'Content-Encoding' header is provided.
+	// It returns the original (or decompressed) body data which is valid only within the handler.
+	// Don't store direct references to the returned data.
+	// If you need to keep the body's data later, make a copy or use the Immutable option.
+	Body() []byte
+	// RequestCtx returns *fasthttp.RequestCtx that carries a deadline
+	// a cancellation signal, and other values across API boundaries.
+	RequestCtx() *fasthttp.RequestCtx
+	// Cookies are used for getting a cookie value by key.
+	// Defaults to the empty string "" if the cookie doesn't exist.
+	// If a default value is given, it will return that value if the cookie doesn't exist.
+	// The returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Cookies(key string, defaultValue ...string) string
+	// Request return the *fasthttp.Request object
+	// This allows you to use all fasthttp request methods
+	// https://godoc.org/github.com/valyala/fasthttp#Request
+	Request() *fasthttp.Request
+	// FormFile returns the first file by key from a MultipartForm.
 	FormFile(key string) (*multipart.FileHeader, error)
+	// FormValue returns the first value by key from a MultipartForm.
+	// Search is performed in QueryArgs, PostArgs, MultipartForm and FormFile in this particular order.
+	// Defaults to the empty string "" if the form value doesn't exist.
+	// If a default value is given, it will return that value if the form value does not exist.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
 	FormValue(key string, defaultValue ...string) string
+	// Fresh returns true when the response is still “fresh” in the client's cache,
+	// otherwise false is returned to indicate that the client cache is now stale
+	// and the full response should be sent.
+	// When a client sends the Cache-Control: no-cache request header to indicate an end-to-end
+	// reload request, this module will return false to make handling these requests transparent.
+	// https://github.com/jshttp/fresh/blob/master/index.js#L33
 	Fresh() bool
+	// Get returns the HTTP request header specified by field.
+	// Field names are case-insensitive
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
 	Get(key string, defaultValue ...string) string
+	// GetHeaders (a.k.a GetReqHeaders) returns the HTTP request headers.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
+	GetHeaders() map[string][]string
+	// Host contains the host derived from the X-Forwarded-Host or Host HTTP header.
+	// Returned value is only valid within the handler. Do not store any references.
+	// In a network context, `Host` refers to the combination of a hostname and potentially a port number used for connecting,
+	// while `Hostname` refers specifically to the name assigned to a device on a network, excluding any port information.
+	// Example: URL: https://example.com:8080 -> Host: example.com:8080
+	// Make copies or use the Immutable setting instead.
+	// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
 	Host() string
+	// Hostname contains the hostname derived from the X-Forwarded-Host or Host HTTP header using the c.Host() method.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Example: URL: https://example.com:8080 -> Hostname: example.com
+	// Make copies or use the Immutable setting instead.
+	// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
 	Hostname() string
-	IP() string
-	IPs() []string
-	Is(extension string) bool
-	IsFromLocal() bool
-	IsProxyTrusted() bool
-	Method(override ...string) string
-	MultipartForm() (*multipart.Form, error)
-	OriginalURL() string
-	Params(key string, defaultValue ...string) string
-	Path(override ...string) string
+	// Port returns the remote port of the request.
 	Port() string
+	// IP returns the remote IP address of the request.
+	// If ProxyHeader and IP Validation is configured, it will parse that header and return the first valid IP address.
+	// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
+	IP() string
+	// extractIPsFromHeader will return a slice of IPs it found given a header name in the order they appear.
+	// When IP validation is enabled, any invalid IPs will be omitted.
+	extractIPsFromHeader(header string) []string
+	// extractIPFromHeader will attempt to pull the real client IP from the given header when IP validation is enabled.
+	// currently, it will return the first valid IP address in header.
+	// when IP validation is disabled, it will simply return the value of the header without any inspection.
+	// Implementation is almost the same as in extractIPsFromHeader, but without allocation of []string.
+	extractIPFromHeader(header string) string
+	// IPs returns a string slice of IP addresses specified in the X-Forwarded-For request header.
+	// When IP validation is enabled, only valid IPs are returned.
+	IPs() []string
+	// Is returns the matching content type,
+	// if the incoming request's Content-Type HTTP header field matches the MIME type specified by the type parameter
+	Is(extension string) bool
+	// Locals makes it possible to pass any values under keys scoped to the request
+	// and therefore available to all following routes that match the request.
+	//
+	// All the values are removed from ctx after returning from the top
+	// RequestHandler. Additionally, Close method is called on each value
+	// implementing io.Closer before removing the value from ctx.
+	Locals(key any, value ...any) any
+	// Method returns the HTTP request method for the context, optionally overridden by the provided argument.
+	// If no override is given or if the provided override is not a valid HTTP method, it returns the current method from the context.
+	// Otherwise, it updates the context's method and returns the overridden method as a string.
+	Method(override ...string) string
+	// MultipartForm parse form entries from binary.
+	// This returns a map[string][]string, so given a key the value will be a string slice.
+	MultipartForm() (*multipart.Form, error)
+	// OriginalURL contains the original request URL.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
+	OriginalURL() string
+	// Params is used to get the route parameters.
+	// Defaults to empty string "" if the param doesn't exist.
+	// If a default value is given, it will return that value if the param doesn't exist.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
+	Params(key string, defaultValue ...string) string
+	// Scheme contains the request protocol string: http or https for TLS requests.
+	// Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
+	Scheme() string
+	// Protocol returns the HTTP protocol of request: HTTP/1.1 and HTTP/2.
 	Protocol() string
-	Queries() map[string]string
+	// Query returns the query string parameter in the url.
+	// Defaults to empty string "" if the query doesn't exist.
+	// If a default value is given, it will return that value if the query doesn't exist.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Query(key string, defaultValue ...string) string
+	// Queries returns a map of query parameters and their values.
+	//
+	// GET /?name=alex&wanna_cake=2&id=
+	// Queries()["name"] == "alex"
+	// Queries()["wanna_cake"] == "2"
+	// Queries()["id"] == ""
+	//
+	// GET /?field1=value1&field1=value2&field2=value3
+	// Queries()["field1"] == "value2"
+	// Queries()["field2"] == "value3"
+	//
+	// GET /?list_a=1&list_a=2&list_a=3&list_b[]=1&list_b[]=2&list_b[]=3&list_c=1,2,3
+	// Queries()["list_a"] == "3"
+	// Queries()["list_b[]"] == "3"
+	// Queries()["list_c"] == "1,2,3"
+	//
+	// GET /api/search?filters.author.name=John&filters.category.name=Technology&filters[customer][name]=Alice&filters[status]=pending
+	// Queries()["filters.author.name"] == "John"
+	// Queries()["filters.category.name"] == "Technology"
+	// Queries()["filters[customer][name]"] == "Alice"
+	// Queries()["filters[status]"] == "pending"
+	Queries() map[string]string
+	// Range returns a struct containing the type and a slice of ranges.
 	Range(size int) (Range, error)
+	// Route returns the matched Route struct.
 	Route() *Route
-	SaveFile(fileheader *multipart.FileHeader, path string) error
-	SaveFileToStorage(fileheader *multipart.FileHeader, path string, storage Storage) error
-	Secure() bool
-	Stale() bool
+	// Subdomains returns a slice of subdomains from the host, excluding the last `offset` components.
+	// If the offset is negative or exceeds the number of subdomains, an empty slice is returned.
+	// If the offset is zero every label (no trimming) is returned.
 	Subdomains(offset ...int) []string
-	XHR() bool
+	// Stale returns the inverse of Fresh, indicating if the client's cached response is considered stale.
+	Stale() bool
+	// IsProxyTrusted checks trustworthiness of remote ip.
+	// If Config.TrustProxy false, it returns true
+	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
+	IsProxyTrusted() bool
+	// IsFromLocal will return true if request came from local.
+	IsFromLocal() bool
+	// Release is a method to reset Req fields when to use ReleaseCtx()
+	release()
+	getBody() []byte
 }

--- a/res.go
+++ b/res.go
@@ -2,117 +2,972 @@ package fiber
 
 import (
 	"bufio"
+	"bytes"
+	"fmt"
+	"html/template"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gofiber/utils/v2"
+	"github.com/valyala/bytebufferpool"
+	"github.com/valyala/fasthttp"
 )
 
-//go:generate ifacemaker --file res.go --struct DefaultRes --iface Res --pkg fiber --output res_interface_gen.go --not-exported true --iface-comment "Res"
+// SendFile defines configuration options when to transfer file with SendFile.
+type SendFile struct {
+	// FS is the file system to serve the static files from.
+	// You can use interfaces compatible with fs.FS like embed.FS, os.DirFS etc.
+	//
+	// Optional. Default: nil
+	FS fs.FS
+
+	// When set to true, the server tries minimizing CPU usage by caching compressed files.
+	// This works differently than the github.com/gofiber/compression middleware.
+	// You have to set Content-Encoding header to compress the file.
+	// Available compression methods are gzip, br, and zstd.
+	//
+	// Optional. Default: false
+	Compress bool `json:"compress"`
+
+	// When set to true, enables byte range requests.
+	//
+	// Optional. Default: false
+	ByteRange bool `json:"byte_range"`
+
+	// When set to true, enables direct download.
+	//
+	// Optional. Default: false
+	Download bool `json:"download"`
+
+	// Expiration duration for inactive file handlers.
+	// Use a negative time.Duration to disable it.
+	//
+	// Optional. Default: 10 * time.Second
+	CacheDuration time.Duration `json:"cache_duration"`
+
+	// The value for the Cache-Control HTTP-header
+	// that is set on the file response. MaxAge is defined in seconds.
+	//
+	// Optional. Default: 0
+	MaxAge int `json:"max_age"`
+}
+
+// sendFileStore is used to keep the SendFile configuration and the handler.
+type sendFileStore struct {
+	handler           fasthttp.RequestHandler
+	cacheControlValue string
+	config            SendFile
+}
+
+// compareConfig compares the current SendFile config with the new one
+// and returns true if they are different.
+//
+// Here we don't use reflect.DeepEqual because it is quite slow compared to manual comparison.
+func (sf *sendFileStore) compareConfig(cfg SendFile) bool {
+	if sf.config.FS != cfg.FS {
+		return false
+	}
+
+	if sf.config.Compress != cfg.Compress {
+		return false
+	}
+
+	if sf.config.ByteRange != cfg.ByteRange {
+		return false
+	}
+
+	if sf.config.Download != cfg.Download {
+		return false
+	}
+
+	if sf.config.CacheDuration != cfg.CacheDuration {
+		return false
+	}
+
+	if sf.config.MaxAge != cfg.MaxAge {
+		return false
+	}
+
+	return true
+}
+
+// Cookie data for c.Cookie
+type Cookie struct {
+	Expires     time.Time `json:"expires"`      // The expiration date of the cookie
+	Name        string    `json:"name"`         // The name of the cookie
+	Value       string    `json:"value"`        // The value of the cookie
+	Path        string    `json:"path"`         // Specifies a URL path which is allowed to receive the cookie
+	Domain      string    `json:"domain"`       // Specifies the domain which is allowed to receive the cookie
+	SameSite    string    `json:"same_site"`    // Controls whether or not a cookie is sent with cross-site requests
+	MaxAge      int       `json:"max_age"`      // The maximum age (in seconds) of the cookie
+	Secure      bool      `json:"secure"`       // Indicates that the cookie should only be transmitted over a secure HTTPS connection
+	HTTPOnly    bool      `json:"http_only"`    // Indicates that the cookie is accessible only through the HTTP protocol
+	Partitioned bool      `json:"partitioned"`  // Indicates if the cookie is stored in a partitioned cookie jar
+	SessionOnly bool      `json:"session_only"` // Indicates if the cookie is a session-only cookie
+}
+
+// ResFmt associates a Content Type to a fiber.Handler for c.Format
+type ResFmt struct {
+	Handler   func(Ctx) error
+	MediaType string
+}
+
+//go:generate ifacemaker --file res.go --struct DefaultRes --iface Res --pkg fiber --output res_interface_gen.go --not-exported true --iface-comment "Res is an interface for response-related Ctx methods."
 type DefaultRes struct {
-	ctx *DefaultCtx
+	c Ctx
 }
 
+// App returns the *App reference to the instance of the Fiber application
+func (r *DefaultRes) App() *App {
+	return r.c.App()
+}
+
+// Append the specified value to the HTTP response header field.
+// If the header is not already set, it creates the header with the specified value.
 func (r *DefaultRes) Append(field string, values ...string) {
-	r.ctx.Append(field, values...)
+	if len(values) == 0 {
+		return
+	}
+	h := r.App().getString(r.Response().Header.Peek(field))
+	originalH := h
+	for _, value := range values {
+		if len(h) == 0 {
+			h = value
+		} else if h != value && !strings.HasPrefix(h, value+",") && !strings.HasSuffix(h, " "+value) &&
+			!strings.Contains(h, " "+value+",") {
+			h += ", " + value
+		}
+	}
+	if originalH != h {
+		r.Set(field, h)
+	}
 }
 
+// Attachment sets the HTTP response Content-Disposition header field to attachment.
 func (r *DefaultRes) Attachment(filename ...string) {
-	r.ctx.Attachment(filename...)
+	if len(filename) > 0 {
+		fname := filepath.Base(filename[0])
+		r.Type(filepath.Ext(fname))
+		app := r.App()
+		var quoted string
+		if app.isASCII(fname) {
+			quoted = app.quoteString(fname)
+		} else {
+			quoted = app.quoteRawString(fname)
+		}
+		disp := `attachment; filename="` + quoted + `"`
+		if !app.isASCII(fname) {
+			disp += `; filename*=UTF-8''` + url.PathEscape(fname)
+		}
+		r.setCanonical(HeaderContentDisposition, disp)
+		return
+	}
+	r.setCanonical(HeaderContentDisposition, "attachment")
 }
 
-func (r *DefaultRes) AutoFormat(body any) error {
-	return r.ctx.AutoFormat(body)
-}
-
-func (r *DefaultRes) CBOR(body any, ctype ...string) error {
-	return r.ctx.CBOR(body, ctype...)
-}
-
+// ClearCookie expires a specific cookie by key on the client side.
+// If no key is provided it expires all cookies that came with the request.
 func (r *DefaultRes) ClearCookie(key ...string) {
-	r.ctx.ClearCookie(key...)
+	request := r.c.Request()
+	response := r.Response()
+	if len(key) > 0 {
+		for i := range key {
+			response.Header.DelClientCookie(key[i])
+		}
+		return
+	}
+	for k := range request.Header.Cookies() {
+		response.Header.DelClientCookieBytes(k)
+	}
 }
 
+// RequestCtx returns *fasthttp.RequestCtx that carries a deadline
+// a cancellation signal, and other values across API boundaries.
+func (r *DefaultRes) RequestCtx() *fasthttp.RequestCtx {
+	return r.c.RequestCtx()
+}
+
+// Cookie sets a cookie by passing a cookie struct.
 func (r *DefaultRes) Cookie(cookie *Cookie) {
-	r.ctx.Cookie(cookie)
+	if cookie.Path == "" {
+		cookie.Path = "/"
+	}
+
+	if cookie.SessionOnly {
+		cookie.MaxAge = 0
+		cookie.Expires = time.Time{}
+	}
+
+	var sameSite http.SameSite
+
+	switch {
+	case utils.EqualFold(cookie.SameSite, CookieSameSiteStrictMode):
+		sameSite = http.SameSiteStrictMode
+	case utils.EqualFold(cookie.SameSite, CookieSameSiteNoneMode):
+		sameSite = http.SameSiteNoneMode
+		// SameSite=None requires Secure=true per RFC and browser requirements
+		cookie.Secure = true
+	case utils.EqualFold(cookie.SameSite, CookieSameSiteDisabled):
+		sameSite = 0
+	case utils.EqualFold(cookie.SameSite, CookieSameSiteLaxMode):
+		sameSite = http.SameSiteLaxMode
+	default:
+		sameSite = http.SameSiteLaxMode
+	}
+
+	// create/validate cookie using net/http
+	hc := &http.Cookie{
+		Name:        cookie.Name,
+		Value:       cookie.Value,
+		Path:        cookie.Path,
+		Domain:      cookie.Domain,
+		Expires:     cookie.Expires,
+		MaxAge:      cookie.MaxAge,
+		Secure:      cookie.Secure,
+		HttpOnly:    cookie.HTTPOnly,
+		SameSite:    sameSite,
+		Partitioned: cookie.Partitioned,
+	}
+
+	if err := hc.Valid(); err != nil {
+		// invalid cookies are ignored, same approach as net/http
+		return
+	}
+
+	// create fasthttp cookie
+	fcookie := fasthttp.AcquireCookie()
+	fcookie.SetKey(hc.Name)
+	fcookie.SetValue(hc.Value)
+	fcookie.SetPath(hc.Path)
+	fcookie.SetDomain(hc.Domain)
+
+	if !cookie.SessionOnly {
+		fcookie.SetMaxAge(hc.MaxAge)
+		fcookie.SetExpire(hc.Expires)
+	}
+
+	fcookie.SetSecure(hc.Secure)
+	fcookie.SetHTTPOnly(hc.HttpOnly)
+
+	switch sameSite {
+	case http.SameSiteLaxMode:
+		fcookie.SetSameSite(fasthttp.CookieSameSiteLaxMode)
+	case http.SameSiteStrictMode:
+		fcookie.SetSameSite(fasthttp.CookieSameSiteStrictMode)
+	case http.SameSiteNoneMode:
+		fcookie.SetSameSite(fasthttp.CookieSameSiteNoneMode)
+	case http.SameSiteDefaultMode:
+		fcookie.SetSameSite(fasthttp.CookieSameSiteDefaultMode)
+	default:
+		fcookie.SetSameSite(fasthttp.CookieSameSiteDisabled)
+	}
+
+	fcookie.SetPartitioned(hc.Partitioned)
+
+	// Set resp header
+	r.Response().Header.SetCookie(fcookie)
+	fasthttp.ReleaseCookie(fcookie)
 }
 
+// Download transfers the file from path as an attachment.
+// Typically, browsers will prompt the user for download.
+// By default, the Content-Disposition header filename= parameter is the filepath (this typically appears in the browser dialog).
+// Override this default with the filename parameter.
 func (r *DefaultRes) Download(file string, filename ...string) error {
-	return r.ctx.Download(file, filename...)
+	var fname string
+	if len(filename) > 0 {
+		fname = filename[0]
+	} else {
+		fname = filepath.Base(file)
+	}
+	app := r.App()
+	var quoted string
+	if app.isASCII(fname) {
+		quoted = app.quoteString(fname)
+	} else {
+		quoted = app.quoteRawString(fname)
+	}
+	disp := `attachment; filename="` + quoted + `"`
+	if !app.isASCII(fname) {
+		disp += `; filename*=UTF-8''` + url.PathEscape(fname)
+	}
+	r.setCanonical(HeaderContentDisposition, disp)
+	return r.SendFile(file)
 }
 
+// Response return the *fasthttp.Response object
+// This allows you to use all fasthttp response methods
+// https://godoc.org/github.com/valyala/fasthttp#Response
+func (r *DefaultRes) Response() *fasthttp.Response {
+	return r.c.Response()
+}
+
+// Format performs content-negotiation on the Accept HTTP header.
+// It uses Accepts to select a proper format and calls the matching
+// user-provided handler function.
+// If no accepted format is found, and a format with MediaType "default" is given,
+// that default handler is called. If no format is found and no default is given,
+// StatusNotAcceptable is sent.
 func (r *DefaultRes) Format(handlers ...ResFmt) error {
-	return r.ctx.Format(handlers...)
+	if len(handlers) == 0 {
+		return ErrNoHandlers
+	}
+
+	r.Vary(HeaderAccept)
+
+	if r.c.Get(HeaderAccept) == "" {
+		r.Response().Header.SetContentType(handlers[0].MediaType)
+		return handlers[0].Handler(r.c)
+	}
+
+	// Using an int literal as the slice capacity allows for the slice to be
+	// allocated on the stack. The number was chosen arbitrarily as an
+	// approximation of the maximum number of content types a user might handle.
+	// If the user goes over, it just causes allocations, so it's not a problem.
+	types := make([]string, 0, 8)
+	var defaultHandler Handler
+	for _, h := range handlers {
+		if h.MediaType == "default" {
+			defaultHandler = h.Handler
+			continue
+		}
+		types = append(types, h.MediaType)
+	}
+	accept := r.c.Accepts(types...)
+
+	if accept == "" {
+		if defaultHandler == nil {
+			return r.SendStatus(StatusNotAcceptable)
+		}
+		return defaultHandler(r.c)
+	}
+
+	for _, h := range handlers {
+		if h.MediaType == accept {
+			r.Response().Header.SetContentType(h.MediaType)
+			return h.Handler(r.c)
+		}
+	}
+
+	return fmt.Errorf("%w: format: an Accept was found but no handler was called", errUnreachable)
 }
 
+// AutoFormat performs content-negotiation on the Accept HTTP header.
+// It uses Accepts to select a proper format.
+// The supported content types are text/html, text/plain, application/json, and application/xml.
+// For more flexible content negotiation, use Format.
+// If the header is not specified or there is no proper format, text/plain is used.
+func (r *DefaultRes) AutoFormat(body any) error {
+	// Get accepted content type
+	accept := r.c.Accepts("html", "json", "txt", "xml", "msgpack")
+	// Set accepted content type
+	r.Type(accept)
+	// Type convert provided body
+	var b string
+	switch val := body.(type) {
+	case string:
+		b = val
+	case []byte:
+		b = r.App().getString(val)
+	default:
+		b = fmt.Sprintf("%v", val)
+	}
+
+	// Format based on the accept content type
+	switch accept {
+	case "html":
+		return r.SendString("<p>" + b + "</p>")
+	case "json":
+		return r.JSON(body)
+	case "msgpack":
+		return r.MsgPack(body)
+	case "txt":
+		return r.SendString(b)
+	case "xml":
+		return r.XML(body)
+	}
+	return r.SendString(b)
+}
+
+// Get (a.k.a. GetRespHeader) returns the HTTP response header specified by field.
+// Field names are case-insensitive
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting instead.
 func (r *DefaultRes) Get(key string, defaultValue ...string) string {
-	return r.ctx.GetRespHeader(key, defaultValue...)
+	return defaultString(r.App().getString(r.Response().Header.Peek(key)), defaultValue)
 }
 
-func (r *DefaultRes) JSON(body any, ctype ...string) error {
-	return r.ctx.JSON(body, ctype...)
+// GetHeaders (a.k.a GetRespHeaders) returns the HTTP response headers.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting instead.
+func (r *DefaultRes) GetHeaders() map[string][]string {
+	app := r.App()
+	headers := make(map[string][]string)
+	for k, v := range r.Response().Header.All() {
+		key := app.getString(k)
+		headers[key] = append(headers[key], app.getString(v))
+	}
+	return headers
 }
 
+// JSON converts any interface or string to JSON.
+// Array and slice values encode as JSON arrays,
+// except that []byte encodes as a base64-encoded string,
+// and a nil slice encodes as the null JSON value.
+// If the ctype parameter is given, this method will set the
+// Content-Type header equal to ctype. If ctype is not given,
+// The Content-Type header will be set to application/json; charset=utf-8.
+func (r *DefaultRes) JSON(data any, ctype ...string) error {
+	raw, err := r.App().config.JSONEncoder(data)
+	if err != nil {
+		return err
+	}
+
+	response := r.Response()
+	response.SetBodyRaw(raw)
+	if len(ctype) > 0 {
+		response.Header.SetContentType(ctype[0])
+	} else {
+		response.Header.SetContentType(MIMEApplicationJSONCharsetUTF8)
+	}
+	return nil
+}
+
+// MsgPack converts any interface or string to MessagePack encoded bytes.
+// If the ctype parameter is given, this method will set the
+// Content-Type header equal to ctype. If ctype is not given,
+// The Content-Type header will be set to application/vnd.msgpack.
+func (r *DefaultRes) MsgPack(data any, ctype ...string) error {
+	raw, err := r.App().config.MsgPackEncoder(data)
+	if err != nil {
+		return err
+	}
+
+	response := r.Response()
+	response.SetBodyRaw(raw)
+	if len(ctype) > 0 {
+		response.Header.SetContentType(ctype[0])
+	} else {
+		response.Header.SetContentType(MIMEApplicationMsgPack)
+	}
+	return nil
+}
+
+// CBOR converts any interface or string to CBOR encoded bytes.
+// If the ctype parameter is given, this method will set the
+// Content-Type header equal to ctype. If ctype is not given,
+// The Content-Type header will be set to application/cbor.
+func (r *DefaultRes) CBOR(data any, ctype ...string) error {
+	raw, err := r.App().config.CBOREncoder(data)
+	if err != nil {
+		return err
+	}
+
+	response := r.Response()
+	r.Response().SetBodyRaw(raw)
+	if len(ctype) > 0 {
+		response.Header.SetContentType(ctype[0])
+	} else {
+		response.Header.SetContentType(MIMEApplicationCBOR)
+	}
+	return nil
+}
+
+// JSONP sends a JSON response with JSONP support.
+// This method is identical to JSON, except that it opts-in to JSONP callback support.
+// By default, the callback name is simply callback.
 func (r *DefaultRes) JSONP(data any, callback ...string) error {
-	return r.ctx.JSONP(data, callback...)
+	raw, err := r.App().config.JSONEncoder(data)
+	if err != nil {
+		return err
+	}
+
+	var result, cb string
+
+	if len(callback) > 0 {
+		cb = callback[0]
+	} else {
+		cb = "callback"
+	}
+
+	result = cb + "(" + r.App().getString(raw) + ");"
+
+	r.setCanonical(HeaderXContentTypeOptions, "nosniff")
+	r.Response().Header.SetContentType(MIMETextJavaScriptCharsetUTF8)
+	return r.SendString(result)
 }
 
-func (r *DefaultRes) Links(link ...string) {
-	r.ctx.Links(link...)
-}
-
-func (r *DefaultRes) Location(path string) {
-	r.ctx.Location(path)
-}
-
-func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
-	return r.ctx.Render(name, bind, layouts...)
-}
-
-func (r *DefaultRes) Send(body []byte) error {
-	return r.ctx.Send(body)
-}
-
-func (r *DefaultRes) SendFile(file string, config ...SendFile) error {
-	return r.ctx.SendFile(file, config...)
-}
-
-func (r *DefaultRes) SendStatus(status int) error {
-	return r.ctx.SendStatus(status)
-}
-
-func (r *DefaultRes) SendString(body string) error {
-	return r.ctx.SendString(body)
-}
-
-func (r *DefaultRes) SendStreamWriter(streamWriter func(*bufio.Writer)) error {
-	return r.ctx.SendStreamWriter(streamWriter)
-}
-
-func (r *DefaultRes) Set(key, val string) {
-	r.ctx.Set(key, val)
-}
-
-func (r *DefaultRes) Status(status int) Ctx {
-	return r.ctx.Status(status)
-}
-
-func (r *DefaultRes) Type(extension string, charset ...string) Ctx {
-	return r.ctx.Type(extension, charset...)
-}
-
-func (r *DefaultRes) Vary(fields ...string) {
-	r.ctx.Vary(fields...)
-}
-
-func (r *DefaultRes) Write(p []byte) (int, error) {
-	return r.ctx.Write(p)
-}
-
-func (r *DefaultRes) Writef(f string, a ...any) (int, error) {
-	return r.ctx.Writef(f, a...)
-}
-
-func (r *DefaultRes) WriteString(s string) (int, error) {
-	return r.ctx.WriteString(s)
-}
-
+// XML converts any interface or string to XML.
+// This method also sets the content header to application/xml; charset=utf-8.
 func (r *DefaultRes) XML(data any) error {
-	return r.ctx.XML(data)
+	raw, err := r.App().config.XMLEncoder(data)
+	if err != nil {
+		return err
+	}
+
+	response := r.Response()
+	response.SetBodyRaw(raw)
+	response.Header.SetContentType(MIMEApplicationXMLCharsetUTF8)
+	return nil
+}
+
+// Links joins the links followed by the property to populate the response's Link HTTP header field.
+func (r *DefaultRes) Links(link ...string) {
+	if len(link) == 0 {
+		return
+	}
+	bb := bytebufferpool.Get()
+	for i := range link {
+		if i%2 == 0 {
+			bb.WriteByte('<')
+			bb.WriteString(link[i])
+			bb.WriteByte('>')
+		} else {
+			bb.WriteString(`; rel="` + link[i] + `",`)
+		}
+	}
+	r.setCanonical(HeaderLink, utils.TrimRight(r.App().getString(bb.Bytes()), ','))
+	bytebufferpool.Put(bb)
+}
+
+// Location sets the response Location HTTP header to the specified path parameter.
+func (r *DefaultRes) Location(path string) {
+	r.setCanonical(HeaderLocation, path)
+}
+
+// OriginalURL contains the original request URL.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting to use the value outside the Handler.
+func (r *DefaultRes) OriginalURL() string {
+	return r.c.OriginalURL()
+}
+
+// Redirect returns the Redirect reference.
+// Use Redirect().Status() to set custom redirection status code.
+// If status is not specified, status defaults to 303 See Other.
+// You can use Redirect().To(), Redirect().Route() and Redirect().Back() for redirection.
+func (r *DefaultRes) Redirect() *Redirect {
+	return r.c.Redirect()
+}
+
+// ViewBind Add vars to default view var map binding to template engine.
+// Variables are read by the Render method and may be overwritten.
+func (r *DefaultRes) ViewBind(vars Map) error {
+	return r.c.ViewBind(vars)
+}
+
+// getLocationFromRoute get URL location from route using parameters
+func (r *DefaultRes) getLocationFromRoute(route Route, params Map) (string, error) {
+	app := r.App()
+	buf := bytebufferpool.Get()
+	for _, segment := range route.routeParser.segs {
+		if !segment.IsParam {
+			_, err := buf.WriteString(segment.Const)
+			if err != nil {
+				return "", fmt.Errorf("failed to write string: %w", err)
+			}
+			continue
+		}
+
+		for key, val := range params {
+			isSame := key == segment.ParamName || (!app.config.CaseSensitive && utils.EqualFold(key, segment.ParamName))
+			isGreedy := segment.IsGreedy && len(key) == 1 && bytes.IndexByte(greedyParameters, key[0]) != -1
+			if isSame || isGreedy {
+				_, err := buf.WriteString(utils.ToString(val))
+				if err != nil {
+					return "", fmt.Errorf("failed to write string: %w", err)
+				}
+			}
+		}
+	}
+	location := buf.String()
+	// release buffer
+	bytebufferpool.Put(buf)
+	return location, nil
+}
+
+// GetRouteURL generates URLs to named routes, with parameters. URLs are relative, for example: "/user/1831"
+func (r *DefaultRes) GetRouteURL(routeName string, params Map) (string, error) {
+	return r.getLocationFromRoute(r.App().GetRoute(routeName), params)
+}
+
+// Render a template with data and sends a text/html response.
+// We support the following engines: https://github.com/gofiber/template
+func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
+	// Get new buffer from pool
+	buf := bytebufferpool.Get()
+	defer bytebufferpool.Put(buf)
+
+	// Initialize empty bind map if bind is nil
+	if bind == nil {
+		bind = make(Map)
+	}
+
+	// Pass-locals-to-views, bind, appListKeys
+	r.renderExtensions(bind)
+
+	rootApp := r.App()
+	var rendered bool
+	for i := len(rootApp.mountFields.appListKeys) - 1; i >= 0; i-- {
+		prefix := rootApp.mountFields.appListKeys[i]
+		app := rootApp.mountFields.appList[prefix]
+		if prefix == "" || strings.Contains(r.OriginalURL(), prefix) {
+			if len(layouts) == 0 && app.config.ViewsLayout != "" {
+				layouts = []string{
+					app.config.ViewsLayout,
+				}
+			}
+
+			// Render template from Views
+			if app.config.Views != nil {
+				if err := app.config.Views.Render(buf, name, bind, layouts...); err != nil {
+					return fmt.Errorf("failed to render: %w", err)
+				}
+
+				rendered = true
+				break
+			}
+		}
+	}
+
+	if !rendered {
+		// Render raw template using 'name' as filepath if no engine is set
+		var tmpl *template.Template
+		if _, err := readContent(buf, name); err != nil {
+			return err
+		}
+		// Parse template
+		tmpl, err := template.New("").Parse(rootApp.getString(buf.Bytes()))
+		if err != nil {
+			return fmt.Errorf("failed to parse: %w", err)
+		}
+		buf.Reset()
+		// Render template
+		if err := tmpl.Execute(buf, bind); err != nil {
+			return fmt.Errorf("failed to execute: %w", err)
+		}
+	}
+
+	response := r.Response()
+
+	// Set Content-Type to text/html
+	response.Header.SetContentType(MIMETextHTMLCharsetUTF8)
+	// Set rendered template to body
+	response.SetBody(buf.Bytes())
+
+	return nil
+}
+
+func (r *DefaultRes) renderExtensions(bind any) {
+	r.c.renderExtensions(bind)
+}
+
+// Send sets the HTTP response body without copying it.
+// From this point onward the body argument must not be changed.
+func (r *DefaultRes) Send(body []byte) error {
+	// Write response body
+	r.Response().SetBodyRaw(body)
+	return nil
+}
+
+// SendFile transfers the file from the specified path.
+// By default, the file is not compressed. To enable compression, set SendFile.Compress to true.
+// The Content-Type response HTTP header field is set based on the file's extension.
+// If the file extension is missing or invalid, the Content-Type is detected from the file's format.
+func (r *DefaultRes) SendFile(file string, config ...SendFile) error {
+	// Save the filename, we will need it in the error message if the file isn't found
+	filename := file
+
+	var cfg SendFile
+	if len(config) > 0 {
+		cfg = config[0]
+	}
+
+	if cfg.CacheDuration == 0 {
+		cfg.CacheDuration = 10 * time.Second
+	}
+
+	var fsHandler fasthttp.RequestHandler
+	var cacheControlValue string
+
+	app := r.App()
+	app.sendfilesMutex.RLock()
+	for _, sf := range app.sendfiles {
+		if sf.compareConfig(cfg) {
+			fsHandler = sf.handler
+			cacheControlValue = sf.cacheControlValue
+			break
+		}
+	}
+	app.sendfilesMutex.RUnlock()
+
+	if fsHandler == nil {
+		fasthttpFS := &fasthttp.FS{
+			Root:                   "",
+			FS:                     cfg.FS,
+			AllowEmptyRoot:         true,
+			GenerateIndexPages:     false,
+			AcceptByteRange:        cfg.ByteRange,
+			Compress:               cfg.Compress,
+			CompressBrotli:         cfg.Compress,
+			CompressZstd:           cfg.Compress,
+			CompressedFileSuffixes: app.config.CompressedFileSuffixes,
+			CacheDuration:          cfg.CacheDuration,
+			SkipCache:              cfg.CacheDuration < 0,
+			IndexNames:             []string{"index.html"},
+			PathNotFound: func(ctx *fasthttp.RequestCtx) {
+				ctx.Response.SetStatusCode(StatusNotFound)
+			},
+		}
+
+		if cfg.FS != nil {
+			fasthttpFS.Root = "."
+		}
+
+		sf := &sendFileStore{
+			config:  cfg,
+			handler: fasthttpFS.NewRequestHandler(),
+		}
+
+		maxAge := cfg.MaxAge
+		if maxAge > 0 {
+			sf.cacheControlValue = "public, max-age=" + strconv.Itoa(maxAge)
+		}
+
+		// set vars
+		fsHandler = sf.handler
+		cacheControlValue = sf.cacheControlValue
+
+		app.sendfilesMutex.Lock()
+		app.sendfiles = append(app.sendfiles, sf)
+		app.sendfilesMutex.Unlock()
+	}
+
+	// Keep original path for mutable params
+	r.c.keepOriginalPath()
+
+	request := r.c.Request()
+
+	// Delete the Accept-Encoding header if compression is disabled
+	if !cfg.Compress {
+		// https://github.com/valyala/fasthttp/blob/7cc6f4c513f9e0d3686142e0a1a5aa2f76b3194a/fs.go#L55
+		request.Header.Del(HeaderAcceptEncoding)
+	}
+
+	// copy of https://github.com/valyala/fasthttp/blob/7cc6f4c513f9e0d3686142e0a1a5aa2f76b3194a/fs.go#L103-L121 with small adjustments
+	if len(file) == 0 || (!filepath.IsAbs(file) && cfg.FS == nil) {
+		// extend relative path to absolute path
+		hasTrailingSlash := len(file) > 0 && (file[len(file)-1] == '/' || file[len(file)-1] == '\\')
+
+		var err error
+		file = filepath.FromSlash(file)
+		if file, err = filepath.Abs(file); err != nil {
+			return fmt.Errorf("failed to determine abs file path: %w", err)
+		}
+		if hasTrailingSlash {
+			file += "/"
+		}
+	}
+
+	// convert the path to forward slashes regardless the OS in order to set the URI properly
+	// the handler will convert back to OS path separator before opening the file
+	file = filepath.ToSlash(file)
+
+	// Restore the original requested URL
+	originalURL := utils.CopyString(r.OriginalURL())
+	defer request.SetRequestURI(originalURL)
+
+	// Set new URI for fileHandler
+	request.SetRequestURI(file)
+
+	// Save status code
+	response := r.Response()
+	status := response.StatusCode()
+
+	// Serve file
+	fsHandler(r.RequestCtx())
+
+	// Sets the response Content-Disposition header to attachment if the Download option is true
+	if cfg.Download {
+		r.Attachment()
+	}
+
+	// Get the status code which is set by fasthttp
+	fsStatus := response.StatusCode()
+
+	// Check for error
+	if status != StatusNotFound && fsStatus == StatusNotFound {
+		return NewError(StatusNotFound, fmt.Sprintf("sendfile: file %s not found", filename))
+	}
+
+	// Set the status code set by the user if it is different from the fasthttp status code and 200
+	if status != fsStatus && status != StatusOK {
+		r.Status(status)
+	}
+
+	// Apply cache control header
+	if status != StatusNotFound && status != StatusForbidden {
+		if len(cacheControlValue) > 0 {
+			response.Header.Set(HeaderCacheControl, cacheControlValue)
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+// SendStatus sets the HTTP status code and if the response body is empty,
+// it sets the correct status message in the body.
+func (r *DefaultRes) SendStatus(status int) error {
+	r.Status(status)
+
+	// Only set status body when there is no response body
+	if len(r.Response().Body()) == 0 {
+		return r.SendString(utils.StatusMessage(status))
+	}
+
+	return nil
+}
+
+// SendString sets the HTTP response body for string types.
+// This means no type assertion, recommended for faster performance
+func (r *DefaultRes) SendString(body string) error {
+	r.Response().SetBodyString(body)
+
+	return nil
+}
+
+// SendStream sets response body stream and optional body size.
+func (r *DefaultRes) SendStream(stream io.Reader, size ...int) error {
+	if len(size) > 0 && size[0] >= 0 {
+		r.Response().SetBodyStream(stream, size[0])
+	} else {
+		r.Response().SetBodyStream(stream, -1)
+	}
+
+	return nil
+}
+
+// SendStreamWriter sets response body stream writer
+func (r *DefaultRes) SendStreamWriter(streamWriter func(*bufio.Writer)) error {
+	r.Response().SetBodyStreamWriter(fasthttp.StreamWriter(streamWriter))
+
+	return nil
+}
+
+// Set sets the response's HTTP header field to the specified key, value.
+func (r *DefaultRes) Set(key, val string) {
+	r.Response().Header.Set(key, val)
+}
+
+func (r *DefaultRes) setCanonical(key, val string) {
+	r.Response().Header.SetCanonical(utils.UnsafeBytes(key), utils.UnsafeBytes(val))
+}
+
+// Status sets the HTTP status for the response.
+// This method is chainable.
+func (r *DefaultRes) Status(status int) Ctx {
+	r.Response().SetStatusCode(status)
+	return r.c
+}
+
+// Type sets the Content-Type HTTP header to the MIME type specified by the file extension.
+func (r *DefaultRes) Type(extension string, charset ...string) Ctx {
+	mimeType := utils.GetMIME(extension)
+
+	if len(charset) > 0 {
+		r.Response().Header.SetContentType(mimeType + "; charset=" + charset[0])
+	} else {
+		// Automatically add UTF-8 charset for text-based MIME types
+		if shouldIncludeCharset(mimeType) {
+			r.Response().Header.SetContentType(mimeType + "; charset=utf-8")
+		} else {
+			r.Response().Header.SetContentType(mimeType)
+		}
+	}
+	return r.c
+}
+
+// shouldIncludeCharset determines if a MIME type should include UTF-8 charset by default
+func shouldIncludeCharset(mimeType string) bool {
+	// Everything under text/ gets UTF-8 by default.
+	if strings.HasPrefix(mimeType, "text/") {
+		return true
+	}
+
+	// Explicit application types that should default to UTF-8.
+	switch mimeType {
+	case MIMEApplicationJSON,
+		MIMEApplicationJavaScript,
+		MIMEApplicationXML:
+		return true
+	}
+
+	// Any application/*+json or application/*+xml.
+	if strings.HasSuffix(mimeType, "+json") || strings.HasSuffix(mimeType, "+xml") {
+		return true
+	}
+
+	return false
+}
+
+// Vary adds the given header field to the Vary response header.
+// This will append the header, if not already listed, otherwise leaves it listed in the current location.
+func (r *DefaultRes) Vary(fields ...string) {
+	r.Append(HeaderVary, fields...)
+}
+
+// Write appends p into response body.
+func (r *DefaultRes) Write(p []byte) (int, error) {
+	r.Response().AppendBody(p)
+	return len(p), nil
+}
+
+// Writef appends f & a into response body writer.
+func (r *DefaultRes) Writef(f string, a ...any) (int, error) {
+	//nolint:wrapcheck // This must not be wrapped
+	return fmt.Fprintf(r.Response().BodyWriter(), f, a...)
+}
+
+// WriteString appends s to response body.
+func (r *DefaultRes) WriteString(s string) (int, error) {
+	r.Response().AppendBodyString(s)
+	return len(s), nil
+}
+
+// Release is a method to reset Res fields when to use ReleaseCtx()
+func (r *DefaultRes) release() {
+	r.c = nil
+}
+
+// Drop closes the underlying connection without sending any response headers or body.
+// This can be useful for silently terminating client connections, such as in DDoS mitigation
+// or when blocking access to sensitive endpoints.
+func (r *DefaultRes) Drop() error {
+	//nolint:wrapcheck // error wrapping is avoided to keep the operation lightweight and focused on connection closure.
+	return r.RequestCtx().Conn().Close()
+}
+
+// End immediately flushes the current response and closes the underlying connection.
+func (r *DefaultRes) End() error {
+	ctx := r.RequestCtx()
+	conn := ctx.Conn()
+
+	bw := bufio.NewWriter(conn)
+	if err := ctx.Response.Write(bw); err != nil {
+		return err
+	}
+
+	if err := bw.Flush(); err != nil {
+		return err //nolint:wrapcheck // unnecessary to wrap it
+	}
+
+	return conn.Close() //nolint:wrapcheck // unnecessary to wrap it
 }

--- a/res_interface_gen.go
+++ b/res_interface_gen.go
@@ -4,35 +4,149 @@ package fiber
 
 import (
 	"bufio"
+	"io"
+
+	"github.com/valyala/fasthttp"
 )
 
-// Res
+// Res is an interface for response-related Ctx methods.
 type Res interface {
+	// App returns the *App reference to the instance of the Fiber application
+	App() *App
+	// Append the specified value to the HTTP response header field.
+	// If the header is not already set, it creates the header with the specified value.
 	Append(field string, values ...string)
+	// Attachment sets the HTTP response Content-Disposition header field to attachment.
 	Attachment(filename ...string)
-	AutoFormat(body any) error
-	CBOR(body any, ctype ...string) error
+	// ClearCookie expires a specific cookie by key on the client side.
+	// If no key is provided it expires all cookies that came with the request.
 	ClearCookie(key ...string)
+	// RequestCtx returns *fasthttp.RequestCtx that carries a deadline
+	// a cancellation signal, and other values across API boundaries.
+	RequestCtx() *fasthttp.RequestCtx
+	// Cookie sets a cookie by passing a cookie struct.
 	Cookie(cookie *Cookie)
+	// Download transfers the file from path as an attachment.
+	// Typically, browsers will prompt the user for download.
+	// By default, the Content-Disposition header filename= parameter is the filepath (this typically appears in the browser dialog).
+	// Override this default with the filename parameter.
 	Download(file string, filename ...string) error
+	// Response return the *fasthttp.Response object
+	// This allows you to use all fasthttp response methods
+	// https://godoc.org/github.com/valyala/fasthttp#Response
+	Response() *fasthttp.Response
+	// Format performs content-negotiation on the Accept HTTP header.
+	// It uses Accepts to select a proper format and calls the matching
+	// user-provided handler function.
+	// If no accepted format is found, and a format with MediaType "default" is given,
+	// that default handler is called. If no format is found and no default is given,
+	// StatusNotAcceptable is sent.
 	Format(handlers ...ResFmt) error
+	// AutoFormat performs content-negotiation on the Accept HTTP header.
+	// It uses Accepts to select a proper format.
+	// The supported content types are text/html, text/plain, application/json, and application/xml.
+	// For more flexible content negotiation, use Format.
+	// If the header is not specified or there is no proper format, text/plain is used.
+	AutoFormat(body any) error
+	// Get (a.k.a. GetRespHeader) returns the HTTP response header specified by field.
+	// Field names are case-insensitive
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
 	Get(key string, defaultValue ...string) string
-	JSON(body any, ctype ...string) error
+	// GetHeaders (a.k.a GetRespHeaders) returns the HTTP response headers.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
+	GetHeaders() map[string][]string
+	// JSON converts any interface or string to JSON.
+	// Array and slice values encode as JSON arrays,
+	// except that []byte encodes as a base64-encoded string,
+	// and a nil slice encodes as the null JSON value.
+	// If the ctype parameter is given, this method will set the
+	// Content-Type header equal to ctype. If ctype is not given,
+	// The Content-Type header will be set to application/json; charset=utf-8.
+	JSON(data any, ctype ...string) error
+	// MsgPack converts any interface or string to MessagePack encoded bytes.
+	// If the ctype parameter is given, this method will set the
+	// Content-Type header equal to ctype. If ctype is not given,
+	// The Content-Type header will be set to application/vnd.msgpack.
+	MsgPack(data any, ctype ...string) error
+	// CBOR converts any interface or string to CBOR encoded bytes.
+	// If the ctype parameter is given, this method will set the
+	// Content-Type header equal to ctype. If ctype is not given,
+	// The Content-Type header will be set to application/cbor.
+	CBOR(data any, ctype ...string) error
+	// JSONP sends a JSON response with JSONP support.
+	// This method is identical to JSON, except that it opts-in to JSONP callback support.
+	// By default, the callback name is simply callback.
 	JSONP(data any, callback ...string) error
-	Links(link ...string)
-	Location(path string)
-	Render(name string, bind any, layouts ...string) error
-	Send(body []byte) error
-	SendFile(file string, config ...SendFile) error
-	SendStatus(status int) error
-	SendString(body string) error
-	SendStreamWriter(streamWriter func(*bufio.Writer)) error
-	Set(key, val string)
-	Status(status int) Ctx
-	Type(extension string, charset ...string) Ctx
-	Vary(fields ...string)
-	Write(p []byte) (int, error)
-	Writef(f string, a ...any) (int, error)
-	WriteString(s string) (int, error)
+	// XML converts any interface or string to XML.
+	// This method also sets the content header to application/xml; charset=utf-8.
 	XML(data any) error
+	// Links joins the links followed by the property to populate the response's Link HTTP header field.
+	Links(link ...string)
+	// Location sets the response Location HTTP header to the specified path parameter.
+	Location(path string)
+	// OriginalURL contains the original request URL.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
+	OriginalURL() string
+	// Redirect returns the Redirect reference.
+	// Use Redirect().Status() to set custom redirection status code.
+	// If status is not specified, status defaults to 303 See Other.
+	// You can use Redirect().To(), Redirect().Route() and Redirect().Back() for redirection.
+	Redirect() *Redirect
+	// ViewBind Add vars to default view var map binding to template engine.
+	// Variables are read by the Render method and may be overwritten.
+	ViewBind(vars Map) error
+	// getLocationFromRoute get URL location from route using parameters
+	getLocationFromRoute(route Route, params Map) (string, error)
+	// GetRouteURL generates URLs to named routes, with parameters. URLs are relative, for example: "/user/1831"
+	GetRouteURL(routeName string, params Map) (string, error)
+	// Render a template with data and sends a text/html response.
+	// We support the following engines: https://github.com/gofiber/template
+	Render(name string, bind any, layouts ...string) error
+	renderExtensions(bind any)
+	// Send sets the HTTP response body without copying it.
+	// From this point onward the body argument must not be changed.
+	Send(body []byte) error
+	// SendFile transfers the file from the specified path.
+	// By default, the file is not compressed. To enable compression, set SendFile.Compress to true.
+	// The Content-Type response HTTP header field is set based on the file's extension.
+	// If the file extension is missing or invalid, the Content-Type is detected from the file's format.
+	SendFile(file string, config ...SendFile) error
+	// SendStatus sets the HTTP status code and if the response body is empty,
+	// it sets the correct status message in the body.
+	SendStatus(status int) error
+	// SendString sets the HTTP response body for string types.
+	// This means no type assertion, recommended for faster performance
+	SendString(body string) error
+	// SendStream sets response body stream and optional body size.
+	SendStream(stream io.Reader, size ...int) error
+	// SendStreamWriter sets response body stream writer
+	SendStreamWriter(streamWriter func(*bufio.Writer)) error
+	// Set sets the response's HTTP header field to the specified key, value.
+	Set(key, val string)
+	setCanonical(key, val string)
+	// Status sets the HTTP status for the response.
+	// This method is chainable.
+	Status(status int) Ctx
+	// Type sets the Content-Type HTTP header to the MIME type specified by the file extension.
+	Type(extension string, charset ...string) Ctx
+	// Vary adds the given header field to the Vary response header.
+	// This will append the header, if not already listed, otherwise leaves it listed in the current location.
+	Vary(fields ...string)
+	// Write appends p into response body.
+	Write(p []byte) (int, error)
+	// Writef appends f & a into response body writer.
+	Writef(f string, a ...any) (int, error)
+	// WriteString appends s to response body.
+	WriteString(s string) (int, error)
+	// Release is a method to reset Res fields when to use ReleaseCtx()
+	release()
+	// Drop closes the underlying connection without sending any response headers or body.
+	// This can be useful for silently terminating client connections, such as in DDoS mitigation
+	// or when blocking access to sensitive endpoints.
+	Drop() error
+	// End immediately flushes the current response and closes the underlying connection.
+	End() error
 }


### PR DESCRIPTION
## Summary
- remove weak SHA-1 and MD5 variants from BasicAuth
- show bcrypt usage in example Authorizer
- document supported hash prefixes
- update tests for remaining algorithms
- merge latest changes from `main`

## Testing
- ❌ `PATH=/usr/local/bin:$PATH make lint` (failed to load config: unsupported version)
- ✅ `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68883be092e88333820224c59c0829ce