### PR TITLE
📒 docs: Improve wording and fix typos

### DIFF
--- a/docs/guide/advance-format.md
+++ b/docs/guide/advance-format.md
@@ -1,17 +1,17 @@
 ---
 id: advance-format
-title: 🐛 Advance Format
+title: 🐛 Advanced Format
 description: >-
   Learn how to use MessagePack (MsgPack) and CBOR for efficient binary serialization in Fiber applications.
 sidebar_position: 9
 ---
 
-## Msgpack
+## MsgPack
 
 Fiber enables efficient binary serialization using MessagePack (MsgPack). You can leverage popular Go libraries to encode and decode MsgPack data within your route handlers.
 
 - Fiber supports binding requests with the `application/vnd.msgpack` content type by default. For more details, see the [Binding documentation](../api/bind.md#msgpack).
-- Use `Ctx.MsgPack()` to bind MsgPack data directly to structs, similar to how you would use JSON binding. Alternatively, use `Ctx.AutoFormat()` to send response as MsgPack when the Accept HTTP header is `application/vnd.msgpack`, For more details, see the [AutoFormat documentation](../api/ctx.md#autoformat).
+- Use `Ctx.MsgPack()` to bind MsgPack data directly to structs, similar to how you would use JSON binding. Alternatively, use `Ctx.AutoFormat()` to send the response as MsgPack when the `Accept` HTTP header is `application/vnd.msgpack`. For more details, see the [AutoFormat documentation](../api/ctx.md#autoformat).
 
 ### Recommended Libraries
 
@@ -56,7 +56,7 @@ func main() {
             return err
         }
         // Content type will be set automatically to application/vnd.msgpack
-        return c.MsgPack(data)
+        return c.MsgPack(user)
     })
 
     app.Listen(":3000")
@@ -65,9 +65,9 @@ func main() {
 
 ## CBOR
 
-Fiber doesn't include a CBOR implementation by default. To enable CBOR encoding and decoding you need to choose a library, for example [fxamacker/cbor](https://github.com/fxamacker/cbor).
+Fiber doesn't include a CBOR implementation by default. To enable CBOR encoding and decoding, choose a library such as [fxamacker/cbor](https://github.com/fxamacker/cbor).
 
-- Use `Ctx.CBOR()` to bind CBOR data directly to structs, similar to how you would use JSON binding. Alternatively, use `Ctx.AutoFormat()` to send response as CBOR when the Accept HTTP header is `application/cbor`. For more details, see the [AutoFormat documentation](../api/ctx.md#autoformat).
+- Use `Ctx.CBOR()` to bind CBOR data directly to structs, similar to how you would use JSON binding. Alternatively, use `Ctx.AutoFormat()` to send the response as CBOR when the `Accept` HTTP header is `application/cbor`. For more details, see the [AutoFormat documentation](../api/ctx.md#autoformat).
 
 ```bash
 go get github.com/fxamacker/cbor/v2

--- a/docs/guide/advance-format.md
+++ b/docs/guide/advance-format.md
@@ -11,7 +11,7 @@ sidebar_position: 9
 Fiber enables efficient binary serialization using MessagePack (MsgPack). You can leverage popular Go libraries to encode and decode MsgPack data within your route handlers.
 
 - Fiber supports binding requests with the `application/vnd.msgpack` content type by default. For more details, see the [Binding documentation](../api/bind.md#msgpack).
-- Use `Ctx.MsgPack()` to bind MsgPack data directly to structs, similar to how you would use JSON binding. Alternatively, use `Ctx.AutoFormat()` to send the response as MsgPack when the `Accept` HTTP header is `application/vnd.msgpack`. For more details, see the [AutoFormat documentation](../api/ctx.md#autoformat).
+- Use `Bind().MsgPack()` to bind MsgPack data directly to structs, similar to how you would use JSON binding. Alternatively, use `Ctx.AutoFormat()` to send the response as MsgPack when the `Accept` HTTP header is `application/vnd.msgpack`. For more details, see the [AutoFormat documentation](../api/ctx.md#autoformat).
 
 ### Recommended Libraries
 
@@ -67,7 +67,7 @@ func main() {
 
 Fiber doesn't include a CBOR implementation by default. To enable CBOR encoding and decoding, choose a library such as [fxamacker/cbor](https://github.com/fxamacker/cbor).
 
-- Use `Ctx.CBOR()` to bind CBOR data directly to structs, similar to how you would use JSON binding. Alternatively, use `Ctx.AutoFormat()` to send the response as CBOR when the `Accept` HTTP header is `application/cbor`. For more details, see the [AutoFormat documentation](../api/ctx.md#autoformat).
+- Use `Bind().CBOR()` to bind CBOR data directly to structs, similar to how you would use JSON binding. Alternatively, use `Ctx.AutoFormat()` to send the response as CBOR when the `Accept` HTTP header is `application/cbor`. For more details, see the [AutoFormat documentation](../api/ctx.md#autoformat).
 
 ```bash
 go get github.com/fxamacker/cbor/v2

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 
 ## Catching Errors
 
-It’s essential to ensure that Fiber catches all errors that occur while running route handlers and middleware. You must return them to the handler function, where Fiber will catch and process them.
+Ensure that Fiber catches all errors from route handlers and middleware by returning them to the handler function for processing.
 
 <Tabs>
 <TabItem value="example" label="Example">
@@ -53,7 +53,7 @@ func main() {
 }
 ```
 
-You could use Fiber's custom error struct to pass an additional `status code` using `fiber.NewError()`. It's optional to pass a message; if this is left empty, it will default to the status code message \(`404` equals `Not Found`\).
+Use Fiber's custom error struct to pass a status code with `fiber.NewError()`. The message parameter is optional; if omitted, it defaults to the standard status text (for example, `404` becomes `Not Found`).
 
 ```go title="Example"
 app.Get("/", func(c fiber.Ctx) error {
@@ -93,7 +93,7 @@ var DefaultErrorHandler = func(c fiber.Ctx, err error) error {
 
 A custom error handler can be set using a [Config](../api/fiber.md#errorhandler) when initializing a [Fiber instance](../api/fiber.md#new).
 
-In most cases, the default error handler should be sufficient. However, a custom error handler can come in handy if you want to capture different types of errors and take action accordingly e.g., send a notification email or log an error to the centralized system. You can also send customized responses to the client e.g., error page or just a JSON response.
+In most cases, the default error handler is sufficient. However, a custom handler is useful when you need to capture different error types and respond accordingly—for example, sending notification emails or logging to a centralized system. You can also send custom responses to the client, such as an error page or a JSON message.
 
 The following example shows how to display error pages for different types of errors.
 

--- a/docs/guide/faster-fiber.md
+++ b/docs/guide/faster-fiber.md
@@ -6,7 +6,7 @@ sidebar_position: 7
 
 ## Custom JSON Encoder/Decoder
 
-Since Fiber v2.32.0, we have adopted `encoding/json` as the default JSON library for its stability and reliability. However, the standard library can be slower than some third-party alternatives. If you find the performance of `encoding/json` unsatisfactory, we suggest considering these libraries:
+Since Fiber v2.32.0, we have adopted `encoding/json` as the default JSON library for its stability and reliability. However, the standard library can be slower than some third-party alternatives. If its performance is unsatisfactory, consider the following libraries:
 
 - [goccy/go-json](https://github.com/goccy/go-json)
 - [bytedance/sonic](https://github.com/bytedance/sonic)
@@ -25,7 +25,7 @@ func main() {
         JSONDecoder: json.Unmarshal,
     })
 
-    # ...
+    // ...
 }
 ```
 

--- a/docs/guide/grouping.md
+++ b/docs/guide/grouping.md
@@ -5,12 +5,12 @@ sidebar_position: 2
 ---
 
 :::info
-In general, the Group functionality in Fiber behaves similarly to ExpressJS. Groups are declared virtually and all routes declared within the group are flattened into a single list with a prefix, which is then checked by the framework in the order it was declared. This means that the behavior of Group in Fiber is identical to that of ExpressJS.
+In general, group functionality in Fiber behaves like Express.js. Groups are declared virtually, and all routes defined within a group are flattened into a single list with a prefix and processed in the order declared. This makes group behavior in Fiber identical to Express.js.
 :::
 
 ## Paths
 
-Like `Routing`, groups can also have paths that belong to a cluster.
+Groups can use path prefixes to organize related routes.
 
 ```go
 func main() {
@@ -30,7 +30,7 @@ func main() {
 }
 ```
 
-A **Group** of paths can have an optional handler.
+A group of paths can include an optional handler.
 
 ```go
 func main() {
@@ -51,12 +51,12 @@ func main() {
 ```
 
 :::caution
-Running **/api**, **/v1** or **/v2** will result in **404** error, make sure you have the errors set.
+Accessing `/api`, `/v1`, or `/v2` directly results in a **404** error, so configure appropriate error handlers.
 :::
 
 ## Group Handlers
 
-Group handlers can also be used as a routing path but they must have **Next** added to them so that the flow can continue.
+Group handlers can also act as routing paths, but they must call `Next` to continue the flow.
 
 ```go
 func main() {

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -52,18 +52,18 @@ type Views interface {
     Load() error
 
     // Outputs a template to the provided buffer using the provided template,
-    // template name, and binded data
+    // template name, and bound data
     Render(io.Writer, string, interface{}, ...string) error
 }
 ```
 
 :::note
-The `Render` method is linked to the [**ctx.Render\(\)**](../api/ctx.md#render) function that accepts a template name and binding data.
+The `Render` method powers the [**ctx.Render\(\)**](../api/ctx.md#render) function, which accepts a template name and data to bind.
 :::
 
 ## Rendering Templates
 
-Once an engine is set up, a route handler can call the [**ctx.Render\(\)**](../api/ctx.md#render) function with a template name and binded data to send the rendered template.
+Once an engine is set up, a route handler can call the [**ctx.Render\(\)**](../api/ctx.md#render) function with a template name and bound data to send the rendered template.
 
 ```go title="Signature"
 func (c Ctx) Render(name string, bind Map, layouts ...string) error

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -4,7 +4,7 @@ id: welcome
 title: 👋 Welcome
 sidebar_position: 1
 ---
-Welcome to the online API documentation for Fiber, complete with examples to help you start building web applications with Fiber right away!
+Welcome to Fiber's online API documentation, complete with examples to help you start building web applications right away!
 
 **Fiber** is an [Express](https://github.com/expressjs/express)-inspired **web framework** built on top of [Fasthttp](https://github.com/valyala/fasthttp), the **fastest** HTTP engine for [Go](https://go.dev/doc/). It is designed to facilitate rapid development with **zero memory allocations** and a strong focus on **performance**.
 
@@ -16,7 +16,7 @@ Looking to practice Fiber concepts hands-on? Check out our [Learning Resources](
 
 First, [download](https://go.dev/dl/) and install Go. Version `1.25` or higher is required.
 
-Installation is done using the [`go get`](https://pkg.go.dev/cmd/go/#hdr-Add_dependencies_to_current_module_and_install_them) command:
+Install Fiber using the [`go get`](https://pkg.go.dev/cmd/go/#hdr-Add_dependencies_to_current_module_and_install_them) command:
 
 ```bash
 go get github.com/gofiber/fiber/v3
@@ -24,7 +24,7 @@ go get github.com/gofiber/fiber/v3
 
 ### Zero Allocation
 
-Fiber is optimized for **high performance**, meaning values returned from **fiber.Ctx** are **not** immutable by default and **will** be reused across requests. As a rule of thumb, you **must** only use context values within the handler and **must not** keep any references. Once you return from the handler, any values obtained from the context will be reused in future requests. Here is an example:
+Fiber is optimized for **high performance**, meaning values returned from **fiber.Ctx** are **not** immutable by default and **will** be reused across requests. As a rule of thumb, you should use context values only within the handler and **must not** keep any references. Once you return from the handler, any values obtained from the context will be reused in future requests. Here is an example:
 
 ```go
 func handler(c fiber.Ctx) error {
@@ -75,7 +75,7 @@ For more information, please refer to [#426](https://github.com/gofiber/fiber/is
 
 ### Hello, World
 
-Below is the most straightforward **Fiber** application you can create:
+Here is the simplest **Fiber** application you can create:
 
 ```go
 package main
@@ -101,7 +101,7 @@ Browse to `http://localhost:3000` and you should see `Hello, World!` displayed o
 
 ### Basic Routing
 
-Routing determines how an application responds to a client request to a particular endpoint, which is a URI (or path) and a specific HTTP request method (`GET`, `PUT`, `POST`, etc.).
+Routing determines how an application responds to a client request at a particular endpoint—a combination of path and HTTP request method (`GET`, `PUT`, `POST`, etc.).
 
 Each route can have **multiple handler functions** that are executed when the route is matched.
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -34,7 +34,7 @@ Here's a quick overview of the changes in Fiber `v3`:
 - [🔄️ Redirect](#-redirect)
 - [🌎 Client package](#-client-package)
 - [🧰 Generic functions](#-generic-functions)
-- [🛠️ Utils](#-utils)
+- [🛠️ Utils](#utils)
 - [🥡 Services](#-services)
 - [📃 Log](#-log)
 - [📦 Storage Interface](#-storage-interface)
@@ -901,7 +901,7 @@ curl "http://localhost:3000/header"
 
 </details>
 
-## 🛠️ Utils
+## 🛠️ Utils {#utils}
 
 Fiber v3 removes the built-in `utils` directory and now imports utility helpers from the separate [`github.com/gofiber/utils/v2`](https://github.com/gofiber/utils) module. See the [migration guide](#utils-migration) for detailed replacement steps and examples.
 
@@ -1439,7 +1439,7 @@ fiber migrate --to v3.0.0-rc.1
 - [🔄 Redirect](#-redirect-1)
 - [🧾 Log](#-log-1)
 - [🌎 Client package](#-client-package-1)
-- [🛠️ Utils](#-utils-1)
+- [🛠️ Utils](#utils-migration)
 - [🧬 Middlewares](#-middlewares-1)
   - [Important Change for Accessing Middleware Data](#important-change-for-accessing-middleware-data)
   - [BasicAuth](#basicauth-1)
@@ -1943,7 +1943,7 @@ import "github.com/gofiber/fiber/v3/client"
 
 </details>
 
-### 🛠️ Utils
+### 🛠️ Utils {#utils-migration}
 
 Fiber v3 removes the in-repo `utils` package in favor of the external [`github.com/gofiber/utils/v2`](https://github.com/gofiber/utils) module.
 


### PR DESCRIPTION
## Summary
- polish intro and routing docs for clearer guidance
- refine JSON encoder advice and fix syntax example
- clarify error handling, templating, advanced format, and grouping docs
