### PR TITLE
♻️ Refactor: Improve Req/Res Benchmarks

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -507,10 +507,6 @@ func (c *DefaultCtx) getMethodInt() int {
 	return c.methodInt
 }
 
-func (c *DefaultCtx) setMethodInt(methodInt int) {
-	c.methodInt = methodInt
-}
-
 func (c *DefaultCtx) getIndexRoute() int {
 	return c.indexRoute
 }
@@ -545,10 +541,6 @@ func (c *DefaultCtx) setMatched(matched bool) {
 
 func (c *DefaultCtx) setRoute(route *Route) {
 	c.route = route
-}
-
-func (c *DefaultCtx) keepOriginalPath() {
-	c.pathOriginal = utils.CopyString(c.pathOriginal)
 }
 
 func (c *DefaultCtx) getPathOriginal() string {

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -141,7 +141,6 @@ type Ctx interface {
 	Bind() *Bind
 	// Methods to use with next stack.
 	getMethodInt() int
-	setMethodInt(methodInt int)
 	getIndexRoute() int
 	getTreePathHash() int
 	getDetectionPath() string
@@ -151,7 +150,6 @@ type Ctx interface {
 	setIndexRoute(route int)
 	setMatched(matched bool)
 	setRoute(route *Route)
-	keepOriginalPath()
 	getPathOriginal() string
 	// Accepts checks if the specified extensions or content types are acceptable.
 	Accepts(offers ...string) string

--- a/req.go
+++ b/req.go
@@ -32,39 +32,39 @@ type DefaultReq struct {
 
 // Accepts checks if the specified extensions or content types are acceptable.
 func (r *DefaultReq) Accepts(offers ...string) string {
-	header := joinHeaderValues(r.Request().Header.PeekAll(HeaderAccept))
+	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderAccept))
 	return getOffer(header, acceptsOfferType, offers...)
 }
 
 // AcceptsCharsets checks if the specified charset is acceptable.
 func (r *DefaultReq) AcceptsCharsets(offers ...string) string {
-	header := joinHeaderValues(r.Request().Header.PeekAll(HeaderAcceptCharset))
+	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptCharset))
 	return getOffer(header, acceptsOffer, offers...)
 }
 
 // AcceptsEncodings checks if the specified encoding is acceptable.
 func (r *DefaultReq) AcceptsEncodings(offers ...string) string {
-	header := joinHeaderValues(r.Request().Header.PeekAll(HeaderAcceptEncoding))
+	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptEncoding))
 	return getOffer(header, acceptsOffer, offers...)
 }
 
 // AcceptsLanguages checks if the specified language is acceptable using
 // RFC 4647 Basic Filtering.
 func (r *DefaultReq) AcceptsLanguages(offers ...string) string {
-	header := joinHeaderValues(r.Request().Header.PeekAll(HeaderAcceptLanguage))
+	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage))
 	return getOffer(header, acceptsLanguageOfferBasic, offers...)
 }
 
 // AcceptsLanguagesExtended checks if the specified language is acceptable using
 // RFC 4647 Extended Filtering.
 func (r *DefaultReq) AcceptsLanguagesExtended(offers ...string) string {
-	header := joinHeaderValues(r.Request().Header.PeekAll(HeaderAcceptLanguage))
+	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage))
 	return getOffer(header, acceptsLanguageOfferExtended, offers...)
 }
 
 // App returns the *App reference to the instance of the Fiber application
 func (r *DefaultReq) App() *App {
-	return r.c.App()
+	return r.c.app
 }
 
 // BaseURL returns (protocol + host + base path).
@@ -89,7 +89,7 @@ func (r *DefaultReq) tryDecodeBodyInOrder(
 		decodesRealized uint8
 	)
 
