### PR TITLE
Fix cache cleanup on storage failures

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -4,6 +4,8 @@ package cache
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"slices"
 	"strconv"
 	"strings"
@@ -98,12 +100,17 @@ func New(config ...Config) fiber.Handler {
 	}()
 
 	// Delete key from both manager and storage
-	deleteKey := func(dkey string) {
-		manager.del(context.Background(), dkey)
+	deleteKey := func(dkey string) error {
+		if err := manager.del(context.Background(), dkey); err != nil {
+			return err
+		}
 		// External storage saves body data with different key
 		if cfg.Storage != nil {
-			manager.del(context.Background(), dkey+"_body")
+			if err := manager.del(context.Background(), dkey+"_body"); err != nil {
+				return err
+			}
 		}
+		return nil
 	}
 
 	// Return new handler
@@ -126,7 +133,10 @@ func New(config ...Config) fiber.Handler {
 		key := cfg.KeyGenerator(c) + "_" + requestMethod
 
 		// Get entry from pool
-		e := manager.get(c, key)
+		e, err := manager.get(c, key)
+		if err != nil && !errors.Is(err, errCacheMiss) {
+			return err
+		}
 
 		// Lock entry
 		mux.Lock()
@@ -143,16 +153,30 @@ func New(config ...Config) fiber.Handler {
 
 			// Check if entry is expired
 			if e.exp != 0 && ts >= e.exp {
-				deleteKey(key)
+				idx := e.heapidx
+				if err := deleteKey(key); err != nil {
+					if e != nil {
+						manager.release(e)
+					}
+					mux.Unlock()
+					return fmt.Errorf("cache: failed to delete expired key %q: %w", key, err)
+				}
+				manager.release(e)
 				if cfg.MaxBytes > 0 {
-					_, size := heap.remove(e.heapidx)
+					_, size := heap.remove(idx)
 					storedBytes -= size
 				}
 			} else if e.exp != 0 && !hasRequestDirective(c, noCache) {
 				// Separate body value to avoid msgp serialization
 				// We can store raw bytes with Storage 👍
 				if cfg.Storage != nil {
-					e.body = manager.getRaw(c, key+"_body")
+					rawBody, err := manager.getRaw(c, key+"_body")
+					if err != nil {
+						manager.release(e)
+						mux.Unlock()
+						return cacheBodyFetchError(key, err)
+					}
+					e.body = rawBody
 				}
 				// Set response headers from cache
 				c.Response().SetBodyRaw(e.body)
@@ -230,7 +254,9 @@ func New(config ...Config) fiber.Handler {
 		if cfg.MaxBytes > 0 {
 			for storedBytes+bodySize > cfg.MaxBytes {
 				keyToRemove, size := heap.removeFirst()
-				deleteKey(keyToRemove)
+				if err := deleteKey(keyToRemove); err != nil {
+					return fmt.Errorf("cache: failed to delete key %q while evicting: %w", keyToRemove, err)
+				}
 				storedBytes -= size
 			}
 		}
@@ -278,21 +304,39 @@ func New(config ...Config) fiber.Handler {
 		e.ttl = uint64(expiration.Seconds())
 
 		// Store entry in heap
+		var heapIdx int
 		if cfg.MaxBytes > 0 {
-			e.heapidx = heap.put(key, e.exp, bodySize)
+			heapIdx = heap.put(key, e.exp, bodySize)
+			e.heapidx = heapIdx
 			storedBytes += bodySize
 		}
 
 		// For external Storage we store raw body separated
+		cleanupStoredEntry := func() {
+			if cfg.MaxBytes > 0 {
+				_, size := heap.remove(heapIdx)
+				storedBytes -= size
+			}
+		}
+
 		if cfg.Storage != nil {
-			manager.setRaw(c, key+"_body", e.body, expiration)
+			if err := manager.setRaw(c, key+"_body", e.body, expiration); err != nil {
+				cleanupStoredEntry()
+				manager.release(e)
+				return err
+			}
 			// avoid body msgp encoding
 			e.body = nil
-			manager.set(c, key, e, expiration)
-			manager.release(e)
+			if err := manager.set(c, key, e, expiration); err != nil {
+				cleanupStoredEntry()
+				return err
+			}
 		} else {
 			// Store entry in memory
-			manager.set(c, key, e, expiration)
+			if err := manager.set(c, key, e, expiration); err != nil {
+				cleanupStoredEntry()
+				return err
+			}
 		}
 
 		c.Set(cfg.CacheHeader, cacheMiss)
@@ -323,6 +367,13 @@ func hasRequestDirective(c fiber.Ctx, directive string) bool {
 	}
 
 	return false
+}
+
+func cacheBodyFetchError(key string, err error) error {
+	if errors.Is(err, errCacheMiss) {
+		return fmt.Errorf("cache: no cached body for key %q: %w", key, err)
+	}
+	return err
 }
 
 // parseMaxAge extracts the max-age directive from a Cache-Control header.

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -4,6 +4,8 @@ package cache
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -20,6 +22,201 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 )
+
+type failingCacheStorage struct {
+	data        map[string][]byte
+	errs        map[string]error
+	deleteCount int
+}
+
+func newFailingCacheStorage() *failingCacheStorage {
+	return &failingCacheStorage{
+		data: make(map[string][]byte),
+		errs: make(map[string]error),
+	}
+}
+
+func (s *failingCacheStorage) GetWithContext(_ context.Context, key string) ([]byte, error) {
+	if err, ok := s.errs["get|"+key]; ok && err != nil {
+		return nil, err
+	}
+	if val, ok := s.data[key]; ok {
+		return append([]byte(nil), val...), nil
+	}
+	return nil, nil
+}
+
+func (s *failingCacheStorage) Get(key string) ([]byte, error) {
+	return s.GetWithContext(context.Background(), key)
+}
+
+func (s *failingCacheStorage) SetWithContext(_ context.Context, key string, val []byte, _ time.Duration) error {
+	if err, ok := s.errs["set|"+key]; ok && err != nil {
+		return err
+	}
+	s.data[key] = append([]byte(nil), val...)
+	return nil
+}
+
+func (s *failingCacheStorage) Set(key string, val []byte, exp time.Duration) error {
+	return s.SetWithContext(context.Background(), key, val, exp)
+}
+
+func (s *failingCacheStorage) DeleteWithContext(_ context.Context, key string) error {
+	if err, ok := s.errs["del|"+key]; ok && err != nil {
+		return err
+	}
+	s.deleteCount++
+	delete(s.data, key)
+	return nil
+}
+
+func (s *failingCacheStorage) Delete(key string) error {
+	return s.DeleteWithContext(context.Background(), key)
+}
+
+func (s *failingCacheStorage) ResetWithContext(context.Context) error {
+	s.data = make(map[string][]byte)
+	s.errs = make(map[string]error)
+	return nil
+}
+
+func (s *failingCacheStorage) Reset() error {
+	return s.ResetWithContext(context.Background())
+}
+
+func (*failingCacheStorage) Close() error { return nil }
+
+func TestCacheStorageGetError(t *testing.T) {
+	t.Parallel()
+
+	storage := newFailingCacheStorage()
+	storage.errs["get|/_GET"] = errors.New("boom")
+
+	var captured error
+	app := fiber.New(fiber.Config{
+		ErrorHandler: func(c fiber.Ctx, err error) error {
+			captured = err
+			return c.Status(fiber.StatusInternalServerError).SendString("storage failure")
+		},
+	})
+
+	app.Use(New(Config{Storage: storage, Expiration: time.Second}))
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+	require.Error(t, captured)
+	require.ErrorContains(t, captured, "cache: failed to get key")
+}
+
+func TestCacheStorageSetError(t *testing.T) {
+	t.Parallel()
+
+	storage := newFailingCacheStorage()
+	storage.errs["set|/_GET_body"] = errors.New("boom")
+
+	var captured error
+	app := fiber.New(fiber.Config{
+		ErrorHandler: func(c fiber.Ctx, err error) error {
+			captured = err
+			return c.Status(fiber.StatusInternalServerError).SendString("storage failure")
+		},
+	})
+
+	app.Use(New(Config{Storage: storage, Expiration: time.Second}))
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+	require.Error(t, captured)
+	require.ErrorContains(t, captured, "cache: failed to store raw key")
+}
+
+func TestCacheStorageSetErrorRollsBackHeapAccounting(t *testing.T) {
+	t.Parallel()
+
+	storage := newFailingCacheStorage()
+	storage.errs["set|/_GET_body"] = errors.New("boom")
+
+	var captured error
+	app := fiber.New(fiber.Config{
+		ErrorHandler: func(c fiber.Ctx, err error) error {
+			captured = err
+			return c.Status(fiber.StatusInternalServerError).SendString("storage failure")
+		},
+	})
+
+	app.Use(New(Config{Storage: storage, Expiration: time.Second, MaxBytes: uint(len("ok"))}))
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+	require.Error(t, captured)
+	require.ErrorContains(t, captured, "cache: failed to store raw key")
+	require.Equal(t, 0, storage.deleteCount, "unexpected eviction after failed storage")
+	require.NoError(t, resp.Body.Close())
+
+	delete(storage.errs, "set|/_GET_body")
+	captured = nil
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Nil(t, captured)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+	require.Equal(t, 0, storage.deleteCount, "evicted stale entry despite rollback")
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+	require.Equal(t, 0, storage.deleteCount, "unexpected eviction during cache hit")
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestCacheStorageDeleteError(t *testing.T) {
+	t.Parallel()
+
+	storage := newFailingCacheStorage()
+	storage.errs["del|/_GET"] = errors.New("boom")
+
+	// Use an obviously expired timestamp without relying on time-based conversions
+	expired := &item{exp: 1}
+	raw, err := expired.MarshalMsg(nil)
+	require.NoError(t, err)
+
+	storage.data["/_GET"] = raw
+
+	var captured error
+	app := fiber.New(fiber.Config{
+		ErrorHandler: func(c fiber.Ctx, err error) error {
+			captured = err
+			return c.Status(fiber.StatusInternalServerError).SendString("storage failure")
+		},
+	})
+
+	app.Use(New(Config{Storage: storage, Expiration: time.Second}))
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", nil))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+	require.Error(t, captured)
+	require.ErrorContains(t, captured, "cache: failed to delete expired key")
+}
 
 func Test_Cache_CacheControl(t *testing.T) {
 	t.Parallel()

--- a/middleware/cache/manager.go
+++ b/middleware/cache/manager.go
@@ -2,6 +2,8 @@ package cache
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -31,6 +33,8 @@ type manager struct {
 	memory  *memory.Storage
 	storage fiber.Storage
 }
+
+var errCacheMiss = errors.New("cache: miss")
 
 func newManager(storage fiber.Storage) *manager {
 	// Create new storage handler
@@ -73,67 +77,102 @@ func (m *manager) release(e *item) {
 }
 
 // get data from storage or memory
-func (m *manager) get(ctx context.Context, key string) *item {
+func (m *manager) get(ctx context.Context, key string) (*item, error) {
 	if m.storage != nil {
 		raw, err := m.storage.GetWithContext(ctx, key)
-		if err != nil || raw == nil {
-			return nil
+		if err != nil {
+			return nil, fmt.Errorf("cache: failed to get key %q from storage: %w", key, err)
+		}
+		if raw == nil {
+			return nil, errCacheMiss
 		}
 
 		it := m.acquire()
 		if _, err := it.UnmarshalMsg(raw); err != nil {
 			m.release(it)
-			return nil
+			return nil, fmt.Errorf("cache: failed to unmarshal key %q: %w", key, err)
 		}
 
-		return it
+		return it, nil
 	}
 
-	if it, _ := m.memory.Get(key).(*item); it != nil { //nolint:errcheck // We store nothing else in the pool
-		return it
+	if value := m.memory.Get(key); value != nil {
+		it, ok := value.(*item)
+		if !ok {
+			return nil, fmt.Errorf("cache: unexpected entry type %T for key %q", value, key)
+		}
+		return it, nil
 	}
 
-	return nil
+	return nil, errCacheMiss
 }
 
 // get raw data from storage or memory
-func (m *manager) getRaw(ctx context.Context, key string) []byte {
-	var raw []byte
+func (m *manager) getRaw(ctx context.Context, key string) ([]byte, error) {
 	if m.storage != nil {
-		raw, _ = m.storage.GetWithContext(ctx, key) //nolint:errcheck // TODO: Handle error here
-	} else {
-		raw, _ = m.memory.Get(key).([]byte) //nolint:errcheck // TODO: Handle error here
-	}
-	return raw
-}
-
-// set data to storage or memory
-func (m *manager) set(ctx context.Context, key string, it *item, exp time.Duration) {
-	if m.storage != nil {
-		if raw, err := it.MarshalMsg(nil); err == nil {
-			_ = m.storage.SetWithContext(ctx, key, raw, exp) //nolint:errcheck // TODO: Handle error here
+		raw, err := m.storage.GetWithContext(ctx, key)
+		if err != nil {
+			return nil, fmt.Errorf("cache: failed to get raw key %q from storage: %w", key, err)
 		}
-		// we can release data because it's serialized to database
-		m.release(it)
-	} else {
-		m.memory.Set(key, it, exp)
+		if raw == nil {
+			return nil, errCacheMiss
+		}
+		return raw, nil
 	}
+
+	if value := m.memory.Get(key); value != nil {
+		raw, ok := value.([]byte)
+		if !ok {
+			return nil, fmt.Errorf("cache: unexpected raw entry type %T for key %q", value, key)
+		}
+		return raw, nil
+	}
+
+	return nil, errCacheMiss
 }
 
 // set data to storage or memory
-func (m *manager) setRaw(ctx context.Context, key string, raw []byte, exp time.Duration) {
+func (m *manager) set(ctx context.Context, key string, it *item, exp time.Duration) error {
 	if m.storage != nil {
-		_ = m.storage.SetWithContext(ctx, key, raw, exp) //nolint:errcheck // TODO: Handle error here
-	} else {
-		m.memory.Set(key, raw, exp)
+		raw, err := it.MarshalMsg(nil)
+		if err != nil {
+			m.release(it)
+			return fmt.Errorf("cache: failed to marshal key %q: %w", key, err)
+		}
+		if err := m.storage.SetWithContext(ctx, key, raw, exp); err != nil {
+			m.release(it)
+			return fmt.Errorf("cache: failed to store key %q: %w", key, err)
+		}
+		m.release(it)
+		return nil
 	}
+
+	m.memory.Set(key, it, exp)
+	return nil
+}
+
+// set data to storage or memory
+func (m *manager) setRaw(ctx context.Context, key string, raw []byte, exp time.Duration) error {
+	if m.storage != nil {
+		if err := m.storage.SetWithContext(ctx, key, raw, exp); err != nil {
+			return fmt.Errorf("cache: failed to store raw key %q: %w", key, err)
+		}
+		return nil
+	}
+
+	m.memory.Set(key, raw, exp)
+	return nil
 }
 
 // delete data from storage or memory
-func (m *manager) del(ctx context.Context, key string) {
+func (m *manager) del(ctx context.Context, key string) error {
 	if m.storage != nil {
-		_ = m.storage.DeleteWithContext(ctx, key) //nolint:errcheck // TODO: Handle error here
-	} else {
-		m.memory.Delete(key)
+		if err := m.storage.DeleteWithContext(ctx, key); err != nil {
+			return fmt.Errorf("cache: failed to delete key %q: %w", key, err)
+		}
+		return nil
 	}
+
+	m.memory.Delete(key)
+	return nil
 }

--- a/middleware/cache/manager_test.go
+++ b/middleware/cache/manager_test.go
@@ -7,6 +7,7 @@ import (
 
 	utils "github.com/gofiber/utils/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_manager_get(t *testing.T) {
@@ -14,14 +15,18 @@ func Test_manager_get(t *testing.T) {
 	cacheManager := newManager(nil)
 	t.Run("Item not found in cache", func(t *testing.T) {
 		t.Parallel()
-		assert.Nil(t, cacheManager.get(context.Background(), utils.UUID()))
+		it, err := cacheManager.get(context.Background(), utils.UUID())
+		require.ErrorIs(t, err, errCacheMiss)
+		assert.Nil(t, it)
 	})
 	t.Run("Item found in cache", func(t *testing.T) {
 		t.Parallel()
 		id := utils.UUID()
 		cacheItem := cacheManager.acquire()
 		cacheItem.body = []byte("test-body")
-		cacheManager.set(context.Background(), id, cacheItem, 10*time.Second)
-		assert.NotNil(t, cacheManager.get(context.Background(), id))
+		require.NoError(t, cacheManager.set(context.Background(), id, cacheItem, 10*time.Second))
+		it, err := cacheManager.get(context.Background(), id)
+		require.NoError(t, err)
+		assert.NotNil(t, it)
 	})
 }

--- a/middleware/csrf/storage_manager.go
+++ b/middleware/csrf/storage_manager.go
@@ -2,6 +2,7 @@ package csrf
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -42,31 +43,56 @@ func newStorageManager(storage fiber.Storage) *storageManager {
 }
 
 // get raw data from storage or memory
-func (m *storageManager) getRaw(ctx context.Context, key string) []byte {
-	var raw []byte
+func (m *storageManager) getRaw(ctx context.Context, key string) ([]byte, error) {
 	if m.storage != nil {
-		raw, _ = m.storage.GetWithContext(ctx, key) //nolint:errcheck // TODO: Do not ignore error
-	} else {
-		raw, _ = m.memory.Get(key).([]byte) //nolint:errcheck // TODO: Do not ignore error
+		raw, err := m.storage.GetWithContext(ctx, key)
+		if err != nil {
+			return nil, fmt.Errorf("csrf: failed to get key %s from storage: %w", redactToken(key), err)
+		}
+		return raw, nil
 	}
-	return raw
+
+	if value := m.memory.Get(key); value != nil {
+		raw, ok := value.([]byte)
+		if !ok {
+			return nil, fmt.Errorf("csrf: unexpected value type %T for key %s", value, redactToken(key))
+		}
+		return raw, nil
+	}
+
+	return nil, nil
 }
 
 // set data to storage or memory
-func (m *storageManager) setRaw(ctx context.Context, key string, raw []byte, exp time.Duration) {
+func (m *storageManager) setRaw(ctx context.Context, key string, raw []byte, exp time.Duration) error {
 	if m.storage != nil {
-		_ = m.storage.SetWithContext(ctx, key, raw, exp) //nolint:errcheck // TODO: Do not ignore error
-	} else {
-		// the key is crucial in crsf and sometimes a reference to another value which can be reused later(pool/unsafe values concept), so a copy is made here
-		m.memory.Set(utils.CopyString(key), raw, exp)
+		if err := m.storage.SetWithContext(ctx, key, raw, exp); err != nil {
+			return fmt.Errorf("csrf: failed to store key %s: %w", redactToken(key), err)
+		}
+		return nil
 	}
+
+	// the key is crucial in crsf and sometimes a reference to another value which can be reused later(pool/unsafe values concept), so a copy is made here
+	m.memory.Set(utils.CopyString(key), utils.CopyBytes(raw), exp)
+	return nil
 }
 
 // delete data from storage or memory
-func (m *storageManager) delRaw(ctx context.Context, key string) {
+func (m *storageManager) delRaw(ctx context.Context, key string) error {
 	if m.storage != nil {
-		_ = m.storage.DeleteWithContext(ctx, key) //nolint:errcheck // TODO: Do not ignore error
-	} else {
-		m.memory.Delete(key)
+		if err := m.storage.DeleteWithContext(ctx, key); err != nil {
+			return fmt.Errorf("csrf: failed to delete key %s: %w", redactToken(key), err)
+		}
+		return nil
 	}
+
+	m.memory.Delete(key)
+	return nil
+}
+
+func redactToken(token string) string {
+	if token == "" {
+		return "<redacted>"
+	}
+	return fmt.Sprintf("<redacted:%d>", len(token))
 }

--- a/middleware/csrf/storage_manager_msgp.go
+++ b/middleware/csrf/storage_manager_msgp.go
@@ -14,21 +14,21 @@ func (z *item) DecodeMsg(dc *msgp.Reader) (err error) {
 	zb0001, err = dc.ReadMapHeader()
 	if err != nil {
 		err = msgp.WrapError(err)
-		return err
+		return
 	}
 	for zb0001 > 0 {
 		zb0001--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			err = msgp.WrapError(err)
-			return err
+			return
 		}
 		switch msgp.UnsafeString(field) {
 		default:
 			err = dc.Skip()
 			if err != nil {
 				err = msgp.WrapError(err)
-				return err
+				return
 			}
 		}
 	}
@@ -41,7 +41,7 @@ func (z item) EncodeMsg(en *msgp.Writer) (err error) {
 	_ = z
 	err = en.Append(0x80)
 	if err != nil {
-		return err
+		return
 	}
 	return
 }
@@ -52,7 +52,7 @@ func (z item) MarshalMsg(b []byte) (o []byte, err error) {
 	// map header, size 0
 	_ = z
 	o = append(o, 0x80)
-	return o, err
+	return
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
@@ -63,32 +63,32 @@ func (z *item) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		err = msgp.WrapError(err)
-		return o, err
+		return
 	}
 	for zb0001 > 0 {
 		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
-			return o, err
+			return
 		}
 		switch msgp.UnsafeString(field) {
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
 				err = msgp.WrapError(err)
-				return o, err
+				return
 			}
 		}
 	}
 	o = bts
-	return o, err
+	return
 }
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z item) Msgsize() (s int) {
 	s = 1
-	return s
+	return
 }
 
 // DecodeMsg implements msgp.Decodable
@@ -99,21 +99,21 @@ func (z *storageManager) DecodeMsg(dc *msgp.Reader) (err error) {
 	zb0001, err = dc.ReadMapHeader()
 	if err != nil {
 		err = msgp.WrapError(err)
-		return err
+		return
 	}
 	for zb0001 > 0 {
 		zb0001--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			err = msgp.WrapError(err)
-			return err
+			return
 		}
 		switch msgp.UnsafeString(field) {
 		default:
 			err = dc.Skip()
 			if err != nil {
 				err = msgp.WrapError(err)
-				return err
+				return
 			}
 		}
 	}
@@ -121,23 +121,23 @@ func (z *storageManager) DecodeMsg(dc *msgp.Reader) (err error) {
 }
 
 // EncodeMsg implements msgp.Encodable
-func (z storageManager) EncodeMsg(en *msgp.Writer) (err error) {
+func (z *storageManager) EncodeMsg(en *msgp.Writer) (err error) {
 	// map header, size 0
 	_ = z
 	err = en.Append(0x80)
 	if err != nil {
-		return err
+		return
 	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z storageManager) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *storageManager) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 0
 	_ = z
 	o = append(o, 0x80)
-	return o, err
+	return
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
@@ -148,30 +148,30 @@ func (z *storageManager) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		err = msgp.WrapError(err)
-		return o, err
+		return
 	}
 	for zb0001 > 0 {
 		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			err = msgp.WrapError(err)
-			return o, err
+			return
 		}
 		switch msgp.UnsafeString(field) {
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
 				err = msgp.WrapError(err)
-				return o, err
+				return
 			}
 		}
 	}
 	o = bts
-	return o, err
+	return
 }
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z storageManager) Msgsize() (s int) {
+func (z *storageManager) Msgsize() (s int) {
 	s = 1
-	return s
+	return
 }

--- a/middleware/limiter/limiter_sliding.go
+++ b/middleware/limiter/limiter_sliding.go
@@ -1,6 +1,7 @@
 package limiter
 
 import (
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -42,7 +43,11 @@ func (SlidingWindow) New(cfg Config) fiber.Handler {
 		mux.Lock()
 
 		// Get entry from pool and release when finished
-		e := manager.get(c, key)
+		e, err := manager.get(c, key)
+		if err != nil {
+			mux.Unlock()
+			return err
+		}
 
 		// Get timestamp
 		ts := uint64(utils.Timestamp())
@@ -96,7 +101,10 @@ func (SlidingWindow) New(cfg Config) fiber.Handler {
 		// we add the expiration to the duration.
 		// Otherwise after the end of "sample window", attackers could launch
 		// a new request with the full window length.
-		manager.set(c, key, e, time.Duration(resetInSec+expiration)*time.Second) //nolint:gosec // Not a concern
+		if setErr := manager.set(c, key, e, time.Duration(resetInSec+expiration)*time.Second); setErr != nil { //nolint:gosec // Not a concern
+			mux.Unlock()
+			return fmt.Errorf("limiter: failed to persist state: %w", setErr)
+		}
 
 		// Unlock entry
 		mux.Unlock()
@@ -115,7 +123,7 @@ func (SlidingWindow) New(cfg Config) fiber.Handler {
 
 		// Continue stack for reaching c.Response().StatusCode()
 		// Store err for returning
-		err := c.Next()
+		err = c.Next()
 
 		// Get the effective status code from either the error or response
 		statusCode := getEffectiveStatusCode(c, err)
@@ -125,10 +133,18 @@ func (SlidingWindow) New(cfg Config) fiber.Handler {
 			(cfg.SkipFailedRequests && statusCode >= fiber.StatusBadRequest) {
 			// Lock entry
 			mux.Lock()
-			e = manager.get(c, key)
+			entry, getErr := manager.get(c, key)
+			if getErr != nil {
+				mux.Unlock()
+				return getErr
+			}
+			e = entry
 			e.currHits--
 			remaining++
-			manager.set(c, key, e, cfg.Expiration)
+			if setErr := manager.set(c, key, e, cfg.Expiration); setErr != nil {
+				mux.Unlock()
+				return fmt.Errorf("limiter: failed to persist state: %w", setErr)
+			}
 			// Unlock entry
 			mux.Unlock()
 		}

--- a/middleware/limiter/manager.go
+++ b/middleware/limiter/manager.go
@@ -2,6 +2,7 @@ package limiter
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -58,37 +59,52 @@ func (m *manager) release(e *item) {
 }
 
 // get data from storage or memory
-func (m *manager) get(ctx context.Context, key string) *item {
-	var it *item
+func (m *manager) get(ctx context.Context, key string) (*item, error) {
 	if m.storage != nil {
-		it = m.acquire()
 		raw, err := m.storage.GetWithContext(ctx, key)
 		if err != nil {
-			return it
+			return nil, fmt.Errorf("limiter: failed to get key %q from storage: %w", key, err)
 		}
 		if raw != nil {
+			it := m.acquire()
 			if _, err := it.UnmarshalMsg(raw); err != nil {
-				return it
+				m.release(it)
+				return nil, fmt.Errorf("limiter: failed to unmarshal key %q: %w", key, err)
 			}
+			return it, nil
 		}
-		return it
+		return m.acquire(), nil
 	}
-	if it, _ = m.memory.Get(key).(*item); it == nil { //nolint:errcheck // We store nothing else in the pool
-		it = m.acquire()
-		return it
+
+	value := m.memory.Get(key)
+	if value == nil {
+		return m.acquire(), nil
 	}
-	return it
+
+	it, ok := value.(*item)
+	if !ok {
+		return nil, fmt.Errorf("limiter: unexpected entry type %T for key %q", value, key)
+	}
+
+	return it, nil
 }
 
 // set data to storage or memory
-func (m *manager) set(ctx context.Context, key string, it *item, exp time.Duration) {
+func (m *manager) set(ctx context.Context, key string, it *item, exp time.Duration) error {
 	if m.storage != nil {
-		if raw, err := it.MarshalMsg(nil); err == nil {
-			_ = m.storage.SetWithContext(ctx, key, raw, exp) //nolint:errcheck // TODO: Handle error here
+		raw, err := it.MarshalMsg(nil)
+		if err != nil {
+			m.release(it)
+			return fmt.Errorf("limiter: failed to marshal key %q: %w", key, err)
 		}
-		// we can release data because it's serialized to database
+		if err := m.storage.SetWithContext(ctx, key, raw, exp); err != nil {
+			m.release(it)
+			return fmt.Errorf("limiter: failed to store key %q: %w", key, err)
+		}
 		m.release(it)
-	} else {
-		m.memory.Set(key, it, exp)
+		return nil
 	}
+
+	m.memory.Set(key, it, exp)
+	return nil
 }

--- a/middleware/session/data_msgp.go
+++ b/middleware/session/data_msgp.go
@@ -36,7 +36,7 @@ func (z *data) DecodeMsg(dc *msgp.Reader) (err error) {
 }
 
 // EncodeMsg implements msgp.Encodable
-func (z data) EncodeMsg(en *msgp.Writer) (err error) {
+func (z *data) EncodeMsg(en *msgp.Writer) (err error) {
 	// map header, size 0
 	_ = z
 	err = en.Append(0x80)
@@ -47,7 +47,7 @@ func (z data) EncodeMsg(en *msgp.Writer) (err error) {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z data) MarshalMsg(b []byte) (o []byte, err error) {
+func (z *data) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 0
 	_ = z
@@ -86,7 +86,7 @@ func (z *data) UnmarshalMsg(bts []byte) (o []byte, err error) {
 }
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z data) Msgsize() (s int) {
+func (z *data) Msgsize() (s int) {
 	s = 1
 	return
 }


### PR DESCRIPTION
## Summary
- ensure cached entries are released and heap accounting is updated when storage deletion succeeds on expiry
- roll back heap usage when cache write operations fail and add regression coverage for storage errors that previously left stale entries

## Testing
- make audit
- make generate
- make betteralign
- make modernize
- make format
- make test *(fails: Test_App_BodyLimit_Zero i/o timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4f44015c833393084e55b88f497b