### PR TITLE
test: cover adapter conversions and document net/http support

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -1,0 +1,61 @@
+package fiber
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/valyala/fasthttp/fasthttpadaptor"
+)
+
+// toFiberHandler converts supported handler types to a Fiber handler.
+// It returns the converted handler and a boolean indicating whether the
+// conversion succeeded.
+func toFiberHandler(handler any) (Handler, bool) {
+	if handler == nil {
+		return nil, true
+	}
+
+	switch h := handler.(type) {
+	case Handler:
+		return h, true
+	case http.HandlerFunc:
+		return wrapHTTPHandler(h), true
+	case http.Handler:
+		return wrapHTTPHandler(h), true
+	case func(http.ResponseWriter, *http.Request):
+		return wrapHTTPHandler(http.HandlerFunc(h)), true
+	default:
+		return nil, false
+	}
+}
+
+// wrapHTTPHandler adapts a net/http handler to a Fiber handler.
+func wrapHTTPHandler(handler http.Handler) Handler {
+	if handler == nil {
+		return nil
+	}
+
+	adapted := fasthttpadaptor.NewFastHTTPHandler(handler)
+
+	return func(c Ctx) error {
+		adapted(c.RequestCtx())
+		return nil
+	}
+}
+
+// collectHandlers converts a slice of handler arguments to Fiber handlers.
+// The context string is used to provide informative panic messages when an
+// unsupported handler type is encountered.
+func collectHandlers(context string, args ...any) []Handler {
+	handlers := make([]Handler, 0, len(args))
+
+	for _, arg := range args {
+		handler, ok := toFiberHandler(arg)
+		if !ok {
+			panic(fmt.Sprintf("%s: invalid handler %T\n", context, arg))
+		}
+		handlers = append(handlers, handler)
+	}
+
+	return handlers
+}

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -1,0 +1,123 @@
+package fiber
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+func TestToFiberHandler_Nil(t *testing.T) {
+	t.Parallel()
+
+	handler, ok := toFiberHandler(nil)
+	require.True(t, ok)
+	require.Nil(t, handler)
+}
+
+func TestToFiberHandler_FiberHandler(t *testing.T) {
+	t.Parallel()
+
+	fiberHandler := func(c Ctx) error { return c.SendStatus(http.StatusAccepted) }
+
+	converted, ok := toFiberHandler(fiberHandler)
+	require.True(t, ok)
+	require.NotNil(t, converted)
+	require.Equal(t, reflect.ValueOf(fiberHandler).Pointer(), reflect.ValueOf(converted).Pointer())
+}
+
+func TestToFiberHandler_HTTPHandler(t *testing.T) {
+	t.Parallel()
+
+	httpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-HTTP", "ok")
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("http"))
+	})
+
+	converted, ok := toFiberHandler(httpHandler)
+	require.True(t, ok)
+	require.NotNil(t, converted)
+
+	app := New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() {
+		app.ReleaseCtx(ctx)
+	})
+
+	err := converted(ctx)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusTeapot, ctx.Response().StatusCode())
+	require.Equal(t, "ok", string(ctx.Response().Header.Peek("X-HTTP")))
+	require.Equal(t, "http", string(ctx.Response().Body()))
+}
+
+func TestToFiberHandler_HTTPHandlerFunc(t *testing.T) {
+	t.Parallel()
+
+	httpFunc := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}
+
+	converted, ok := toFiberHandler(httpFunc)
+	require.True(t, ok)
+	require.NotNil(t, converted)
+
+	app := New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() {
+		app.ReleaseCtx(ctx)
+	})
+
+	err := converted(ctx)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, ctx.Response().StatusCode())
+}
+
+func TestWrapHTTPHandler_Nil(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, wrapHTTPHandler(nil))
+}
+
+func TestCollectHandlers_InvalidType(t *testing.T) {
+	t.Parallel()
+
+	require.PanicsWithValue(t, "context: invalid handler int\n", func() {
+		collectHandlers("context", 42)
+	})
+}
+
+func TestCollectHandlers_MixedHandlers(t *testing.T) {
+	t.Parallel()
+
+	before := func(c Ctx) error {
+		c.Set("X-Before", "fiber")
+		return nil
+	}
+	httpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("done"))
+	})
+
+	handlers := collectHandlers("test", before, httpHandler, nil)
+	require.Len(t, handlers, 3)
+	require.Equal(t, reflect.ValueOf(before).Pointer(), reflect.ValueOf(handlers[0]).Pointer())
+	require.NotNil(t, handlers[1])
+	require.Nil(t, handlers[2])
+
+	app := New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() {
+		app.ReleaseCtx(ctx)
+	})
+
+	err := handlers[0](ctx)
+	require.NoError(t, err)
+
+	err = handlers[1](ctx)
+	require.NoError(t, err)
+	require.Equal(t, "done", string(ctx.Response().Body()))
+	require.Equal(t, "fiber", string(ctx.Response().Header.Peek("X-Before")))
+}

