### PR TITLE
🧹 chore: Improve KeyAuth middleware RFC compliance

### DIFF
--- a/docs/middleware/keyauth.md
+++ b/docs/middleware/keyauth.md
@@ -263,6 +263,11 @@ app.Use(keyauth.New(keyauth.Config{
 | Validator       | `func(fiber.Ctx, string) (bool, error)`  | **Required.** Validator is a function to validate the key.                                                           | `nil` (panic) |
 | Extractor       | `keyauth.Extractor`                    | Extractor defines how to retrieve the key from the request. Use helper functions like `keyauth.FromAuthHeader` or `keyauth.FromCookie`. | `keyauth.FromAuthHeader("Authorization", "Bearer")` |
 | Realm           | `string`                                 | Realm specifies the protected area name used in the `WWW-Authenticate` header. | `"Restricted"` |
+| Challenge       | `string`                                 | Value of the `WWW-Authenticate` header when no `Authorization` scheme is present. | `ApiKey realm="Restricted"` |
+| Error           | `string`                                 | Error code appended as the `error` parameter in Bearer challenges. Must be `invalid_request`, `invalid_token`, or `insufficient_scope`. | `""` |
+| ErrorDescription| `string`                                 | Human-readable text for the `error_description` parameter in Bearer challenges. Requires `Error`. | `""` |
+| ErrorURI        | `string`                                 | URI identifying a human-readable web page with information about the `error` in Bearer challenges. Requires `Error` and must be an absolute URI. | `""` |
+| Scope           | `string`                                 | Space-delimited list of scopes for the `scope` parameter in Bearer challenges. Each token must conform to the RFC 6750 `scope-token` syntax and requires `Error` set to `insufficient_scope`. | `""` |
 
 ## Default Config
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1156,6 +1156,7 @@ Refer to the [healthcheck middleware migration guide](./middleware/healthcheck.m
 
 The keyauth middleware was updated to introduce a configurable `Realm` field for the `WWW-Authenticate` header.
 The old string-based `KeyLookup` configuration has been replaced with an `Extractor` field. Use helper functions like `keyauth.FromHeader`, `keyauth.FromAuthHeader`, or `keyauth.FromCookie` to define where the key should be retrieved from. Multiple sources can be combined with `keyauth.Chain`. See the migration guide below.
+New `Challenge`, `Error`, `ErrorDescription`, `ErrorURI`, and `Scope` fields allow customizing the `WWW-Authenticate` header, returning Bearer error details, and specifying required scopes. `ErrorURI` values are validated as absolute, a default `ApiKey` challenge is emitted when using non-Authorization extractors, Bearer `error` values are validated, credentials must conform to RFC 7235 `token68` syntax, and `scope` values are checked against RFC 6750's `scope-token` format. The header is also emitted only after the status code is finalized.
 
 ### Logger
 
@@ -2085,6 +2086,7 @@ options to further control authentication behavior.
 
 The keyauth middleware was updated to introduce a configurable `Realm` field for the `WWW-Authenticate` header.
 The old string-based `KeyLookup` configuration has been replaced with an `Extractor` field, and the `AuthScheme` field has been removed. The auth scheme is now inferred from the extractor used (e.g., `keyauth.FromAuthHeader`). Use helper functions like `keyauth.FromHeader`, `keyauth.FromAuthHeader`, or `keyauth.FromCookie` to define where the key should be retrieved from. Multiple sources can be combined with `keyauth.Chain`.
+New `Challenge`, `Error`, `ErrorDescription`, `ErrorURI`, and `Scope` options let you customize challenge responses, include Bearer error parameters, and specify required scopes. `ErrorURI` values are validated as absolute, credentials containing whitespace are rejected, and when multiple authorization extractors are chained, all schemes are advertised in the `WWW-Authenticate` header. The middleware defers emitting `WWW-Authenticate` until a 401 status is final, and `FromAuthHeader` now trims surrounding whitespace.
 
 ```go
 // Before

--- a/middleware/keyauth/config.go
+++ b/middleware/keyauth/config.go
@@ -8,6 +8,12 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
+const (
+	ErrorInvalidRequest    = "invalid_request"
+	ErrorInvalidToken      = "invalid_token"
+	ErrorInsufficientScope = "insufficient_scope"
+)
+
 // Config defines the config for middleware.
 type Config struct {
 	// Next defines a function to skip this middleware when returned true.
@@ -124,7 +130,7 @@ func configDefault(config ...Config) Config {
 
 	if cfg.Error != "" {
 		switch cfg.Error {
-		case "invalid_request", "invalid_token", "insufficient_scope":
+		case ErrorInvalidRequest, ErrorInvalidToken, ErrorInsufficientScope:
 		default:
 			panic("fiber: keyauth unsupported error token")
 		}
@@ -140,7 +146,7 @@ func configDefault(config ...Config) Config {
 			panic("fiber: keyauth error_uri must be absolute")
 		}
 	}
-	if cfg.Error == "insufficient_scope" {
+	if cfg.Error == ErrorInsufficientScope {
 		if cfg.Scope == "" {
 			panic("fiber: keyauth insufficient_scope requires scope")
 		}

--- a/middleware/keyauth/config.go
+++ b/middleware/keyauth/config.go
@@ -1,6 +1,10 @@
 package keyauth
 
 import (
+	"fmt"
+	"net/url"
+	"strings"
+
 	"github.com/gofiber/fiber/v3"
 )
 
@@ -32,6 +36,42 @@ type Config struct {
 	//
 	// Optional. Default value "Restricted".
 	Realm string
+
+	// Challenge defines the full `WWW-Authenticate` header value used when
+	// the middleware responds with 401 and no Authorization scheme is
+	// present.
+	//
+	// Optional. Default: `ApiKey realm="<Realm>"` when no Authorization scheme
+	// is configured.
+	Challenge string
+
+	// Error is the RFC 6750 `error` parameter appended to Bearer
+	// `WWW-Authenticate` challenges when validation fails. Allowed values
+	// are `invalid_request`, `invalid_token`, or `insufficient_scope`.
+	//
+	// Optional. Default: "".
+	Error string
+
+	// ErrorDescription is the RFC 6750 `error_description` parameter
+	// appended to Bearer `WWW-Authenticate` challenges when validation
+	// fails. This field requires that `Error` is also set.
+	//
+	// Optional. Default: "".
+	ErrorDescription string
+
+	// ErrorURI is the RFC 6750 `error_uri` parameter appended to Bearer
+	// `WWW-Authenticate` challenges when validation fails. This field
+	// requires that `Error` is also set.
+	//
+	// Optional. Default: "".
+	ErrorURI string
+
+	// Scope is the RFC 6750 `scope` parameter appended to Bearer
+	// challenges when the `error` is `insufficient_scope`. This field
+	// requires that `Error` is set to `insufficient_scope`.
+	//
+	// Optional. Default: "".
+	Scope string
 
 	// Extractor is a function to extract the key from the request.
 	//
@@ -78,5 +118,50 @@ func configDefault(config ...Config) Config {
 		cfg.ErrorHandler = ConfigDefault.ErrorHandler
 	}
 
+	if len(getAuthSchemes(cfg.Extractor)) == 0 && cfg.Challenge == "" {
+		cfg.Challenge = fmt.Sprintf("ApiKey realm=%q", cfg.Realm)
+	}
+
+	if cfg.Error != "" {
+		switch cfg.Error {
+		case "invalid_request", "invalid_token", "insufficient_scope":
+		default:
+			panic("fiber: keyauth unsupported error token")
+		}
+	}
+	if cfg.ErrorDescription != "" && cfg.Error == "" {
+		panic("fiber: keyauth error_description requires error")
+	}
+	if cfg.ErrorURI != "" {
+		if cfg.Error == "" {
+			panic("fiber: keyauth error_uri requires error")
+		}
+		if u, err := url.Parse(cfg.ErrorURI); err != nil || !u.IsAbs() {
+			panic("fiber: keyauth error_uri must be absolute")
+		}
+	}
+	if cfg.Error == "insufficient_scope" {
+		if cfg.Scope == "" {
+			panic("fiber: keyauth insufficient_scope requires scope")
+		}
+		for scope := range strings.SplitSeq(cfg.Scope, " ") {
+			if scope == "" || !isScopeToken(scope) {
+				panic("fiber: keyauth scope contains invalid token")
+			}
+		}
+	} else if cfg.Scope != "" {
+		panic("fiber: keyauth scope requires insufficient_scope error")
+	}
+
 	return cfg
+}
+
+func isScopeToken(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 0x21 || c > 0x7e || c == '"' || c == '\\' {
+			return false
+		}
+	}
+	return s != ""
 }

--- a/middleware/keyauth/extractors.go
+++ b/middleware/keyauth/extractors.go
@@ -6,6 +6,13 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
+func isToken68Char(c byte) bool {
+	return (c >= 'A' && c <= 'Z') ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= '0' && c <= '9') ||
+		c == '-' || c == '.' || c == '_' || c == '~' || c == '+' || c == '/' || c == '='
+}
+
 // Source represents the type of source from which an API key is extracted.
 // This is informational metadata that helps developers understand the extractor behavior.
 type Source int
@@ -80,7 +87,7 @@ func FromAuthHeader(header, authScheme string) Extractor {
 				seenEq := false
 				for j := 0; j < len(token); j++ {
 					c := token[j]
-					if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '.' || c == '_' || c == '~' || c == '+' || c == '/' || c == '=') {
+					if !isToken68Char(c) {
 						return "", ErrMissingOrMalformedAPIKey
 					}
 					if c == '=' {

--- a/middleware/keyauth/extractors.go
+++ b/middleware/keyauth/extractors.go
@@ -86,11 +86,11 @@ func FromAuthHeader(header, authScheme string) Extractor {
 				}
 				seenEq := false
 				for j := 0; j < len(token); j++ {
-					c := token[j]
-					if !isToken68Char(c) {
+					currChar := token[j]
+					if !isToken68Char(currChar) {
 						return "", ErrMissingOrMalformedAPIKey
 					}
-					if c == '=' {
+					if currChar == '=' {
 						if j == 0 {
 							return "", ErrMissingOrMalformedAPIKey
 						}

--- a/middleware/keyauth/extractors.go
+++ b/middleware/keyauth/extractors.go
@@ -74,7 +74,7 @@ func FromAuthHeader(header, authScheme string) Extractor {
 					return "", ErrMissingOrMalformedAPIKey
 				}
 				token := rest[i:]
-				if token == "" || strings.IndexAny(token, " \t") >= 0 {
+				if token == "" || strings.ContainsAny(token, " \t") {
 					return "", ErrMissingOrMalformedAPIKey
 				}
 				seenEq := false

--- a/middleware/keyauth/extractors.go
+++ b/middleware/keyauth/extractors.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
+	utils "github.com/gofiber/utils/v2"
 )
 
 func isToken68Char(c byte) bool {
@@ -66,7 +67,7 @@ func FromAuthHeader(header, authScheme string) Extractor {
 			// Check if the header starts with the specified auth scheme
 			if authScheme != "" {
 				schemeLen := len(authScheme)
-				if len(authHeader) <= schemeLen || !strings.EqualFold(authHeader[:schemeLen], authScheme) {
+				if len(authHeader) <= schemeLen || !utils.EqualFold(authHeader[:schemeLen], authScheme) {
 					return "", ErrMissingOrMalformedAPIKey
 				}
 				rest := authHeader[schemeLen:]

--- a/middleware/keyauth/extractors_test.go
+++ b/middleware/keyauth/extractors_test.go
@@ -253,6 +253,13 @@ func Test_FromAuthHeader_TokenChars(t *testing.T) {
 	app.ReleaseCtx(ctx)
 
 	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
+	ctx.Request().Header.Set(fiber.HeaderAuthorization, "Bearer =abcd")
+	token, err = FromAuthHeader(fiber.HeaderAuthorization, "Bearer").Extract(ctx)
+	require.Empty(t, token)
+	require.Equal(t, ErrMissingOrMalformedAPIKey, err)
+	app.ReleaseCtx(ctx)
+
+	ctx = app.AcquireCtx(&fasthttp.RequestCtx{})
 	ctx.Request().Header.Set(fiber.HeaderAuthorization, "Bearer ab=cd")
 	token, err = FromAuthHeader(fiber.HeaderAuthorization, "Bearer").Extract(ctx)
 	require.Empty(t, token)

--- a/middleware/keyauth/keyauth.go
+++ b/middleware/keyauth/keyauth.go
@@ -3,6 +3,7 @@ package keyauth
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/gofiber/fiber/v3"
 )
@@ -24,8 +25,8 @@ func New(config ...Config) fiber.Handler {
 	// Init config
 	cfg := configDefault(config...)
 
-	// Determine the auth scheme from the extractor.
-	authScheme := getAuthScheme(cfg.Extractor)
+	// Determine the auth schemes from the extractor chain.
+	authSchemes := getAuthSchemes(cfg.Extractor)
 
 	// Return middleware handler
 	return func(c fiber.Ctx) error {
@@ -45,12 +46,42 @@ func New(config ...Config) fiber.Handler {
 			}
 		}
 
-		// If we have an error, set the WWW-Authenticate header if appropriate
-		if authScheme != "" {
-			c.Set(fiber.HeaderWWWAuthenticate, fmt.Sprintf("%s realm=%q", authScheme, cfg.Realm))
+		// Execute the error handler first
+		handlerErr := cfg.ErrorHandler(c, err)
+
+		status := c.Response().StatusCode()
+		if status == fiber.StatusUnauthorized || status == fiber.StatusProxyAuthRequired {
+			header := fiber.HeaderWWWAuthenticate
+			if status == fiber.StatusProxyAuthRequired {
+				header = fiber.HeaderProxyAuthenticate
+			}
+			if len(authSchemes) > 0 {
+				challenges := make([]string, 0, len(authSchemes))
+				for _, scheme := range authSchemes {
+					challenge := fmt.Sprintf("%s realm=%q", scheme, cfg.Realm)
+					if strings.EqualFold(scheme, "Bearer") {
+						if cfg.Error != "" {
+							challenge += fmt.Sprintf(", error=%q", cfg.Error)
+							if cfg.ErrorDescription != "" {
+								challenge += fmt.Sprintf(", error_description=%q", cfg.ErrorDescription)
+							}
+							if cfg.ErrorURI != "" {
+								challenge += fmt.Sprintf(", error_uri=%q", cfg.ErrorURI)
+							}
+							if cfg.Error == "insufficient_scope" {
+								challenge += fmt.Sprintf(", scope=%q", cfg.Scope)
+							}
+						}
+					}
+					challenges = append(challenges, challenge)
+				}
+				c.Set(header, strings.Join(challenges, ", "))
+			} else if cfg.Challenge != "" {
+				c.Set(header, cfg.Challenge)
+			}
 		}
 
-		return cfg.ErrorHandler(c, err)
+		return handlerErr
 	}
 }
 
@@ -64,16 +95,16 @@ func TokenFromContext(c fiber.Ctx) string {
 	return token
 }
 
-// getAuthScheme inspects an extractor and its chain to find the auth scheme
-// used by FromAuthHeader. It returns the scheme, or an empty string if not found.
-func getAuthScheme(e Extractor) string {
-	if e.Source == SourceAuthHeader {
-		return e.AuthScheme
+// getAuthSchemes inspects an extractor and its chain to find all auth schemes
+// used by FromAuthHeader. It returns a slice of schemes, or an empty slice if
+// none are found.
+func getAuthSchemes(e Extractor) []string {
+	var schemes []string
+	if e.Source == SourceAuthHeader && e.AuthScheme != "" {
+		schemes = append(schemes, e.AuthScheme)
 	}
 	for _, ex := range e.Chain {
-		if ex.Source == SourceAuthHeader {
-			return ex.AuthScheme
-		}
+		schemes = append(schemes, getAuthSchemes(ex)...)
 	}
-	return ""
+	return schemes
 }

--- a/middleware/keyauth/keyauth.go
+++ b/middleware/keyauth/keyauth.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
+	utils "github.com/gofiber/utils/v2"
 )
 
 // The contextKey type is unexported to prevent collisions with context keys defined in
@@ -60,7 +61,7 @@ func New(config ...Config) fiber.Handler {
 				for _, scheme := range authSchemes {
 					var b strings.Builder
 					fmt.Fprintf(&b, "%s realm=%q", scheme, cfg.Realm)
-					if strings.EqualFold(scheme, "Bearer") {
+					if utils.EqualFold(scheme, "Bearer") {
 						if cfg.Error != "" {
 							fmt.Fprintf(&b, ", error=%q", cfg.Error)
 							if cfg.ErrorDescription != "" {

--- a/middleware/keyauth/keyauth.go
+++ b/middleware/keyauth/keyauth.go
@@ -58,22 +58,23 @@ func New(config ...Config) fiber.Handler {
 			if len(authSchemes) > 0 {
 				challenges := make([]string, 0, len(authSchemes))
 				for _, scheme := range authSchemes {
-					challenge := fmt.Sprintf("%s realm=%q", scheme, cfg.Realm)
+					var b strings.Builder
+					fmt.Fprintf(&b, "%s realm=%q", scheme, cfg.Realm)
 					if strings.EqualFold(scheme, "Bearer") {
 						if cfg.Error != "" {
-							challenge += fmt.Sprintf(", error=%q", cfg.Error)
+							fmt.Fprintf(&b, ", error=%q", cfg.Error)
 							if cfg.ErrorDescription != "" {
-								challenge += fmt.Sprintf(", error_description=%q", cfg.ErrorDescription)
+								fmt.Fprintf(&b, ", error_description=%q", cfg.ErrorDescription)
 							}
 							if cfg.ErrorURI != "" {
-								challenge += fmt.Sprintf(", error_uri=%q", cfg.ErrorURI)
+								fmt.Fprintf(&b, ", error_uri=%q", cfg.ErrorURI)
 							}
-							if cfg.Error == "insufficient_scope" {
-								challenge += fmt.Sprintf(", scope=%q", cfg.Scope)
+							if cfg.Error == ErrorInsufficientScope {
+								fmt.Fprintf(&b, ", scope=%q", cfg.Scope)
 							}
 						}
 					}
-					challenges = append(challenges, challenge)
+					challenges = append(challenges, b.String())
 				}
 				c.Set(header, strings.Join(challenges, ", "))
 			} else if cfg.Challenge != "" {

--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -945,7 +945,7 @@ func Test_BearerInsufficientScope(t *testing.T) {
 		Validator: func(_ fiber.Ctx, _ string) (bool, error) {
 			return false, errors.New("invalid")
 		},
-		Error: "insufficient_scope",
+		Error: ErrorInsufficientScope,
 		Scope: "read",
 	}))
 	app.Get("/", func(c fiber.Ctx) error { return c.SendString("OK") })
@@ -969,14 +969,14 @@ func Test_ScopeValidation(t *testing.T) {
 	require.PanicsWithValue(t, "fiber: keyauth insufficient_scope requires scope", func() {
 		New(Config{
 			Validator: func(_ fiber.Ctx, _ string) (bool, error) { return true, nil },
-			Error:     "insufficient_scope",
+			Error:     ErrorInsufficientScope,
 		})
 	})
 
 	require.PanicsWithValue(t, "fiber: keyauth scope contains invalid token", func() {
 		New(Config{
 			Validator: func(_ fiber.Ctx, _ string) (bool, error) { return true, nil },
-			Error:     "insufficient_scope",
+			Error:     ErrorInsufficientScope,
 			Scope:     "read \"write\"",
 		})
 	})
@@ -984,7 +984,7 @@ func Test_ScopeValidation(t *testing.T) {
 	require.NotPanics(t, func() {
 		New(Config{
 			Validator: func(_ fiber.Ctx, _ string) (bool, error) { return true, nil },
-			Error:     "insufficient_scope",
+			Error:     ErrorInsufficientScope,
 			Scope:     "read write:all",
 		})
 	})


### PR DESCRIPTION
## Summary
- use `Proxy-Authenticate` on 407 responses
- validate bearer error tokens and require `error_description` to pair with `error`
- default to an `ApiKey` challenge when no Authorization scheme is present
- include optional Bearer `error_uri` parameter
- advertise all configured auth schemes in `WWW-Authenticate` headers
- reject tabs between auth scheme and credentials
- support Bearer `scope` parameter for `insufficient_scope` errors
- trim mixed leading/trailing spaces and tabs around Authorization headers
- reject Authorization credentials containing spaces or tabs
- validate `error_uri` as an absolute URI
- validate Authorization credentials as RFC 7235 token68 strings with trailing `=` padding only at the end
- enforce RFC 6750 scope-token syntax

Related #3383