### PR TITLE
test: expand binder coverage

### DIFF
--- a/binder/cookie_test.go
+++ b/binder/cookie_test.go
@@ -85,3 +85,16 @@ func Benchmark_CookieBinder_Bind(b *testing.B) {
 	require.Contains(b, user.Posts, "post2")
 	require.Contains(b, user.Posts, "post3")
 }
+
+func Test_CookieBinder_Bind_ParseError(t *testing.T) {
+	b := &CookieBinding{}
+	type User struct {
+		Age int `cookie:"age"`
+	}
+	var user User
+	req := fasthttp.AcquireRequest()
+	req.Header.SetCookie("age", "invalid")
+	t.Cleanup(func() { fasthttp.ReleaseRequest(req) })
+	err := b.Bind(req, &user)
+	require.Error(t, err)
+}

--- a/binder/header_test.go
+++ b/binder/header_test.go
@@ -85,3 +85,16 @@ func Benchmark_HeaderBinder_Bind(b *testing.B) {
 	require.Contains(b, user.Posts, "post2")
 	require.Contains(b, user.Posts, "post3")
 }
+
+func Test_HeaderBinder_Bind_ParseError(t *testing.T) {
+	b := &HeaderBinding{}
+	type User struct {
+		Age int `header:"Age"`
+	}
+	var user User
+	req := fasthttp.AcquireRequest()
+	req.Header.Set("age", "invalid")
+	t.Cleanup(func() { fasthttp.ReleaseRequest(req) })
+	err := b.Bind(req, &user)
+	require.Error(t, err)
+}

--- a/binder/resp_header_test.go
+++ b/binder/resp_header_test.go
@@ -75,3 +75,16 @@ func Benchmark_RespHeaderBinder_Bind(b *testing.B) {
 	require.Equal(b, 42, user.Age)
 	require.Equal(b, []string{"post1", "post2", "post3"}, user.Posts)
 }
+
+func Test_RespHeaderBinder_Bind_ParseError(t *testing.T) {
+	b := &RespHeaderBinding{}
+	type User struct {
+		Age int `respHeader:"age"`
+	}
+	var user User
+	resp := fasthttp.AcquireResponse()
+	resp.Header.Set("age", "invalid")
+	t.Cleanup(func() { fasthttp.ReleaseResponse(resp) })
+	err := b.Bind(resp, &user)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- add error path tests for cookie, header, and resp header binders
- broaden mapping tests covering decoder builder and edge cases

## Testing
- `go test ./binder -coverprofile=binder.out`
- `make audit` *(fails: EncodeMsg passes lock by value)*
- `make generate`
- `make betteralign`
- `make modernize`
- `make format`
- `make test` *(fails: i/o timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8fe1a1c88333ad95f31eb0f6c8d5