### PR TITLE
fix cors subdomain wildcard boundary

### DIFF
--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -361,6 +361,19 @@ func Test_CORS_Subdomain(t *testing.T) {
 	ctx.Request.Reset()
 	ctx.Response.Reset()
 
+	// Make request with malformed subdomain (disallowed)
+	ctx.Request.SetRequestURI("/")
+	ctx.Request.Header.SetMethod(fiber.MethodOptions)
+	ctx.Request.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodGet)
+	ctx.Request.Header.Set(fiber.HeaderOrigin, "http://evil.comexample.com")
+
+	handler(ctx)
+
+	require.Equal(t, "", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
+
+	ctx.Request.Reset()
+	ctx.Response.Reset()
+
 	// Make request with allowed origin
 	ctx.Request.SetRequestURI("/")
 	ctx.Request.Header.SetMethod(fiber.MethodOptions)

--- a/middleware/cors/utils.go
+++ b/middleware/cors/utils.go
@@ -62,5 +62,20 @@ type subdomain struct {
 }
 
 func (s subdomain) match(o string) bool {
-	return len(o) >= len(s.prefix)+len(s.suffix) && strings.HasPrefix(o, s.prefix) && strings.HasSuffix(o, s.suffix)
+	if len(o) < len(s.prefix)+len(s.suffix) {
+		return false
+	}
+
+	if !strings.HasPrefix(o, s.prefix) || !strings.HasSuffix(o, s.suffix) {
+		return false
+	}
+
+	domain := normalizeDomain(o[len(s.prefix):])
+
+	suffix := normalizeDomain(s.suffix)
+	if strings.HasPrefix(suffix, ".") {
+		suffix = suffix[1:]
+	}
+
+	return strings.HasSuffix(domain, "."+suffix)
 }

--- a/middleware/cors/utils_test.go
+++ b/middleware/cors/utils_test.go
@@ -179,6 +179,12 @@ func Test_CORS_SubdomainMatch(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "no match with malformed subdomain",
+			sub:      subdomain{prefix: "https://", suffix: ".example.com"},
+			origin:   "https://evil.comexample.com",
+			expected: false,
+		},
+		{
 			name:     "partial match not considered a match",
 			sub:      subdomain{prefix: "https://service.", suffix: ".example.com"},
 			origin:   "https://api.example.com",


### PR DESCRIPTION
## Summary
- harden CORS subdomain wildcard handling by verifying normalized host boundaries
- add regression tests to prevent malformed subdomain matches

## Testing
- `make audit` *(fails: storage and session code copy lock values)*
- `make generate`
- `make betteralign` *(fails: packages require Go 1.25)*
- `make modernize` *(fails: packages require Go 1.25)*
- `make format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0cc2e119c8333a3d8c3b739f023ff