### PR TITLE
use project toolchain for go run tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+GOVERSION ?= $(shell go env GOVERSION)
+
 ## help: 💡 Display available commands
 .PHONY: help
 help:
@@ -9,7 +11,7 @@ help:
 audit:
 	go mod verify
 	go vet ./...
-	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+	GOTOOLCHAIN=$(GOVERSION) go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
 ## benchmark: 📈 Benchmark code performance
 .PHONY: benchmark
@@ -19,13 +21,13 @@ benchmark:
 ## coverage: ☂️  Generate coverage report
 .PHONY: coverage
 coverage:
-	go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1 -coverprofile=/tmp/coverage.out -covermode=atomic
+	GOTOOLCHAIN=$(GOVERSION) go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1 -coverprofile=/tmp/coverage.out -covermode=atomic
 	go tool cover -html=/tmp/coverage.out
 
 ## format: 🎨 Fix code format issues
 .PHONY: format
 format:
-	go run mvdan.cc/gofumpt@latest -w -l .
+	GOTOOLCHAIN=$(GOVERSION) go run mvdan.cc/gofumpt@latest -w -l .
 
 ## markdown: 🎨 Find markdown format issues (Requires markdownlint-cli2)
 .PHONY: markdown
@@ -47,17 +49,17 @@ install-lint:
 ## modernize: 🛠 Run gopls modernize
 .PHONY: modernize
 modernize:
-	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test=false ./...
+	GOTOOLCHAIN=$(GOVERSION) go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test=false ./...
 
 ## test: 🚦 Execute all tests
 .PHONY: test
 test:
-	go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1 -shuffle=on
+	GOTOOLCHAIN=$(GOVERSION) go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1 -shuffle=on
 
 ## longtest: 🚦 Execute all tests 10x
 .PHONY: longtest
 longtest:
-	go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=15 -shuffle=on
+	GOTOOLCHAIN=$(GOVERSION) go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=15 -shuffle=on
 
 ## tidy: 📌 Clean and tidy dependencies
 .PHONY: tidy
@@ -67,7 +69,7 @@ tidy:
 ## betteralign: 📐 Optimize alignment of fields in structs
 .PHONY: betteralign
 betteralign:
-	go run github.com/dkorunic/betteralign/cmd/betteralign@latest -test_files -generated_files -apply ./...
+	GOTOOLCHAIN=$(GOVERSION) go run github.com/dkorunic/betteralign/cmd/betteralign@v0.7.2 -test_files -generated_files -apply ./...
 
 ## generate: ⚡️ Generate msgp && interface implementations
 .PHONY: generate


### PR DESCRIPTION
## Summary
- restore direct `go run` invocations for govulncheck, gotestsum, gofumpt, betteralign and modernize
- prefix each tool invocation with `GOTOOLCHAIN=$(GOVERSION)` to match the project's Go toolchain

## Testing
- `make audit` *(fails: EncodeMsg passes lock by value)*
- `make generate`
- `make betteralign`
- `make modernize`
- `make format`
- `make test` *(fails: Test_App_BodyLimit_LargerThanDefault)*

------
https://chatgpt.com/codex/tasks/task_e_68aaabc23d3c8326840fb396b83b76e3