### PR TITLE
🐛 bug: Fix bind All() merging logic

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -309,7 +309,7 @@ func (b *Bind) All(out any) error {
 
 	// Precedence: URL Params -> Body -> Query -> Headers -> Cookies
 	sources := []func(any) error{b.URI}
-if b.ctx.RequestCtx().Request.Header.ContentLength() != 0 && len(b.ctx.RequestCtx().Request.Header.ContentType()) > 0 {
+	if b.ctx.RequestCtx().Request.Header.ContentLength() != 0 {
 		sources = append(sources, b.Body)
 	}
 	sources = append(sources, b.Query, b.Header, b.Cookie)

--- a/bind.go
+++ b/bind.go
@@ -310,8 +310,8 @@ func (b *Bind) All(out any) error {
 	// Precedence: URL Params -> Body -> Query -> Headers -> Cookies
 	sources := []func(any) error{b.URI}
 
-	// Check if both Content-Length and Content-Type are set
-	if b.ctx.RequestCtx().Request.Header.ContentLength() != 0 && len(b.ctx.RequestCtx().Request.Header.ContentType()) > 0 {
+	// Check if both Body and Content-Type are set
+	if len(b.ctx.Request().Body()) > 0 && len(b.ctx.RequestCtx().Request.Header.ContentType()) > 0 {
 		sources = append(sources, b.Body)
 	}
 	sources = append(sources, b.Query, b.Header, b.Cookie)

--- a/bind.go
+++ b/bind.go
@@ -24,6 +24,7 @@ type StructValidator interface {
 type Bind struct {
 	ctx            Ctx
 	dontHandleErrs bool
+	skipValidation bool
 }
 
 // WithoutAutoHandling If you want to handle binder errors manually, you can use `WithoutAutoHandling`.
@@ -55,6 +56,9 @@ func (b *Bind) returnErr(err error) error {
 
 // Struct validation.
 func (b *Bind) validateStruct(out any) error {
+	if b.skipValidation {
+		return nil
+	}
 	validator := b.ctx.App().config.StructValidator
 	if validator != nil {
 		return validator.Validate(out)
@@ -304,21 +308,21 @@ func (b *Bind) All(out any) error {
 	outElem := outVal.Elem()
 
 	// Precedence: URL Params -> Body -> Query -> Headers -> Cookies
-	sources := []func(any) error{
-		b.URI,
-		b.Body,
-		b.Query,
-		b.Header,
-		b.Cookie,
+	sources := []func(any) error{b.URI}
+	if len(b.ctx.Body()) > 0 && len(b.ctx.RequestCtx().Request.Header.ContentType()) > 0 {
+		sources = append(sources, b.Body)
 	}
-
-	tempStruct := reflect.New(outElem.Type()).Interface()
+	sources = append(sources, b.Query, b.Header, b.Cookie)
+	prevSkip := b.skipValidation
+	b.skipValidation = true
 
 	// TODO: Support custom precedence with an optional binding_source tag
 	// TODO: Create WithOverrideEmptyValues
 	// Bind from each source, but only update unset fields
 	for _, bindFunc := range sources {
+		tempStruct := reflect.New(outElem.Type()).Interface()
 		if err := bindFunc(tempStruct); err != nil {
+			b.skipValidation = prevSkip
 			return err
 		}
 
@@ -326,7 +330,8 @@ func (b *Bind) All(out any) error {
 		mergeStruct(outElem, tempStructVal)
 	}
 
-	return nil
+	b.skipValidation = prevSkip
+	return b.returnErr(b.validateStruct(out))
 }
 
 func mergeStruct(dst, src reflect.Value) {

--- a/bind.go
+++ b/bind.go
@@ -309,7 +309,7 @@ func (b *Bind) All(out any) error {
 
 	// Precedence: URL Params -> Body -> Query -> Headers -> Cookies
 	sources := []func(any) error{b.URI}
-	if len(b.ctx.Body()) > 0 && len(b.ctx.RequestCtx().Request.Header.ContentType()) > 0 {
+if b.ctx.RequestCtx().Request.Header.ContentLength() != 0 && len(b.ctx.RequestCtx().Request.Header.ContentType()) > 0 {
 		sources = append(sources, b.Body)
 	}
 	sources = append(sources, b.Query, b.Header, b.Cookie)

--- a/bind.go
+++ b/bind.go
@@ -309,7 +309,9 @@ func (b *Bind) All(out any) error {
 
 	// Precedence: URL Params -> Body -> Query -> Headers -> Cookies
 	sources := []func(any) error{b.URI}
-	if b.ctx.RequestCtx().Request.Header.ContentLength() != 0 {
+
+	// Check if both Content-Length and Content-Type are set
+	if b.ctx.RequestCtx().Request.Header.ContentLength() != 0 && len(b.ctx.RequestCtx().Request.Header.ContentType()) > 0 {
 		sources = append(sources, b.Body)
 	}
 	sources = append(sources, b.Query, b.Header, b.Cookie)

--- a/bind_test.go
+++ b/bind_test.go
@@ -1854,7 +1854,7 @@ func (*structValidator) Validate(out any) error {
 }
 
 type simpleQuery struct {
-	Name string `query:"name"`
+	Name string `query:"name" json:"name"`
 }
 
 // go test -run Test_Bind_StructValidator
@@ -2048,6 +2048,17 @@ func Test_Bind_All(t *testing.T) {
 				Email: "form@doe.com",
 			},
 		},
+		{
+			name: "Skip body when content-type missing",
+			out:  new(User),
+			config: &RequestConfig{
+				Body:  []byte(`{"name":"bodyname"}`),
+				Query: "name=queryname",
+			},
+			expected: &User{
+				Name: "queryname",
+			},
+		},
 	}
 
 	app := New()
@@ -2111,6 +2122,46 @@ func Test_Bind_All_Uri_Precedence(t *testing.T) {
 	res, err := app.Test(req)
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
+}
+
+// go test -run Test_Bind_All_Query_Precedence
+func Test_Bind_All_Query_Precedence(t *testing.T) {
+	t.Parallel()
+	type Data struct {
+		ID int `query:"id" header:"id" cookie:"id"`
+	}
+
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	c.Request().URI().SetQueryString("id=5")
+	c.Request().Header.Set("id", "3")
+	c.Request().Header.SetCookie("id", "2")
+
+	d := new(Data)
+	require.NoError(t, (&Bind{ctx: c}).All(d))
+	require.Equal(t, 5, d.ID)
+}
+
+// go test -run Test_Bind_All_StructValidator
+func Test_Bind_All_StructValidator(t *testing.T) {
+	t.Parallel()
+	app := New(Config{StructValidator: &structValidator{}})
+
+	// Success case: name comes from body only
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	ctx.Request().Header.SetContentType(MIMEApplicationJSON)
+	ctx.Request().SetBody([]byte(`{"name":"john"}`))
+	sq := new(simpleQuery)
+	require.NoError(t, (&Bind{ctx: ctx}).All(sq))
+	require.Equal(t, "john", sq.Name)
+
+	// Failure: missing name everywhere
+	ctxFail := app.AcquireCtx(&fasthttp.RequestCtx{})
+	ctxFail.Request().Header.SetContentType(MIMEApplicationJSON)
+	ctxFail.Request().SetBody([]byte(`{}`))
+	sqFail := new(simpleQuery)
+	err := (&Bind{ctx: ctxFail}).WithoutAutoHandling().All(sqFail)
+	require.EqualError(t, err, "you should have entered right name")
 }
 
 // go test -v -run=^$ -bench=Benchmark_Bind_All -benchmem -count=4

--- a/bind_test.go
+++ b/bind_test.go
@@ -2059,6 +2059,18 @@ func Test_Bind_All(t *testing.T) {
 				Name: "queryname",
 			},
 		},
+		{
+			name: "Skip empty body despite content-type",
+			out:  new(User),
+			config: &RequestConfig{
+				ContentType: MIMEApplicationJSON,
+				Body:        []byte{},
+				Query:       "name=queryname",
+			},
+			expected: &User{
+				Name: "queryname",
+			},
+		},
 	}
 
 	app := New()


### PR DESCRIPTION
## Summary
- add internal validation skip to Bind
- merge all sources without early validation and skip empty bodies
- avoid body binding when Content-Type header is missing
- expand All() tests for query precedence, validators, and missing Content-Type cases

Fixes #3658 