### PR TITLE
Refactor KeyAuth Middleware: Extractor-Based Configuration and Enhanced Flexibility

### DIFF
--- a/docs/middleware/encryptcookie.md
+++ b/docs/middleware/encryptcookie.md
@@ -67,7 +67,7 @@ To generate a 32 char key, use `openssl rand -base64 32` or `encryptcookie.Gener
 |:----------|:----------------------------------------------------|:------------------------------------------------------------------------------------------------------|:-----------------------------|
 | Next      | `func(fiber.Ctx) bool`                             | A function to skip this middleware when returned true.                                                | `nil`                        |
 | Except    | `[]string`                                          | Array of cookie keys that should not be encrypted.                                                    | `[]`                         |
-| Key       | `string`                                            | A base64-encoded unique key to encode & decode cookies. Required. Key length should be 32 characters. | (No default, required field) |
+| Key       | `string`                                            | A base64-encoded unique key to encode & decode cookies. Required. Key length should be 16, 24, or 32 bytes. | (No default, required field) |
 | Encryptor | `func(decryptedString, key string) (string, error)` | A custom function to encrypt cookies.                                                                 | `EncryptCookie`              |
 | Decryptor | `func(encryptedString, key string) (string, error)` | A custom function to decrypt cookies.                                                                 | `DecryptCookie`              |
 
@@ -95,7 +95,7 @@ app.Use(encryptcookie.New(encryptcookie.Config{
     Except: []string{csrf.ConfigDefault.CookieName}, // exclude CSRF cookie
 }))
 app.Use(csrf.New(csrf.Config{
-    KeyLookup:      "header:" + csrf.HeaderName,
+    Extractor:      csrf.FromHeader(csrf.HeaderName),
     CookieSameSite: "Lax",
     CookieSecure:   true,
     CookieHTTPOnly: false,

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1093,7 +1093,7 @@ The `Expiration` field in the CSRF middleware configuration has been renamed to 
 
 ### EncryptCookie
 
-Added support for specifying Key length when using `encryptcookie.GenerateKey(length)`. This allows the user to generate keys compatible with `AES-128`, `AES-192`, and `AES-256` (Default).
+Added support for specifying key length when using `encryptcookie.GenerateKey(length)`. Keys must be base64-encoded and may be 16, 24, or 32 bytes when decoded, supporting AES-128, AES-192, and AES-256 (default).
 
 ### EnvVar
 
@@ -1113,6 +1113,7 @@ Refer to the [healthcheck middleware migration guide](./middleware/healthcheck.m
 ### KeyAuth
 
 The keyauth middleware was updated to introduce a configurable `Realm` field for the `WWW-Authenticate` header.
+The old string-based `KeyLookup` configuration has been replaced with an `Extractor` field. Use helper functions like `keyauth.FromHeader`, `keyauth.FromAuthHeader`, or `keyauth.FromCookie` to define where the key should be retrieved from. Multiple sources can be combined with `keyauth.Chain`. See the migration guide below.
 
 ### Logger
 
@@ -1937,6 +1938,28 @@ Passwords configured for BasicAuth must now be pre-hashed. If no prefix is suppl
 
 You can also set the optional `HeaderLimit` and `Charset`
 options to further control authentication behavior.
+
+#### KeyAuth
+
+The keyauth middleware was updated to introduce a configurable `Realm` field for the `WWW-Authenticate` header.
+The old string-based `KeyLookup` configuration has been replaced with an `Extractor` field, and the `AuthScheme` field has been removed. The auth scheme is now inferred from the extractor used (e.g., `keyauth.FromAuthHeader`). Use helper functions like `keyauth.FromHeader`, `keyauth.FromAuthHeader`, or `keyauth.FromCookie` to define where the key should be retrieved from. Multiple sources can be combined with `keyauth.Chain`.
+
+```go
+// Before
+app.Use(keyauth.New(keyauth.Config{
+    KeyLookup: "header:Authorization",
+    AuthScheme: "Bearer",
+    Validator: validateAPIKey,
+}))
+
+// After
+app.Use(keyauth.New(keyauth.Config{
+    Extractor: keyauth.FromAuthHeader(fiber.HeaderAuthorization, "Bearer"),
+    Validator: validateAPIKey,
+}))
+```
+
+Combine multiple sources with `keyauth.Chain()` when needed.
 
 #### Cache
 

--- a/middleware/keyauth/config_test.go
+++ b/middleware/keyauth/config_test.go
@@ -1,0 +1,71 @@
+package keyauth
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_KeyAuth_ConfigDefault_NoConfig tests the case where no config is provided.
+func Test_KeyAuth_ConfigDefault_NoConfig(t *testing.T) {
+	t.Parallel()
+	// The New function will call configDefault with no arguments
+	// which will panic because ConfigDefault.Validator is nil.
+	assert.PanicsWithValue(t, "fiber: keyauth middleware requires a validator function", func() {
+		New()
+	}, "Calling New() without a validator should panic")
+}
+
+// Test_KeyAuth_ConfigDefault_PanicWithoutValidator tests that configDefault panics when Validator is nil.
+func Test_KeyAuth_ConfigDefault_PanicWithoutValidator(t *testing.T) {
+	t.Parallel()
+	assert.PanicsWithValue(t, "fiber: keyauth middleware requires a validator function", func() {
+		configDefault(Config{})
+	}, "configDefault should panic if validator is not provided")
+}
+
+// Test_KeyAuth_ConfigDefault_WithValidator tests that default values are set when only a validator is provided.
+func Test_KeyAuth_ConfigDefault_WithValidator(t *testing.T) {
+	t.Parallel()
+	validator := func(fiber.Ctx, string) (bool, error) { return true, nil }
+	cfg := configDefault(Config{
+		Validator: validator,
+	})
+
+	require.NotNil(t, cfg.Validator)
+	assert.Equal(t, ConfigDefault.Realm, cfg.Realm)
+	require.NotNil(t, cfg.SuccessHandler)
+	require.NotNil(t, cfg.ErrorHandler)
+	require.NotNil(t, cfg.Extractor.Extract)
+}
+
+// Test_KeyAuth_ConfigDefault_CustomConfig tests that custom values are preserved.
+func Test_KeyAuth_ConfigDefault_CustomConfig(t *testing.T) {
+	t.Parallel()
+	nextFunc := func(_ fiber.Ctx) bool { return true }
+	successHandler := func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusOK) }
+	errorHandler := func(c fiber.Ctx, _ error) error { return c.SendStatus(fiber.StatusForbidden) }
+	validator := func(_ fiber.Ctx, _ string) (bool, error) { return true, nil }
+	extractor := FromHeader("X-API-Key")
+
+	cfg := configDefault(Config{
+		Next:           nextFunc,
+		SuccessHandler: successHandler,
+		ErrorHandler:   errorHandler,
+		Validator:      validator,
+		Realm:          "API",
+		Extractor:      extractor,
+	})
+
+	// Using reflect.ValueOf to compare function pointers
+	assert.Equal(t, reflect.ValueOf(nextFunc).Pointer(), reflect.ValueOf(cfg.Next).Pointer())
+	assert.Equal(t, reflect.ValueOf(successHandler).Pointer(), reflect.ValueOf(cfg.SuccessHandler).Pointer())
+	assert.Equal(t, reflect.ValueOf(errorHandler).Pointer(), reflect.ValueOf(cfg.ErrorHandler).Pointer())
+	assert.Equal(t, reflect.ValueOf(validator).Pointer(), reflect.ValueOf(cfg.Validator).Pointer())
+	assert.Equal(t, reflect.ValueOf(extractor.Extract).Pointer(), reflect.ValueOf(cfg.Extractor.Extract).Pointer())
+
+	assert.Equal(t, "API", cfg.Realm)
+}

--- a/middleware/keyauth/extractors.go
+++ b/middleware/keyauth/extractors.go
@@ -1,0 +1,252 @@
+package keyauth
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+// Source represents the type of source from which an API key is extracted.
+// This is informational metadata that helps developers understand the extractor behavior.
+type Source int
+
+const (
+	// SourceHeader indicates the key is extracted from an HTTP header.
+	SourceHeader Source = iota
+
+	// SourceAuthHeader indicates the key is extracted from the Authorization header.
+	// This is a common method for API key extraction, often with a 'Bearer' or other scheme.
+	SourceAuthHeader
+
+	// SourceForm indicates the key is extracted from form data.
+	SourceForm
+
+	// SourceQuery indicates the key is extracted from URL query parameters.
+	// This can be less secure as URLs may be logged.
+	SourceQuery
+
+	// SourceParam indicates the key is extracted from URL path parameters.
+	// This can be less secure as URLs may be logged.
+	SourceParam
+
+	// SourceCookie indicates the key is extracted from cookies.
+	SourceCookie
+
+	// SourceCustom indicates the key is extracted using a custom extractor function.
+	// Security depends on the implementation of the custom extractor.
+	SourceCustom
+)
+
+// Extractor defines an API key extraction method with metadata.
+type Extractor struct {
+	Extract    func(fiber.Ctx) (string, error)
+	Key        string      // The parameter/header name used for extraction
+	AuthScheme string      // The auth scheme, e.g., "Bearer" for AuthHeader
+	Chain      []Extractor // For chaining multiple extractors
+	Source     Source      // The type of source being extracted from
+}
+
+var (
+	ErrMissingAPIKey         = errors.New("missing api key")
+	ErrMissingAPIKeyInHeader = errors.New("missing api key in header")
+	ErrMissingAPIKeyInQuery  = errors.New("missing api key in query")
+	ErrMissingAPIKeyInParam  = errors.New("missing api key in param")
+	ErrMissingAPIKeyInForm   = errors.New("missing api key in form")
+	ErrMissingAPIKeyInCookie = errors.New("missing api key in cookie")
+)
+
+// FromAuthHeader extracts an API key from the specified header and authentication scheme.
+// It's commonly used for the "Authorization" header with a "Bearer" scheme.
+func FromAuthHeader(header, authScheme string) Extractor {
+	return Extractor{
+		Extract: func(c fiber.Ctx) (string, error) {
+			authHeader := c.Get(header)
+			if authHeader == "" {
+				return "", ErrMissingAPIKeyInHeader
+			}
+
+			// Check if the header starts with the specified auth scheme
+			if len(authScheme) > 0 {
+				schemeLen := len(authScheme)
+				if len(authHeader) > schemeLen+1 && strings.EqualFold(authHeader[:schemeLen], authScheme) && authHeader[schemeLen] == ' ' {
+					return strings.TrimSpace(authHeader[schemeLen+1:]), nil
+				}
+				return "", ErrMissingAPIKeyInHeader
+			}
+
+			return strings.TrimSpace(authHeader), nil
+		},
+		Key:        header,
+		Source:     SourceAuthHeader,
+		AuthScheme: authScheme,
+	}
+}
+
+// FromCookie creates an Extractor that retrieves an API key from a specified cookie in the request.
+//
+// Parameters:
+//   - key: The name of the cookie from which to extract the API key.
+//
+// Returns:
+//
+//	An Extractor that attempts to retrieve the API key from the specified cookie. If the cookie
+//	is not present or does not contain an API key, it returns an error (ErrMissingAPIKeyInCookie).
+func FromCookie(key string) Extractor {
+	return Extractor{
+		Extract: func(c fiber.Ctx) (string, error) {
+			apiKey := c.Cookies(key)
+			if apiKey == "" {
+				return "", ErrMissingAPIKeyInCookie
+			}
+			return apiKey, nil
+		},
+		Key:    key,
+		Source: SourceCookie,
+	}
+}
+
+// FromParam creates an Extractor that retrieves an API key from a specified URL parameter in the request.
+//
+// Parameters:
+//   - param: The name of the URL parameter from which to extract the API key.
+//
+// Returns:
+//
+//	An Extractor that attempts to retrieve the API key from the specified URL parameter. If the
+//	parameter is not present or does not contain an API key, it returns an error (ErrMissingAPIKeyInParam).
+func FromParam(param string) Extractor {
+	return Extractor{
+		Extract: func(c fiber.Ctx) (string, error) {
+			apiKey := c.Params(param)
+			if apiKey == "" {
+				return "", ErrMissingAPIKeyInParam
+			}
+			return apiKey, nil
+		},
+		Key:    param,
+		Source: SourceParam,
+	}
+}
+
+// FromForm creates an Extractor that retrieves an API key from a specified form field in the request.
+//
+// Parameters:
+//   - param: The name of the form field from which to extract the API key.
+//
+// Returns:
+//
+//	An Extractor that attempts to retrieve the API key from the specified form field. If the
+//	field is not present or does not contain an API key, it returns an error (ErrMissingAPIKeyInForm).
+func FromForm(param string) Extractor {
+	return Extractor{
+		Extract: func(c fiber.Ctx) (string, error) {
+			apiKey := c.FormValue(param)
+			if apiKey == "" {
+				return "", ErrMissingAPIKeyInForm
+			}
+			return apiKey, nil
+		},
+		Key:    param,
+		Source: SourceForm,
+	}
+}
+
+// FromHeader creates an Extractor that retrieves an API key from a specified HTTP header in the request.
+//
+// Parameters:
+//   - param: The name of the HTTP header from which to extract the API key.
+//
+// Returns:
+//
+//	An Extractor that attempts to retrieve the API key from the specified HTTP header. If the
+//	header is not present or does not contain an API key, it returns an error (ErrMissingAPIKeyInHeader).
+func FromHeader(param string) Extractor {
+	return Extractor{
+		Extract: func(c fiber.Ctx) (string, error) {
+			apiKey := c.Get(param)
+			if apiKey == "" {
+				return "", ErrMissingAPIKeyInHeader
+			}
+			return apiKey, nil
+		},
+		Key:    param,
+		Source: SourceHeader,
+	}
+}
+
+// FromQuery creates an Extractor that retrieves an API key from a specified query parameter in the request.
+//
+// Parameters:
+//   - param: The name of the query parameter from which to extract the API key.
+//
+// Returns:
+//
+//	An Extractor that attempts to retrieve the API key from the specified query parameter. If the
+//	parameter is not present or does not contain an API key, it returns an error (ErrMissingAPIKeyInQuery).
+func FromQuery(param string) Extractor {
+	return Extractor{
+		Extract: func(c fiber.Ctx) (string, error) {
+			apiKey := fiber.Query[string](c, param)
+			if apiKey == "" {
+				return "", ErrMissingAPIKeyInQuery
+			}
+			return apiKey, nil
+		},
+		Key:    param,
+		Source: SourceQuery,
+	}
+}
+
+// Chain creates an Extractor that tries multiple extractors in order until one succeeds.
+//
+// Parameters:
+//   - extractors: A variadic list of Extractor instances to try in sequence.
+//
+// Returns:
+//
+//	An Extractor that attempts each provided extractor in order and returns the first successful
+//	extraction. If all extractors fail, it returns the last error encountered, or ErrMissingAPIKey
+//	if no errors were returned. If no extractors are provided, it always fails with ErrMissingAPIKey.
+func Chain(extractors ...Extractor) Extractor {
+	if len(extractors) == 0 {
+		return Extractor{
+			Extract: func(fiber.Ctx) (string, error) {
+				return "", ErrMissingAPIKey
+			},
+			Source: SourceCustom,
+			Key:    "",
+			Chain:  []Extractor{},
+		}
+	}
+
+	// Use the source and key from the first extractor as the primary
+	primarySource := extractors[0].Source
+	primaryKey := extractors[0].Key
+
+	return Extractor{
+		Extract: func(c fiber.Ctx) (string, error) {
+			var lastErr error
+
+			for _, extractor := range extractors {
+				token, err := extractor.Extract(c)
+
+				if err == nil && token != "" {
+					return token, nil
+				}
+
+				// Only update lastErr if we got an actual error
+				if err != nil {
+					lastErr = err
+				}
+			}
+			if lastErr != nil {
+				return "", lastErr
+			}
+			return "", ErrMissingAPIKey
+		},
+		Source: primarySource,
+		Key:    primaryKey,
+		Chain:  extractors,
+	}
+}

--- a/middleware/keyauth/extractors.go
+++ b/middleware/keyauth/extractors.go
@@ -67,7 +67,7 @@ func FromAuthHeader(header, authScheme string) Extractor {
 			}
 
 			// Check if the header starts with the specified auth scheme
-			if len(authScheme) > 0 {
+			if authScheme != "" {
 				schemeLen := len(authScheme)
 				if len(authHeader) > schemeLen+1 && strings.EqualFold(authHeader[:schemeLen], authScheme) && authHeader[schemeLen] == ' ' {
 					return strings.TrimSpace(authHeader[schemeLen+1:]), nil

--- a/middleware/keyauth/extractors_test.go
+++ b/middleware/keyauth/extractors_test.go
@@ -158,7 +158,7 @@ func Test_Extractor_Chain(t *testing.T) {
 	require.Empty(t, token)
 	require.Equal(t, ErrMissingAPIKeyInQuery, err)
 
-	// All extractors find nothing (return empty string and nil error), should return ErrTokenNotFound
+// All extractors find nothing (return empty string and nil error), should return ErrMissingAPIKey
 	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 	defer app.ReleaseCtx(ctx)
 	// This extractor will return "", nil

--- a/middleware/keyauth/extractors_test.go
+++ b/middleware/keyauth/extractors_test.go
@@ -1,0 +1,175 @@
+package keyauth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// go test -run Test_Extractors_Missing
+func Test_Extractors_Missing(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	// Add a route to test the missing param
+	app.Get("/test", func(c fiber.Ctx) error {
+		token, err := FromParam("api_key").Extract(c)
+		require.Empty(t, token)
+		require.Equal(t, ErrMissingAPIKeyInParam, err)
+		return nil
+	})
+	_, err := app.Test(newRequest(fiber.MethodGet, "/test"))
+	require.NoError(t, err)
+
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+
+	// Missing form
+	token, err := FromForm("api_key").Extract(ctx)
+	require.Empty(t, token)
+	require.Equal(t, ErrMissingAPIKeyInForm, err)
+
+	// Missing query
+	token, err = FromQuery("api_key").Extract(ctx)
+	require.Empty(t, token)
+	require.Equal(t, ErrMissingAPIKeyInQuery, err)
+
+	// Missing header
+	token, err = FromHeader("X-Api-Key").Extract(ctx)
+	require.Empty(t, token)
+	require.Equal(t, ErrMissingAPIKeyInHeader, err)
+
+	// Missing Auth header
+	token, err = FromAuthHeader(fiber.HeaderAuthorization, "Bearer").Extract(ctx)
+	require.Empty(t, token)
+	require.Equal(t, ErrMissingAPIKeyInHeader, err)
+
+	// Missing cookie
+	token, err = FromCookie("api_key").Extract(ctx)
+	require.Empty(t, token)
+	require.Equal(t, ErrMissingAPIKeyInCookie, err)
+}
+
+// newRequest creates a new *http.Request for Fiber's app.Test
+func newRequest(method, target string) *http.Request {
+	req, err := http.NewRequestWithContext(context.Background(), method, target, nil)
+	if err != nil {
+		panic(err)
+	}
+	return req
+}
+
+// go test -run Test_Extractors
+func Test_Extractors(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+
+	// FromParam
+	app.Get("/test/:api_key", func(c fiber.Ctx) error {
+		token, err := FromParam("api_key").Extract(c)
+		require.NoError(t, err)
+		require.Equal(t, "token_from_param", token)
+		return nil
+	})
+	_, err := app.Test(newRequest(fiber.MethodGet, "/test/token_from_param"))
+	require.NoError(t, err)
+
+	// FromForm
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+	ctx.Request().Header.SetContentType(fiber.MIMEApplicationForm)
+	ctx.Request().SetBodyString("api_key=token_from_form")
+	token, err := FromForm("api_key").Extract(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "token_from_form", token)
+
+	// FromQuery
+	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+	ctx.Request().SetRequestURI("/?api_key=token_from_query")
+	token, err = FromQuery("api_key").Extract(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "token_from_query", token)
+
+	// FromHeader
+	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+	ctx.Request().Header.Set("X-Api-Key", "token_from_header")
+	token, err = FromHeader("X-Api-Key").Extract(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "token_from_header", token)
+
+	// FromAuthHeader
+	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+	ctx.Request().Header.Set(fiber.HeaderAuthorization, "Bearer token_from_auth_header")
+	token, err = FromAuthHeader(fiber.HeaderAuthorization, "Bearer").Extract(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "token_from_auth_header", token)
+
+	// FromCookie
+	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+	ctx.Request().Header.SetCookie("api_key", "token_from_cookie")
+	token, err = FromCookie("api_key").Extract(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "token_from_cookie", token)
+}
+
+// go test -run Test_Extractor_Chain
+func Test_Extractor_Chain(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+
+	// No extractors
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+	token, err := Chain().Extract(ctx)
+	require.Empty(t, token)
+	require.Equal(t, ErrMissingAPIKey, err)
+
+	// First extractor succeeds
+	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+	ctx.Request().Header.Set("X-Api-Key", "token_from_header")
+	ctx.Request().SetRequestURI("/?api_key=token_from_query")
+	token, err = Chain(FromHeader("X-Api-Key"), FromQuery("api_key")).Extract(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "token_from_header", token)
+
+	// Second extractor succeeds
+	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+	ctx.Request().SetRequestURI("/?api_key=token_from_query")
+	token, err = Chain(FromHeader("X-Api-Key"), FromQuery("api_key")).Extract(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "token_from_query", token)
+
+	// All extractors fail, should return the last error
+	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+	token, err = Chain(FromHeader("X-Api-Key"), FromQuery("api_key")).Extract(ctx)
+	require.Empty(t, token)
+	require.Equal(t, ErrMissingAPIKeyInQuery, err)
+
+	// All extractors find nothing (return empty string and nil error), should return ErrTokenNotFound
+	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+	// This extractor will return "", nil
+	dummyExtractor := Extractor{
+		Extract: func(_ fiber.Ctx) (string, error) {
+			return "", nil
+		},
+		Source: SourceCustom,
+		Key:    "api_key",
+	}
+	token, err = Chain(dummyExtractor).Extract(ctx)
+	require.Empty(t, token)
+	require.Equal(t, ErrMissingAPIKey, err)
+}

--- a/middleware/keyauth/extractors_test.go
+++ b/middleware/keyauth/extractors_test.go
@@ -158,7 +158,7 @@ func Test_Extractor_Chain(t *testing.T) {
 	require.Empty(t, token)
 	require.Equal(t, ErrMissingAPIKeyInQuery, err)
 
-// All extractors find nothing (return empty string and nil error), should return ErrMissingAPIKey
+	// All extractors find nothing (return empty string and nil error), should return ErrMissingAPIKey
 	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 	defer app.ReleaseCtx(ctx)
 	// This extractor will return "", nil


### PR DESCRIPTION
## Description

This PR modernizes the `keyauth` middleware by replacing the legacy string-based key extraction configuration (`KeyLookup`, `AuthScheme`, `CustomKeyLookup`) with a robust, type-safe extractor system. This update improves flexibility, composability, and clarity for users implementing API key authentication in Fiber.

### **Key Changes**

- **Extractor-Based API Key Retrieval:**  
  - Introduces a new `Extractor` field for configuration, allowing explicit selection of where to extract the API key (header, auth header, query, param, cookie, form).
  - Provides helper functions:  
    - `FromHeader(header string)`
    - `FromAuthHeader(header, scheme string)`
    - `FromCookie(name string)`
    - `FromQuery(param string)`
    - `FromParam(param string)`
    - `FromForm(name string)`
    - `Chain(...)` for chaining multiple extractors.

- **Config Refactoring:**  
  - Removes `KeyLookup`, `AuthScheme`, and `CustomKeyLookup`.
  - Makes `Validator` **required**; panics if missing.
  - Updates default error handling for missing/invalid keys.

- **WWW-Authenticate Header and Realm:**  
  - Automatically sets the `WWW-Authenticate` header on authentication failure when using an auth header extractor.
  - Adds configurable `Realm` support.

- **Comprehensive Tests and Documentation:**  
  - Adds new tests covering all extractors, chaining, and error scenarios.
  - Updates docs to explain new extractor usage, migration steps, and typical patterns.

### **Migration Guide**

**Before:**
```go
app.Use(keyauth.New(keyauth.Config{
    KeyLookup: "header:Authorization",
    AuthScheme: "Bearer",
    Validator: validateAPIKey,
}))
```

**After:**
```go
app.Use(keyauth.New(keyauth.Config{
    Extractor: keyauth.FromAuthHeader(fiber.HeaderAuthorization, "Bearer"),
    Validator: validateAPIKey,
}))
```
You can combine multiple sources:
```go
app.Use(keyauth.New(keyauth.Config{
    Extractor: keyauth.Chain(
        keyauth.FromHeader("X-API-Key"),
        keyauth.FromQuery("api_key"),
    ),
    Validator: validateAPIKey,
}))
```

### **Why?**

- **Type Safety & Extensibility:**  
  Explicit extractor configuration avoids fragile string parsing and makes it easier to extend/customize key source logic.
- **Composability:**  
  Easily combine multiple sources for API key retrieval using `Chain`.
- **Clearer Error Handling:**  
  Consistent error messages and `WWW-Authenticate` support.
- **Cleaner Configuration:**  
  No ambiguous string formats; everything is explicit and documented.

---

**Breaking Changes:**  
- `KeyLookup`, `AuthScheme`, and `CustomKeyLookup` have been removed.
- You must use the new `Extractor` configuration with provided helper functions.

See updated documentation and migration notes for further details.