### PR TITLE
🐛 bug: Handle invalid path in filesystem

### DIFF
--- a/middleware/filesystem/filesystem.go
+++ b/middleware/filesystem/filesystem.go
@@ -144,11 +144,11 @@ func New(config ...Config) fiber.Handler {
 			path = utils.TrimRight(path, '/')
 		}
 		file, err := cfg.Root.Open(path)
-		if err != nil && errors.Is(err, fs.ErrNotExist) && cfg.NotFoundFile != "" {
+		if err != nil && (errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrInvalid)) && cfg.NotFoundFile != "" {
 			file, err = cfg.Root.Open(cfg.NotFoundFile)
 		}
 		if err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
+			if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrInvalid) {
 				return c.Status(fiber.StatusNotFound).Next()
 			}
 			return fmt.Errorf("failed to open: %w", err)

--- a/middleware/filesystem/filesystem_test.go
+++ b/middleware/filesystem/filesystem_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
@@ -38,6 +39,10 @@ func Test_FileSystem(t *testing.T) {
 	app.Use("/prefix", New(Config{
 		Root:       http.Dir("../../.github/testdata/fs"),
 		PathPrefix: "img",
+	}))
+
+	app.Use("/errinvalid", New(Config{
+		Root: http.FS(os.DirFS("../../.github/testdata/fs")),
 	}))
 
 	tests := []struct {
@@ -115,6 +120,11 @@ func Test_FileSystem(t *testing.T) {
 			url:         "/prefix/fiber.png",
 			statusCode:  200,
 			contentType: "image/png",
+		},
+		{
+			name:       "Should return status 404 for invalid path",
+			url:        "/errinvalid/](//invalid",
+			statusCode: 404,
 		},
 	}
 


### PR DESCRIPTION
# Description

When using `os.DirFS` as the filesystem root and accessing an invalid path the server return a HTTP status 500. This PR changes this to return 404.

Minimal example to reproduce the issue:

```go
package main

import (
	"log"
	"net/http"
	"os"

	"github.com/gofiber/fiber/v2"
	"github.com/gofiber/fiber/v2/middleware/filesystem"
)

func main() {
	app := fiber.New()
	app.Use("/", filesystem.New(filesystem.Config{
		Root: http.FS(os.DirFS("./static")),
	}))
	log.Fatal(app.Listen(":3000"))
}
```
Run and navigate to `http://localhost:3000/](//invalid` which causes an internal error.

## Type of change

- [x] Enhancement (improvement to existing features and functionality)