### PR TITLE
Respect immutable config for params and protocol

### DIFF
--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -320,7 +320,7 @@ type Ctx interface {
 	Format(handlers ...ResFmt) error
 	// AutoFormat performs content-negotiation on the Accept HTTP header.
 	// It uses Accepts to select a proper format.
-	// The supported content types are text/html, text/plain, application/json, and application/xml.
+	// The supported content types are text/html, text/plain, application/json, application/xml, application/vnd.msgpack, and application/cbor.
 	// For more flexible content negotiation, use Format.
 	// If the header is not specified or there is no proper format, text/plain is used.
 	AutoFormat(body any) error

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -3112,6 +3112,24 @@ func Test_Ctx_Params_Case_Sensitive(t *testing.T) {
 	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
 }
 
+func Test_Ctx_Params_Immutable(t *testing.T) {
+	t.Parallel()
+	app := New(Config{Immutable: true})
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
+
+	c.route = &Route{Params: []string{"user"}}
+	c.path = []byte("/test/john")
+	c.values[0] = utils.UnsafeString(c.path[6:])
+
+	param := c.Params("user")
+	c.path[6] = 'p'
+	c.path[7] = 'a'
+	c.path[8] = 'u'
+	c.path[9] = 'l'
+
+	require.Equal(t, "john", param)
+}
+
 // go test -v -run=^$ -bench=Benchmark_Ctx_Params -benchmem -count=4
 func Benchmark_Ctx_Params(b *testing.B) {
 	app := New()

--- a/req.go
+++ b/req.go
@@ -137,7 +137,7 @@ func (r *DefaultReq) Body() []byte {
 	request := r.Request()
 
 	// Get Content-Encoding header
-	headerEncoding = utils.ToLower(utils.UnsafeString(request.Header.ContentEncoding()))
+	headerEncoding = utils.ToLower(r.App().getString(request.Header.ContentEncoding()))
 
 	// If no encoding is provided, return the original body
 	if len(headerEncoding) == 0 {
@@ -580,7 +580,11 @@ func (r *DefaultReq) Params(key string, defaultValue ...string) string {
 			if len(values) <= i || len(values[i]) == 0 {
 				break
 			}
-			return values[i]
+			val := values[i]
+			if r.App().config.Immutable {
+				return utils.CopyString(val)
+			}
+			return val
 		}
 	}
 	return defaultString("", defaultValue)
@@ -651,7 +655,7 @@ func (r *DefaultReq) Scheme() string {
 
 // Protocol returns the HTTP protocol of request: HTTP/1.1 and HTTP/2.
 func (r *DefaultReq) Protocol() string {
-	return utils.UnsafeString(r.Request().Header.Protocol())
+	return r.App().getString(r.Request().Header.Protocol())
 }
 
 // Query returns the query string parameter in the url.

--- a/res_interface_gen.go
+++ b/res_interface_gen.go
@@ -44,7 +44,7 @@ type Res interface {
 	Format(handlers ...ResFmt) error
 	// AutoFormat performs content-negotiation on the Accept HTTP header.
 	// It uses Accepts to select a proper format.
-	// The supported content types are text/html, text/plain, application/json, and application/xml.
+	// The supported content types are text/html, text/plain, application/json, application/xml, application/vnd.msgpack, and application/cbor.
 	// For more flexible content negotiation, use Format.
 	// If the header is not specified or there is no proper format, text/plain is used.
 	AutoFormat(body any) error


### PR DESCRIPTION
## Summary
- ensure route parameters copy when Immutable config enabled
- use config-aware getter for HTTP protocol and Content-Encoding headers
- add test ensuring Params uses independent memory under Immutable

## Testing
- `make audit` *(fails: EncodeMsg passes lock by value)*
- `make generate`
- `make betteralign`
- `make modernize`
- `make format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689850834ea88333bd092bb5be0e03b2