### PR TITLE
🧹 chore: Add missing checks in Ctx tests

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -208,6 +208,11 @@ func Test_App_Custom_Middleware_404_Should_Not_SetMethodNotAllowed(t *testing.T)
 	resp, err := app.Test(httptest.NewRequest(MethodGet, "/", nil))
 	require.NoError(t, err)
 	require.Equal(t, 404, resp.StatusCode)
+	require.Equal(t, MIMETextPlainCharsetUTF8, resp.Header.Get(HeaderContentType))
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "Not Found", string(body))
+	require.Equal(t, strconv.Itoa(len("Not Found")), resp.Header.Get(HeaderContentLength))
 
 	g := app.Group("/with-next", func(c Ctx) error {
 		return c.Status(404).Next()
@@ -218,6 +223,11 @@ func Test_App_Custom_Middleware_404_Should_Not_SetMethodNotAllowed(t *testing.T)
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/with-next", nil))
 	require.NoError(t, err)
 	require.Equal(t, 404, resp.StatusCode)
+	require.Equal(t, MIMETextPlainCharsetUTF8, resp.Header.Get(HeaderContentType))
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "Not Found", string(body))
+	require.Equal(t, strconv.Itoa(len("Not Found")), resp.Header.Get(HeaderContentLength))
 }
 
 func Test_App_ServerErrorHandler_SmallReadBuffer(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"


### PR DESCRIPTION
## Summary
- extend context tests with response content-type and size assertions
- add coverage for missing Accept header