### PR TITLE
Add sync pool and release helpers for Bind

### DIFF
--- a/bind_test.go
+++ b/bind_test.go
@@ -32,6 +32,21 @@ func Test_returnErr(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// go test -run Test_AcquireReleaseBind -v
+func Test_AcquireReleaseBind(t *testing.T) {
+	b := AcquireBind()
+	b.dontHandleErrs = false
+	b.skipValidation = true
+	b.ctx = &DefaultCtx{}
+	ReleaseBind(b)
+
+	b2 := AcquireBind()
+	require.Nil(t, b2.ctx)
+	require.True(t, b2.dontHandleErrs)
+	require.False(t, b2.skipValidation)
+	ReleaseBind(b2)
+}
+
 // go test -run Test_Bind_Query -v
 func Test_Bind_Query(t *testing.T) {
 	t.Parallel()

--- a/ctx.go
+++ b/ctx.go
@@ -445,7 +445,10 @@ func (c *DefaultCtx) Reset(fctx *fasthttp.RequestCtx) {
 func (c *DefaultCtx) release() {
 	c.route = nil
 	c.fasthttp = nil
-	c.bind = nil
+	if c.bind != nil {
+		ReleaseBind(c.bind)
+		c.bind = nil
+	}
 	c.flashMessages = c.flashMessages[:0]
 	c.viewBindMap = sync.Map{}
 	if c.redirect != nil {
@@ -493,11 +496,9 @@ func (c *DefaultCtx) renderExtensions(bind any) {
 // Replacement of: BodyParser, ParamsParser, GetReqHeaders, GetRespHeaders, AllParams, QueryParser, ReqHeaderParser
 func (c *DefaultCtx) Bind() *Bind {
 	if c.bind == nil {
-		c.bind = &Bind{
-			ctx:            c,
-			dontHandleErrs: true,
-		}
+		c.bind = AcquireBind()
 	}
+	c.bind.ctx = c
 	return c.bind
 }
 


### PR DESCRIPTION
## Summary
- reuse Bind objects via sync.Pool with AcquireBind/ReleaseBind
- release Bind from context lifecycle
- test bind pooling behavior

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6891a51dad34832688a090fd9490d4eb