### PR TITLE
docs: note removal of context keys

### DIFF
--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1998,9 +1998,7 @@ The `github.com/gofiber/utils/v2` module also introduces new helpers like `Parse
 **Impact:** Directly accessing these middleware-provided values via `c.Locals("some_string_key")` will no longer work.
 
 **Migration Action:**
-You must update your code to use the dedicated exported functions provided by each affected middleware to retrieve its data from the context.
-
-All middlewares have also dropped their `ContextKey` configuration option. Values are no longer stored under user-defined keys; instead, retrieve them with the helper functions described below.
+The `ContextKey` configuration option has been removed from all middlewares. Values are no longer stored under user-defined keys. You must update your code to use the dedicated exported functions provided by each affected middleware to retrieve its data from the context.
 
 **Examples of new helper functions to use:**
 


### PR DESCRIPTION
## Summary
- remove ContextKey mentions from BasicAuth and KeyAuth docs
- add a single changelog note explaining that all middlewares dropped the ContextKey option

## Testing
- `make audit` *(fails: EncodeMsg passes lock by value; session/data_msgp.go lock copy)*
- `make generate`
- `make betteralign` *(fails: package requires newer Go version go1.25 (application built with go1.24))*
- `make modernize` *(fails: package requires newer Go version go1.25 (application built with go1.24))*
- `make format`
- `make test` *(fails: Test_App_BodyLimit_LargerThanDefault timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f436ea1883268b1f69302fb4ca60