### PR TITLE
Reject invalid Accept-Language ranges and add extended filtering

### DIFF
--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -159,8 +159,12 @@ type Ctx interface {
 	AcceptsCharsets(offers ...string) string
 	// AcceptsEncodings checks if the specified encoding is acceptable.
 	AcceptsEncodings(offers ...string) string
-	// AcceptsLanguages checks if the specified language is acceptable.
+	// AcceptsLanguages checks if the specified language is acceptable using
+	// RFC 4647 Basic Filtering.
 	AcceptsLanguages(offers ...string) string
+	// AcceptsLanguagesExtended checks if the specified language is acceptable using
+	// RFC 4647 Extended Filtering.
+	AcceptsLanguagesExtended(offers ...string) string
 	// BodyRaw contains the raw body submitted in a POST request.
 	// Returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting instead.
@@ -320,7 +324,7 @@ type Ctx interface {
 	Format(handlers ...ResFmt) error
 	// AutoFormat performs content-negotiation on the Accept HTTP header.
 	// It uses Accepts to select a proper format.
-	// The supported content types are text/html, text/plain, application/json, and application/xml.
+	// The supported content types are text/html, text/plain, application/json, application/xml, application/vnd.msgpack, and application/cbor.
 	// For more flexible content negotiation, use Format.
 	// If the header is not specified or there is no proper format, text/plain is used.
 	AutoFormat(body any) error

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -317,6 +317,9 @@ func Test_Ctx_AcceptsLanguages_BasicFiltering(t *testing.T) {
 
 	c.Request().Header.Set(HeaderAcceptLanguage, "en_US")
 	require.Equal(t, "", c.AcceptsLanguages("en-US"))
+
+	c.Request().Header.Set(HeaderAcceptLanguage, "en-*")
+	require.Equal(t, "", c.AcceptsLanguages("en-US"))
 }
 
 // go test -run Test_Ctx_AcceptsLanguages_CaseInsensitive
@@ -327,6 +330,22 @@ func Test_Ctx_AcceptsLanguages_CaseInsensitive(t *testing.T) {
 
 	c.Request().Header.Set(HeaderAcceptLanguage, "EN-us")
 	require.Equal(t, "en-US", c.AcceptsLanguages("en-US"))
+}
+
+// go test -run Test_Ctx_AcceptsLanguagesExtended
+func Test_Ctx_AcceptsLanguagesExtended(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	c.Request().Header.Set(HeaderAcceptLanguage, "en-*")
+	require.Equal(t, "en-US", c.AcceptsLanguagesExtended("en-US"))
+
+	c.Request().Header.Set(HeaderAcceptLanguage, "*-US")
+	require.Equal(t, "en-US", c.AcceptsLanguagesExtended("en-US", "fr-CA"))
+
+	c.Request().Header.Set(HeaderAcceptLanguage, "en-US-*")
+	require.Equal(t, "", c.AcceptsLanguagesExtended("en-US"))
 }
 
 // go test -v -run=^$ -bench=Benchmark_Ctx_AcceptsLanguages -benchmem -count=4

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -444,6 +444,7 @@ func (c fiber.Ctx) Accepts(offers ...string) string
 func (c fiber.Ctx) AcceptsCharsets(offers ...string) string
 func (c fiber.Ctx) AcceptsEncodings(offers ...string) string
 func (c fiber.Ctx) AcceptsLanguages(offers ...string) string
+func (c fiber.Ctx) AcceptsLanguagesExtended(offers ...string) string
 ```
 
 ```go title="Example"
@@ -520,6 +521,9 @@ app.Get("/", func(c fiber.Ctx) error {
 
   c.AcceptsLanguages("pt", "nl", "ru")
   // "nl"
+
+  c.AcceptsLanguagesExtended("en-US", "fr-CA")
+  // depends on extended ranges in the request header
   // ...
 })
 ```

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -63,12 +63,19 @@ func Test_Utils_GetOffer(t *testing.T) {
 	require.Equal(t, "", getOffer([]byte("gzip, deflate;q=0"), acceptsOffer, "deflate"))
 
 	// Accept-Language Basic Filtering
-	require.True(t, acceptsLanguageOffer("en", "en-US", nil))
-	require.False(t, acceptsLanguageOffer("en-US", "en", nil))
-	require.True(t, acceptsLanguageOffer("EN", "en-us", nil))
-	require.False(t, acceptsLanguageOffer("en", "en_US", nil))
-	require.Equal(t, "en-US", getOffer([]byte("fr-CA;q=0.8, en-US"), acceptsLanguageOffer, "en-US", "fr-CA"))
-	require.Equal(t, "", getOffer([]byte("xx"), acceptsLanguageOffer, "en"))
+	require.True(t, acceptsLanguageOfferBasic("en", "en-US", nil))
+	require.False(t, acceptsLanguageOfferBasic("en-US", "en", nil))
+	require.True(t, acceptsLanguageOfferBasic("EN", "en-us", nil))
+	require.False(t, acceptsLanguageOfferBasic("en", "en_US", nil))
+	require.Equal(t, "en-US", getOffer([]byte("fr-CA;q=0.8, en-US"), acceptsLanguageOfferBasic, "en-US", "fr-CA"))
+	require.Equal(t, "", getOffer([]byte("xx"), acceptsLanguageOfferBasic, "en"))
+	require.False(t, acceptsLanguageOfferBasic("en-*", "en-US", nil))
+
+	// Accept-Language Extended Filtering
+	require.True(t, acceptsLanguageOfferExtended("en-*", "en-US", nil))
+	require.True(t, acceptsLanguageOfferExtended("*-US", "en-US", nil))
+	require.False(t, acceptsLanguageOfferExtended("en-US-*", "en-US", nil))
+	require.Equal(t, "en-US", getOffer([]byte("fr-CA;q=0.8, en-*"), acceptsLanguageOfferExtended, "en-US", "fr-CA"))
 }
 
 // go test -v -run=^$ -bench=Benchmark_Utils_GetOffer -benchmem -count=4

--- a/req.go
+++ b/req.go
@@ -49,10 +49,18 @@ func (r *DefaultReq) AcceptsEncodings(offers ...string) string {
 	return getOffer(header, acceptsOffer, offers...)
 }
 
-// AcceptsLanguages checks if the specified language is acceptable.
+// AcceptsLanguages checks if the specified language is acceptable using
+// RFC 4647 Basic Filtering.
 func (r *DefaultReq) AcceptsLanguages(offers ...string) string {
 	header := joinHeaderValues(r.Request().Header.PeekAll(HeaderAcceptLanguage))
-	return getOffer(header, acceptsLanguageOffer, offers...)
+	return getOffer(header, acceptsLanguageOfferBasic, offers...)
+}
+
+// AcceptsLanguagesExtended checks if the specified language is acceptable using
+// RFC 4647 Extended Filtering.
+func (r *DefaultReq) AcceptsLanguagesExtended(offers ...string) string {
+	header := joinHeaderValues(r.Request().Header.PeekAll(HeaderAcceptLanguage))
+	return getOffer(header, acceptsLanguageOfferExtended, offers...)
 }
 
 // App returns the *App reference to the instance of the Fiber application

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -16,8 +16,12 @@ type Req interface {
 	AcceptsCharsets(offers ...string) string
 	// AcceptsEncodings checks if the specified encoding is acceptable.
 	AcceptsEncodings(offers ...string) string
-	// AcceptsLanguages checks if the specified language is acceptable.
+	// AcceptsLanguages checks if the specified language is acceptable using
+	// RFC 4647 Basic Filtering.
 	AcceptsLanguages(offers ...string) string
+	// AcceptsLanguagesExtended checks if the specified language is acceptable using
+	// RFC 4647 Extended Filtering.
+	AcceptsLanguagesExtended(offers ...string) string
 	// App returns the *App reference to the instance of the Fiber application
 	App() *App
 	// BaseURL returns (protocol + host + base path).

--- a/res_interface_gen.go
+++ b/res_interface_gen.go
@@ -44,7 +44,7 @@ type Res interface {
 	Format(handlers ...ResFmt) error
 	// AutoFormat performs content-negotiation on the Accept HTTP header.
 	// It uses Accepts to select a proper format.
-	// The supported content types are text/html, text/plain, application/json, and application/xml.
+	// The supported content types are text/html, text/plain, application/json, application/xml, application/vnd.msgpack, and application/cbor.
 	// For more flexible content negotiation, use Format.
 	// If the header is not specified or there is no proper format, text/plain is used.
 	AutoFormat(body any) error


### PR DESCRIPTION
## Summary
- reject language ranges that contain `*` after a hyphen
- add extended Accept-Language filtering with wildcard subtags
- document and test basic vs extended Accept-Language parsing

## Testing
- `make audit` *(fails: storage_manager_msgp.go: EncodeMsg passes lock by value, etc.)*
- `make generate`
- `make betteralign`
- `make modernize`
- `make format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689788efbc9c8333a93f6a599888140c