### PR TITLE
♻️ Refactor: Improve performance analyseConstantPart

### DIFF
--- a/path.go
+++ b/path.go
@@ -119,12 +119,8 @@ var (
 	routeDelimiter = []byte{slashDelimiter, '-', '.'}
 	// list of greedy parameters
 	greedyParameters = []byte{wildcardParam, plusParam}
-	// list of chars for the parameter recognizing
-	parameterStartChars = []byte{wildcardParam, plusParam, paramStarterChar}
 	// list of chars of delimiters and the starting parameter name char
 	parameterDelimiterChars = append([]byte{paramStarterChar, escapeChar}, routeDelimiter...)
-	// list of chars to find the end of a parameter
-	parameterEndChars = append([]byte{optionalParam}, parameterDelimiterChars...)
 )
 
 // RoutePatternMatch reports whether path matches the provided Fiber route pattern.
@@ -280,22 +276,27 @@ func addParameterMetaInfo(segs []*routeSegment) []*routeSegment {
 // findNextParamPosition search for the next possible parameter start position
 func findNextParamPosition(pattern string) int {
 	// Find the first parameter position
-	nextParamPosition := findNextNonEscapedCharsetPosition(pattern, parameterStartChars)
-
-	// If pattern contains a parameter and it's not a wildcard
-	if nextParamPosition != -1 && len(pattern) > nextParamPosition && pattern[nextParamPosition] != wildcardParam {
-		// checking the found parameterStartChar is a cluster
-		i := nextParamPosition + 1
-		for i < len(pattern) {
-			if findNextNonEscapedCharsetPosition(pattern[i:i+1], parameterStartChars) != 0 {
-				// It was a single parameter start char or end of cluster
-				break
-			}
-			nextParamPosition++
-			i++
+	var search = [256]bool{
+		wildcardParam:    true,
+		plusParam:        true,
+		paramStarterChar: true,
+	}
+	next := -1
+	for i := range pattern {
+		if search[pattern[i]] && (i == 0 || pattern[i-1] != escapeChar) {
+			next = i
+			break
 		}
 	}
-	return nextParamPosition
+	if next > 0 && pattern[next] != wildcardParam {
+		// checking the found parameterStartChar is a cluster
+		for i := next + 1; i < len(pattern); i++ {
+			if !search[pattern[i]] {
+				return i - 1
+			}
+		}
+	}
+	return next
 }
 
 // analyseConstantPart find the end of the constant part and create the route segment
@@ -318,29 +319,46 @@ func (parser *routeParser) analyseParameterPart(pattern string, customConstraint
 	isWildCard := pattern[0] == wildcardParam
 	isPlusParam := pattern[0] == plusParam
 
-	var parameterEndPosition int
-	if strings.ContainsRune(pattern, rune(paramConstraintStart)) && strings.ContainsRune(pattern, rune(paramConstraintEnd)) {
-		parameterEndPosition = findNextCharsetPositionConstraint(pattern[1:], parameterEndChars)
-	} else {
-		parameterEndPosition = findNextNonEscapedCharsetPosition(pattern[1:], parameterEndChars)
-	}
-
+	parameterEndPosition := 0
 	parameterConstraintStart := -1
 	parameterConstraintEnd := -1
-	// handle wildcard end
-	switch {
-	case isWildCard, isPlusParam:
-		parameterEndPosition = 0
-	case parameterEndPosition == -1:
-		parameterEndPosition = len(pattern) - 1
-	case bytes.IndexByte(parameterDelimiterChars, pattern[parameterEndPosition+1]) == -1:
-		parameterEndPosition++
-	}
 
-	// find constraint part if exists in the parameter part and remove it
-	if parameterEndPosition > 0 {
-		parameterConstraintStart = findNextNonEscapedCharPosition(pattern[:parameterEndPosition], paramConstraintStart)
-		parameterConstraintEnd = strings.LastIndexByte(pattern[:parameterEndPosition+1], paramConstraintEnd)
+	// handle wildcard end
+	if !isWildCard && !isPlusParam {
+		parameterEndChars := [256]bool{
+			optionalParam:    true,
+			paramStarterChar: true,
+			escapeChar:       true,
+			slashDelimiter:   true,
+			'-':              true,
+			'.':              true,
+		}
+		parameterEndPosition = -1
+		search := pattern[1:]
+		for i := range search {
+			if parameterConstraintStart == -1 && search[i] == paramConstraintStart && (i == 0 || search[i-1] != escapeChar) {
+				parameterConstraintStart = i + 1
+				continue
+			}
+			if parameterConstraintEnd == -1 && search[i] == paramConstraintEnd && (i == 0 || search[i-1] != escapeChar) {
+				parameterConstraintEnd = i + 1
+				continue
+			}
+			if parameterEndChars[search[i]] {
+				// if (parameterConstraintStart == -1 && parameterConstraintEnd == -1) ||
+				// 	  (parameterConstraintStart != -1 && parameterConstraintEnd != -1)
+				if parameterConstraintStart^parameterConstraintEnd >= 0 {
+					parameterEndPosition = i
+					break
+				}
+			}
+		}
+		switch {
+		case parameterEndPosition == -1:
+			parameterEndPosition = len(pattern) - 1
+		case bytes.IndexByte(parameterDelimiterChars, pattern[parameterEndPosition+1]) == -1:
+			parameterEndPosition++
+		}
 	}
 
 	// cut params part
@@ -420,57 +438,6 @@ func (parser *routeParser) analyseParameterPart(pattern string, customConstraint
 	}
 
 	return n, segment
-}
-
-// findNextCharsetPosition search the next char position from the charset
-func findNextCharsetPosition(search string, charset []byte) int {
-	nextPosition := -1
-	for _, char := range charset {
-		if pos := strings.IndexByte(search, char); pos != -1 && (pos < nextPosition || nextPosition == -1) {
-			nextPosition = pos
-		}
-	}
-
-	return nextPosition
-}
-
-// findNextCharsetPositionConstraint searches the next char position from the charset
-// unlike findNextCharsetPosition, it takes care of constraint start-end chars to parse route pattern
-func findNextCharsetPositionConstraint(search string, charset []byte) int {
-	constraintStart := findNextNonEscapedCharPosition(search, paramConstraintStart)
-	constraintEnd := findNextNonEscapedCharPosition(search, paramConstraintEnd)
-	nextPosition := -1
-
-	for _, char := range charset {
-		pos := strings.IndexByte(search, char)
-
-		if pos != -1 && (pos < nextPosition || nextPosition == -1) {
-			if (pos > constraintStart && pos > constraintEnd) || (pos < constraintStart && pos < constraintEnd) {
-				nextPosition = pos
-			}
-		}
-	}
-
-	return nextPosition
-}
-
-// findNextNonEscapedCharsetPosition searches the next char position from the charset and skips the escaped characters
-func findNextNonEscapedCharsetPosition(search string, charset []byte) int {
-	pos := findNextCharsetPosition(search, charset)
-	for pos > 0 && search[pos-1] == escapeChar {
-		if len(search) == pos+1 {
-			// escaped character is at the end
-			return -1
-		}
-		nextPossiblePos := findNextCharsetPosition(search[pos+1:], charset)
-		if nextPossiblePos == -1 {
-			return -1
-		}
-		// the previous character is taken into consideration
-		pos = nextPossiblePos + pos + 1
-	}
-
-	return pos
 }
 
 // findNextNonEscapedCharPosition searches the next char position and skips the escaped characters

--- a/path.go
+++ b/path.go
@@ -276,7 +276,7 @@ func addParameterMetaInfo(segs []*routeSegment) []*routeSegment {
 // findNextParamPosition search for the next possible parameter start position
 func findNextParamPosition(pattern string) int {
 	// Find the first parameter position
-	var search = [256]bool{
+	search := [256]bool{
 		wildcardParam:    true,
 		plusParam:        true,
 		paramStarterChar: true,
@@ -295,6 +295,7 @@ func findNextParamPosition(pattern string) int {
 				return i - 1
 			}
 		}
+		next = len(pattern) - 1
 	}
 	return next
 }


### PR DESCRIPTION
# Description

+ Refactor functions `findNextCharsetPosition`, `findNextCharsetPositionConstraint`, and `findNextNonEscapedCharsetPosition` to reduce time complexity from **O(len(search)len(charset))** to **O(len(search))** and inline them into the function `analyseParameterPart`.
+ Improve the performance of `findNextParamPosition`.

```
goos: linux
goarch: amd64
pkg: github.com/gofiber/fiber/v3
cpu: AMD EPYC 7763 64-Core Processor                
                                                                              │   old.txt   │               new.txt               │
                                                                              │   sec/op    │   sec/op     vs base                │
_RoutePatternMatch//api/v1/const_|_match_|_/api/v1/const-2                      227.8n ± 2%   207.8n ± 5%   -8.82% (p=0.000 n=20)
_RoutePatternMatch//api/v1/const_|_not_match_|_/api/v1-2                        218.5n ± 5%   202.2n ± 3%   -7.44% (p=0.000 n=20)
_RoutePatternMatch//api/v1/const_|_not_match_|_/api/v1/-2                       219.0n ± 3%   204.3n ± 3%   -6.71% (p=0.000 n=20)
_RoutePatternMatch//api/v1/const_|_not_match_|_/api/v1/something-2              221.8n ± 3%   204.8n ± 6%   -7.66% (p=0.000 n=20)
_RoutePatternMatch//api/:param/fixedEnd_|_match_|_/api/abc/fixedEnd-2           665.9n ± 3%   559.4n ± 4%  -15.99% (p=0.000 n=20)
_RoutePatternMatch//api/:param/fixedEnd_|_not_match_|_/api/abc/def/fixedEnd-2   653.5n ± 3%   566.1n ± 4%  -13.37% (p=0.000 n=20)
_RoutePatternMatch//api/v1/:param/*_|_match_|_/api/v1/entity-2                  752.5n ± 4%   606.9n ± 5%  -19.35% (p=0.000 n=20)
_RoutePatternMatch//api/v1/:param/*_|_match_|_/api/v1/entity/-2                 740.9n ± 3%   598.2n ± 3%  -19.26% (p=0.000 n=20)
_RoutePatternMatch//api/v1/:param/*_|_match_|_/api/v1/entity/1-2                725.4n ± 4%   605.9n ± 4%  -16.47% (p=0.000 n=20)
_RoutePatternMatch//api/v1/:param/*_|_not_match_|_/api/v-2                      701.0n ± 2%   566.0n ± 5%  -19.26% (p=0.000 n=20)
_RoutePatternMatch//api/v1/:param/*_|_not_match_|_/api/v2-2                     698.8n ± 4%   564.9n ± 2%  -19.15% (p=0.000 n=20)
_RoutePatternMatch//api/v1/:param/*_|_not_match_|_/api/v1/-2                    730.6n ± 3%   582.8n ± 4%  -20.24% (p=0.000 n=20)
geomean                                                                         480.7n        410.4n       -14.63%

                                                                              │  old.txt   │               new.txt               │
                                                                              │    B/op    │    B/op     vs base                 │
_RoutePatternMatch//api/v1/const_|_match_|_/api/v1/const-2                      128.0 ± 0%   128.0 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/const_|_not_match_|_/api/v1-2                        128.0 ± 0%   128.0 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/const_|_not_match_|_/api/v1/-2                       128.0 ± 0%   128.0 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/const_|_not_match_|_/api/v1/something-2              128.0 ± 0%   128.0 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/:param/fixedEnd_|_match_|_/api/abc/fixedEnd-2           368.0 ± 0%   368.0 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/:param/fixedEnd_|_not_match_|_/api/abc/def/fixedEnd-2   368.0 ± 0%   368.0 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/:param/*_|_match_|_/api/v1/entity-2                  416.0 ± 0%   416.0 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/:param/*_|_match_|_/api/v1/entity/-2                 416.0 ± 0%   416.0 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/:param/*_|_match_|_/api/v1/entity/1-2                416.0 ± 0%   416.0 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/:param/*_|_not_match_|_/api/v-2                      416.0 ± 0%   416.0 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/:param/*_|_not_match_|_/api/v2-2                     416.0 ± 0%   416.0 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/:param/*_|_not_match_|_/api/v1/-2                    416.0 ± 0%   416.0 ± 0%       ~ (p=1.000 n=20) ¹
geomean                                                                         275.2        275.2       +0.00%
¹ all samples are equal

                                                                              │  old.txt   │               new.txt               │
                                                                              │ allocs/op  │ allocs/op   vs base                 │
_RoutePatternMatch//api/v1/const_|_match_|_/api/v1/const-2                      3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/const_|_not_match_|_/api/v1-2                        3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/const_|_not_match_|_/api/v1/-2                       3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/const_|_not_match_|_/api/v1/something-2              3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/:param/fixedEnd_|_match_|_/api/abc/fixedEnd-2           9.000 ± 0%   9.000 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/:param/fixedEnd_|_not_match_|_/api/abc/def/fixedEnd-2   9.000 ± 0%   9.000 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/:param/*_|_match_|_/api/v1/entity-2                  8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/:param/*_|_match_|_/api/v1/entity/-2                 8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/:param/*_|_match_|_/api/v1/entity/1-2                8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/:param/*_|_not_match_|_/api/v-2                      8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/:param/*_|_not_match_|_/api/v2-2                     8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=20) ¹
_RoutePatternMatch//api/v1/:param/*_|_not_match_|_/api/v1/-2                    8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=20) ¹
geomean                                                                         5.883        5.883       +0.00%
¹ all samples are equal
```

## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [ ] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [ ] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [ ] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [ ] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [ ] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [ ] Examples: Provide examples demonstrating the new features or changes in action.

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (improvement to existing features and functionality)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.