### PR TITLE
🩹 fix: cfg.CacheControl being ignored

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -147,7 +147,7 @@ func New(config ...Config) fiber.Handler {
 					_, size := heap.remove(e.heapidx)
 					storedBytes -= size
 				}
-			} else if e.exp != 0 && !hasRequestDirective(c, noCache) {
+			} else if e.exp != 0 && (!cfg.CacheControl || !hasRequestDirective(c, noCache)) {
 				// Separate body value to avoid msgp serialization
 				// We can store raw bytes with Storage 👍
 				if cfg.Storage != nil {


### PR DESCRIPTION
# Description

The caching middleware inside of GoFiber has an option called "CacheControl". By default, this is set to false. However, it is never actually enforced and browsers with "No-Cache" as its cache control header will still bypass (when on false). This PR fixes that.

## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [ ] Changelog/What's New: Fixed CacheControl config in cache middleware being ignored.

## Type of change

- [ ] Enhancement (improvement to existing features and functionality)

## Checklist

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [ ] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [ ] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
