### PR TITLE
feat(ctx): add request inspection helpers

### DIFF
--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -108,6 +108,18 @@ type Ctx interface {
 	ViewBind(vars Map) error
 	// Route returns the matched Route struct.
 	Route() *Route
+	// IsFound returns true if the current request path was matched by the router.
+	IsFound() bool
+	// IsNotFound returns true if the current request path was not matched by the router.
+	IsNotFound() bool
+	// IsMiddleware returns true if the current request handler was registered as middleware.
+	IsMiddleware() bool
+	// HasBody returns true if the request has a body or a Content-Length header greater than zero.
+	HasBody() bool
+	// IsWebSocket returns true if the request includes a WebSocket upgrade handshake.
+	IsWebSocket() bool
+	// IsPreflight returns true if the request is a CORS preflight.
+	IsPreflight() bool
 	// SaveFile saves any multipart file to disk.
 	SaveFile(fileheader *multipart.FileHeader, path string) error
 	// SaveFileToStorage saves any multipart file to an external storage system.

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -384,6 +384,108 @@ func MyMiddleware() fiber.Handler {
 }
 ```
 
+### IsFound
+
+Returns `true` if the current request path was matched by the router.
+
+```go title="Signature"
+func (c fiber.Ctx) IsFound() bool
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  if c.IsFound() {
+    return c.SendStatus(fiber.StatusOK)
+  }
+  return nil
+})
+```
+
+### IsNotFound
+
+Returns `true` if the current request path was not matched by the router.
+
+```go title="Signature"
+func (c fiber.Ctx) IsNotFound() bool
+```
+
+```go title="Example"
+app := fiber.New(fiber.Config{
+  ErrorHandler: func(c fiber.Ctx, err error) error {
+    if c.IsNotFound() {
+      return c.Status(fiber.StatusNotFound).SendString("Not Found")
+    }
+    return err
+  },
+})
+```
+
+### IsMiddleware
+
+Returns `true` if the current request handler was registered as middleware.
+
+```go title="Signature"
+func (c fiber.Ctx) IsMiddleware() bool
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  fmt.Println(c.IsMiddleware()) // true
+  return c.Next()
+})
+```
+
+### HasBody
+
+Returns `true` if the incoming request contains a body or a `Content-Length` header greater than zero.
+
+```go title="Signature"
+func (c fiber.Ctx) HasBody() bool
+```
+
+```go title="Example"
+app.Post("/", func(c fiber.Ctx) error {
+  if !c.HasBody() {
+    return c.SendStatus(fiber.StatusBadRequest)
+  }
+  return c.SendString("OK")
+})
+```
+
+### IsWebSocket
+
+Returns `true` if the request includes a WebSocket upgrade handshake.
+
+```go title="Signature"
+func (c fiber.Ctx) IsWebSocket() bool
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  if c.IsWebSocket() {
+    // handle websocket
+  }
+  return c.Next()
+})
+```
+
+### IsPreflight
+
+Returns `true` if the request is a CORS preflight (`OPTIONS` + `Access-Control-Request-Method`).
+
+```go title="Signature"
+func (c fiber.Ctx) IsPreflight() bool
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  if c.IsPreflight() {
+    return c.SendStatus(fiber.StatusNoContent)
+  }
+  return c.Next()
+})
+```
+
 ### String
 
 Returns a unique string representation of the context.


### PR DESCRIPTION
## Summary
- add `HasBody`, `IsWebSocket`, `IsPreflight`, and `IsFound` helpers on `Ctx`
- document new helpers in the Ctx API guide
- exercise helpers with unit tests
- release acquired contexts in helper tests

## Testing
- `make audit` *(fails: EncodeMsg passes lock by value in csrf and session middleware)*
- `make generate`
- `make betteralign`
- `make modernize`
- `make format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b40371a96083339454dd9bd04805f4