### PR TITLE
chore: configure editor formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,17 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+
+[Makefile]
+indent_style = tab
+
+[*.{yml,yaml,json,md}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
## Summary
- ensure IDE formatting matches gofumpt by expanding `.editorconfig`

## Testing
- `make format`
- `make lint` *(fails: unsupported configuration version)*
- `make test` *(fails: Test_App_BodyLimit_LargerThanDefault i/o timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6894b5194c9883268b4d935f17540af5