### PR TITLE
📒docs: Fix pprof middleware docs and default config

### DIFF
--- a/docs/middleware/pprof.md
+++ b/docs/middleware/pprof.md
@@ -9,7 +9,7 @@ Pprof middleware for [Fiber](https://github.com/gofiber/fiber) that serves via i
 ## Signatures
 
 ```go
-func New() fiber.Handler
+func New(config ...Config) fiber.Handler
 ```
 
 ## Examples
@@ -39,10 +39,10 @@ app.Use(pprof.New(pprof.Config{Prefix: "/endpoint-prefix"}))
 
 ## Config
 
-| Property | Type                    | Description                                                                                                                                     | Default |
-|:---------|:------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|:--------|
-| Next     | `func(fiber.Ctx) bool` | Next defines a function to skip this middleware when returned true.                                                                             | `nil`   |
-| Prefix   | `string`                | Prefix defines a URL prefix added before "/debug/pprof". Note that it should start with (but not end with) a slash. Example: "/federated-fiber" | ""      |
+| Property | Type                    | Description                                                                                                                                                                          | Default |
+|:---------|:------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------:|
+| Next     | `func(fiber.Ctx) bool` | Next defines a function to skip this middleware when returned true.                                                                                                                  | `nil`   |
+| Prefix   | `string`                | Prefix defines a URL prefix added before "/debug/pprof". Note that it should start with (but not end with) a slash. Example: "/federated-fiber"                                   | `""`   |
 
 ## Default Config
 

--- a/middleware/pprof/config.go
+++ b/middleware/pprof/config.go
@@ -20,7 +20,8 @@ type Config struct {
 }
 
 var ConfigDefault = Config{
-	Next: nil,
+	Next:   nil,
+	Prefix: "",
 }
 
 func configDefault(config ...Config) Config {
@@ -35,6 +36,9 @@ func configDefault(config ...Config) Config {
 	// Set default values
 	if cfg.Next == nil {
 		cfg.Next = ConfigDefault.Next
+	}
+	if cfg.Prefix == "" {
+		cfg.Prefix = ConfigDefault.Prefix
 	}
 
 	return cfg


### PR DESCRIPTION
## Summary
- correct pprof middleware signature in docs
- fix formatting for pprof config table
- include Prefix in ConfigDefault
- set default Prefix when omitted