### PR TITLE
docs: document RoutePatternMatch

### DIFF
--- a/docs/api/fiber.md
+++ b/docs/api/fiber.md
@@ -118,3 +118,18 @@ if !fiber.IsChild() {
 
 // ...
 ```
+
+## RoutePatternMatch
+
+RoutePatternMatch reports whether the given request path would match the provided Fiber route pattern using the same rules as the router. This can be handy in tests or tooling where you need to verify patterns without registering them on an App instance.
+
+An optional Config may be passed to control matching behaviour such as case-sensitivity or strict routing. When no configuration is supplied the default Config is used.
+
+```go title="Signature"
+func RoutePatternMatch(path, pattern string, cfg ...Config) bool
+```
+
+```go title="Example"
+match := fiber.RoutePatternMatch("/api/v1/users", "/api/:version/*")
+// match == true
+```

--- a/docs/api/fiber.md
+++ b/docs/api/fiber.md
@@ -123,7 +123,7 @@ if !fiber.IsChild() {
 
 RoutePatternMatch reports whether the given request path would match the provided Fiber route pattern using the same rules as the router. This can be handy in tests or tooling where you need to verify patterns without registering them on an App instance.
 
-An optional Config may be passed to control matching behaviour such as case-sensitivity or strict routing. When no configuration is supplied the default Config is used.
+An optional Config may be passed to control matching behavior such as case-sensitivity or strict routing. When no configuration is supplied the default Config is used.
 
 ```go title="Signature"
 func RoutePatternMatch(path, pattern string, cfg ...Config) bool

--- a/path.go
+++ b/path.go
@@ -119,7 +119,7 @@ var (
 // handy in tests or tooling where you need to verify patterns without
 // registering them on an App instance.
 //
-// An optional Config may be passed to control matching behaviour such as
+// An optional Config may be passed to control matching behavior such as
 // case-sensitivity or strict routing. When no configuration is supplied the
 // default Config is used.
 //

--- a/path.go
+++ b/path.go
@@ -114,7 +114,19 @@ var (
 	parameterConstraintDataSeparatorChars = []byte{paramConstraintDataSeparator}
 )
 
-// RoutePatternMatch checks if a given path matches a Fiber route pattern.
+// RoutePatternMatch reports whether the given request path would match the
+// provided Fiber route pattern using the same rules as the router. This can be
+// handy in tests or tooling where you need to verify patterns without
+// registering them on an App instance.
+//
+// An optional Config may be passed to control matching behaviour such as
+// case-sensitivity or strict routing. When no configuration is supplied the
+// default Config is used.
+//
+// Example:
+//
+//	match := fiber.RoutePatternMatch("/api/v1/users", "/api/:version/*")
+//	// match == true
 func RoutePatternMatch(path, pattern string, cfg ...Config) bool {
 	// See logic in (*Route).match and (*App).register
 	var ctxParams [maxParams]string


### PR DESCRIPTION
## Summary
- elaborate on RoutePatternMatch documentation and add usage example
- add RoutePatternMatch section to API markdown docs

## Testing
- `go test -mod=mod ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b43282adf48326841365362c3e0043