### PR TITLE
Use ephemeral ports in unit tests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1653,7 +1653,7 @@ func Test_Client_SetProxyURL(t *testing.T) {
 
 		require.NoError(t, err)
 
-		resp, err := client.Get("http://example.com")
+		resp, err := client.Get("http://localhost:3000")
 		require.NoError(t, err)
 
 		require.Equal(t, 200, resp.StatusCode())
@@ -1667,7 +1667,7 @@ func Test_Client_SetProxyURL(t *testing.T) {
 		err := client.SetProxyURL(":this is not a proxy")
 		require.NoError(t, err)
 
-		_, err = client.Get("http://example.com")
+		_, err = client.Get("http://localhost:3000")
 		require.Error(t, err)
 	})
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1653,7 +1653,7 @@ func Test_Client_SetProxyURL(t *testing.T) {
 
 		require.NoError(t, err)
 
-		resp, err := client.Get("http://localhost:3000")
+		resp, err := client.Get("http://example.com")
 		require.NoError(t, err)
 
 		require.Equal(t, 200, resp.StatusCode())
@@ -1667,7 +1667,7 @@ func Test_Client_SetProxyURL(t *testing.T) {
 		err := client.SetProxyURL(":this is not a proxy")
 		require.NoError(t, err)
 
-		_, err = client.Get("http://localhost:3000")
+		_, err = client.Get("http://example.com")
 		require.Error(t, err)
 	})
 }

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -281,7 +281,7 @@ func Test_Hook_OnListen(t *testing.T) {
 		time.Sleep(1000 * time.Millisecond)
 		assert.NoError(t, app.Shutdown())
 	}()
-	require.NoError(t, app.Listen(":9000"))
+	require.NoError(t, app.Listen(":0"))
 
 	require.Equal(t, "ready", buf.String())
 }
@@ -305,7 +305,7 @@ func Test_Hook_OnListenPrefork(t *testing.T) {
 		assert.NoError(t, app.Shutdown())
 	}()
 
