### PR TITLE
Ensure middleware prefix matching requires slash boundary

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -709,6 +709,25 @@ func Test_App_Use_MultiplePrefix(t *testing.T) {
 	require.Equal(t, "/test/doe", string(body))
 }
 
+func Test_Group_Use_NoBoundary(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	grp := app.Group("/api")
+
+	grp.Use("/foo", func(c Ctx) error {
+		return c.SendStatus(StatusOK)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/api/foo/bar", nil))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
+
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/api/foobar", nil))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusNotFound, resp.StatusCode, "Status code")
+}
+
 func Test_App_Use_StrictRouting(t *testing.T) {
 	t.Parallel()
 	app := New(Config{StrictRouting: true})

--- a/path.go
+++ b/path.go
@@ -498,8 +498,29 @@ func splitNonEscaped(s string, sep byte) []string {
 	return append(result, s)
 }
 
+func hasPartialMatchBoundary(path string, matchedLength int) bool {
+	if matchedLength < 0 || matchedLength > len(path) {
+		return false
+	}
+	if matchedLength == len(path) {
+		return true
+	}
+	if matchedLength == 0 {
+		return false
+	}
+	if path[matchedLength-1] == slashDelimiter {
+		return true
+	}
+	if matchedLength < len(path) && path[matchedLength] == slashDelimiter {
+		return true
+	}
+
+	return false
+}
+
 // getMatch parses the passed url and tries to match it against the route segments and determine the parameter positions
 func (parser *routeParser) getMatch(detectionPath, path string, params *[maxParams]string, partialCheck bool) bool { //nolint:revive // Accepting a bool param is fine here
+	originalDetectionPath := detectionPath
 	var i, paramsIterator, partLen int
 	for _, segment := range parser.segs {
 		partLen = len(detectionPath)
@@ -539,8 +560,14 @@ func (parser *routeParser) getMatch(detectionPath, path string, params *[maxPara
 			detectionPath, path = detectionPath[i:], path[i:]
 		}
 	}
-	if detectionPath != "" && !partialCheck {
-		return false
+	if detectionPath != "" {
+		if !partialCheck {
+			return false
+		}
+		consumedLength := len(originalDetectionPath) - len(detectionPath)
+		if !hasPartialMatchBoundary(originalDetectionPath, consumedLength) {
+			return false
+		}
 	}
 
 	return true

--- a/path_testcases_test.go
+++ b/path_testcases_test.go
@@ -345,6 +345,23 @@ func init() {
 				},
 			},
 			{
+				pattern: "/partialCheck/foo",
+				testCases: []routeTestCase{
+					{url: "/partialCheck/foo", params: nil, match: true, partialCheck: true},
+					{url: "/partialCheck/foo/", params: nil, match: true, partialCheck: true},
+					{url: "/partialCheck/foo/bar", params: nil, match: true, partialCheck: true},
+					{url: "/partialCheck/foobar", params: nil, match: false, partialCheck: true},
+				},
+			},
+			{
+				pattern: "/partialCheck/:param",
+				testCases: []routeTestCase{
+					{url: "/partialCheck/value", params: []string{"value"}, match: true, partialCheck: true},
+					{url: "/partialCheck/value/", params: []string{"value"}, match: true, partialCheck: true},
+					{url: "/partialCheck/value/next", params: []string{"value"}, match: true, partialCheck: true},
+				},
+			},
+			{
 				pattern: "/",
 				testCases: []routeTestCase{
 					{url: "/api", params: nil, match: false},

--- a/router.go
+++ b/router.go
@@ -94,7 +94,9 @@ func (r *Route) match(detectionPath, path string, params *[maxParams]string) boo
 				return true
 			}
 		} else if len(detectionPath) >= plen && detectionPath[:plen] == r.path {
-			return true
+			if hasPartialMatchBoundary(detectionPath, plen) {
+				return true
+			}
 		}
 	} else if len(r.path) == len(detectionPath) && detectionPath == r.path {
 		// Check exact match

--- a/router_test.go
+++ b/router_test.go
@@ -309,6 +309,20 @@ func Test_Route_Match_Middleware_HasPrefix(t *testing.T) {
 	require.Equal(t, "middleware", app.toString(body))
 }
 
+func Test_Route_Match_Middleware_NoBoundary(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+
+	app.Use("/foo", func(c Ctx) error {
+		return c.SendStatus(StatusOK)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/foobar", nil))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusNotFound, resp.StatusCode, "Status code")
+}
+
 func Test_Route_Match_Middleware_Root(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- require middleware prefix matches to either fully match or stop at a slash boundary by sharing a helper between the path parser and router
- add path parser fixtures plus router and group tests to cover the tightened matching rules

## Testing
- make audit *(fails: go vet copylocks warning in generated msgp files)*
- make generate
- make betteralign
- make modernize
- make format
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cd6b1fb1648326ae0646c347dbb672