-	request := r.Request()
+	request := &r.c.fasthttp.Request
 	for idx := range encodings {
 		i := len(encodings) - 1 - idx
 		encoding := encodings[i]
@@ -141,7 +141,7 @@ func (r *DefaultReq) Body() []byte {
 		encodingOrder      = []string{"", "", ""}
 	)
 
-	request := r.Request()
+	request := &r.c.fasthttp.Request
 
 	// Get Content-Encoding header
 	headerEncoding = utils.ToLower(utils.UnsafeString(request.Header.ContentEncoding()))
@@ -171,14 +171,14 @@ func (r *DefaultReq) Body() []byte {
 	if err != nil {
 		switch {
 		case errors.Is(err, ErrUnsupportedMediaType):
-			_ = r.c.SendStatus(StatusUnsupportedMediaType) //nolint:errcheck // It is fine to ignore the error
+			_ = r.c.DefaultRes.SendStatus(StatusUnsupportedMediaType) //nolint:errcheck // It is fine to ignore the error
 		case errors.Is(err, ErrNotImplemented):
-			_ = r.c.SendStatus(StatusNotImplemented) //nolint:errcheck // It is fine to ignore the error
+			_ = r.c.DefaultRes.SendStatus(StatusNotImplemented) //nolint:errcheck // It is fine to ignore the error
 		}
 		return []byte(err.Error())
 	}
 
-	if r.App().config.Immutable {
+	if r.c.app.config.Immutable {
 		return utils.CopyBytes(body)
 	}
 	return body
@@ -187,7 +187,7 @@ func (r *DefaultReq) Body() []byte {
 // RequestCtx returns *fasthttp.RequestCtx that carries a deadline
 // a cancellation signal, and other values across API boundaries.
 func (r *DefaultReq) RequestCtx() *fasthttp.RequestCtx {
-	return r.c.RequestCtx()
+	return r.c.fasthttp
 }
 
 // Cookies are used for getting a cookie value by key.
@@ -196,19 +196,19 @@ func (r *DefaultReq) RequestCtx() *fasthttp.RequestCtx {
 // The returned value is only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting to use the value outside the Handler.
 func (r *DefaultReq) Cookies(key string, defaultValue ...string) string {
-	return defaultString(r.App().getString(r.Request().Header.Cookie(key)), defaultValue)
+	return defaultString(r.c.app.getString(r.c.fasthttp.Request.Header.Cookie(key)), defaultValue)
 }
 
 // Request return the *fasthttp.Request object
 // This allows you to use all fasthttp request methods
 // https://godoc.org/github.com/valyala/fasthttp#Request
 func (r *DefaultReq) Request() *fasthttp.Request {
-	return r.c.Request()
+	return &r.c.fasthttp.Request
 }
 
 // FormFile returns the first file by key from a MultipartForm.
 func (r *DefaultReq) FormFile(key string) (*multipart.FileHeader, error) {
-	return r.RequestCtx().FormFile(key)
+	return r.c.fasthttp.FormFile(key)
 }
 
 // FormValue returns the first value by key from a MultipartForm.
@@ -218,7 +218,7 @@ func (r *DefaultReq) FormFile(key string) (*multipart.FileHeader, error) {
 // Returned value is only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting instead.
 func (r *DefaultReq) FormValue(key string, defaultValue ...string) string {
-	return defaultString(r.App().getString(r.RequestCtx().FormValue(key)), defaultValue)
+	return defaultString(r.c.app.getString(r.c.fasthttp.FormValue(key)), defaultValue)
 }
 
 // Fresh returns true when the response is still “fresh” in the client's cache,
@@ -228,7 +228,7 @@ func (r *DefaultReq) FormValue(key string, defaultValue ...string) string {
 // reload request, this module will return false to make handling these requests transparent.
 // https://github.com/jshttp/fresh/blob/master/index.js#L33
 func (r *DefaultReq) Fresh() bool {
-	header := &r.c.Request().Header
+	header := &r.c.fasthttp.Request.Header
 
 	// fields
 	modifiedSince := header.Peek(HeaderIfModifiedSince)
@@ -249,8 +249,8 @@ func (r *DefaultReq) Fresh() bool {
 
 	// if-none-match
 	if len(noneMatch) > 0 && (len(noneMatch) != 1 || noneMatch[0] != '*') {
-		app := r.App()
-		response := r.c.Response()
+		app := r.c.app
+		response := &r.c.fasthttp.Response
 		etag := app.getString(response.Header.Peek(HeaderETag))
 		if etag == "" {
 			return false
@@ -301,9 +301,9 @@ func GetReqHeader[V GenericType](c Ctx, key string, defaultValue ...V) V {
 // Returned value is only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting instead.
 func (r *DefaultReq) GetHeaders() map[string][]string {
-	app := r.App()
+	app := r.c.app
 	headers := make(map[string][]string)
-	for k, v := range r.Request().Header.All() {
+	for k, v := range r.c.fasthttp.Request.Header.All() {
 		key := app.getString(k)
 		headers[key] = append(headers[key], app.getString(v))
 	}
@@ -327,7 +327,7 @@ func (r *DefaultReq) Host() string {
 			return host
 		}
 	}
-	return r.App().getString(r.Request().URI().Host())
+	return r.c.app.getString(r.c.fasthttp.Request.URI().Host())
 }
 
 // Hostname contains the hostname derived from the X-Forwarded-Host or Host HTTP header using the c.Host() method.
@@ -343,7 +343,7 @@ func (r *DefaultReq) Hostname() string {
 
 // Port returns the remote port of the request.
 func (r *DefaultReq) Port() string {
-	tcpaddr, ok := r.RequestCtx().RemoteAddr().(*net.TCPAddr)
+	tcpaddr, ok := r.c.fasthttp.RemoteAddr().(*net.TCPAddr)
 	if !ok {
 		panic(errors.New("failed to type-assert to *net.TCPAddr"))
 	}
@@ -354,12 +354,12 @@ func (r *DefaultReq) Port() string {
 // If ProxyHeader and IP Validation is configured, it will parse that header and return the first valid IP address.
 // Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
 func (r *DefaultReq) IP() string {
-	app := r.App()
+	app := r.c.app
 	if r.IsProxyTrusted() && len(app.config.ProxyHeader) > 0 {
 		return r.extractIPFromHeader(app.config.ProxyHeader)
 	}
 
-	return r.RequestCtx().RemoteIP().String()
+	return r.c.fasthttp.RemoteIP().String()
 }
 
 // extractIPsFromHeader will return a slice of IPs it found given a header name in the order they appear.
@@ -378,6 +378,7 @@ func (r *DefaultReq) extractIPsFromHeader(header string) []string {
 
 	ipsFound := make([]string, 0, estimatedCount)
 
+	app := r.c.app
 	i := 0
 	j := -1
 
@@ -408,7 +409,7 @@ iploop:
 
 		s := utils.TrimRight(headerValue[i:j], ' ')
 
-		if r.App().config.EnableIPValidation {
+		if app.config.EnableIPValidation {
 			// Skip validation if IP is clearly not IPv4/IPv6, otherwise validate without allocations
 			if (!v6 && !v4) || (v6 && !utils.IsIPv6(s)) || (v4 && !utils.IsIPv4(s)) {
 				continue iploop
@@ -426,7 +427,7 @@ iploop:
 // when IP validation is disabled, it will simply return the value of the header without any inspection.
 // Implementation is almost the same as in extractIPsFromHeader, but without allocation of []string.
 func (r *DefaultReq) extractIPFromHeader(header string) string {
-	app := r.App()
+	app := r.c.app
 	if app.config.EnableIPValidation {
 		headerValue := r.Get(header)
 
@@ -469,7 +470,7 @@ func (r *DefaultReq) extractIPFromHeader(header string) string {
 			return s
 		}
 
-		return r.RequestCtx().RemoteIP().String()
+		return r.c.fasthttp.RemoteIP().String()
 	}
 
 	// default behavior if IP validation is not enabled is just to return whatever value is
@@ -491,7 +492,7 @@ func (r *DefaultReq) Is(extension string) bool {
 		return false
 	}
 
-	ct := r.App().getString(r.Request().Header.ContentType())
+	ct := r.c.app.getString(r.c.fasthttp.Request.Header.ContentType())
 	if i := strings.IndexByte(ct, ';'); i != -1 {
 		ct = ct[:i]
 	}
@@ -507,9 +508,9 @@ func (r *DefaultReq) Is(extension string) bool {
 // implementing io.Closer before removing the value from ctx.
 func (r *DefaultReq) Locals(key any, value ...any) any {
 	if len(value) == 0 {
-		return r.RequestCtx().UserValue(key)
+		return r.c.fasthttp.UserValue(key)
 	}
-	r.RequestCtx().SetUserValue(key, value[0])
+	r.c.fasthttp.SetUserValue(key, value[0])
 	return value[0]
 }
 
@@ -538,33 +539,33 @@ func Locals[V any](c Ctx, key any, value ...V) V {
 // If no override is given or if the provided override is not a valid HTTP method, it returns the current method from the context.
 // Otherwise, it updates the context's method and returns the overridden method as a string.
 func (r *DefaultReq) Method(override ...string) string {
-	app := r.App()
+	app := r.c.app
 	if len(override) == 0 {
 		// Nothing to override, just return current method from context
-		return app.method(r.c.getMethodInt())
+		return app.method(r.c.methodInt)
 	}
 
 	method := utils.ToUpper(override[0])
 	methodInt := app.methodInt(method)
 	if methodInt == -1 {
 		// Provided override does not valid HTTP method, no override, return current method
-		return app.method(r.c.getMethodInt())
+		return app.method(r.c.methodInt)
 	}
-	r.c.setMethodInt(methodInt)
+	r.c.methodInt = methodInt
 	return method
 }
 
 // MultipartForm parse form entries from binary.
 // This returns a map[string][]string, so given a key the value will be a string slice.
 func (r *DefaultReq) MultipartForm() (*multipart.Form, error) {
-	return r.RequestCtx().MultipartForm()
+	return r.c.fasthttp.MultipartForm()
 }
 
 // OriginalURL contains the original request URL.
 // Returned value is only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting to use the value outside the Handler.
 func (r *DefaultReq) OriginalURL() string {
-	return r.App().getString(r.Request().Header.RequestURI())
+	return r.c.app.getString(r.c.fasthttp.Request.Header.RequestURI())
 }
 
 // Params is used to get the route parameters.
@@ -577,9 +578,9 @@ func (r *DefaultReq) Params(key string, defaultValue ...string) string {
 		key += "1"
 	}
 
-	app := r.App()
-	route := r.Route()
-	values := r.c.getValues()
+	app := r.c.app
+	route := r.c.Route()
+	values := &r.c.values
 	for i := range route.Params {
 		if len(key) != len(route.Params[i]) {
 			continue
@@ -590,7 +591,7 @@ func (r *DefaultReq) Params(key string, defaultValue ...string) string {
 				break
 			}
 			val := values[i]
-			if r.App().config.Immutable {
+			if r.c.app.config.Immutable {
 				return utils.CopyString(val)
 			}
 			return val
@@ -625,7 +626,7 @@ func Params[V GenericType](c Ctx, key string, defaultValue ...V) V {
 // Scheme contains the request protocol string: http or https for TLS requests.
 // Please use Config.TrustProxy to prevent header spoofing, in case when your app is behind the proxy.
 func (r *DefaultReq) Scheme() string {
-	ctx := r.RequestCtx()
+	ctx := r.c.fasthttp
 	if ctx.IsTLS() {
 		return schemeHTTPS
 	}
@@ -633,7 +634,7 @@ func (r *DefaultReq) Scheme() string {
 		return schemeHTTP
 	}
 
-	app := r.App()
+	app := r.c.app
 	scheme := schemeHTTP
 	const lenXHeaderName = 12
 	for key, val := range ctx.Request.Header.All() {
@@ -664,7 +665,7 @@ func (r *DefaultReq) Scheme() string {
 
 // Protocol returns the HTTP protocol of request: HTTP/1.1 and HTTP/2.
 func (r *DefaultReq) Protocol() string {
-	return r.App().getString(r.Request().Header.Protocol())
+	return r.c.app.getString(r.c.fasthttp.Request.Header.Protocol())
 }
 
 // Query returns the query string parameter in the url.
@@ -698,8 +699,8 @@ func (r *DefaultReq) Query(key string, defaultValue ...string) string {
 // Queries()["filters[customer][name]"] == "Alice"
 // Queries()["filters[status]"] == "pending"
 func (r *DefaultReq) Queries() map[string]string {
-	app := r.App()
-	queryArgs := r.RequestCtx().QueryArgs()
+	app := r.c.app
+	queryArgs := r.c.fasthttp.QueryArgs()
 
 	m := make(map[string]string, queryArgs.Len())
 	for key, value := range queryArgs.All() {
@@ -804,8 +805,8 @@ func (r *DefaultReq) Range(size int) (Range, error) {
 		})
 	}
 	if len(rangeData.Ranges) < 1 {
-		r.c.Status(StatusRequestedRangeNotSatisfiable)
-		r.c.Set(HeaderContentRange, "bytes */"+strconv.Itoa(size))
+		r.c.DefaultRes.Status(StatusRequestedRangeNotSatisfiable)
+		r.c.DefaultRes.Set(HeaderContentRange, "bytes */"+strconv.Itoa(size))
 		return rangeData, ErrRequestedRangeNotSatisfiable
 	}
 
@@ -879,12 +880,12 @@ func (r *DefaultReq) Stale() bool {
 // If Config.TrustProxy false, it returns true
 // IsProxyTrusted can check remote ip by proxy ranges and ip map.
 func (r *DefaultReq) IsProxyTrusted() bool {
-	config := r.App().config
+	config := r.c.app.config
 	if !config.TrustProxy {
 		return true
 	}
 
-	ip := r.RequestCtx().RemoteIP()
+	ip := r.c.fasthttp.RemoteIP()
 
 	if (config.TrustProxyConfig.Loopback && ip.IsLoopback()) ||
 		(config.TrustProxyConfig.Private && ip.IsPrivate()) ||
@@ -907,7 +908,7 @@ func (r *DefaultReq) IsProxyTrusted() bool {
 
 // IsFromLocal will return true if request came from local.
 func (r *DefaultReq) IsFromLocal() bool {
-	return r.RequestCtx().RemoteIP().IsLoopback()
+	return r.c.fasthttp.RemoteIP().IsLoopback()
 }
 
 // Release is a method to reset Req fields when to use ReleaseCtx()
@@ -916,9 +917,9 @@ func (r *DefaultReq) release() {
 }
 
 func (r *DefaultReq) getBody() []byte {
-	if r.App().config.Immutable {
-		return utils.CopyBytes(r.Request().Body())
+	if r.c.app.config.Immutable {
+		return utils.CopyBytes(r.c.fasthttp.Request.Body())
 	}
 
-	return r.Request().Body()
+	return r.c.fasthttp.Request.Body()
 }

--- a/res.go
+++ b/res.go
@@ -125,7 +125,7 @@ type DefaultRes struct {
 
 // App returns the *App reference to the instance of the Fiber application
 func (r *DefaultRes) App() *App {
-	return r.c.App()
+	return r.c.app
 }
 
 // Append the specified value to the HTTP response header field.
@@ -134,7 +134,7 @@ func (r *DefaultRes) Append(field string, values ...string) {
 	if len(values) == 0 {
 		return
 	}
-	h := r.App().getString(r.Response().Header.Peek(field))
+	h := r.c.app.getString(r.c.fasthttp.Response.Header.Peek(field))
 	originalH := h
 	for _, value := range values {
 		if len(h) == 0 {
@@ -154,7 +154,7 @@ func (r *DefaultRes) Attachment(filename ...string) {
 	if len(filename) > 0 {
 		fname := filepath.Base(filename[0])
 		r.Type(filepath.Ext(fname))
-		app := r.App()
+		app := r.c.app
 		var quoted string
 		if app.isASCII(fname) {
 			quoted = app.quoteString(fname)
@@ -174,8 +174,8 @@ func (r *DefaultRes) Attachment(filename ...string) {
 // ClearCookie expires a specific cookie by key on the client side.
 // If no key is provided it expires all cookies that came with the request.
 func (r *DefaultRes) ClearCookie(key ...string) {
-	request := r.c.Request()
-	response := r.Response()
+	request := &r.c.fasthttp.Request
+	response := &r.c.fasthttp.Response
 	if len(key) > 0 {
 		for i := range key {
 			response.Header.DelClientCookie(key[i])
@@ -190,7 +190,7 @@ func (r *DefaultRes) ClearCookie(key ...string) {
 // RequestCtx returns *fasthttp.RequestCtx that carries a deadline
 // a cancellation signal, and other values across API boundaries.
 func (r *DefaultRes) RequestCtx() *fasthttp.RequestCtx {
-	return r.c.RequestCtx()
+	return r.c.fasthttp
 }
 
 // Cookie sets a cookie by passing a cookie struct.
@@ -271,7 +271,7 @@ func (r *DefaultRes) Cookie(cookie *Cookie) {
 	fcookie.SetPartitioned(hc.Partitioned)
 
 	// Set resp header
-	r.Response().Header.SetCookie(fcookie)
+	r.c.fasthttp.Response.Header.SetCookie(fcookie)
 	fasthttp.ReleaseCookie(fcookie)
 }
 
@@ -286,7 +286,7 @@ func (r *DefaultRes) Download(file string, filename ...string) error {
 	} else {
 		fname = filepath.Base(file)
 	}
-	app := r.App()
+	app := r.c.app
 	var quoted string
 	if app.isASCII(fname) {
 		quoted = app.quoteString(fname)
@@ -305,7 +305,7 @@ func (r *DefaultRes) Download(file string, filename ...string) error {
 // This allows you to use all fasthttp response methods
 // https://godoc.org/github.com/valyala/fasthttp#Response
 func (r *DefaultRes) Response() *fasthttp.Response {
-	return r.c.Response()
+	return &r.c.fasthttp.Response
 }
 
 // Format performs content-negotiation on the Accept HTTP header.
@@ -321,8 +321,8 @@ func (r *DefaultRes) Format(handlers ...ResFmt) error {
 
 	r.Vary(HeaderAccept)
 
-	if r.c.Get(HeaderAccept) == "" {
-		r.Response().Header.SetContentType(handlers[0].MediaType)
+	if r.c.DefaultReq.Get(HeaderAccept) == "" {
+		r.c.fasthttp.Response.Header.SetContentType(handlers[0].MediaType)
 		return handlers[0].Handler(r.c)
 	}
 
@@ -339,7 +339,7 @@ func (r *DefaultRes) Format(handlers ...ResFmt) error {
 		}
 		types = append(types, h.MediaType)
 	}
-	accept := r.c.Accepts(types...)
+	accept := r.c.DefaultReq.Accepts(types...)
 
 	if accept == "" {
 		if defaultHandler == nil {
@@ -350,7 +350,7 @@ func (r *DefaultRes) Format(handlers ...ResFmt) error {
 
 	for _, h := range handlers {
 		if h.MediaType == accept {
-			r.Response().Header.SetContentType(h.MediaType)
+			r.c.fasthttp.Response.Header.SetContentType(h.MediaType)
 			return h.Handler(r.c)
 		}
 	}
@@ -365,7 +365,7 @@ func (r *DefaultRes) Format(handlers ...ResFmt) error {
 // If the header is not specified or there is no proper format, text/plain is used.
 func (r *DefaultRes) AutoFormat(body any) error {
 	// Get accepted content type
-	accept := r.c.Accepts("html", "json", "txt", "xml", "msgpack", "cbor")
+	accept := r.c.DefaultReq.Accepts("html", "json", "txt", "xml", "msgpack", "cbor")
 
 	// Set accepted content type
 	r.Type(accept)
@@ -375,7 +375,7 @@ func (r *DefaultRes) AutoFormat(body any) error {
 	case string:
 		b = val
 	case []byte:
-		b = r.App().getString(val)
+		b = r.c.app.getString(val)
 	default:
 		b = fmt.Sprintf("%v", val)
 	}
@@ -405,16 +405,16 @@ func (r *DefaultRes) AutoFormat(body any) error {
 // Returned value is only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting instead.
 func (r *DefaultRes) Get(key string, defaultValue ...string) string {
-	return defaultString(r.App().getString(r.Response().Header.Peek(key)), defaultValue)
+	return defaultString(r.c.app.getString(r.c.fasthttp.Response.Header.Peek(key)), defaultValue)
 }
 
 // GetHeaders (a.k.a GetRespHeaders) returns the HTTP response headers.
 // Returned value is only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting instead.
 func (r *DefaultRes) GetHeaders() map[string][]string {
-	app := r.App()
+	app := r.c.app
 	headers := make(map[string][]string)
-	for k, v := range r.Response().Header.All() {
+	for k, v := range r.c.fasthttp.Response.Header.All() {
 		key := app.getString(k)
 		headers[key] = append(headers[key], app.getString(v))
 	}
@@ -429,12 +429,12 @@ func (r *DefaultRes) GetHeaders() map[string][]string {
 // Content-Type header equal to ctype. If ctype is not given,
 // The Content-Type header will be set to application/json; charset=utf-8.
 func (r *DefaultRes) JSON(data any, ctype ...string) error {
-	raw, err := r.App().config.JSONEncoder(data)
+	raw, err := r.c.app.config.JSONEncoder(data)
 	if err != nil {
 		return err
 	}
 
-	response := r.Response()
+	response := &r.c.fasthttp.Response
 	response.SetBodyRaw(raw)
 	if len(ctype) > 0 {
 		response.Header.SetContentType(ctype[0])
@@ -449,12 +449,12 @@ func (r *DefaultRes) JSON(data any, ctype ...string) error {
 // Content-Type header equal to ctype. If ctype is not given,
 // The Content-Type header will be set to application/vnd.msgpack.
 func (r *DefaultRes) MsgPack(data any, ctype ...string) error {
-	raw, err := r.App().config.MsgPackEncoder(data)
+	raw, err := r.c.app.config.MsgPackEncoder(data)
 	if err != nil {
 		return err
 	}
 
-	response := r.Response()
+	response := &r.c.fasthttp.Response
 	response.SetBodyRaw(raw)
 	if len(ctype) > 0 {
 		response.Header.SetContentType(ctype[0])
@@ -469,13 +469,13 @@ func (r *DefaultRes) MsgPack(data any, ctype ...string) error {
 // Content-Type header equal to ctype. If ctype is not given,
 // The Content-Type header will be set to application/cbor.
 func (r *DefaultRes) CBOR(data any, ctype ...string) error {
-	raw, err := r.App().config.CBOREncoder(data)
+	raw, err := r.c.app.config.CBOREncoder(data)
 	if err != nil {
 		return err
 	}
 
-	response := r.Response()
-	r.Response().SetBodyRaw(raw)
+	response := &r.c.fasthttp.Response
+	response.SetBodyRaw(raw)
 	if len(ctype) > 0 {
 		response.Header.SetContentType(ctype[0])
 	} else {
@@ -488,7 +488,7 @@ func (r *DefaultRes) CBOR(data any, ctype ...string) error {
 // This method is identical to JSON, except that it opts-in to JSONP callback support.
 // By default, the callback name is simply callback.
 func (r *DefaultRes) JSONP(data any, callback ...string) error {
-	raw, err := r.App().config.JSONEncoder(data)
+	raw, err := r.c.app.config.JSONEncoder(data)
 	if err != nil {
 		return err
 	}
@@ -501,22 +501,22 @@ func (r *DefaultRes) JSONP(data any, callback ...string) error {
 		cb = "callback"
 	}
 
-	result = cb + "(" + r.App().getString(raw) + ");"
+	result = cb + "(" + r.c.app.getString(raw) + ");"
 
 	r.setCanonical(HeaderXContentTypeOptions, "nosniff")
-	r.Response().Header.SetContentType(MIMETextJavaScriptCharsetUTF8)
+	r.c.fasthttp.Response.Header.SetContentType(MIMETextJavaScriptCharsetUTF8)
 	return r.SendString(result)
 }
 
 // XML converts any interface or string to XML.
 // This method also sets the content header to application/xml; charset=utf-8.
 func (r *DefaultRes) XML(data any) error {
-	raw, err := r.App().config.XMLEncoder(data)
+	raw, err := r.c.app.config.XMLEncoder(data)
 	if err != nil {
 		return err
 	}
 
-	response := r.Response()
+	response := &r.c.fasthttp.Response
 	response.SetBodyRaw(raw)
 	response.Header.SetContentType(MIMEApplicationXMLCharsetUTF8)
 	return nil
@@ -537,7 +537,7 @@ func (r *DefaultRes) Links(link ...string) {
 			bb.WriteString(`; rel="` + link[i] + `",`)
 		}
 	}
-	r.setCanonical(HeaderLink, utils.TrimRight(r.App().getString(bb.Bytes()), ','))
+	r.setCanonical(HeaderLink, utils.TrimRight(r.c.app.getString(bb.Bytes()), ','))
 	bytebufferpool.Put(bb)
 }
 
@@ -569,7 +569,7 @@ func (r *DefaultRes) ViewBind(vars Map) error {
 
 // getLocationFromRoute get URL location from route using parameters
 func (r *DefaultRes) getLocationFromRoute(route Route, params Map) (string, error) {
-	app := r.App()
+	app := r.c.app
 	buf := bytebufferpool.Get()
 	for _, segment := range route.routeParser.segs {
 		if !segment.IsParam {
@@ -599,7 +599,7 @@ func (r *DefaultRes) getLocationFromRoute(route Route, params Map) (string, erro
 
 // GetRouteURL generates URLs to named routes, with parameters. URLs are relative, for example: "/user/1831"
 func (r *DefaultRes) GetRouteURL(routeName string, params Map) (string, error) {
-	return r.getLocationFromRoute(r.App().GetRoute(routeName), params)
+	return r.getLocationFromRoute(r.c.app.GetRoute(routeName), params)
 }
 
 // Render a template with data and sends a text/html response.
@@ -615,14 +615,14 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 	}
 
 	// Pass-locals-to-views, bind, appListKeys
-	r.renderExtensions(bind)
+	r.c.renderExtensions(bind)
 
-	rootApp := r.App()
+	rootApp := r.c.app
 	var rendered bool
 	for i := len(rootApp.mountFields.appListKeys) - 1; i >= 0; i-- {
 		prefix := rootApp.mountFields.appListKeys[i]
 		app := rootApp.mountFields.appList[prefix]
-		if prefix == "" || strings.Contains(r.OriginalURL(), prefix) {
+		if prefix == "" || strings.Contains(r.c.OriginalURL(), prefix) {
 			if len(layouts) == 0 && app.config.ViewsLayout != "" {
 				layouts = []string{
 					app.config.ViewsLayout,
@@ -659,7 +659,7 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 		}
 	}
 
-	response := r.Response()
+	response := &r.c.fasthttp.Response
 
 	// Set Content-Type to text/html
 	response.Header.SetContentType(MIMETextHTMLCharsetUTF8)
@@ -677,7 +677,7 @@ func (r *DefaultRes) renderExtensions(bind any) {
 // From this point onward the body argument must not be changed.
 func (r *DefaultRes) Send(body []byte) error {
 	// Write response body
-	r.Response().SetBodyRaw(body)
+	r.c.fasthttp.Response.SetBodyRaw(body)
 	return nil
 }
 
@@ -701,7 +701,7 @@ func (r *DefaultRes) SendFile(file string, config ...SendFile) error {
 	var fsHandler fasthttp.RequestHandler
 	var cacheControlValue string
 
-	app := r.App()
+	app := r.c.app
 	app.sendfilesMutex.RLock()
 	for _, sf := range app.sendfiles {
 		if sf.compareConfig(cfg) {
@@ -755,9 +755,9 @@ func (r *DefaultRes) SendFile(file string, config ...SendFile) error {
 	}
 
 	// Keep original path for mutable params
-	r.c.keepOriginalPath()
+	r.c.pathOriginal = utils.CopyString(r.c.pathOriginal)
 
-	request := r.c.Request()
+	request := &r.c.fasthttp.Request
 
 	// Delete the Accept-Encoding header if compression is disabled
 	if !cfg.Compress {
@@ -785,18 +785,18 @@ func (r *DefaultRes) SendFile(file string, config ...SendFile) error {
 	file = filepath.ToSlash(file)
 
 	// Restore the original requested URL
-	originalURL := utils.CopyString(r.OriginalURL())
+	originalURL := utils.CopyString(r.c.OriginalURL())
 	defer request.SetRequestURI(originalURL)
 
 	// Set new URI for fileHandler
 	request.SetRequestURI(file)
 
 	// Save status code
-	response := r.Response()
+	response := &r.c.fasthttp.Response
 	status := response.StatusCode()
 
 	// Serve file
-	fsHandler(r.RequestCtx())
+	fsHandler(r.c.fasthttp)
 
 	// Sets the response Content-Disposition header to attachment if the Download option is true
 	if cfg.Download {
@@ -834,7 +834,7 @@ func (r *DefaultRes) SendStatus(status int) error {
 	r.Status(status)
 
 	// Only set status body when there is no response body
-	if len(r.Response().Body()) == 0 {
+	if len(r.c.fasthttp.Response.Body()) == 0 {
 		return r.SendString(utils.StatusMessage(status))
 	}
 
@@ -844,7 +844,7 @@ func (r *DefaultRes) SendStatus(status int) error {
 // SendString sets the HTTP response body for string types.
 // This means no type assertion, recommended for faster performance
 func (r *DefaultRes) SendString(body string) error {
-	r.Response().SetBodyString(body)
+	r.c.fasthttp.Response.SetBodyString(body)
 
 	return nil
 }
@@ -852,9 +852,9 @@ func (r *DefaultRes) SendString(body string) error {
 // SendStream sets response body stream and optional body size.
 func (r *DefaultRes) SendStream(stream io.Reader, size ...int) error {
 	if len(size) > 0 && size[0] >= 0 {
-		r.Response().SetBodyStream(stream, size[0])
+		r.c.fasthttp.Response.SetBodyStream(stream, size[0])
 	} else {
-		r.Response().SetBodyStream(stream, -1)
+		r.c.fasthttp.Response.SetBodyStream(stream, -1)
 	}
 
 	return nil
@@ -862,24 +862,24 @@ func (r *DefaultRes) SendStream(stream io.Reader, size ...int) error {
 
 // SendStreamWriter sets response body stream writer
 func (r *DefaultRes) SendStreamWriter(streamWriter func(*bufio.Writer)) error {
-	r.Response().SetBodyStreamWriter(fasthttp.StreamWriter(streamWriter))
+	r.c.fasthttp.Response.SetBodyStreamWriter(fasthttp.StreamWriter(streamWriter))
 
 	return nil
 }
 
 // Set sets the response's HTTP header field to the specified key, value.
 func (r *DefaultRes) Set(key, val string) {
-	r.Response().Header.Set(key, val)
+	r.c.fasthttp.Response.Header.Set(key, val)
 }
 
 func (r *DefaultRes) setCanonical(key, val string) {
-	r.Response().Header.SetCanonical(utils.UnsafeBytes(key), utils.UnsafeBytes(val))
+	r.c.fasthttp.Response.Header.SetCanonical(utils.UnsafeBytes(key), utils.UnsafeBytes(val))
 }
 
 // Status sets the HTTP status for the response.
 // This method is chainable.
 func (r *DefaultRes) Status(status int) Ctx {
-	r.Response().SetStatusCode(status)
+	r.c.fasthttp.Response.SetStatusCode(status)
 	return r.c
 }
 
@@ -888,13 +888,13 @@ func (r *DefaultRes) Type(extension string, charset ...string) Ctx {
 	mimeType := utils.GetMIME(extension)
 
 	if len(charset) > 0 {
-		r.Response().Header.SetContentType(mimeType + "; charset=" + charset[0])
+		r.c.fasthttp.Response.Header.SetContentType(mimeType + "; charset=" + charset[0])
 	} else {
 		// Automatically add UTF-8 charset for text-based MIME types
 		if shouldIncludeCharset(mimeType) {
-			r.Response().Header.SetContentType(mimeType + "; charset=utf-8")
+			r.c.fasthttp.Response.Header.SetContentType(mimeType + "; charset=utf-8")
 		} else {
-			r.Response().Header.SetContentType(mimeType)
+			r.c.fasthttp.Response.Header.SetContentType(mimeType)
 		}
 	}
 	return r.c
@@ -931,19 +931,19 @@ func (r *DefaultRes) Vary(fields ...string) {
 
 // Write appends p into response body.
 func (r *DefaultRes) Write(p []byte) (int, error) {
-	r.Response().AppendBody(p)
+	r.c.fasthttp.Response.AppendBody(p)
 	return len(p), nil
 }
 
 // Writef appends f & a into response body writer.
 func (r *DefaultRes) Writef(f string, a ...any) (int, error) {
 	//nolint:wrapcheck // This must not be wrapped
-	return fmt.Fprintf(r.Response().BodyWriter(), f, a...)
+	return fmt.Fprintf(r.c.fasthttp.Response.BodyWriter(), f, a...)
 }
 
 // WriteString appends s to response body.
 func (r *DefaultRes) WriteString(s string) (int, error) {
-	r.Response().AppendBodyString(s)
+	r.c.fasthttp.Response.AppendBodyString(s)
 	return len(s), nil
 }
 
@@ -957,12 +957,12 @@ func (r *DefaultRes) release() {
 // or when blocking access to sensitive endpoints.
 func (r *DefaultRes) Drop() error {
 	//nolint:wrapcheck // error wrapping is avoided to keep the operation lightweight and focused on connection closure.
-	return r.RequestCtx().Conn().Close()
+	return r.c.fasthttp.Conn().Close()
 }
 
 // End immediately flushes the current response and closes the underlying connection.
 func (r *DefaultRes) End() error {
-	ctx := r.RequestCtx()
+	ctx := r.c.fasthttp
 	conn := ctx.Conn()
 
 	bw := bufio.NewWriter(conn)


### PR DESCRIPTION
# Description

This PR is in continuation of issue #3632, to help improve benchmarks for Req and Res. This overhead is largely from the amount of indirection that occurs when accessing data stored inside of `DefaultCtx` from inside of a `DefaultReq` or `DefaultRes`. This also occurs when some methods require both `Req` and `Res` methods.

The PR reduces this level of indirection by accessing data directly from `DefaultCtx` or `DefaultReq`/`DefaultRes`.

e.g.
- `r.c.Method()` -> `r.c.DefaultReq.Method()`
- `r.Method()` -> `r.c.member`
- etc...

Fixes #3632

## Changes introduced

- [X] Benchmarks: Refactors the Req and Res methods to reduce unnecessary function call overhead when not using the `Req` or `Res` interfaces.

## Type of change

- [X] Enhancement (improvement to existing features and functionality)
- [X] Performance improvement (non-breaking change which improves efficiency)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [X] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [X] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [X] Ensured that new and existing unit tests pass locally with the changes.
- [X] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [X] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.
