### PR TITLE
use reflect.TypeAssert

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -502,7 +502,7 @@ func getOffer(header []byte, isAccepted func(spec, offer string, specParams head
 					quality = q
 				}
 			} else {
-				params, _ = headerParamPool.Get().(headerParams) //nolint:errcheck // only contains headerParams
+				params, _ = reflect.TypeAssert[headerParams](reflect.ValueOf(headerParamPool.Get())) //nolint:errcheck // only contains headerParams
 				for k := range params {
 					delete(params, k)
 				}

--- a/middleware/basicauth/basicauth.go
+++ b/middleware/basicauth/basicauth.go
@@ -2,6 +2,7 @@ package basicauth
 
 import (
 	"encoding/base64"
+	"reflect"
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
@@ -80,9 +81,12 @@ func New(config Config) fiber.Handler {
 // UsernameFromContext returns the username found in the context
 // returns an empty string if the username does not exist
 func UsernameFromContext(c fiber.Ctx) string {
-	username, ok := c.Locals(usernameKey).(string)
-	if !ok {
+	v := c.Locals(usernameKey)
+	if v == nil {
 		return ""
 	}
-	return username
+	if username, ok := reflect.TypeAssert[string](reflect.ValueOf(v)); ok {
+		return username
+	}
+	return ""
 }

--- a/middleware/cache/heap.go
+++ b/middleware/cache/heap.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"container/heap"
+	"reflect"
 )
 
 type heapEntry struct {
@@ -41,7 +42,8 @@ func (h indexedHeap) Swap(i, j int) {
 }
 
 func (h *indexedHeap) Push(x any) {
-	h.pushInternal(x.(heapEntry)) //nolint:forcetypeassert,errcheck // Forced type assertion required to implement the heap.Interface interface
+	entry, _ := reflect.TypeAssert[heapEntry](reflect.ValueOf(x)) //nolint:errcheck // Forced type assertion
+	h.pushInternal(entry)
 }
 
 func (h *indexedHeap) Pop() any {
@@ -77,7 +79,7 @@ func (h *indexedHeap) put(key string, exp uint64, bytes uint) int {
 }
 
 func (h *indexedHeap) removeInternal(realIdx int) (string, uint) {
-	x := heap.Remove(h, realIdx).(heapEntry) //nolint:forcetypeassert,errcheck // Forced type assertion required to implement the heap.Interface interface
+	x, _ := reflect.TypeAssert[heapEntry](reflect.ValueOf(heap.Remove(h, realIdx))) //nolint:errcheck // Forced type assertion required to implement the heap.Interface interface
 	return x.key, x.bytes
 }
 

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -3,6 +3,7 @@ package csrf
 import (
 	"errors"
 	"net/url"
+	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -191,17 +192,24 @@ func New(config ...Config) fiber.Handler {
 // TokenFromContext returns the token found in the context
 // returns an empty string if the token does not exist
 func TokenFromContext(c fiber.Ctx) string {
-	token, ok := c.Locals(tokenKey).(string)
-	if !ok {
+	v := c.Locals(tokenKey)
+	if v == nil {
 		return ""
 	}
-	return token
+	if token, ok := reflect.TypeAssert[string](reflect.ValueOf(v)); ok {
+		return token
+	}
+	return ""
 }
 
 // HandlerFromContext returns the Handler found in the context
 // returns nil if the handler does not exist
 func HandlerFromContext(c fiber.Ctx) *Handler {
-	handler, ok := c.Locals(handlerKey).(*Handler)
+	v := c.Locals(handlerKey)
+	if v == nil {
+		return nil
+	}
+	handler, ok := reflect.TypeAssert[*Handler](reflect.ValueOf(v))
 	if !ok {
 		return nil
 	}

--- a/middleware/csrf/session_manager.go
+++ b/middleware/csrf/session_manager.go
@@ -1,6 +1,7 @@
 package csrf
 
 import (
+	"reflect"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -39,7 +40,9 @@ func (m *sessionManager) getRaw(c fiber.Ctx, key string, raw []byte) []byte {
 	var ok bool
 
 	if sess != nil {
-		token, ok = sess.Get(sessionKey).(Token)
+		if v := sess.Get(sessionKey); v != nil {
+			token, ok = reflect.TypeAssert[Token](reflect.ValueOf(v))
+		}
 	} else {
 		// Try to get the session from the store
 		storeSess, err := m.session.Get(c)
@@ -47,7 +50,9 @@ func (m *sessionManager) getRaw(c fiber.Ctx, key string, raw []byte) []byte {
 			// Handle error
 			return nil
 		}
-		token, ok = storeSess.Get(sessionKey).(Token)
+		if v := storeSess.Get(sessionKey); v != nil {
+			token, ok = reflect.TypeAssert[Token](reflect.ValueOf(v))
+		}
 	}
 
 	if ok {

--- a/middleware/keyauth/keyauth.go
+++ b/middleware/keyauth/keyauth.go
@@ -3,6 +3,7 @@ package keyauth
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/gofiber/fiber/v3"
 )
@@ -57,11 +58,14 @@ func New(config ...Config) fiber.Handler {
 // TokenFromContext returns the bearer token from the request context.
 // returns an empty string if the token does not exist
 func TokenFromContext(c fiber.Ctx) string {
-	token, ok := c.Locals(tokenKey).(string)
-	if !ok {
+	v := c.Locals(tokenKey)
+	if v == nil {
 		return ""
 	}
-	return token
+	if token, ok := reflect.TypeAssert[string](reflect.ValueOf(v)); ok {
+		return token
+	}
+	return ""
 }
 
 // getAuthScheme inspects an extractor and its chain to find the auth scheme

--- a/middleware/logger/default_logger.go
+++ b/middleware/logger/default_logger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"strconv"
 
 	"github.com/gofiber/fiber/v3"
@@ -35,9 +36,10 @@ func defaultLoggerInstance(c fiber.Ctx, data *Data, cfg Config) error {
 			if data.ChainErr != nil {
 				formatErr = colors.Red + " | " + data.ChainErr.Error() + colors.Reset
 			}
+			ts, _ := reflect.TypeAssert[string](reflect.ValueOf(data.Timestamp.Load()))
 			buf.WriteString(
 				fmt.Sprintf("%s |%s %3d %s| %13v | %15s |%s %-7s %s| %-"+data.ErrPaddingStr+"s %s\n",
-					data.Timestamp.Load().(string), //nolint:forcetypeassert,errcheck // Timestamp is always a string
+					ts,
 					statusColor(c.Response().StatusCode(), colors), c.Response().StatusCode(), colors.Reset,
 					data.Stop.Sub(data.Start),
 					c.IP(),
@@ -67,7 +69,9 @@ func defaultLoggerInstance(c fiber.Ctx, data *Data, cfg Config) error {
 			}
 
 			// Timestamp
-			buf.WriteString(data.Timestamp.Load().(string)) //nolint:forcetypeassert,errcheck // Timestamp is always a string
+			if ts, ok := reflect.TypeAssert[string](reflect.ValueOf(data.Timestamp.Load())); ok {
+				buf.WriteString(ts)
+			}
 			buf.WriteString(" | ")
 
 			// Status Code with 3 fixed width, right aligned

--- a/middleware/requestid/requestid.go
+++ b/middleware/requestid/requestid.go
@@ -1,6 +1,8 @@
 package requestid
 
 import (
+	"reflect"
+
 	"github.com/gofiber/fiber/v3"
 )
 
@@ -44,7 +46,11 @@ func New(config ...Config) fiber.Handler {
 // FromContext returns the request ID from context.
 // If there is no request ID, an empty string is returned.
 func FromContext(c fiber.Ctx) string {
-	if rid, ok := c.Locals(requestIDKey).(string); ok {
+	v := c.Locals(requestIDKey)
+	if v == nil {
+		return ""
+	}
+	if rid, ok := reflect.TypeAssert[string](reflect.ValueOf(v)); ok {
 		return rid
 	}
 	return ""

--- a/middleware/session/data.go
+++ b/middleware/session/data.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"reflect"
 	"sync"
 )
 
@@ -30,7 +31,10 @@ var dataPool = sync.Pool{
 //	d := acquireData()
 func acquireData() *data {
 	obj := dataPool.Get()
-	if d, ok := obj.(*data); ok {
+	if obj == nil {
+		panic("unexpected type in data pool")
+	}
+	if d, ok := reflect.TypeAssert[*data](reflect.ValueOf(obj)); ok {
 		return d
 	}
 	// Handle unexpected type in the pool

--- a/middleware/session/middleware.go
+++ b/middleware/session/middleware.go
@@ -4,6 +4,7 @@ package session
 
 import (
 	"errors"
+	"reflect"
 	"sync"
 
 	"github.com/gofiber/fiber/v3"
@@ -139,7 +140,11 @@ func (m *Middleware) saveSession() {
 
 // acquireMiddleware retrieves a middleware instance from the pool.
 func acquireMiddleware() *Middleware {
-	m, ok := middlewarePool.Get().(*Middleware)
+	v := middlewarePool.Get()
+	if v == nil {
+		panic(ErrTypeAssertionFailed.Error())
+	}
+	m, ok := reflect.TypeAssert[*Middleware](reflect.ValueOf(v))
 	if !ok {
 		panic(ErrTypeAssertionFailed.Error())
 	}
@@ -176,7 +181,11 @@ func releaseMiddleware(m *Middleware) {
 //
 //	m := session.FromContext(c)
 func FromContext(c fiber.Ctx) *Middleware {
-	m, ok := c.Locals(middlewareContextKey).(*Middleware)
+	v := c.Locals(middlewareContextKey)
+	if v == nil {
+		return nil
+	}
+	m, ok := reflect.TypeAssert[*Middleware](reflect.ValueOf(v))
 	if !ok {
 		return nil
 	}

--- a/req.go
+++ b/req.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"mime/multipart"
 	"net"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -523,10 +524,14 @@ func (r *DefaultReq) Locals(key any, value ...any) any {
 func Locals[V any](c Ctx, key any, value ...V) V {
 	var v V
 	var ok bool
+	var raw any
 	if len(value) == 0 {
-		v, ok = c.Locals(key).(V)
+		raw = c.Locals(key)
 	} else {
-		v, ok = c.Locals(key, value[0]).(V)
+		raw = c.Locals(key, value[0])
+	}
+	if raw != nil {
+		v, ok = reflect.TypeAssert[V](reflect.ValueOf(raw))
 	}
 	if !ok {
 		return v // return zero of type V


### PR DESCRIPTION
## Summary
- replace direct type assertions with `reflect.TypeAssert` in middleware, request helpers, and logging utilities
- expand reflection-based checks for sessions, context locals, and pooled resources
- update utilities and cache managers to use `reflect.TypeAssert`

## Testing
- `make audit` *(fails: EncodeMsg passes lock by value)*
- `make generate`
- `make betteralign` *(fails: package requires newer Go version go1.25 (application built with go1.24))*
- `make modernize` *(fails: package requires newer Go version go1.25 (application built with go1.24))*
- `make format`
- `make test` *(fails: Test_SendFile_withRoutes)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f87e83048326918e6f33385ba1cf