### PR TITLE
🧹 chore: require Go 1.25

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: "1.24.x"
+          go-version: "1.25.x"
 
       - name: Run Benchmark
         run: set -o pipefail; go test ./... -benchmem -run=^$ -bench . | tee output.txt

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: "1.24.x"
+          go-version: "1.25.x"
           cache: false
 
       - name: golangci-lint

--- a/.github/workflows/modernize.yml
+++ b/.github/workflows/modernize.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: "1.24.x"
+          go-version: "1.25.x"
           cache: false
 
       - name: modernize

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   unit:
     strategy:
       matrix:
-        go-version: [1.24.x]
+        go-version: [1.25.x]
         platform: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -31,7 +31,7 @@ jobs:
         run: go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1 -coverprofile=coverage.txt -covermode=atomic -shuffle=on
 
       - name: Upload coverage reports to Codecov
-        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.24.x' }}
+        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.25.x' }}
         uses: codecov/codecov-action@v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -12,7 +12,7 @@ These docs are for **Fiber v3**, which was released on **Month xx, 202x**.
 
 ### Installation
 
-First, [download](https://go.dev/dl/) and install Go. Version `1.24` or higher is required.
+First, [download](https://go.dev/dl/) and install Go. Version `1.25` or higher is required.
 
 Installation is done using the [`go get`](https://pkg.go.dev/cmd/go/#hdr-Add_dependencies_to_current_module_and_install_them) command:
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -48,7 +48,7 @@ Here's a quick overview of the changes in Fiber `v3`:
 
 ## Drop for old Go versions
 
-Fiber `v3` drops support for Go versions below `1.24`. We recommend upgrading to Go `1.24` or higher to use Fiber `v3`.
+Fiber `v3` drops support for Go versions below `1.25`. We recommend upgrading to Go `1.25` or higher to use Fiber `v3`.
 
 ## 🚀 App
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofiber/fiber/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/gofiber/schema v1.6.0


### PR DESCRIPTION
## Summary
- raise minimum Go version requirement to 1.25
- update documentation to match Go 1.25 requirement
- update CI workflows to run on Go 1.25

## Testing
- `make audit` *(fails: storage_manager_msgp.go: EncodeMsg passes lock by value)*
- `make generate`
- `make betteralign` *(fails: package requires newer Go version go1.25 (application built with go1.24))*
- `make modernize` *(fails: package requires newer Go version go1.25 (application built with go1.24))*
- `make format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689bafd750548326add32c4e4266702c