### PR TITLE
🧹 chore: Return generic errors in KeyAuth middleware

### DIFF
--- a/docs/middleware/keyauth.md
+++ b/docs/middleware/keyauth.md
@@ -63,17 +63,17 @@ func main() {
 **Test:**
 
 ```bash
-# No api-key specified -> 401 Invalid or expired API Key
+# No api-key specified -> 401 Missing or invalid API Key
 curl http://localhost:3000
-#> Invalid or expired API Key
+#> Missing or invalid API Key
 
 # Correct API key -> 200 OK
 curl --cookie "access_token=correct horse battery staple" http://localhost:3000
 #> Successfully authenticated!
 
-# Incorrect API key -> 401 Invalid or expired API Key
+# Incorrect API key -> 401 Missing or invalid API Key
 curl --cookie "access_token=Clearly A Wrong Key" http://localhost:3000
-#> Invalid or expired API Key
+#> Missing or invalid API Key
 ```
 
 For a more detailed example, see also the [`github.com/gofiber/recipes`](https://github.com/gofiber/recipes) repository and specifically the `fiber-envoy-extauthz` repository and the [`keyauth example`](https://github.com/gofiber/recipes/blob/master/fiber-envoy-extauthz/authz/main.go) code.
@@ -271,8 +271,8 @@ var ConfigDefault = Config{
     SuccessHandler: func(c fiber.Ctx) error {
         return c.Next()
     },
-    ErrorHandler: func(c fiber.Ctx, err error) error {
-        return c.Status(fiber.StatusUnauthorized).SendString("Invalid or expired API Key")
+    ErrorHandler: func(c fiber.Ctx, _ error) error {
+        return c.Status(fiber.StatusUnauthorized).SendString(ErrMissingOrMalformedAPIKey.Error())
     },
     Realm:     "Restricted",
     Extractor: FromAuthHeader(fiber.HeaderAuthorization, "Bearer"),

--- a/docs/middleware/keyauth.md
+++ b/docs/middleware/keyauth.md
@@ -272,16 +272,6 @@ var ConfigDefault = Config{
         return c.Next()
     },
     ErrorHandler: func(c fiber.Ctx, err error) error {
-        switch {
-        case errors.Is(err, ErrMissingOrMalformedAPIKey),
-            errors.Is(err, ErrMissingAPIKey),
-            errors.Is(err, ErrMissingAPIKeyInHeader),
-            errors.Is(err, ErrMissingAPIKeyInQuery),
-            errors.Is(err, ErrMissingAPIKeyInParam),
-            errors.Is(err, ErrMissingAPIKeyInForm),
-            errors.Is(err, ErrMissingAPIKeyInCookie):
-            return c.Status(fiber.StatusUnauthorized).SendString(err.Error())
-        }
         return c.Status(fiber.StatusUnauthorized).SendString("Invalid or expired API Key")
     },
     Realm:     "Restricted",

--- a/docs/middleware/keyauth.md
+++ b/docs/middleware/keyauth.md
@@ -63,9 +63,9 @@ func main() {
 **Test:**
 
 ```bash
-# No api-key specified -> 401 missing api key in cookie
+# No api-key specified -> 401 Invalid or expired API Key
 curl http://localhost:3000
-#> missing api key in cookie
+#> Invalid or expired API Key
 
 # Correct API key -> 200 OK
 curl --cookie "access_token=correct horse battery staple" http://localhost:3000

--- a/middleware/keyauth/config.go
+++ b/middleware/keyauth/config.go
@@ -1,8 +1,6 @@
 package keyauth
 
 import (
-	"errors"
-
 	"github.com/gofiber/fiber/v3"
 )
 
@@ -46,17 +44,7 @@ var ConfigDefault = Config{
 	SuccessHandler: func(c fiber.Ctx) error {
 		return c.Next()
 	},
-	ErrorHandler: func(c fiber.Ctx, err error) error {
-		switch {
-		case errors.Is(err, ErrMissingOrMalformedAPIKey),
-			errors.Is(err, ErrMissingAPIKey),
-			errors.Is(err, ErrMissingAPIKeyInHeader),
-			errors.Is(err, ErrMissingAPIKeyInQuery),
-			errors.Is(err, ErrMissingAPIKeyInParam),
-			errors.Is(err, ErrMissingAPIKeyInForm),
-			errors.Is(err, ErrMissingAPIKeyInCookie):
-			return c.Status(fiber.StatusUnauthorized).SendString(err.Error())
-		}
+	ErrorHandler: func(c fiber.Ctx, _ error) error {
 		return c.Status(fiber.StatusUnauthorized).SendString("Invalid or expired API Key")
 	},
 	Realm:     "Restricted",

--- a/middleware/keyauth/config.go
+++ b/middleware/keyauth/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	// ErrorHandler defines a function which is executed for an invalid key.
 	// It may be used to define a custom error.
 	//
-	// Optional. Default: 401 Invalid or expired API Key
+	// Optional. Default: 401 Missing or invalid API Key
 	ErrorHandler fiber.ErrorHandler
 
 	// Validator is a function to validate the key.
@@ -45,7 +45,7 @@ var ConfigDefault = Config{
 		return c.Next()
 	},
 	ErrorHandler: func(c fiber.Ctx, _ error) error {
-		return c.Status(fiber.StatusUnauthorized).SendString("Invalid or expired API Key")
+		return c.Status(fiber.StatusUnauthorized).SendString(ErrMissingOrMalformedAPIKey.Error())
 	},
 	Realm:     "Restricted",
 	Extractor: FromAuthHeader(fiber.HeaderAuthorization, "Bearer"),

--- a/middleware/keyauth/extractors_test.go
+++ b/middleware/keyauth/extractors_test.go
@@ -19,7 +19,7 @@ func Test_Extractors_Missing(t *testing.T) {
 	app.Get("/test", func(c fiber.Ctx) error {
 		token, err := FromParam("api_key").Extract(c)
 		require.Empty(t, token)
-		require.Equal(t, ErrMissingAPIKeyInParam, err)
+		require.Equal(t, ErrMissingOrMalformedAPIKey, err)
 		return nil
 	})
 	_, err := app.Test(newRequest(fiber.MethodGet, "/test"))
@@ -31,27 +31,27 @@ func Test_Extractors_Missing(t *testing.T) {
 	// Missing form
 	token, err := FromForm("api_key").Extract(ctx)
 	require.Empty(t, token)
-	require.Equal(t, ErrMissingAPIKeyInForm, err)
+	require.Equal(t, ErrMissingOrMalformedAPIKey, err)
 
 	// Missing query
 	token, err = FromQuery("api_key").Extract(ctx)
 	require.Empty(t, token)
-	require.Equal(t, ErrMissingAPIKeyInQuery, err)
+	require.Equal(t, ErrMissingOrMalformedAPIKey, err)
 
 	// Missing header
 	token, err = FromHeader("X-Api-Key").Extract(ctx)
 	require.Empty(t, token)
-	require.Equal(t, ErrMissingAPIKeyInHeader, err)
+	require.Equal(t, ErrMissingOrMalformedAPIKey, err)
 
 	// Missing Auth header
 	token, err = FromAuthHeader(fiber.HeaderAuthorization, "Bearer").Extract(ctx)
 	require.Empty(t, token)
-	require.Equal(t, ErrMissingAPIKeyInHeader, err)
+	require.Equal(t, ErrMissingOrMalformedAPIKey, err)
 
 	// Missing cookie
 	token, err = FromCookie("api_key").Extract(ctx)
 	require.Empty(t, token)
-	require.Equal(t, ErrMissingAPIKeyInCookie, err)
+	require.Equal(t, ErrMissingOrMalformedAPIKey, err)
 }
 
 // newRequest creates a new *http.Request for Fiber's app.Test
@@ -132,7 +132,7 @@ func Test_Extractor_Chain(t *testing.T) {
 	defer app.ReleaseCtx(ctx)
 	token, err := Chain().Extract(ctx)
 	require.Empty(t, token)
-	require.Equal(t, ErrMissingAPIKey, err)
+	require.Equal(t, ErrMissingOrMalformedAPIKey, err)
 
 	// First extractor succeeds
 	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
@@ -156,9 +156,9 @@ func Test_Extractor_Chain(t *testing.T) {
 	defer app.ReleaseCtx(ctx)
 	token, err = Chain(FromHeader("X-Api-Key"), FromQuery("api_key")).Extract(ctx)
 	require.Empty(t, token)
-	require.Equal(t, ErrMissingAPIKeyInQuery, err)
+	require.Equal(t, ErrMissingOrMalformedAPIKey, err)
 
-	// All extractors find nothing (return empty string and nil error), should return ErrMissingAPIKey
+	// All extractors find nothing (return empty string and nil error), should return ErrMissingOrMalformedAPIKey
 	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 	defer app.ReleaseCtx(ctx)
 	// This extractor will return "", nil
@@ -171,5 +171,5 @@ func Test_Extractor_Chain(t *testing.T) {
 	}
 	token, err = Chain(dummyExtractor).Extract(ctx)
 	require.Empty(t, token)
-	require.Equal(t, ErrMissingAPIKey, err)
+	require.Equal(t, ErrMissingOrMalformedAPIKey, err)
 }

--- a/middleware/keyauth/keyauth.go
+++ b/middleware/keyauth/keyauth.go
@@ -17,7 +17,7 @@ const (
 )
 
 // ErrMissingOrMalformedAPIKey is returned when the API key is missing or invalid.
-var ErrMissingOrMalformedAPIKey = errors.New("Missing or invalid API Key")
+var ErrMissingOrMalformedAPIKey = errors.New("missing or invalid API Key")
 
 // New creates a new middleware handler
 func New(config ...Config) fiber.Handler {

--- a/middleware/keyauth/keyauth.go
+++ b/middleware/keyauth/keyauth.go
@@ -16,8 +16,8 @@ const (
 	tokenKey contextKey = iota
 )
 
-// When there is no request of the key thrown ErrMissingOrMalformedAPIKey
-var ErrMissingOrMalformedAPIKey = errors.New("missing or malformed API Key")
+// ErrMissingOrMalformedAPIKey is returned when the API key is missing or invalid.
+var ErrMissingOrMalformedAPIKey = errors.New("Missing or invalid API Key")
 
 // New creates a new middleware handler
 func New(config ...Config) fiber.Handler {

--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -57,7 +57,7 @@ func Test_AuthSources(t *testing.T) {
 			description:   "auth with no key",
 			APIKey:        "",
 			expectedCode:  401, // 404 in case of param authentication
-			expectedBody:  "Invalid or expired API Key",
+			expectedBody:  ErrMissingOrMalformedAPIKey.Error(),
 		},
 		{
 			route:         "/",
@@ -65,7 +65,7 @@ func Test_AuthSources(t *testing.T) {
 			description:   "auth with wrong key",
 			APIKey:        "WRONGKEY",
 			expectedCode:  401,
-			expectedBody:  "Invalid or expired API Key",
+			expectedBody:  "Missing or invalid API Key",
 		},
 	}
 
@@ -172,7 +172,7 @@ func Test_AuthSources(t *testing.T) {
 				expectedCode := test.expectedCode
 				expectedBody := test.expectedBody
 				if test.APIKey == "" || test.APIKey == "WRONGKEY" {
-					expectedBody = "Invalid or expired API Key"
+					expectedBody = "Missing or invalid API Key"
 				}
 
 				if authSource == paramExtractorName && testKey == "" {
@@ -249,7 +249,7 @@ func TestMultipleKeyLookup(t *testing.T) {
 	require.NoError(t, err)
 	errBody, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
-	require.Equal(t, "Invalid or expired API Key", string(errBody))
+	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(errBody))
 }
 
 func Test_MultipleKeyAuth(t *testing.T) {
@@ -326,14 +326,14 @@ func Test_MultipleKeyAuth(t *testing.T) {
 			description:  "Wrong API Key",
 			APIKey:       "WRONG KEY",
 			expectedCode: 401,
-			expectedBody: "Invalid or expired API Key",
+			expectedBody: ErrMissingOrMalformedAPIKey.Error(),
 		},
 		{
 			route:        "/auth1",
 			description:  "Wrong API Key",
 			APIKey:       "", // NO KEY
 			expectedCode: 401,
-			expectedBody: "Invalid or expired API Key",
+			expectedBody: ErrMissingOrMalformedAPIKey.Error(),
 		},
 
 		// Auth 2 has a different password
@@ -349,14 +349,14 @@ func Test_MultipleKeyAuth(t *testing.T) {
 			description:  "Wrong API Key",
 			APIKey:       "WRONG KEY",
 			expectedCode: 401,
-			expectedBody: "Invalid or expired API Key",
+			expectedBody: ErrMissingOrMalformedAPIKey.Error(),
 		},
 		{
 			route:        "/auth2",
 			description:  "Wrong API Key",
 			APIKey:       "", // NO KEY
 			expectedCode: 401,
-			expectedBody: "Invalid or expired API Key",
+			expectedBody: ErrMissingOrMalformedAPIKey.Error(),
 		},
 	}
 
@@ -483,7 +483,7 @@ func Test_CustomNextFunc(t *testing.T) {
 
 	// Check that the response has the expected status code and body
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Equal(t, "Invalid or expired API Key", string(body))
+	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
 
 	// Create a request with a different path and send it to the app with correct key
 	req = httptest.NewRequest(fiber.MethodGet, "/not-allowed", nil)
@@ -612,7 +612,7 @@ func Test_AuthSchemeBasic(t *testing.T) {
 
 	// Check that the response has the expected status code and body
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Equal(t, "Invalid or expired API Key", string(body))
+	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
 
 	// Create a request with a valid API key in the "Authorization" header using the "Basic" scheme
 	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
@@ -684,7 +684,7 @@ func Test_DefaultErrorHandlerInvalid(t *testing.T) {
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Equal(t, "Invalid or expired API Key", string(body))
+	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
 	require.Equal(t, "Bearer realm=\"Restricted\"", res.Header.Get("WWW-Authenticate"))
 }
 
@@ -724,7 +724,7 @@ func Test_HeaderSchemeMissingSpace(t *testing.T) {
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Equal(t, "Invalid or expired API Key", string(body))
+	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
 }
 
 func Test_HeaderSchemeNoToken(t *testing.T) {
@@ -741,7 +741,7 @@ func Test_HeaderSchemeNoToken(t *testing.T) {
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Equal(t, "Invalid or expired API Key", string(body))
+	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
 }
 
 func Test_HeaderSchemeNoSeparator(t *testing.T) {
@@ -760,7 +760,7 @@ func Test_HeaderSchemeNoSeparator(t *testing.T) {
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Equal(t, "Invalid or expired API Key", string(body))
+	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
 }
 
 func Test_HeaderSchemeEmptyTokenAfterTrim(t *testing.T) {
@@ -780,7 +780,7 @@ func Test_HeaderSchemeEmptyTokenAfterTrim(t *testing.T) {
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	require.Equal(t, "Invalid or expired API Key", string(body))
+	require.Equal(t, ErrMissingOrMalformedAPIKey.Error(), string(body))
 }
 
 func Test_WWWAuthenticateHeader(t *testing.T) {

--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -65,7 +65,7 @@ func Test_AuthSources(t *testing.T) {
 			description:   "auth with wrong key",
 			APIKey:        "WRONGKEY",
 			expectedCode:  401,
-			expectedBody:  "Missing or invalid API Key",
+			expectedBody:  ErrMissingOrMalformedAPIKey.Error(),
 		},
 	}
 
@@ -172,7 +172,7 @@ func Test_AuthSources(t *testing.T) {
 				expectedCode := test.expectedCode
 				expectedBody := test.expectedBody
 				if test.APIKey == "" || test.APIKey == "WRONGKEY" {
-					expectedBody = "Missing or invalid API Key"
+					expectedBody = ErrMissingOrMalformedAPIKey.Error()
 				}
 
 				if authSource == paramExtractorName && testKey == "" {


### PR DESCRIPTION
## Summary
- send a generic error message for all KeyAuth failures
- update KeyAuth tests and docs to use the generic message