### PR TITLE
refactor(csrf): align subdomain matching with cors

### DIFF
--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -60,16 +60,17 @@ func New(config ...Config) fiber.Handler {
 	trustedSubOrigins := []subdomain{}
 
 	for _, origin := range cfg.TrustedOrigins {
-		if i := strings.Index(origin, "://*."); i != -1 {
-			trimmedOrigin := utils.Trim(origin[:i+3]+origin[i+4:], ' ')
-			isValid, normalizedOrigin := normalizeOrigin(trimmedOrigin)
+		trimmedOrigin := utils.Trim(origin, ' ')
+		if i := strings.Index(trimmedOrigin, "://*."); i != -1 {
+			withoutWildcard := trimmedOrigin[:i+len("://")] + trimmedOrigin[i+len("://*."):]
+			isValid, normalizedOrigin := normalizeOrigin(withoutWildcard)
 			if !isValid {
 				panic("[CSRF] Invalid origin format in configuration:" + origin)
 			}
-			sd := subdomain{prefix: normalizedOrigin[:i+3], suffix: normalizedOrigin[i+3:]}
+			schemeSep := strings.Index(normalizedOrigin, "://") + len("://")
+			sd := subdomain{prefix: normalizedOrigin[:schemeSep], suffix: normalizedOrigin[schemeSep:]}
 			trustedSubOrigins = append(trustedSubOrigins, sd)
 		} else {
-			trimmedOrigin := utils.Trim(origin, ' ')
 			isValid, normalizedOrigin := normalizeOrigin(trimmedOrigin)
 			if !isValid {
 				panic("[CSRF] Invalid origin format in configuration:" + origin)

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -850,6 +850,20 @@ func Test_CSRF_TrustedOrigins(t *testing.T) {
 	h(ctx)
 	require.Equal(t, 403, ctx.Response.StatusCode())
 
+	// Test Trusted Origin malformed subdomain
+	ctx.Request.Reset()
+	ctx.Response.Reset()
+	ctx.Request.Header.SetMethod(fiber.MethodPost)
+	ctx.Request.URI().SetScheme("http")
+	ctx.Request.URI().SetHost("domain-1.com")
+	ctx.Request.Header.SetProtocol("http")
+	ctx.Request.Header.SetHost("domain-1.com")
+	ctx.Request.Header.Set(fiber.HeaderOrigin, "http://evil.comdomain-1.com")
+	ctx.Request.Header.Set(HeaderName, token)
+	ctx.Request.Header.SetCookie(ConfigDefault.CookieName, token)
+	h(ctx)
+	require.Equal(t, 403, ctx.Response.StatusCode())
+
 	// Test Trusted Referer
 	ctx.Request.Reset()
 	ctx.Response.Reset()

--- a/middleware/csrf/helpers.go
+++ b/middleware/csrf/helpers.go
@@ -53,5 +53,32 @@ type subdomain struct {
 }
 
 func (s subdomain) match(o string) bool {
-	return len(o) >= len(s.prefix)+len(s.suffix) && strings.HasPrefix(o, s.prefix) && strings.HasSuffix(o, s.suffix)
+	// Not a subdomain if not long enough for a dot separator.
+	if len(o) < len(s.prefix)+len(s.suffix)+1 {
+		return false
+	}
+
+	if !strings.HasPrefix(o, s.prefix) || !strings.HasSuffix(o, s.suffix) {
+		return false
+	}
+
+	// Check for the dot separator and validate that there is at least one
+	// non-empty label between prefix and suffix. Empty labels like
+	// "https://.example.com" or "https://..example.com" should not match.
+	suffixStartIndex := len(o) - len(s.suffix)
+	if suffixStartIndex <= len(s.prefix) {
+		return false
+	}
+	if o[suffixStartIndex-1] != '.' {
+		return false
+	}
+
+	// Extract the subdomain part (without the trailing dot) and ensure it
+	// doesn't contain empty labels.
+	sub := o[len(s.prefix) : suffixStartIndex-1]
+	if sub == "" || strings.HasPrefix(sub, ".") || strings.Contains(sub, "..") {
+		return false
+	}
+
+	return true
 }

--- a/middleware/csrf/helpers_test.go
+++ b/middleware/csrf/helpers_test.go
@@ -63,51 +63,69 @@ func TestSubdomainMatch(t *testing.T) {
 	}{
 		{
 			name:     "match with different scheme",
-			sub:      subdomain{prefix: "http://api.", suffix: ".example.com"},
+			sub:      subdomain{prefix: "http://api.", suffix: "example.com"},
 			origin:   "https://api.service.example.com",
 			expected: false,
 		},
 		{
 			name:     "match with different scheme",
-			sub:      subdomain{prefix: "https://", suffix: ".example.com"},
+			sub:      subdomain{prefix: "https://", suffix: "example.com"},
 			origin:   "http://api.service.example.com",
 			expected: false,
 		},
 		{
 			name:     "match with valid subdomain",
-			sub:      subdomain{prefix: "https://", suffix: ".example.com"},
+			sub:      subdomain{prefix: "https://", suffix: "example.com"},
 			origin:   "https://api.service.example.com",
 			expected: true,
 		},
 		{
 			name:     "match with valid nested subdomain",
-			sub:      subdomain{prefix: "https://", suffix: ".example.com"},
+			sub:      subdomain{prefix: "https://", suffix: "example.com"},
 			origin:   "https://1.2.api.service.example.com",
 			expected: true,
 		},
 
 		{
 			name:     "no match with invalid prefix",
-			sub:      subdomain{prefix: "https://abc.", suffix: ".example.com"},
+			sub:      subdomain{prefix: "https://abc.", suffix: "example.com"},
 			origin:   "https://service.example.com",
 			expected: false,
 		},
 		{
 			name:     "no match with invalid suffix",
-			sub:      subdomain{prefix: "https://", suffix: ".example.com"},
+			sub:      subdomain{prefix: "https://", suffix: "example.com"},
 			origin:   "https://api.example.org",
 			expected: false,
 		},
 		{
 			name:     "no match with empty origin",
-			sub:      subdomain{prefix: "https://", suffix: ".example.com"},
+			sub:      subdomain{prefix: "https://", suffix: "example.com"},
 			origin:   "",
 			expected: false,
 		},
 		{
+			name:     "no match with malformed subdomain",
+			sub:      subdomain{prefix: "https://", suffix: "example.com"},
+			origin:   "https://evil.comexample.com",
+			expected: false,
+		},
+		{
 			name:     "partial match not considered a match",
-			sub:      subdomain{prefix: "https://service.", suffix: ".example.com"},
+			sub:      subdomain{prefix: "https://service.", suffix: "example.com"},
 			origin:   "https://api.example.com",
+			expected: false,
+		},
+		{
+			name:     "no match with empty host label",
+			sub:      subdomain{prefix: "https://", suffix: "example.com"},
+			origin:   "https://.example.com",
+			expected: false,
+		},
+		{
+			name:     "no match with malformed host label",
+			sub:      subdomain{prefix: "https://", suffix: "example.com"},
+			origin:   "https://..example.com",
 			expected: false,
 		},
 	}
@@ -124,7 +142,7 @@ func TestSubdomainMatch(t *testing.T) {
 func Benchmark_CSRF_SubdomainMatch(b *testing.B) {
 	s := subdomain{
 		prefix: "www",
-		suffix: ".example.com",
+		suffix: "example.com",
 	}
 
 	o := "www.example.com"


### PR DESCRIPTION
## Summary
- ensure CSRF trusted-origin parsing mirrors CORS logic
- harden CSRF subdomain matching and cover edge cases
- test malformed subdomain rejection

## Testing
- `make audit` (fails: EncodeMsg passes lock by value)
- `make generate`
- `make betteralign` (fails: package requires newer Go version go1.25)
- `make modernize` (fails: package requires newer Go version go1.25)
- `make format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a54414aa948333ba5869aa8be36368