-	require.NoError(t, app.Listen(":9000", ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
+	require.NoError(t, app.Listen(":0", ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
 	require.Equal(t, "ready", buf.String())
 }
 
@@ -326,7 +326,7 @@ func Test_Hook_OnHook(t *testing.T) {
 		return nil
 	})
 
-	require.NoError(t, app.prefork(":3000", nil, ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
+	require.NoError(t, app.prefork(":0", nil, ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
 }
 
 func Test_Hook_OnMount(t *testing.T) {

--- a/listen_test.go
+++ b/listen_test.go
@@ -519,7 +519,9 @@ func Test_Listen_Master_Process_Show_Startup_Message(t *testing.T) {
 
 	ln, err := net.Listen(NetworkTCP4, "127.0.0.1:0")
 	require.NoError(t, err)
-	port := ln.Addr().(*net.TCPAddr).Port
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	port := addr.Port
 	require.NoError(t, ln.Close())
 
 	startupMessage := captureOutput(func() {
@@ -543,7 +545,9 @@ func Test_Listen_Master_Process_Show_Startup_MessageWithAppName(t *testing.T) {
 	app := New(Config{AppName: "Test App v3.0.0"})
 	ln, err := net.Listen(NetworkTCP4, "127.0.0.1:0")
 	require.NoError(t, err)
-	port := ln.Addr().(*net.TCPAddr).Port
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	port := addr.Port
 	require.NoError(t, ln.Close())
 
 	startupMessage := captureOutput(func() {
@@ -564,7 +568,9 @@ func Test_Listen_Master_Process_Show_Startup_MessageWithAppNameNonAscii(t *testi
 
 	ln, err := net.Listen(NetworkTCP4, "127.0.0.1:0")
 	require.NoError(t, err)
-	port := ln.Addr().(*net.TCPAddr).Port
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	port := addr.Port
 	require.NoError(t, ln.Close())
 
 	startupMessage := captureOutput(func() {
@@ -583,7 +589,9 @@ func Test_Listen_Master_Process_Show_Startup_MessageWithDisabledPreforkAndCustom
 	app := New(Config{AppName: appName})
 	ln, err := net.Listen(NetworkTCP4, "127.0.0.1:0")
 	require.NoError(t, err)
-	port := ln.Addr().(*net.TCPAddr).Port
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	port := addr.Port
 	require.NoError(t, ln.Close())
 
 	startupMessage := captureOutput(func() {

--- a/listen_test.go
+++ b/listen_test.go
@@ -34,7 +34,7 @@ func Test_Listen(t *testing.T) {
 		assert.NoError(t, app.Shutdown())
 	}()
 
-	require.NoError(t, app.Listen(":4003", ListenConfig{DisableStartupMessage: true}))
+	require.NoError(t, app.Listen(":0", ListenConfig{DisableStartupMessage: true}))
 }
 
 // go test -run Test_Listen_Graceful_Shutdown
@@ -169,7 +169,7 @@ func Test_Listen_Prefork(t *testing.T) {
 
 	app := New()
 
-	require.NoError(t, app.Listen(":99999", ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
+	require.NoError(t, app.Listen(":0", ListenConfig{DisableStartupMessage: true, EnablePrefork: true}))
 }
 
 // go test -run Test_Listen_TLSMinVersion
@@ -180,18 +180,18 @@ func Test_Listen_TLSMinVersion(t *testing.T) {
 
 	// Invalid TLSMinVersion
 	require.Panics(t, func() {
-		_ = app.Listen(":443", ListenConfig{TLSMinVersion: tls.VersionTLS10}) //nolint:errcheck // ignore error
+		_ = app.Listen(":0", ListenConfig{TLSMinVersion: tls.VersionTLS10}) //nolint:errcheck // ignore error
 	})
 	require.Panics(t, func() {
-		_ = app.Listen(":443", ListenConfig{TLSMinVersion: tls.VersionTLS11}) //nolint:errcheck // ignore error
+		_ = app.Listen(":0", ListenConfig{TLSMinVersion: tls.VersionTLS11}) //nolint:errcheck // ignore error
 	})
 
 	// Prefork
 	require.Panics(t, func() {
-		_ = app.Listen(":443", ListenConfig{DisableStartupMessage: true, EnablePrefork: true, TLSMinVersion: tls.VersionTLS10}) //nolint:errcheck // ignore error
+		_ = app.Listen(":0", ListenConfig{DisableStartupMessage: true, EnablePrefork: true, TLSMinVersion: tls.VersionTLS10}) //nolint:errcheck // ignore error
 	})
 	require.Panics(t, func() {
-		_ = app.Listen(":443", ListenConfig{DisableStartupMessage: true, EnablePrefork: true, TLSMinVersion: tls.VersionTLS11}) //nolint:errcheck // ignore error
+		_ = app.Listen(":0", ListenConfig{DisableStartupMessage: true, EnablePrefork: true, TLSMinVersion: tls.VersionTLS11}) //nolint:errcheck // ignore error
 	})
 
 	// Valid TLSMinVersion
@@ -206,7 +206,7 @@ func Test_Listen_TLSMinVersion(t *testing.T) {
 		time.Sleep(1000 * time.Millisecond)
 		assert.NoError(t, app.Shutdown())
 	}()
-	require.NoError(t, app.Listen(":99999", ListenConfig{DisableStartupMessage: true, EnablePrefork: true, TLSMinVersion: tls.VersionTLS13}))
+	require.NoError(t, app.Listen(":0", ListenConfig{DisableStartupMessage: true, EnablePrefork: true, TLSMinVersion: tls.VersionTLS13}))
 }
 
 // go test -run Test_Listen_TLS
@@ -249,7 +249,7 @@ func Test_Listen_TLS_Prefork(t *testing.T) {
 		assert.NoError(t, app.Shutdown())
 	}()
 
-	require.NoError(t, app.Listen(":99999", ListenConfig{
+	require.NoError(t, app.Listen(":0", ListenConfig{
 		DisableStartupMessage: true,
 		EnablePrefork:         true,
 		CertFile:              "./.github/testdata/ssl.pem",
@@ -300,7 +300,7 @@ func Test_Listen_MutualTLS_Prefork(t *testing.T) {
 		assert.NoError(t, app.Shutdown())
 	}()
 
-	require.NoError(t, app.Listen(":99999", ListenConfig{
+	require.NoError(t, app.Listen(":0", ListenConfig{
 		DisableStartupMessage: true,
 		EnablePrefork:         true,
 		CertFile:              "./.github/testdata/ssl.pem",
@@ -517,13 +517,18 @@ func Test_Listen_Master_Process_Show_Startup_Message(t *testing.T) {
 		EnablePrefork: true,
 	}
 
+	ln, err := net.Listen(NetworkTCP4, "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
 	startupMessage := captureOutput(func() {
 		New().
-			startupMessage(":3000", true, strings.Repeat(",11111,22222,33333,44444,55555,60000", 10), cfg)
+			startupMessage(fmt.Sprintf(":%d", port), true, strings.Repeat(",11111,22222,33333,44444,55555,60000", 10), cfg)
 	})
 	colors := Colors{}
-	require.Contains(t, startupMessage, "https://127.0.0.1:3000")
-	require.Contains(t, startupMessage, "(bound on host 0.0.0.0 and port 3000)")
+	require.Contains(t, startupMessage, fmt.Sprintf("https://127.0.0.1:%d", port))
+	require.Contains(t, startupMessage, fmt.Sprintf("(bound on host 0.0.0.0 and port %d)", port))
 	require.Contains(t, startupMessage, "Child PIDs")
 	require.Contains(t, startupMessage, "11111, 22222, 33333, 44444, 55555, 60000")
 	require.Contains(t, startupMessage, fmt.Sprintf("Prefork: \t\t\t%sEnabled%s", colors.Blue, colors.Reset))
@@ -536,8 +541,13 @@ func Test_Listen_Master_Process_Show_Startup_MessageWithAppName(t *testing.T) {
 	}
 
 	app := New(Config{AppName: "Test App v3.0.0"})
+	ln, err := net.Listen(NetworkTCP4, "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
 	startupMessage := captureOutput(func() {
-		app.startupMessage(":3000", true, strings.Repeat(",11111,22222,33333,44444,55555,60000", 10), cfg)
+		app.startupMessage(fmt.Sprintf(":%d", port), true, strings.Repeat(",11111,22222,33333,44444,55555,60000", 10), cfg)
 	})
 	require.Equal(t, "Test App v3.0.0", app.Config().AppName)
 	require.Contains(t, startupMessage, app.Config().AppName)
@@ -552,8 +562,13 @@ func Test_Listen_Master_Process_Show_Startup_MessageWithAppNameNonAscii(t *testi
 	appName := "Serveur de vérification des données"
 	app := New(Config{AppName: appName})
 
+	ln, err := net.Listen(NetworkTCP4, "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
 	startupMessage := captureOutput(func() {
-		app.startupMessage(":3000", false, "", cfg)
+		app.startupMessage(fmt.Sprintf(":%d", port), false, "", cfg)
 	})
 	require.Contains(t, startupMessage, "Serveur de vérification des données")
 }
@@ -566,13 +581,19 @@ func Test_Listen_Master_Process_Show_Startup_MessageWithDisabledPreforkAndCustom
 
 	appName := "Fiber Example Application"
 	app := New(Config{AppName: appName})
+	ln, err := net.Listen(NetworkTCP4, "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
 	startupMessage := captureOutput(func() {
-		app.startupMessage("server.com:8081", true, strings.Repeat(",11111,22222,33333,44444,55555,60000", 5), cfg)
+		app.startupMessage(fmt.Sprintf("server.com:%d", port), true, strings.Repeat(",11111,22222,33333,44444,55555,60000", 5), cfg)
 	})
 	colors := Colors{}
 	require.Contains(t, startupMessage, fmt.Sprintf("%sINFO%s", colors.Green, colors.Reset))
 	require.Contains(t, startupMessage, fmt.Sprintf("%s%s%s", colors.Blue, appName, colors.Reset))
-	require.Contains(t, startupMessage, fmt.Sprintf("%s%s%s", colors.Blue, "https://server.com:8081", colors.Reset))
+	expectedURL := fmt.Sprintf("https://server.com:%d", port)
+	require.Contains(t, startupMessage, fmt.Sprintf("%s%s%s", colors.Blue, expectedURL, colors.Reset))
 	require.Contains(t, startupMessage, fmt.Sprintf("Prefork: \t\t\t%sDisabled%s", colors.Red, colors.Reset))
 }
 

--- a/prefork_test.go
+++ b/prefork_test.go
@@ -61,7 +61,7 @@ func Test_App_Prefork_Master_Process(t *testing.T) {
 		assert.NoError(t, app.Shutdown())
 	}()
 
-	require.NoError(t, app.prefork(":3000", nil, listenConfigDefault()))
+	require.NoError(t, app.prefork(":0", nil, listenConfigDefault()))
 
 	dummyChildCmd.Store("invalid")
 
@@ -83,7 +83,7 @@ func Test_App_Prefork_Child_Process_Never_Show_Startup_Message(t *testing.T) {
 
 	os.Stdout = w
 
-	New().startupProcess().startupMessage(":3000", false, "", listenConfigDefault())
+	New().startupProcess().startupMessage(":0", false, "", listenConfigDefault())
 
 	require.NoError(t, w.Close())
 


### PR DESCRIPTION
## Summary
- use OS-assigned ports for prefork startup message test
- derive dynamic ports for startup message assertions to avoid fixed values

## Testing
- `make audit` *(fails: lock value copy warnings in generated files)*
- `make generate`
- `make betteralign` *(fails: analysis skipped due to errors)*
- `make modernize` *(fails: package requires Go 1.25)*
- `make format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e3dcbed6c832698832ba4094c29a9