### PR TITLE
docs: add early hints documentation

### DIFF
--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -2045,6 +2045,32 @@ app.Get("/", func(c fiber.Ctx) error {
 })
 ```
 
+### SendEarlyHints
+
+Sends an informational `103 Early Hints` response with one or more
+[`Link` headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Link)
+before the final response. This allows the browser to start preloading
+resources while the server prepares the full response.
+
+:::caution
+This feature requires HTTP/2 or newer. Some legacy HTTP/1.1 clients may not
+understand or may misbehave when receiving early hints.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) SendEarlyHints(hints []string) error
+```
+
+```go title="Example"
+hints := []string{"<https://cdn.com/app.js>; rel=preload; as=script"}
+app.Get("/early", func(c fiber.Ctx) error {
+  if err := c.SendEarlyHints(hints); err != nil {
+    return err
+  }
+  return c.SendString("done")
+})
+```
+
 ### SendFile
 
 Transfers the file from the given path. Sets the [Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) response HTTP header field based on the **file** extension or format.

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -464,6 +464,7 @@ testConfig := fiber.TestConfig{
 - **IsProxyTrusted**: Checks the trustworthiness of the remote IP.
 - **Reset**: Resets context fields for server handlers.
 - **Schema**: Similar to Express.js, returns the schema (HTTP or HTTPS) of the request.
+- **SendEarlyHints**: Sends `103 Early Hints` with `Link` headers so browsers can preload resources while the final response is being prepared.
 - **SendStream**: Similar to Express.js, sends a stream as the response.
 - **SendStreamWriter**: Sends a stream using a writer function.
 - **SendString**: Similar to Express.js, sends a string as the response.
@@ -502,6 +503,24 @@ testConfig := fiber.TestConfig{
   specified by [RFC 6266](https://www.rfc-editor.org/rfc/rfc6266) and
   [RFC 8187](https://www.rfc-editor.org/rfc/rfc8187).
 - **Context()**: Renamed to `RequestCtx()` to access the underlying `fasthttp.RequestCtx`.
+
+### SendEarlyHints
+
+`SendEarlyHints` enables servers to emit [`103 Early Hints`](https://developer.chrome.com/docs/web-platform/early-hints) so
+ browsers can start preloading assets declared in `Link` headers while the final response is still being prepared. Only `Link`
+ headers written before calling `SendEarlyHints` are forwarded to the client.
+
+```go
+hints := []string{"<https://cdn.com/app.js>; rel=preload; as=script"}
+app.Get("/early", func(c fiber.Ctx) error {
+    if err := c.SendEarlyHints(hints); err != nil {
+        return err
+    }
+    return c.SendString("done")
+})
+```
+
+Older HTTP/1.1 clients may ignore these interim responses or handle them inconsistently.
 
 ### SendStreamWriter
 


### PR DESCRIPTION
## Summary
- document SendEarlyHints in ctx API reference
- highlight SendEarlyHints in v3 What's New guide with example

## Testing
- `make audit` *(fails: EncodeMsg passes lock by value)*
- `make generate`
- `make betteralign` *(fails: package requires newer Go version go1.25)*
- `make modernize` *(fails: package requires newer Go version go1.25)*
- `make format`
- `make test` *(fails: Test_App_BodyLimit_Zero i/o timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a6be9f88548326944b0a5c9eb7c49d