### PR TITLE
🐛 bug: Fix usage of runtime RO data for ppc64 and s390x platforms

### DIFF
--- a/readonly.go
+++ b/readonly.go
@@ -1,3 +1,5 @@
+//go:build !s390x && !ppc64 && !ppc64le
+
 package fiber
 
 import (

--- a/readonly_strict.go
+++ b/readonly_strict.go
@@ -1,0 +1,9 @@
+//go:build s390x || ppc64 || ppc64le
+
+package fiber
+
+import "unsafe"
+
+func isReadOnly(_ unsafe.Pointer) bool {
+	return false
+}


### PR DESCRIPTION
## Summary
- restrict the runtime rodata alignment helper to platforms other than s390x/ppc64/ppc64le
- provide a strict-alignment fallback that always treats pointers as writable on those platforms

Fixes #3771 