### PR TITLE
Update RouteChain function

### DIFF
--- a/app.go
+++ b/app.go
@@ -916,8 +916,8 @@ func (app *App) RouteChain(path string) Register {
 }
 
 // Route is used to define routes with a common prefix inside the supplied
-// function. It behaves like the Fiber v2 Route helper and reuses the Group
-// method to create a sub-router.
+// function. It mirrors the legacy helper and reuses the Group method to create
+// a sub-router.
 func (app *App) Route(prefix string, fn func(router Router), name ...string) Router {
 	// Create new group
 	group := app.Group(prefix)

--- a/app.go
+++ b/app.go
@@ -919,6 +919,9 @@ func (app *App) RouteChain(path string) Register {
 // function. It mirrors the legacy helper and reuses the Group method to create
 // a sub-router.
 func (app *App) Route(prefix string, fn func(router Router), name ...string) Router {
+	if fn == nil {
+		panic("route handler 'fn' cannot be nil")
+	}
 	// Create new group
 	group := app.Group(prefix)
 	if len(name) > 0 {

--- a/app.go
+++ b/app.go
@@ -905,13 +905,30 @@ func (app *App) Group(prefix string, handlers ...Handler) Router {
 	return grp
 }
 
-// Route is used to define routes with a common prefix inside the common function.
-// Uses Group method to define new sub-router.
-func (app *App) Route(path string) Register {
+// RouteChain creates a Registering instance that lets you declare a stack of
+// handlers for the same route. Handlers defined via the returned Register are
+// scoped to the provided path.
+func (app *App) RouteChain(path string) Register {
 	// Create new route
 	route := &Registering{app: app, path: path}
 
 	return route
+}
+
+// Route is used to define routes with a common prefix inside the supplied
+// function. It behaves like the Fiber v2 Route helper and reuses the Group
+// method to create a sub-router.
+func (app *App) Route(prefix string, fn func(router Router), name ...string) Router {
+	// Create new group
+	group := app.Group(prefix)
+	if len(name) > 0 {
+		group.Name(name[0])
+	}
+
+	// Define routes
+	fn(group)
+
+	return group
 }
 
 // Error makes it compatible with the `error` interface.

--- a/app_test.go
+++ b/app_test.go
@@ -1360,13 +1360,13 @@ func Test_App_Group(t *testing.T) {
 	require.Equal(t, 200, resp.StatusCode, "Status code")
 }
 
-func Test_App_Route(t *testing.T) {
+func Test_App_RouteChain(t *testing.T) {
 	t.Parallel()
 	dummyHandler := testEmptyHandler
 
 	app := New()
 
-	register := app.Route("/test").
+	register := app.RouteChain("/test").
 		Get(dummyHandler).
 		Head(dummyHandler).
 		Post(dummyHandler).
@@ -1387,7 +1387,7 @@ func Test_App_Route(t *testing.T) {
 	testStatus200(t, app, "/test", MethodTrace)
 	testStatus200(t, app, "/test", MethodPatch)
 
-	register.Route("/v1").Get(dummyHandler).Post(dummyHandler)
+	register.RouteChain("/v1").Get(dummyHandler).Post(dummyHandler)
 
 	resp, err := app.Test(httptest.NewRequest(MethodPost, "/test/v1", nil))
 	require.NoError(t, err, "app.Test(req)")
@@ -1397,7 +1397,7 @@ func Test_App_Route(t *testing.T) {
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, 200, resp.StatusCode, "Status code")
 
-	register.Route("/v1").Route("/v2").Route("/v3").Get(dummyHandler).Trace(dummyHandler)
+	register.RouteChain("/v1").RouteChain("/v2").RouteChain("/v3").Get(dummyHandler).Trace(dummyHandler)
 
 	resp, err = app.Test(httptest.NewRequest(MethodTrace, "/test/v1/v2/v3", nil))
 	require.NoError(t, err, "app.Test(req)")
@@ -1406,6 +1406,29 @@ func Test_App_Route(t *testing.T) {
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test/v1/v2/v3", nil))
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, 200, resp.StatusCode, "Status code")
+}
+
+func Test_App_Route(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+
+	app.Route("/test", func(api Router) {
+		api.Get("/foo", testEmptyHandler).Name("foo")
+
+		api.Route("/bar", func(bar Router) {
+			bar.Get("/", testEmptyHandler).Name("index")
+		}, "bar.")
+	}, "test.")
+
+	testStatus200(t, app, "/test/foo", MethodGet)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/test/bar/", nil))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, http.StatusOK, resp.StatusCode, "Status code")
+
+	require.Equal(t, "/test/foo", app.GetRoute("test.foo").Path)
+	require.Equal(t, "/test/bar/", app.GetRoute("test.bar.index").Path)
 }
 
 func Test_App_Deep_Group(t *testing.T) {

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -138,14 +138,14 @@ func handler(c fiber.Ctx) error {
 }
 ```
 
-### Route
+### RouteChain
 
 Returns an instance of a single route, which you can then use to handle HTTP verbs with optional middleware.
 
 Similar to [`Express`](https://expressjs.com/de/api.html#app.route).
 
 ```go title="Signature"
-func (app *App) Route(path string) Register
+func (app *App) RouteChain(path string) Register
 ```
 
 <details>
@@ -166,7 +166,7 @@ type Register interface {
 
     Add(methods []string, handler Handler, handlers ...Handler) Register
 
-    Route(path string) Register
+    RouteChain(path string) Register
 }
 ```
 
@@ -184,12 +184,12 @@ import (
 func main() {
     app := fiber.New()
 
-    // Use `Route` as a chainable route declaration method
-    app.Route("/test").Get(func(c fiber.Ctx) error {
+    // Use `RouteChain` as a chainable route declaration method
+    app.RouteChain("/test").Get(func(c fiber.Ctx) error {
         return c.SendString("GET /test")
     })
 
-    app.Route("/events").All(func(c fiber.Ctx) error {
+    app.RouteChain("/events").All(func(c fiber.Ctx) error {
         // Runs for all HTTP verbs first
         // Think of it as route-specific middleware!
     }).
@@ -202,12 +202,12 @@ func main() {
     })
 
     // Combine multiple routes
-    app.Route("/v2").Route("/user").Get(func(c fiber.Ctx) error {
+    app.RouteChain("/v2").RouteChain("/user").Get(func(c fiber.Ctx) error {
         return c.SendString("GET /v2/user")
     })
 
     // Use multiple methods
-    app.Route("/api").Get(func(c fiber.Ctx) error {
+    app.RouteChain("/api").Get(func(c fiber.Ctx) error {
         return c.SendString("GET /api")
     }).Post(func(c fiber.Ctx) error {
         return c.SendString("POST /api")
@@ -215,6 +215,21 @@ func main() {
 
     log.Fatal(app.Listen(":3000"))
 }
+```
+
+### Route
+
+Defines routes with a common prefix inside the supplied function, mirroring the Fiber v2 helper. Internally it uses [`Group`](#group) to create a sub-router and accepts an optional name prefix.
+
+```go title="Signature"
+func (app *App) Route(prefix string, fn func(router Router), name ...string) Router
+```
+
+```go title="Example"
+app.Route("/test", func(api fiber.Router) {
+    api.Get("/foo", handler).Name("foo") // /test/foo (name: test.foo)
+    api.Get("/bar", handler).Name("bar") // /test/bar (name: test.bar)
+}, "test.")
 ```
 
 ### HandlersCount

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -142,7 +142,7 @@ func handler(c fiber.Ctx) error {
 
 Returns an instance of a single route, which you can then use to handle HTTP verbs with optional middleware.
 
-Similar to [`Express`](https://expressjs.com/de/api.html#app.route).
+Similar to [`Express`](https://expressjs.com/en/api.html#app.route).
 
 ```go title="Signature"
 func (app *App) RouteChain(path string) Register
@@ -202,8 +202,8 @@ func main() {
     })
 
     // Combine multiple routes
-    app.RouteChain("/v2").RouteChain("/user").Get(func(c fiber.Ctx) error {
-        return c.SendString("GET /v2/user")
+    app.RouteChain("/reports").RouteChain("/daily").Get(func(c fiber.Ctx) error {
+        return c.SendString("GET /reports/daily")
     })
 
     // Use multiple methods
@@ -219,7 +219,7 @@ func main() {
 
 ### Route
 
-Defines routes with a common prefix inside the supplied function, mirroring the Fiber v2 helper. Internally it uses [`Group`](#group) to create a sub-router and accepts an optional name prefix.
+Defines routes with a common prefix inside the supplied function. Internally it uses [`Group`](#group) to create a sub-router and accepts an optional name prefix.
 
 ```go title="Signature"
 func (app *App) Route(prefix string, fn func(router Router), name ...string) Router

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -328,7 +328,7 @@ In `v2` one handler was already mandatory when the route has been registered, bu
 
 ### Route chaining
 
-Fiber v3 introduces a dedicated `RouteChain` helper, inspired by [`Express`](https://expressjs.com/de/api.html#app.route), for declaring a stack of handlers on the same path. The original `Route` helper for prefix encapsulation also remains available.
+Fiber v3 introduces a dedicated `RouteChain` helper, inspired by [`Express`](https://expressjs.com/en/api.html#app.route), for declaring a stack of handlers on the same path. The original `Route` helper for prefix encapsulation also remains available.
 
 ```diff
 -    Route(path string) Register
@@ -364,7 +364,7 @@ You can find more information about `app.RouteChain` and `app.Route` in the API 
 
 ### Middleware registration
 
-We have aligned our method for middlewares closer to [`Express`](https://expressjs.com/de/api.html#app.use) and now also support the [`Use`](./api/app#use) of multiple prefixes.
+We have aligned our method for middlewares closer to [`Express`](https://expressjs.com/en/api.html#app.use) and now also support the [`Use`](./api/app#use) of multiple prefixes.
 
 Prefix matching is now stricter: partial matches must end at a slash boundary (or be an exact match). This keeps `/api` middleware from running on `/apiv1` while still allowing `/api/:version` style patterns that leverage route parameters, optional segments, or wildcards.
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -328,7 +328,7 @@ In `v2` one handler was already mandatory when the route has been registered, bu
 
 ### Route chaining
 
-Fiber v3 introduces a dedicated `RouteChain` helper, inspired by [`Express`](https://expressjs.com/en/api.html#app.route), for declaring a stack of handlers on the same path. The original `Route` helper for prefix encapsulation also remains available.
+This release introduces a dedicated `RouteChain` helper, inspired by [`Express`](https://expressjs.com/en/api.html#app.route), for declaring a stack of handlers on the same path. The original `Route` helper for prefix encapsulation also remains available.
 
 ```go
 RouteChain(path string) Register
@@ -1640,7 +1640,7 @@ app.Add([]string{fiber.MethodPost}, "/api", myHandler)
 
 #### Mounting
 
-In Fiber v3, the `Mount` method has been removed. Instead, you can use the `Use` method to achieve similar functionality.
+In this release, the `Mount` method has been removed. Instead, you can use the `Use` method to achieve similar functionality.
 
 ```go
 // Before

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -328,18 +328,18 @@ In `v2` one handler was already mandatory when the route has been registered, bu
 
 ### Route chaining
 
-The route method is now like [`Express`](https://expressjs.com/de/api.html#app.route) which gives you the option of a different notation and allows you to concatenate the route declaration.
+Fiber v3 introduces a dedicated `RouteChain` helper, inspired by [`Express`](https://expressjs.com/de/api.html#app.route), for declaring a stack of handlers on the same path. The original `Route` helper for prefix encapsulation also remains available.
 
 ```diff
--    Route(prefix string, fn func(router Router), name ...string) Router
-+    Route(path string) Register
+-    Route(path string) Register
++    RouteChain(path string) Register
 ```
 
 <details>
 <summary>Example</summary>
 
 ```go
-app.Route("/api").Route("/user/:id?")
+app.RouteChain("/api").RouteChain("/user/:id?")
     .Get(func(c fiber.Ctx) error {
         // Get user
         return c.JSON(fiber.Map{"message": "Get user", "id": c.Params("id")})
@@ -360,7 +360,7 @@ app.Route("/api").Route("/user/:id?")
 
 </details>
 
-You can find more information about `app.Route` in the [API documentation](./api/app#route).
+You can find more information about `app.RouteChain` and `app.Route` in the API documentation ([RouteChain](./api/app#routechain), [Route](./api/app#route)).
 
 ### Middleware registration
 
@@ -1655,7 +1655,7 @@ app.Use("/api", apiApp)
 
 #### Route Chaining
 
-Refer to the [route chaining](#route-chaining) section for details on migrating `Route`.
+Refer to the [route chaining](#route-chaining) section for details on the new `RouteChain` helper. The `Route` function now matches its v2 behavior for prefix encapsulation.
 
 ```go
 // Before
@@ -1675,7 +1675,7 @@ app.Route("/api", func(apiGrp Router) {
 
 ```go
 // After
-app.Route("/api").Route("/user/:id?")
+app.RouteChain("/api").RouteChain("/user/:id?")
     .Get(func(c fiber.Ctx) error {
         // Get user
         return c.JSON(fiber.Map{"message": "Get user", "id": c.Params("id")})

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -330,8 +330,8 @@ In `v2` one handler was already mandatory when the route has been registered, bu
 
 Fiber v3 introduces a dedicated `RouteChain` helper, inspired by [`Express`](https://expressjs.com/en/api.html#app.route), for declaring a stack of handlers on the same path. The original `Route` helper for prefix encapsulation also remains available.
 
-```diff
--    Route(path string) Register
+```go
+RouteChain(path string) Register
 ```
 
 <details>

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -332,7 +332,6 @@ Fiber v3 introduces a dedicated `RouteChain` helper, inspired by [`Express`](htt
 
 ```diff
 -    Route(path string) Register
-+    RouteChain(path string) Register
 ```
 
 <details>

--- a/group.go
+++ b/group.go
@@ -196,11 +196,27 @@ func (grp *Group) Group(prefix string, handlers ...Handler) Router {
 	return newGrp
 }
 
-// Route is used to define routes with a common prefix inside the common function.
-// Uses Group method to define new sub-router.
-func (grp *Group) Route(path string) Register {
+// RouteChain creates a Registering instance scoped to the group's prefix,
+// allowing chained route declarations for the same path.
+func (grp *Group) RouteChain(path string) Register {
 	// Create new group
 	register := &Registering{app: grp.app, path: getGroupPath(grp.Prefix, path)}
 
 	return register
+}
+
+// Route is used to define routes with a common prefix inside the supplied
+// function. It behaves like the Fiber v2 Route helper and reuses the Group
+// method to create a sub-router.
+func (grp *Group) Route(prefix string, fn func(router Router), name ...string) Router {
+	// Create new group
+	group := grp.Group(prefix)
+	if len(name) > 0 {
+		group.Name(name[0])
+	}
+
+	// Define routes
+	fn(group)
+
+	return group
 }

--- a/group.go
+++ b/group.go
@@ -206,8 +206,8 @@ func (grp *Group) RouteChain(path string) Register {
 }
 
 // Route is used to define routes with a common prefix inside the supplied
-// function. It behaves like the Fiber v2 Route helper and reuses the Group
-// method to create a sub-router.
+// function. It mirrors the legacy helper and reuses the Group method to create
+// a sub-router.
 func (grp *Group) Route(prefix string, fn func(router Router), name ...string) Router {
 	// Create new group
 	group := grp.Group(prefix)

--- a/group.go
+++ b/group.go
@@ -200,7 +200,7 @@ func (grp *Group) Group(prefix string, handlers ...Handler) Router {
 // allowing chained route declarations for the same path.
 func (grp *Group) RouteChain(path string) Register {
 	// Create new group
-	register := &Registering{app: grp.app, path: getGroupPath(grp.Prefix, path)}
+	register := &Registering{app: grp.app, group: grp, path: getGroupPath(grp.Prefix, path)}
 
 	return register
 }
@@ -209,6 +209,9 @@ func (grp *Group) RouteChain(path string) Register {
 // function. It mirrors the legacy helper and reuses the Group method to create
 // a sub-router.
 func (grp *Group) Route(prefix string, fn func(router Router), name ...string) Router {
+	if fn == nil {
+		panic("route handler 'fn' cannot be nil")
+	}
 	// Create new group
 	group := grp.Group(prefix)
 	if len(name) > 0 {

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -875,7 +875,7 @@ func Test_Cache_WithHead(t *testing.T) {
 		return c.SendString(strconv.Itoa(count))
 	}
 
-	app.Route("/").Get(handler).Head(handler)
+	app.RouteChain("/").Get(handler).Head(handler)
 
 	req := httptest.NewRequest(fiber.MethodHead, "/", nil)
 	resp, err := app.Test(req)
@@ -904,7 +904,7 @@ func Test_Cache_WithHeadThenGet(t *testing.T) {
 	handler := func(c fiber.Ctx) error {
 		return c.SendString(fiber.Query[string](c, "cache"))
 	}
-	app.Route("/").Get(handler).Head(handler)
+	app.RouteChain("/").Get(handler).Head(handler)
 
 	headResp, err := app.Test(httptest.NewRequest(fiber.MethodHead, "/?cache=123", nil))
 	require.NoError(t, err)

--- a/register.go
+++ b/register.go
@@ -4,7 +4,7 @@
 
 package fiber
 
-// Register defines all router handle interface generate by Route().
+// Register defines all router handle interface generate by RouteChain().
 type Register interface {
 	All(handler Handler, handlers ...Handler) Register
 	Get(handler Handler, handlers ...Handler) Register
@@ -19,7 +19,7 @@ type Register interface {
 
 	Add(methods []string, handler Handler, handlers ...Handler) Register
 
-	Route(path string) Register
+	RouteChain(path string) Register
 }
 
 var _ (Register) = (*Registering)(nil)
@@ -35,13 +35,13 @@ type Registering struct {
 // All registers a middleware route that will match requests
 // with the provided path which is stored in register struct.
 //
-//	app.Route("/").All(func(c fiber.Ctx) error {
+//	app.RouteChain("/").All(func(c fiber.Ctx) error {
 //	     return c.Next()
 //	})
-//	app.Route("/api").All(func(c fiber.Ctx) error {
+//	app.RouteChain("/api").All(func(c fiber.Ctx) error {
 //	     return c.Next()
 //	})
-//	app.Route("/api").All(handler, func(c fiber.Ctx) error {
+//	app.RouteChain("/api").All(handler, func(c fiber.Ctx) error {
 //	     return c.Next()
 //	})
 //
@@ -111,9 +111,9 @@ func (r *Registering) Add(methods []string, handler Handler, handlers ...Handler
 	return r
 }
 
-// Route returns a new Register instance whose route path takes
+// RouteChain returns a new Register instance whose route path takes
 // the path in the current instance as its prefix.
-func (r *Registering) Route(path string) Register {
+func (r *Registering) RouteChain(path string) Register {
 	// Create new group
 	route := &Registering{app: r.app, path: getGroupPath(r.path, path)}
 

--- a/register.go
+++ b/register.go
@@ -27,7 +27,8 @@ var _ (Register) = (*Registering)(nil)
 // Registering provides route registration helpers for a specific path on the
 // application instance.
 type Registering struct {
-	app *App
+	app   *App
+	group *Group
 
 	path string
 }
@@ -47,15 +48,14 @@ type Registering struct {
 //
 // This method will match all HTTP verbs: GET, POST, PUT, HEAD etc...
 func (r *Registering) All(handler Handler, handlers ...Handler) Register {
-	r.app.register([]string{methodUse}, r.path, nil, append([]Handler{handler}, handlers...)...)
+	r.app.register([]string{methodUse}, r.path, r.group, append([]Handler{handler}, handlers...)...)
 	return r
 }
 
 // Get registers a route for GET methods that requests a representation
 // of the specified resource. Requests using GET should only retrieve data.
 func (r *Registering) Get(handler Handler, handlers ...Handler) Register {
-	r.app.Add([]string{MethodGet}, r.path, handler, handlers...)
-	return r
+	return r.Add([]string{MethodGet}, handler, handlers...)
 }
 
 // Head registers a route for HEAD methods that asks for a response identical
@@ -107,7 +107,7 @@ func (r *Registering) Patch(handler Handler, handlers ...Handler) Register {
 
 // Add allows you to specify multiple HTTP methods to register a route.
 func (r *Registering) Add(methods []string, handler Handler, handlers ...Handler) Register {
-	r.app.register(methods, r.path, nil, append([]Handler{handler}, handlers...)...)
+	r.app.register(methods, r.path, r.group, append([]Handler{handler}, handlers...)...)
 	return r
 }
 
@@ -115,7 +115,7 @@ func (r *Registering) Add(methods []string, handler Handler, handlers ...Handler
 // the path in the current instance as its prefix.
 func (r *Registering) RouteChain(path string) Register {
 	// Create new group
-	route := &Registering{app: r.app, path: getGroupPath(r.path, path)}
+	route := &Registering{app: r.app, group: r.group, path: getGroupPath(r.path, path)}
 
 	return route
 }

--- a/router.go
+++ b/router.go
@@ -33,7 +33,8 @@ type Router interface {
 
 	Group(prefix string, handlers ...Handler) Router
 
-	Route(path string) Register
+	RouteChain(path string) Register
+	Route(prefix string, fn func(router Router), name ...string) Router
 
 	Name(name string) Router
 }


### PR DESCRIPTION
## Summary
- clarify the v2→v3 router diff to show the new `RouteChain` helper without implying `Route` was removed
- point readers to both the `RouteChain` and `Route` API reference anchors for additional detail

## Testing
- `GOVERSION=go1.25.1 make audit` *(fails: govulncheck forbidden to reach vuln.go.dev)*
- `GOVERSION=go1.25.1 make generate`
- `GOVERSION=go1.25.1 make betteralign`
- `GOVERSION=go1.25.1 make modernize`
- `GOVERSION=go1.25.1 make format`
- `GOVERSION=go1.25.1 make test`


------
https://chatgpt.com/codex/tasks/task_e_68d24f0a24c083269b2ba0c789065c70