### PR TITLE
docs: clarify context interface implementation

### DIFF
--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -10,7 +10,7 @@ sidebar_position: 3
 
 ### context.Context
 
-`Ctx` implements `context.Context`. However due to [current limitations in how fasthttp](https://github.com/valyala/fasthttp/issues/965#issuecomment-777268945) works, `Deadline()`, `Done()` and `Err()` operate as a nop. The `fiber.Ctx` instance is reused after the handler returns and must not be used for asynchronous operations once the handler has completed. Call [`Context`](#context) within the handler to obtain a `context.Context` that can be used outside the handler.
+`Ctx` implements `context.Context`. However due to [current limitations in how fasthttp](https://github.com/valyala/fasthttp/issues/965#issuecomment-777268945) works, `Deadline()`, `Done()` and `Err()` are no-ops. The `fiber.Ctx` instance is reused after the handler returns and must not be used for asynchronous operations once the handler has completed. Call [`Context`](#context) within the handler to obtain a `context.Context` that can be used outside the handler.
 
 ```go title="Signature"
 func (c fiber.Ctx) Deadline() (deadline time.Time, ok bool)


### PR DESCRIPTION
## Summary
- rename `Context()` section to `Context`
- move `context.Context` description near the top to clarify the interface implementation

## Testing
- `make audit` *(fails: EncodeMsg/MarshalMsg/Msgsize passes lock by value in msgp-generated files)*
- `make generate`
- `make betteralign`
- `make modernize`
- `make format`
- `make test` *(fails: Test_App_BodyLimit_Zero: i/o timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b87e5f72288326a3f76384c208d3c0