### PR TITLE
🧹 chore: Improve Compress middleware RFC compliance

### DIFF
--- a/docs/middleware/compress.md
+++ b/docs/middleware/compress.md
@@ -10,6 +10,12 @@ Compression middleware for [Fiber](https://github.com/gofiber/fiber) that automa
 Bodies smaller than 200 bytes remain uncompressed because compression would likely increase their size and waste CPU cycles. [See the fasthttp source](https://github.com/valyala/fasthttp/blob/497922a21ef4b314f393887e9c6147b8c3e3eda4/http.go#L1713-L1715).
 :::
 
+## Behavior
+
+- Skips compression for responses that already define `Content-Encoding`, for range requests, `206` responses, status codes without bodies, or when either side sends `Cache-Control: no-transform`.
+- `HEAD` requests negotiate compression so `Content-Encoding`, `Content-Length`, `ETag`, and `Vary` reflect the encoded representation, but the body is removed before sending.
+- When compression runs, strong `ETag` values are recomputed from the compressed bytes; when skipped, `Accept-Encoding` is still merged into `Vary` unless the header is `*` or already present.
+
 ## Signatures
 
 ```go

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1127,7 +1127,11 @@ We've updated several fields from a single string (containing comma-separated va
 
 ### Compression
 
-We've added support for `zstd` compression on top of `gzip`, `deflate`, and `brotli`.
+- Added support for `zstd` compression alongside `gzip`, `deflate`, and `brotli`.
+- Strong `ETag` values are now recomputed for compressed payloads so validators remain accurate.
+- Compression is bypassed for responses that already specify `Content-Encoding`, for range requests or `206` statuses, and when either side sends `Cache-Control: no-transform`.
+- `HEAD` requests still negotiate compression so `Content-Encoding`, `Content-Length`, `ETag`, and `Vary` match a corresponding `GET`, but the body is omitted.
+- `Vary: Accept-Encoding` is merged into responses even when compression is skipped, preventing caches from mixing encoded and unencoded variants.
 
 ### CSRF
 

--- a/middleware/compress/compress.go
+++ b/middleware/compress/compress.go
@@ -113,7 +113,7 @@ func New(config ...Config) fiber.Handler {
 		compressor(c.RequestCtx())
 
 		if tag := c.GetRespHeader(fiber.HeaderETag); tag != "" && !strings.HasPrefix(tag, "W/") {
-			c.Set(fiber.HeaderETag, string(etag.Generate(c.Response().Body(), false)))
+			c.Set(fiber.HeaderETag, string(etag.Generate(c.Response().Body())))
 		}
 
 		appendVaryAcceptEncoding(c)

--- a/middleware/compress/compress.go
+++ b/middleware/compress/compress.go
@@ -1,9 +1,54 @@
 package compress
 
 import (
+	"strings"
+
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/middleware/etag"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
+
+func hasToken(header, token string) bool {
+	for part := range strings.SplitSeq(header, ",") {
+		if strings.EqualFold(utils.Trim(part, ' '), token) {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldSkip(c fiber.Ctx) bool {
+	status := c.Response().StatusCode()
+	if status < 200 ||
+		status == fiber.StatusNoContent ||
+		status == fiber.StatusResetContent ||
+		status == fiber.StatusNotModified ||
+		status == fiber.StatusPartialContent ||
+		len(c.Response().Body()) == 0 ||
+		c.Get(fiber.HeaderRange) != "" ||
+		hasToken(c.Get(fiber.HeaderCacheControl), "no-transform") ||
+		hasToken(c.GetRespHeader(fiber.HeaderCacheControl), "no-transform") {
+		return true
+	}
+	return false
+}
+
+func appendVaryAcceptEncoding(c fiber.Ctx) {
+	vary := c.GetRespHeader(fiber.HeaderVary)
+	switch {
+	case vary == "":
+		c.Set(fiber.HeaderVary, fiber.HeaderAcceptEncoding)
+	case vary == "*":
+		// do not append anything to Vary: *
+	case utils.Trim(vary, ' ') == "*":
+		// do not append anything to Vary: *
+	default:
+		if !hasToken(vary, fiber.HeaderAcceptEncoding) {
+			c.Set(fiber.HeaderVary, vary+", "+fiber.HeaderAcceptEncoding)
+		}
+	}
+}
 
 // New creates a new middleware handler
 func New(config ...Config) fiber.Handler {
@@ -55,10 +100,30 @@ func New(config ...Config) fiber.Handler {
 			return err
 		}
 
-		// Compress response
+		if shouldSkip(c) {
+			appendVaryAcceptEncoding(c)
+			return nil
+		}
+
+		if c.GetRespHeader(fiber.HeaderContentEncoding) != "" {
+			appendVaryAcceptEncoding(c)
+			return nil
+		}
+
 		compressor(c.RequestCtx())
 
-		// Return from handler
+		if tag := c.GetRespHeader(fiber.HeaderETag); tag != "" && !strings.HasPrefix(tag, "W/") {
+			c.Set(fiber.HeaderETag, string(etag.Generate(c.Response().Body(), false)))
+		}
+
+		appendVaryAcceptEncoding(c)
+
+		if c.Method() == fiber.MethodHead {
+			clen := len(c.Response().Body())
+			c.RequestCtx().ResetBody()
+			c.Response().Header.SetContentLength(clen)
+		}
+
 		return nil
 	}
 }

--- a/middleware/compress/compress.go
+++ b/middleware/compress/compress.go
@@ -36,18 +36,14 @@ func shouldSkip(c fiber.Ctx) bool {
 
 func appendVaryAcceptEncoding(c fiber.Ctx) {
 	vary := c.GetRespHeader(fiber.HeaderVary)
-	switch {
-	case vary == "":
+	if vary == "" {
 		c.Set(fiber.HeaderVary, fiber.HeaderAcceptEncoding)
-	case vary == "*":
-		// do not append anything to Vary: *
-	case utils.Trim(vary, ' ') == "*":
-		// do not append anything to Vary: *
-	default:
-		if !hasToken(vary, fiber.HeaderAcceptEncoding) {
-			c.Set(fiber.HeaderVary, vary+", "+fiber.HeaderAcceptEncoding)
-		}
+		return
 	}
+	if hasToken(vary, "*") || hasToken(vary, fiber.HeaderAcceptEncoding) {
+		return
+	}
+	c.Set(fiber.HeaderVary, vary+", "+fiber.HeaderAcceptEncoding)
 }
 
 // New creates a new middleware handler

--- a/middleware/compress/compress.go
+++ b/middleware/compress/compress.go
@@ -11,7 +11,7 @@ import (
 
 func hasToken(header, token string) bool {
 	for part := range strings.SplitSeq(header, ",") {
-		if strings.EqualFold(utils.Trim(part, ' '), token) {
+		if utils.EqualFold(utils.Trim(part, ' '), token) {
 			return true
 		}
 	}

--- a/middleware/compress/compress.go
+++ b/middleware/compress/compress.go
@@ -19,6 +19,10 @@ func hasToken(header, token string) bool {
 }
 
 func shouldSkip(c fiber.Ctx) bool {
+	if c.Method() == fiber.MethodHead {
+		return true
+	}
+
 	status := c.Response().StatusCode()
 	if status < 200 ||
 		status == fiber.StatusNoContent ||
@@ -94,14 +98,6 @@ func New(config ...Config) fiber.Handler {
 		// Continue stack
 		if err := c.Next(); err != nil {
 			return err
-		}
-
-		if c.Method() == fiber.MethodHead {
-			defer func() {
-				clen := len(c.Response().Body())
-				c.RequestCtx().ResetBody()
-				c.Response().Header.SetContentLength(clen)
-			}()
 		}
 
 		if shouldSkip(c) {

--- a/middleware/compress/compress.go
+++ b/middleware/compress/compress.go
@@ -10,7 +10,7 @@ import (
 )
 
 func hasToken(header, token string) bool {
-	for _, part := range strings.Split(header, ",") {
+	for part := range strings.SplitSeq(header, ",") {
 		if strings.EqualFold(utils.Trim(part, ' '), token) {
 			return true
 		}

--- a/middleware/compress/compress_test.go
+++ b/middleware/compress/compress_test.go
@@ -6,10 +6,12 @@ import (
 	"io"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/middleware/etag"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 )
@@ -185,6 +187,393 @@ func Test_Compress_Disabled(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, len(body), len(filedata))
+}
+
+func Test_Compress_Adds_Vary_Header(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("hello")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, "Accept-Encoding", resp.Header.Get(fiber.HeaderVary))
+}
+
+func Test_Compress_Vary_Star(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderVary, "*")
+		return c.SendString("hello")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, "*", resp.Header.Get(fiber.HeaderVary))
+}
+
+func Test_Compress_Vary_Similar_Substring(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderVary, "Accept-Encoding2")
+		return c.SendString("hello")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, "Accept-Encoding2, Accept-Encoding", resp.Header.Get(fiber.HeaderVary))
+}
+
+func Test_Compress_Skip_When_Content_Encoding_Set(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderContentEncoding, "gzip")
+		c.Set(fiber.HeaderETag, "\"abc\"")
+		return c.SendString("hello")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(body))
+	require.Equal(t, "gzip", resp.Header.Get(fiber.HeaderContentEncoding))
+	require.Equal(t, "\"abc\"", resp.Header.Get(fiber.HeaderETag))
+	require.Equal(t, "Accept-Encoding", resp.Header.Get(fiber.HeaderVary))
+}
+
+func Test_Compress_Skip_When_Content_Encoding_Set_Vary_Star(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderContentEncoding, "gzip")
+		c.Set(fiber.HeaderVary, "*")
+		return c.SendString("hello")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, "*", resp.Header.Get(fiber.HeaderVary))
+}
+
+func Test_Compress_Skip_When_Content_Encoding_Set_Vary_Similar_Substring(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderContentEncoding, "gzip")
+		c.Set(fiber.HeaderVary, "Accept-Encoding2")
+		return c.SendString("hello")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, "Accept-Encoding2, Accept-Encoding", resp.Header.Get(fiber.HeaderVary))
+}
+
+func Test_Compress_Strong_ETag_Recalculated(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderContentType, fiber.MIMETextPlainCharsetUTF8)
+		c.Set(fiber.HeaderETag, "\"abc\"")
+		return c.Send(filedata)
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, "gzip", resp.Header.Get(fiber.HeaderContentEncoding))
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	expected := string(etag.Generate(body, false))
+	require.Equal(t, expected, resp.Header.Get(fiber.HeaderETag))
+}
+
+func Test_Compress_Weak_ETag_Unchanged(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderContentType, fiber.MIMETextPlainCharsetUTF8)
+		c.Set(fiber.HeaderETag, "W/\"abc\"")
+		return c.Send(filedata)
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, "gzip", resp.Header.Get(fiber.HeaderContentEncoding))
+	require.Equal(t, "W/\"abc\"", resp.Header.Get(fiber.HeaderETag))
+}
+
+func Test_Compress_Head_Metadata(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	handler := func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderETag, "\"abc\"")
+		return c.SendString("hello")
+	}
+	app.Get("/", handler)
+	app.Head("/", handler)
+
+	getReq := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	getReq.Header.Set("Accept-Encoding", "gzip")
+
+	getResp, err := app.Test(getReq, testConfig)
+	require.NoError(t, err, "app.Test(getReq)")
+	getBody, err := io.ReadAll(getResp.Body)
+	require.NoError(t, err)
+	require.NotEmpty(t, getBody)
+	expectedCL := strconv.Itoa(len(getBody))
+	require.Equal(t, expectedCL, getResp.Header.Get(fiber.HeaderContentLength))
+
+	headReq := httptest.NewRequest(fiber.MethodHead, "/", nil)
+	headReq.Header.Set("Accept-Encoding", "gzip")
+
+	headResp, err := app.Test(headReq, testConfig)
+	require.NoError(t, err, "app.Test(headReq)")
+	headBody, err := io.ReadAll(headResp.Body)
+	require.NoError(t, err)
+	require.Len(t, headBody, 0)
+
+	require.Equal(t, getResp.Header.Get(fiber.HeaderContentEncoding), headResp.Header.Get(fiber.HeaderContentEncoding))
+	require.Equal(t, getResp.Header.Get(fiber.HeaderVary), headResp.Header.Get(fiber.HeaderVary))
+	require.Equal(t, getResp.Header.Get(fiber.HeaderETag), headResp.Header.Get(fiber.HeaderETag))
+	require.Equal(t, expectedCL, headResp.Header.Get(fiber.HeaderContentLength))
+}
+
+func Test_Compress_Skip_Status_NoContent(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderETag, "\"abc\"")
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, fiber.StatusNoContent, resp.StatusCode)
+	require.Equal(t, "", resp.Header.Get(fiber.HeaderContentEncoding))
+	require.Equal(t, "\"abc\"", resp.Header.Get(fiber.HeaderETag))
+}
+
+func Test_Compress_Skip_Status_NotModified(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderETag, "\"abc\"")
+		c.Status(fiber.StatusNotModified)
+		return nil
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, fiber.StatusNotModified, resp.StatusCode)
+	require.Equal(t, "", resp.Header.Get(fiber.HeaderContentEncoding))
+	require.Equal(t, "\"abc\"", resp.Header.Get(fiber.HeaderETag))
+}
+
+func Test_Compress_Skip_Range(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("hello")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	req.Header.Set("Range", "bytes=0-1")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, "", resp.Header.Get(fiber.HeaderContentEncoding))
+	require.Equal(t, "Accept-Encoding", resp.Header.Get(fiber.HeaderVary))
+}
+
+func Test_Compress_Skip_Range_NoAcceptEncoding(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("hello")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Range", "bytes=0-1")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, "", resp.Header.Get(fiber.HeaderContentEncoding))
+	require.Equal(t, "Accept-Encoding", resp.Header.Get(fiber.HeaderVary))
+}
+
+func Test_Compress_Skip_Range_Vary_Star(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderVary, "*")
+		return c.SendString("hello")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	req.Header.Set("Range", "bytes=0-1")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, "", resp.Header.Get(fiber.HeaderContentEncoding))
+	require.Equal(t, "*", resp.Header.Get(fiber.HeaderVary))
+}
+
+func Test_Compress_Skip_Range_Vary_Similar_Substring(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderVary, "Accept-Encoding2")
+		return c.SendString("hello")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	req.Header.Set("Range", "bytes=0-1")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, "", resp.Header.Get(fiber.HeaderContentEncoding))
+	require.Equal(t, "Accept-Encoding2, Accept-Encoding", resp.Header.Get(fiber.HeaderVary))
+}
+
+func Test_Compress_Skip_Status_PartialContent(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Status(fiber.StatusPartialContent)
+		return c.SendString("hello")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, fiber.StatusPartialContent, resp.StatusCode)
+	require.Equal(t, "", resp.Header.Get(fiber.HeaderContentEncoding))
+}
+
+func Test_Compress_Skip_NoTransform(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		setRequest bool
+	}{
+		{name: "request", setRequest: true},
+		{name: "response", setRequest: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			app := fiber.New()
+
+			app.Use(New())
+
+			app.Get("/", func(c fiber.Ctx) error {
+				if !tt.setRequest {
+					c.Set(fiber.HeaderCacheControl, "no-transform")
+				}
+				return c.SendString("hello")
+			})
+
+			req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+			req.Header.Set("Accept-Encoding", "gzip")
+			if tt.setRequest {
+				req.Header.Set(fiber.HeaderCacheControl, "no-transform")
+			}
+
+			resp, err := app.Test(req, testConfig)
+			require.NoError(t, err, "app.Test(req)")
+			require.Equal(t, "", resp.Header.Get(fiber.HeaderContentEncoding))
+		})
+	}
 }
 
 func Test_Compress_Next_Error(t *testing.T) {

--- a/middleware/compress/compress_test.go
+++ b/middleware/compress/compress_test.go
@@ -394,6 +394,27 @@ func Test_Compress_Weak_ETag_Unchanged(t *testing.T) {
 	require.Equal(t, "W/\"abc\"", resp.Header.Get(fiber.HeaderETag))
 }
 
+func Test_Compress_Strong_ETag_Unchanged_When_Not_Compressed(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderETag, "\"abc\"")
+		return c.SendString("tiny")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err)
+	require.Equal(t, "", resp.Header.Get(fiber.HeaderContentEncoding))
+	require.Equal(t, "\"abc\"", resp.Header.Get(fiber.HeaderETag))
+	require.Equal(t, "Accept-Encoding", resp.Header.Get(fiber.HeaderVary))
+}
+
 func Test_Compress_Head_Metadata(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()

--- a/middleware/compress/compress_test.go
+++ b/middleware/compress/compress_test.go
@@ -330,7 +330,7 @@ func Test_Compress_Strong_ETag_Recalculated(t *testing.T) {
 	require.Equal(t, "gzip", resp.Header.Get(fiber.HeaderContentEncoding))
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	expected := string(etag.Generate(body, false))
+	expected := string(etag.Generate(body))
 	require.Equal(t, expected, resp.Header.Get(fiber.HeaderETag))
 }
 
@@ -386,7 +386,7 @@ func Test_Compress_Head_Metadata(t *testing.T) {
 	require.NoError(t, err, "app.Test(headReq)")
 	headBody, err := io.ReadAll(headResp.Body)
 	require.NoError(t, err)
-	require.Len(t, headBody, 0)
+	require.Empty(t, headBody)
 
 	require.Equal(t, getResp.Header.Get(fiber.HeaderContentEncoding), headResp.Header.Get(fiber.HeaderContentEncoding))
 	require.Equal(t, getResp.Header.Get(fiber.HeaderVary), headResp.Header.Get(fiber.HeaderVary))
@@ -549,7 +549,6 @@ func Test_Compress_Skip_NoTransform(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			app := fiber.New()

--- a/middleware/compress/compress_test.go
+++ b/middleware/compress/compress_test.go
@@ -226,6 +226,25 @@ func Test_Compress_Vary_Star(t *testing.T) {
 	require.Equal(t, "*", resp.Header.Get(fiber.HeaderVary))
 }
 
+func Test_Compress_Vary_List_Star(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderVary, "User-Agent, *")
+		return c.SendString("hello")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, "User-Agent, *", resp.Header.Get(fiber.HeaderVary))
+}
+
 func Test_Compress_Vary_Similar_Substring(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
@@ -288,6 +307,26 @@ func Test_Compress_Skip_When_Content_Encoding_Set_Vary_Star(t *testing.T) {
 	resp, err := app.Test(req, testConfig)
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, "*", resp.Header.Get(fiber.HeaderVary))
+}
+
+func Test_Compress_Skip_When_Content_Encoding_Set_Vary_List_Star(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Use(New())
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderContentEncoding, "gzip")
+		c.Set(fiber.HeaderVary, "User-Agent, *")
+		return c.SendString("hello")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := app.Test(req, testConfig)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, "User-Agent, *", resp.Header.Get(fiber.HeaderVary))
 }
 
 func Test_Compress_Skip_When_Content_Encoding_Set_Vary_Similar_Substring(t *testing.T) {

--- a/middleware/etag/etag.go
+++ b/middleware/etag/etag.go
@@ -20,15 +20,14 @@ func Generate(body []byte) []byte {
 		return nil
 	}
 	bb := bytebufferpool.Get()
+	defer bytebufferpool.Put(bb)
 	b := bb.B[:0]
 	b = append(b, '"')
 	b = appendUint(b, uint32(len(body))) // #nosec G115 -- length checked above
 	b = append(b, '-')
 	b = appendUint(b, crc32.Checksum(body, crc32q))
 	b = append(b, '"')
-	etag := append([]byte(nil), b...)
-	bytebufferpool.Put(bb)
-	return etag
+	return append([]byte(nil), b...)
 }
 
 // GenerateWeak returns a weak ETag for body.


### PR DESCRIPTION
## Summary
- skip compression when Content-Encoding already set
- add Accept-Encoding to Vary header when compressing
- tokenize Vary merging and avoid appending when header is `*`
- recompute strong ETags after compression using shared generator
- skip compression for status codes with no body or range/206 responses
- honor `Cache-Control: no-transform` on requests and responses
- propagate compression headers on HEAD responses while omitting the body
- emit `Vary: Accept-Encoding` even when compression is skipped, including when the request lacks `Accept-Encoding`
- cover Vary header, pre-encoded responses, ETag recalculation, no-body skips, range requests, no-transform, HEAD metadata, and skip-branch Vary merging in tests
- document compression behavior in middleware docs and whats_new

Related #3383 