### PR TITLE
feat: add CBOR autoformat

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1528,6 +1528,8 @@ func Test_Ctx_AutoFormat(t *testing.T) {
 	app := New(Config{
 		MsgPackEncoder: msgpack.Marshal,
 		MsgPackDecoder: msgpack.Unmarshal,
+		CBOREncoder:    cbor.Marshal,
+		CBORDecoder:    cbor.Unmarshal,
 	})
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 
@@ -1551,6 +1553,14 @@ func Test_Ctx_AutoFormat(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte{
 		0xad, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c,
+		0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21,
+	}, c.Response().Body())
+
+	c.Request().Header.Set(HeaderAccept, MIMEApplicationCBOR)
+	err = c.AutoFormat("Hello, World!")
+	require.NoError(t, err)
+	require.Equal(t, []byte{
+		0x6d, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c,
 		0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21,
 	}, c.Response().Body())
 
@@ -1585,6 +1595,8 @@ func Test_Ctx_AutoFormat_Struct(t *testing.T) {
 	app := New(Config{
 		MsgPackEncoder: msgpack.Marshal,
 		MsgPackDecoder: msgpack.Unmarshal,
+		CBOREncoder:    cbor.Marshal,
+		CBORDecoder:    cbor.Unmarshal,
 	})
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 
@@ -1620,6 +1632,12 @@ func Test_Ctx_AutoFormat_Struct(t *testing.T) {
 		0x3,
 	},
 		c.Response().Body())
+
+	c.Request().Header.Set(HeaderAccept, MIMEApplicationCBOR)
+	err = c.AutoFormat(data)
+	require.NoError(t, err)
+	require.Equal(t, "a36653656e646572654361726f6c6a526563697069656e74738265416c69636563426f6267557267656e637903",
+		hex.EncodeToString(c.Response().Body()))
 
 	c.Request().Header.Set(HeaderAccept, MIMEApplicationXML)
 	err = c.AutoFormat(data)

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -1473,7 +1473,7 @@ app.Get("/non-ascii", func(c fiber.Ctx) error {
 ### AutoFormat
 
 Performs content-negotiation on the [Accept](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) HTTP header. It uses [Accepts](ctx.md#accepts) to select a proper format.
-The supported content types are `text/html`, `text/plain`, `application/json`, `application/vnd.msgpack`, and `application/xml`.
+The supported content types are `text/html`, `text/plain`, `application/json`, `application/vnd.msgpack`, `application/xml`, and `application/cbor`.
 For more flexible content negotiation, use [Format](ctx.md#format).
 
 :::info
@@ -1506,6 +1506,10 @@ app.Get("/", func(c fiber.Ctx) error {
   // Accept: application/vnd.msgpack
   c.AutoFormat(user)
   // => 82 a4 6e 61 6d 65 a4 6a 6f 68 6e a4 70 61 73 73 a3 64 6f 65
+
+  // Accept: application/cbor
+  c.AutoFormat(user)
+  // => a1 64 4e 61 6d 65 68 4a 6f 68 6e 20 44 6f 65
 
   // Accept: application/xml
   c.AutoFormat(user)

--- a/docs/guide/advance-format.md
+++ b/docs/guide/advance-format.md
@@ -67,6 +67,8 @@ func main() {
 
 Fiber doesn't include a CBOR implementation by default. To enable CBOR encoding and decoding you need to choose a library, for example [fxamacker/cbor](https://github.com/fxamacker/cbor).
 
+- Use `Ctx.CBOR()` to bind CBOR data directly to structs, similar to how you would use JSON binding. Alternatively, use `Ctx.AutoFormat()` to send response as CBOR when the Accept HTTP header is `application/cbor`, For more details, see the [AutoFormat documentation](../api/ctx.md#autoformat).
+
 ```bash
 go get github.com/fxamacker/cbor/v2
 ```

--- a/res.go
+++ b/res.go
@@ -360,12 +360,12 @@ func (r *DefaultRes) Format(handlers ...ResFmt) error {
 
 // AutoFormat performs content-negotiation on the Accept HTTP header.
 // It uses Accepts to select a proper format.
-// The supported content types are text/html, text/plain, application/json, and application/xml.
+// The supported content types are text/html, text/plain, application/json, application/xml, application/vnd.msgpack, and application/cbor.
 // For more flexible content negotiation, use Format.
 // If the header is not specified or there is no proper format, text/plain is used.
 func (r *DefaultRes) AutoFormat(body any) error {
 	// Get accepted content type
-	accept := r.c.Accepts("html", "json", "txt", "xml", "msgpack")
+	accept := r.c.Accepts("html", "json", "txt", "xml", "msgpack", "cbor")
 	// Set accepted content type
 	r.Type(accept)
 	// Type convert provided body
@@ -387,6 +387,8 @@ func (r *DefaultRes) AutoFormat(body any) error {
 		return r.JSON(body)
 	case "msgpack":
 		return r.MsgPack(body)
+	case "cbor":
+		return r.CBOR(body)
 	case "txt":
 		return r.SendString(b)
 	case "xml":


### PR DESCRIPTION
## Summary
- support `application/cbor` in `AutoFormat`
- document CBOR usage in AutoFormat and advanced formats guide
- test CBOR handling in `AutoFormat`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6893fd85ea84833398ef9a8622013a9e