### PR TITLE
docs: document utils package migration

### DIFF
--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1922,7 +1922,7 @@ Fiber v3 removes the in-repo `utils` package in favor of the external [`github.c
 + import "github.com/gofiber/utils/v2"
 ```
 
-2. Review function changes:
+1. Review function changes:
 
 | v2 function | v3 replacement |
 | --- | --- |
@@ -1961,7 +1961,7 @@ Fiber v3 removes the in-repo `utils` package in favor of the external [`github.c
 | `EqualFold` | `strings.EqualFold` |
 | `StartTimeStampUpdater` | `utils.StartTimeStampUpdater` (new `utils.Timestamp` provides the current value) |
 
-3. Update your code. For example:
+1. Update your code. For example:
 
 ```go
 // v2


### PR DESCRIPTION
## Summary
- document replacement of in-repo utils with `github.com/gofiber/utils`
- move utils migration details to dedicated migration guide section with mapping table and example

## Testing
- `make audit` *(fails: EncodeMsg passes lock by value)*
- `make generate`
- `make betteralign` *(fails: package requires newer Go version go1.25)*
- `make modernize` *(fails: package requires newer Go version go1.25)*
- `make format`
- `make test`
- `make markdown`


------
https://chatgpt.com/codex/tasks/task_e_68a8e7a57d3c8326b4ae7856b0010af5