### PR TITLE
Redact cache and limiter keys in diagnostics

### DIFF
--- a/middleware/idempotency/idempotency.go
+++ b/middleware/idempotency/idempotency.go
@@ -21,6 +21,8 @@ const (
 	localsKeyWasPutToCache
 )
 
+const redactedKey = "[redacted]"
+
 // IsFromCache reports whether the middleware served the response from the
 // cache for the current request.
 func IsFromCache(c fiber.Ctx) bool {
@@ -104,7 +106,7 @@ func New(config ...Config) fiber.Handler {
 		}
 		defer func() {
 			if err := cfg.Lock.Unlock(key); err != nil {
-				log.Errorf("[IDEMPOTENCY] failed to unlock key %q: %v", key, err)
+				log.Errorf("idempotency: failed to unlock key %s: %v", redactedKey, err)
 			}
 		}()
 


### PR DESCRIPTION
## Summary
- replace cache manager error messages to use a redacted key placeholder instead of raw values
- update limiter manager errors to use the shared redacted token when formatting
- log idempotency unlock failures with a redacted key placeholder while avoiding expensive per-request metadata

## Testing
- make audit
- make generate
- make betteralign
- make modernize
- make format
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d1352243808333b96bea2ecbe7003e