### PR TITLE
📒 docs: Add context guide

### DIFF
--- a/docs/guide/context.md
+++ b/docs/guide/context.md
@@ -1,6 +1,6 @@
 ---
-id: context
-title: "\U0001F9E0 Context"
+id: go-context
+title: "\U0001F9E0 Go Context"
 description: >-
   Learn how Fiber's Ctx integrates with Go's context.Context,
   how to interact with the underlying fasthttp RequestCtx,


### PR DESCRIPTION
## Summary
- document Fiber's Ctx as a `context.Context`
- explain using `fasthttp.RequestCtx` and `fasthttpctx`
- cover helper functions like `requestid.FromContext`