--- a/app.go
+++ b/app.go
@@ -804,7 +804,11 @@ func (app *App) Use(args ...any) Router {
 		case Handler:
 			handlers = append(handlers, arg)
 		default:
-			panic(fmt.Sprintf("use: invalid handler %v\n", reflect.TypeOf(arg)))
+			handler, ok := toFiberHandler(arg)
+			if !ok {
+				panic(fmt.Sprintf("use: invalid handler %v\n", reflect.TypeOf(arg)))
+			}
+			handlers = append(handlers, handler)
 		}
 	}
 
@@ -826,66 +830,67 @@ func (app *App) Use(args ...any) Router {
 
 // Get registers a route for GET methods that requests a representation
 // of the specified resource. Requests using GET should only retrieve data.
-func (app *App) Get(path string, handler Handler, handlers ...Handler) Router {
+func (app *App) Get(path string, handler any, handlers ...any) Router {
 	return app.Add([]string{MethodGet}, path, handler, handlers...)
 }
 
 // Head registers a route for HEAD methods that asks for a response identical
 // to that of a GET request, but without the response body.
-func (app *App) Head(path string, handler Handler, handlers ...Handler) Router {
+func (app *App) Head(path string, handler any, handlers ...any) Router {
 	return app.Add([]string{MethodHead}, path, handler, handlers...)
 }
 
 // Post registers a route for POST methods that is used to submit an entity to the
 // specified resource, often causing a change in state or side effects on the server.
-func (app *App) Post(path string, handler Handler, handlers ...Handler) Router {
+func (app *App) Post(path string, handler any, handlers ...any) Router {
 	return app.Add([]string{MethodPost}, path, handler, handlers...)
 }
 
 // Put registers a route for PUT methods that replaces all current representations
 // of the target resource with the request payload.
-func (app *App) Put(path string, handler Handler, handlers ...Handler) Router {
+func (app *App) Put(path string, handler any, handlers ...any) Router {
 	return app.Add([]string{MethodPut}, path, handler, handlers...)
 }
 
 // Delete registers a route for DELETE methods that deletes the specified resource.
-func (app *App) Delete(path string, handler Handler, handlers ...Handler) Router {
+func (app *App) Delete(path string, handler any, handlers ...any) Router {
 	return app.Add([]string{MethodDelete}, path, handler, handlers...)
 }
 
 // Connect registers a route for CONNECT methods that establishes a tunnel to the
 // server identified by the target resource.
-func (app *App) Connect(path string, handler Handler, handlers ...Handler) Router {
+func (app *App) Connect(path string, handler any, handlers ...any) Router {
 	return app.Add([]string{MethodConnect}, path, handler, handlers...)
 }
 
 // Options registers a route for OPTIONS methods that is used to describe the
 // communication options for the target resource.
-func (app *App) Options(path string, handler Handler, handlers ...Handler) Router {
+func (app *App) Options(path string, handler any, handlers ...any) Router {
 	return app.Add([]string{MethodOptions}, path, handler, handlers...)
 }
 
 // Trace registers a route for TRACE methods that performs a message loop-back
 // test along the path to the target resource.
-func (app *App) Trace(path string, handler Handler, handlers ...Handler) Router {
+func (app *App) Trace(path string, handler any, handlers ...any) Router {
 	return app.Add([]string{MethodTrace}, path, handler, handlers...)
 }
 
 // Patch registers a route for PATCH methods that is used to apply partial
 // modifications to a resource.
-func (app *App) Patch(path string, handler Handler, handlers ...Handler) Router {
+func (app *App) Patch(path string, handler any, handlers ...any) Router {
 	return app.Add([]string{MethodPatch}, path, handler, handlers...)
 }
 
 // Add allows you to specify multiple HTTP methods to register a route.
-func (app *App) Add(methods []string, path string, handler Handler, handlers ...Handler) Router {
-	app.register(methods, path, nil, append([]Handler{handler}, handlers...)...)
+func (app *App) Add(methods []string, path string, handler any, handlers ...any) Router {
+	converted := collectHandlers("add", append([]any{handler}, handlers...)...)
+	app.register(methods, path, nil, converted...)
 
 	return app
 }
 
 // All will register the handler on all HTTP methods
-func (app *App) All(path string, handler Handler, handlers ...Handler) Router {
+func (app *App) All(path string, handler any, handlers ...any) Router {
 	return app.Add(app.config.RequestMethods, path, handler, handlers...)
 }
 
@@ -893,10 +898,11 @@ func (app *App) All(path string, handler Handler, handlers ...Handler) Router {
 //
 //	api := app.Group("/api")
 //	api.Get("/users", handler)
-func (app *App) Group(prefix string, handlers ...Handler) Router {
+func (app *App) Group(prefix string, handlers ...any) Router {
 	grp := &Group{Prefix: prefix, app: app}
 	if len(handlers) > 0 {
-		app.register([]string{methodUse}, prefix, grp, handlers...)
+		converted := collectHandlers("group", handlers...)
+		app.register([]string{methodUse}, prefix, grp, converted...)
 	}
 	if err := app.hooks.executeOnGroupHooks(*grp); err != nil {
 		panic(err)

--- a/app_test.go
+++ b/app_test.go
@@ -198,6 +198,26 @@ func Test_App_MethodNotAllowed(t *testing.T) {
 	require.Equal(t, "GET, HEAD, POST, OPTIONS", resp.Header.Get(HeaderAllow))
 }
 
+func Test_App_RegisterNetHTTPHandler(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+
+	app.Get("/foo", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Test", "ok")
+		_, _ = w.Write([]byte("hello from net/http"))
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/foo", nil))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "hello from net/http", string(body))
+	require.Equal(t, "ok", resp.Header.Get("X-Test"))
+}
+
 func Test_App_Custom_Middleware_404_Should_Not_SetMethodNotAllowed(t *testing.T) {
 	t.Parallel()
 	app := New()

--- a/docs/extra/faq.md
+++ b/docs/extra/faq.md
@@ -177,7 +177,12 @@ For more information, see issue [#750](https://github.com/gofiber/fiber/issues/7
 
 ## How can I handle conversions between Fiber and net/http?
 
-The `adaptor` middleware provides utilities for converting between Fiber and `net/http`. It allows seamless integration of `net/http` handlers, middleware, and requests into Fiber applications, and vice versa.
+Fiber can register common `net/http` handlers directly—just pass an
+`http.Handler`, `http.HandlerFunc`, or compatible function to your routing
+method. For other interoperability scenarios, the `adaptor` middleware provides
+utilities for converting between Fiber and `net/http`. It allows seamless
+integration of `net/http` handlers, middleware, and requests into Fiber
+applications, and vice versa.
 
 For details on how to:
 

--- a/docs/middleware/adaptor.md
+++ b/docs/middleware/adaptor.md
@@ -6,6 +6,14 @@ id: adaptor
 
 The `adaptor` package converts between Fiber and `net/http`, letting you reuse handlers, middleware, and requests across both frameworks.
 
+:::tip
+Fiber can register plain `net/http` handlers directly—just pass an `http.Handler`,
+`http.HandlerFunc`, or `func(http.ResponseWriter, *http.Request)` to any router
+method and it will be adapted automatically. The adaptor helpers remain valuable
+when you need to convert middleware, swap handler directions, or transform
+requests explicitly.
+:::
+
 ## Features
 
 - Convert `net/http` handlers and middleware to Fiber handlers
@@ -31,7 +39,8 @@ The `adaptor` package converts between Fiber and `net/http`, letting you reuse h
 
 ### 1. Using `net/http` handlers in Fiber
 
-This example shows how to run a standard `net/http` handler within a Fiber app:
+This example shows how to run a standard `net/http` handler within a Fiber app
+without calling the adaptor explicitly:
 
 ```go
 package main
@@ -40,14 +49,13 @@ import (
     "fmt"
     "net/http"
     "github.com/gofiber/fiber/v3"
-    "github.com/gofiber/fiber/v3/middleware/adaptor"
 )
 
 func main() {
     app := fiber.New()
 
-    // Convert an http.Handler to a Fiber handler
-    app.Get("/", adaptor.HTTPHandler(http.HandlerFunc(helloHandler)))
+    // Fiber adapts net/http handlers for you during registration
+    app.Get("/", http.HandlerFunc(helloHandler))
 
     app.Listen(":3000")
 }
@@ -55,6 +63,14 @@ func main() {
 func helloHandler(w http.ResponseWriter, r *http.Request) {
     fmt.Fprint(w, "Hello from net/http!")
 }
+```
+
+If you prefer to reuse the converted handler in multiple places, you can still
+obtain it manually via `github.com/gofiber/fiber/v3/middleware/adaptor`:
+
+```go
+converted := adaptor.HTTPHandler(http.HandlerFunc(helloHandler))
+app.Get("/cached", converted)
 ```
 
 ### 2. Using `net/http` middleware with Fiber

--- a/docs/partials/routing/handler.md
+++ b/docs/partials/routing/handler.md
@@ -9,29 +9,41 @@ Registers a route bound to a specific [HTTP method](https://developer.mozilla.or
 
 ```go title="Signatures"
 // HTTP methods
-func (app *App) Get(path string, handler Handler, handlers ...Handler) Router
-func (app *App) Head(path string, handler Handler, handlers ...Handler) Router
-func (app *App) Post(path string, handler Handler, handlers ...Handler) Router
-func (app *App) Put(path string, handler Handler, handlers ...Handler) Router
-func (app *App) Delete(path string, handler Handler, handlers ...Handler) Router
-func (app *App) Connect(path string, handler Handler, handlers ...Handler) Router
-func (app *App) Options(path string, handler Handler, handlers ...Handler) Router
-func (app *App) Trace(path string, handler Handler, handlers ...Handler) Router
-func (app *App) Patch(path string, handler Handler, handlers ...Handler) Router
+func (app *App) Get(path string, handler any, handlers ...any) Router
+func (app *App) Head(path string, handler any, handlers ...any) Router
+func (app *App) Post(path string, handler any, handlers ...any) Router
+func (app *App) Put(path string, handler any, handlers ...any) Router
+func (app *App) Delete(path string, handler any, handlers ...any) Router
+func (app *App) Connect(path string, handler any, handlers ...any) Router
+func (app *App) Options(path string, handler any, handlers ...any) Router
+func (app *App) Trace(path string, handler any, handlers ...any) Router
+func (app *App) Patch(path string, handler any, handlers ...any) Router
 
-// Add allows you to specify a method as value
-func (app *App) Add(method, path string, handler Handler, handlers ...Handler) Router
+// Add allows you to specify multiple methods at once
+func (app *App) Add(methods []string, path string, handler any, handlers ...any) Router
 
 // All will register the route on all HTTP methods
 // Almost the same as app.Use but not bound to prefixes
-func (app *App) All(path string, handler Handler, handlers ...Handler) Router
+func (app *App) All(path string, handler any, handlers ...any) Router
 ```
+
+Handlers can be native Fiber handlers (`func(fiber.Ctx) error`) or familiar `net/http`
+shapes such as `http.Handler`, `http.HandlerFunc`, or
+`func(http.ResponseWriter, *http.Request)`. Fiber automatically adapts supported
+`net/http` values for you during registration.
 
 ```go title="Examples"
 // Simple GET handler
 app.Get("/api/list", func(c fiber.Ctx) error {
     return c.SendString("I'm a GET request!")
 })
+
+// Reuse an existing net/http handler without manual adaptation
+httpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    w.WriteHeader(http.StatusNoContent)
+})
+
+app.Get("/legacy", httpHandler)
 
 // Simple POST handler
 app.Post("/api/register", func(c fiber.Ctx) error {

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1634,6 +1634,14 @@ app.Listen(":3000", fiber.ListenConfig{
 
 ### 🗺 Router
 
+#### Direct `net/http` handlers
+
+Route registration helpers now accept native `net/http` handlers. Pass an
+`http.Handler`, `http.HandlerFunc`, or compatible function directly to methods
+such as `app.Get`, `Group`, or `RouteChain` and Fiber will adapt it at
+registration time. Manual wrapping through the adaptor middleware is no longer
+required for these common cases.
+
 #### Middleware Registration
 
 The signatures for [`Add`](#middleware-registration) and [`Route`](#route-chaining) have been changed.

--- a/group.go
+++ b/group.go
@@ -81,10 +81,12 @@ func (grp *Group) Use(args ...any) Router {
 			subApp = arg
 		case []string:
 			prefixes = arg
-		case Handler:
-			handlers = append(handlers, arg)
 		default:
-			panic(fmt.Sprintf("use: invalid handler %v\n", reflect.TypeOf(arg)))
+			handler, ok := toFiberHandler(arg)
+			if !ok {
+				panic(fmt.Sprintf("use: invalid handler %v\n", reflect.TypeOf(arg)))
+			}
+			handlers = append(handlers, handler)
 		}
 	}
 
@@ -110,60 +112,61 @@ func (grp *Group) Use(args ...any) Router {
 
 // Get registers a route for GET methods that requests a representation
 // of the specified resource. Requests using GET should only retrieve data.
-func (grp *Group) Get(path string, handler Handler, handlers ...Handler) Router {
+func (grp *Group) Get(path string, handler any, handlers ...any) Router {
 	return grp.Add([]string{MethodGet}, path, handler, handlers...)
 }
 
 // Head registers a route for HEAD methods that asks for a response identical
 // to that of a GET request, but without the response body.
-func (grp *Group) Head(path string, handler Handler, handlers ...Handler) Router {
+func (grp *Group) Head(path string, handler any, handlers ...any) Router {
 	return grp.Add([]string{MethodHead}, path, handler, handlers...)
 }
 
 // Post registers a route for POST methods that is used to submit an entity to the
 // specified resource, often causing a change in state or side effects on the server.
-func (grp *Group) Post(path string, handler Handler, handlers ...Handler) Router {
+func (grp *Group) Post(path string, handler any, handlers ...any) Router {
 	return grp.Add([]string{MethodPost}, path, handler, handlers...)
 }
 
 // Put registers a route for PUT methods that replaces all current representations
 // of the target resource with the request payload.
-func (grp *Group) Put(path string, handler Handler, handlers ...Handler) Router {
+func (grp *Group) Put(path string, handler any, handlers ...any) Router {
 	return grp.Add([]string{MethodPut}, path, handler, handlers...)
 }
 
 // Delete registers a route for DELETE methods that deletes the specified resource.
-func (grp *Group) Delete(path string, handler Handler, handlers ...Handler) Router {
+func (grp *Group) Delete(path string, handler any, handlers ...any) Router {
 	return grp.Add([]string{MethodDelete}, path, handler, handlers...)
 }
 
 // Connect registers a route for CONNECT methods that establishes a tunnel to the
 // server identified by the target resource.
-func (grp *Group) Connect(path string, handler Handler, handlers ...Handler) Router {
+func (grp *Group) Connect(path string, handler any, handlers ...any) Router {
 	return grp.Add([]string{MethodConnect}, path, handler, handlers...)
 }
 
 // Options registers a route for OPTIONS methods that is used to describe the
 // communication options for the target resource.
-func (grp *Group) Options(path string, handler Handler, handlers ...Handler) Router {
+func (grp *Group) Options(path string, handler any, handlers ...any) Router {
 	return grp.Add([]string{MethodOptions}, path, handler, handlers...)
 }
 
 // Trace registers a route for TRACE methods that performs a message loop-back
 // test along the path to the target resource.
-func (grp *Group) Trace(path string, handler Handler, handlers ...Handler) Router {
+func (grp *Group) Trace(path string, handler any, handlers ...any) Router {
 	return grp.Add([]string{MethodTrace}, path, handler, handlers...)
 }
 
 // Patch registers a route for PATCH methods that is used to apply partial
 // modifications to a resource.
-func (grp *Group) Patch(path string, handler Handler, handlers ...Handler) Router {
+func (grp *Group) Patch(path string, handler any, handlers ...any) Router {
 	return grp.Add([]string{MethodPatch}, path, handler, handlers...)
 }
 
 // Add allows you to specify multiple HTTP methods to register a route.
-func (grp *Group) Add(methods []string, path string, handler Handler, handlers ...Handler) Router {
-	grp.app.register(methods, getGroupPath(grp.Prefix, path), grp, append([]Handler{handler}, handlers...)...)
+func (grp *Group) Add(methods []string, path string, handler any, handlers ...any) Router {
+	converted := collectHandlers("group", append([]any{handler}, handlers...)...)
+	grp.app.register(methods, getGroupPath(grp.Prefix, path), grp, converted...)
 	if !grp.anyRouteDefined {
 		grp.anyRouteDefined = true
 	}
@@ -172,7 +175,7 @@ func (grp *Group) Add(methods []string, path string, handler Handler, handlers .
 }
 
 // All will register the handler on all HTTP methods
-func (grp *Group) All(path string, handler Handler, handlers ...Handler) Router {
+func (grp *Group) All(path string, handler any, handlers ...any) Router {
 	_ = grp.Add(grp.app.config.RequestMethods, path, handler, handlers...)
 	return grp
 }
@@ -181,10 +184,11 @@ func (grp *Group) All(path string, handler Handler, handlers ...Handler) Router 
 //
 //	api := app.Group("/api")
 //	api.Get("/users", handler)
-func (grp *Group) Group(prefix string, handlers ...Handler) Router {
+func (grp *Group) Group(prefix string, handlers ...any) Router {
 	prefix = getGroupPath(grp.Prefix, prefix)
 	if len(handlers) > 0 {
-		grp.app.register([]string{methodUse}, prefix, grp, handlers...)
+		converted := collectHandlers("group", handlers...)
+		grp.app.register([]string{methodUse}, prefix, grp, converted...)
 	}
 
 	// Create new group

--- a/register.go
+++ b/register.go
@@ -6,18 +6,18 @@ package fiber
 
 // Register defines all router handle interface generate by RouteChain().
 type Register interface {
-	All(handler Handler, handlers ...Handler) Register
-	Get(handler Handler, handlers ...Handler) Register
-	Head(handler Handler, handlers ...Handler) Register
-	Post(handler Handler, handlers ...Handler) Register
-	Put(handler Handler, handlers ...Handler) Register
-	Delete(handler Handler, handlers ...Handler) Register
-	Connect(handler Handler, handlers ...Handler) Register
-	Options(handler Handler, handlers ...Handler) Register
-	Trace(handler Handler, handlers ...Handler) Register
-	Patch(handler Handler, handlers ...Handler) Register
+	All(handler any, handlers ...any) Register
+	Get(handler any, handlers ...any) Register
+	Head(handler any, handlers ...any) Register
+	Post(handler any, handlers ...any) Register
+	Put(handler any, handlers ...any) Register
+	Delete(handler any, handlers ...any) Register
+	Connect(handler any, handlers ...any) Register
+	Options(handler any, handlers ...any) Register
+	Trace(handler any, handlers ...any) Register
+	Patch(handler any, handlers ...any) Register
 
-	Add(methods []string, handler Handler, handlers ...Handler) Register
+	Add(methods []string, handler any, handlers ...any) Register
 
 	RouteChain(path string) Register
 }
@@ -47,67 +47,69 @@ type Registering struct {
 //	})
 //
 // This method will match all HTTP verbs: GET, POST, PUT, HEAD etc...
-func (r *Registering) All(handler Handler, handlers ...Handler) Register {
-	r.app.register([]string{methodUse}, r.path, r.group, append([]Handler{handler}, handlers...)...)
+func (r *Registering) All(handler any, handlers ...any) Register {
+	converted := collectHandlers("register", append([]any{handler}, handlers...)...)
+	r.app.register([]string{methodUse}, r.path, r.group, converted...)
 	return r
 }
 
 // Get registers a route for GET methods that requests a representation
 // of the specified resource. Requests using GET should only retrieve data.
-func (r *Registering) Get(handler Handler, handlers ...Handler) Register {
+func (r *Registering) Get(handler any, handlers ...any) Register {
 	return r.Add([]string{MethodGet}, handler, handlers...)
 }
 
 // Head registers a route for HEAD methods that asks for a response identical
 // to that of a GET request, but without the response body.
-func (r *Registering) Head(handler Handler, handlers ...Handler) Register {
+func (r *Registering) Head(handler any, handlers ...any) Register {
 	return r.Add([]string{MethodHead}, handler, handlers...)
 }
 
 // Post registers a route for POST methods that is used to submit an entity to the
 // specified resource, often causing a change in state or side effects on the server.
-func (r *Registering) Post(handler Handler, handlers ...Handler) Register {
+func (r *Registering) Post(handler any, handlers ...any) Register {
 	return r.Add([]string{MethodPost}, handler, handlers...)
 }
 
 // Put registers a route for PUT methods that replaces all current representations
 // of the target resource with the request payload.
-func (r *Registering) Put(handler Handler, handlers ...Handler) Register {
+func (r *Registering) Put(handler any, handlers ...any) Register {
 	return r.Add([]string{MethodPut}, handler, handlers...)
 }
 
 // Delete registers a route for DELETE methods that deletes the specified resource.
-func (r *Registering) Delete(handler Handler, handlers ...Handler) Register {
+func (r *Registering) Delete(handler any, handlers ...any) Register {
 	return r.Add([]string{MethodDelete}, handler, handlers...)
 }
 
 // Connect registers a route for CONNECT methods that establishes a tunnel to the
 // server identified by the target resource.
-func (r *Registering) Connect(handler Handler, handlers ...Handler) Register {
+func (r *Registering) Connect(handler any, handlers ...any) Register {
 	return r.Add([]string{MethodConnect}, handler, handlers...)
 }
 
 // Options registers a route for OPTIONS methods that is used to describe the
 // communication options for the target resource.
-func (r *Registering) Options(handler Handler, handlers ...Handler) Register {
+func (r *Registering) Options(handler any, handlers ...any) Register {
 	return r.Add([]string{MethodOptions}, handler, handlers...)
 }
 
 // Trace registers a route for TRACE methods that performs a message loop-back
 // test along the r.Path to the target resource.
-func (r *Registering) Trace(handler Handler, handlers ...Handler) Register {
+func (r *Registering) Trace(handler any, handlers ...any) Register {
 	return r.Add([]string{MethodTrace}, handler, handlers...)
 }
 
 // Patch registers a route for PATCH methods that is used to apply partial
 // modifications to a resource.
-func (r *Registering) Patch(handler Handler, handlers ...Handler) Register {
+func (r *Registering) Patch(handler any, handlers ...any) Register {
 	return r.Add([]string{MethodPatch}, handler, handlers...)
 }
 
 // Add allows you to specify multiple HTTP methods to register a route.
-func (r *Registering) Add(methods []string, handler Handler, handlers ...Handler) Register {
-	r.app.register(methods, r.path, r.group, append([]Handler{handler}, handlers...)...)
+func (r *Registering) Add(methods []string, handler any, handlers ...any) Register {
+	converted := collectHandlers("register", append([]any{handler}, handlers...)...)
+	r.app.register(methods, r.path, r.group, converted...)
 	return r
 }
 

--- a/router.go
+++ b/router.go
@@ -18,20 +18,20 @@ import (
 type Router interface {
 	Use(args ...any) Router
 
-	Get(path string, handler Handler, handlers ...Handler) Router
-	Head(path string, handler Handler, handlers ...Handler) Router
-	Post(path string, handler Handler, handlers ...Handler) Router
-	Put(path string, handler Handler, handlers ...Handler) Router
-	Delete(path string, handler Handler, handlers ...Handler) Router
-	Connect(path string, handler Handler, handlers ...Handler) Router
-	Options(path string, handler Handler, handlers ...Handler) Router
-	Trace(path string, handler Handler, handlers ...Handler) Router
-	Patch(path string, handler Handler, handlers ...Handler) Router
+	Get(path string, handler any, handlers ...any) Router
+	Head(path string, handler any, handlers ...any) Router
+	Post(path string, handler any, handlers ...any) Router
+	Put(path string, handler any, handlers ...any) Router
+	Delete(path string, handler any, handlers ...any) Router
+	Connect(path string, handler any, handlers ...any) Router
+	Options(path string, handler any, handlers ...any) Router
+	Trace(path string, handler any, handlers ...any) Router
+	Patch(path string, handler any, handlers ...any) Router
 
-	Add(methods []string, path string, handler Handler, handlers ...Handler) Router
-	All(path string, handler Handler, handlers ...Handler) Router
+	Add(methods []string, path string, handler any, handlers ...any) Router
+	All(path string, handler any, handlers ...any) Router
 
-	Group(prefix string, handlers ...Handler) Router
+	Group(prefix string, handlers ...any) Router
 
 	RouteChain(path string) Register
 	Route(prefix string, fn func(router Router), name ...string) Router

--- a/router_test.go
+++ b/router_test.go
@@ -68,6 +68,127 @@ func Test_Route_Handler_Order(t *testing.T) {
 	require.Equal(t, expectedOrder, order, "Handler order")
 }
 
+func Test_Route_MixedFiberAndHTTPHandlers(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+
+	var order []string
+
+	fiberBefore := func(c Ctx) error {
+		order = append(order, "fiber-before")
+		c.Set("X-Fiber", "1")
+		return c.Next()
+	}
+
+	httpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		order = append(order, "http-final")
+		w.Header().Set("X-HTTP", "true")
+		_, _ = w.Write([]byte("http"))
+	})
+
+	fiberAfter := func(c Ctx) error {
+		order = append(order, "fiber-after")
+		return c.SendString("fiber")
+	}
+
+	app.Get("/mixed", fiberBefore, httpHandler, fiberAfter)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/mixed", nil))
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	t.Cleanup(func() {
+		require.NoError(t, resp.Body.Close())
+	})
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "http", string(body))
+	require.Equal(t, "true", resp.Header.Get("X-HTTP"))
+	require.Equal(t, "1", resp.Header.Get("X-Fiber"))
+
+	require.Equal(t, []string{"fiber-before", "http-final"}, order)
+}
+
+func Test_Route_Group_WithHTTPHandlers(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+
+	var order []string
+
+	app.Use("/api", func(c Ctx) error {
+		order = append(order, "app-use")
+		return c.Next()
+	})
+
+	grp := app.Group("/api", func(c Ctx) error {
+		order = append(order, "group-middleware")
+		return c.Next()
+	})
+
+	grp.Get("/users", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		order = append(order, "http-handler")
+		_, _ = w.Write([]byte("users"))
+	}))
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/api/users", nil))
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	t.Cleanup(func() {
+		require.NoError(t, resp.Body.Close())
+	})
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "users", string(body))
+
+	require.Equal(t, []string{"app-use", "group-middleware", "http-handler"}, order)
+}
+
+func Test_RouteChain_WithHTTPHandlers(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+
+	chain := app.RouteChain("/combo")
+	chain.Get(func(c Ctx) error {
+		c.Set("X-Chain", "fiber")
+		return c.Next()
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("combo"))
+	}))
+
+	chain.RouteChain("/nested").Get(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Nested", "true")
+		_, _ = w.Write([]byte("nested"))
+	}))
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/combo", nil))
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	require.Equal(t, "fiber", resp.Header.Get("X-Chain"))
+	t.Cleanup(func() {
+		require.NoError(t, resp.Body.Close())
+	})
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "combo", string(body))
+
+	nestedResp, err := app.Test(httptest.NewRequest(MethodGet, "/combo/nested", nil))
+	require.NoError(t, err)
+	require.Equal(t, 200, nestedResp.StatusCode)
+	require.Equal(t, "true", nestedResp.Header.Get("X-Nested"))
+	t.Cleanup(func() {
+		require.NoError(t, nestedResp.Body.Close())
+	})
+
+	nestedBody, err := io.ReadAll(nestedResp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "nested", string(nestedBody))
+}
+
 func Test_Route_Match_SameLength(t *testing.T) {
 	t.Parallel()
 
@@ -431,6 +552,11 @@ func Test_Router_NotFound_HTML_Inject(t *testing.T) {
 }
 
 func registerTreeManipulationRoutes(app *App, middleware ...func(Ctx) error) {
+	converted := make([]any, len(middleware))
+	for i, h := range middleware {
+		converted[i] = h
+	}
+
 	app.Get("/test", func(c Ctx) error {
 		app.Get("/dynamically-defined", func(c Ctx) error {
 			return c.SendStatus(StatusOK)
@@ -439,7 +565,7 @@ func registerTreeManipulationRoutes(app *App, middleware ...func(Ctx) error) {
 		app.RebuildTree()
 
 		return c.SendStatus(StatusOK)
-	}, middleware...)
+	}, converted...)
 }
 
 func verifyRequest(tb testing.TB, app *App, path string, expectedStatus int) *http.Response {


### PR DESCRIPTION
## Summary
- rename the internal adapter helpers to adapter.go and add targeted tests for their conversions
- exercise mixed Fiber and net/http handlers throughout the router, including groups and RouteChain
- document direct net/http handler registration across the routing guide, adaptor docs, and release notes

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d93a689e808333958822985d7e74f9