### PR TITLE
Fix context changes doc

### DIFF
--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -110,8 +110,8 @@ app.Get("/login/:id<ulid>", func(c fiber.Ctx) error {
 - **ListenTLSWithCertificate**: Use `app.Listen()` with `tls.Config`.
 - **ListenMutualTLS**: Use `app.Listen()` with `tls.Config`.
 - **ListenMutualTLSWithCertificate**: Use `app.Listen()` with `tls.Config`.
-- **Context()**: Use `Ctx` instead, it follow the `context.Context` interface
-- **SetContext()**: Use `Ctx` instead, it follow the `context.Context` interface
+- **Context()**: Removed. `Ctx` now directly implements `context.Context`, so pass `c` anywhere a `context.Context` is required.
+- **SetContext()**: Removed. Attach additional context information using `Locals` or middleware if needed.
 
 ### Method Changes
 


### PR DESCRIPTION
## Summary
- clarify removal of Context() and SetContext() in `whats_new.md`
- mention that `Ctx` implements the `context.Context` interface

## Testing
- `go list -m -mod=readonly all`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688c930877ac83269d417e451c2c7b1e