### PR TITLE
🐛 bug: Respect DisablePathNormalizing during client requests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -38,6 +38,8 @@ type Client struct {
 	cookies *Cookie
 	path    *PathParam
 
+	disablePathNormalizing bool
+
 	jsonMarshal   utils.JSONMarshal
 	jsonUnmarshal utils.JSONUnmarshal
 	xmlMarshal    utils.XMLMarshal
@@ -353,6 +355,17 @@ func (c *Client) SetReferer(r string) *Client {
 	return c
 }
 
+// DisablePathNormalizing reports whether path normalizing is disabled for the client.
+func (c *Client) DisablePathNormalizing() bool {
+	return c.disablePathNormalizing
+}
+
+// SetDisablePathNormalizing configures the client to disable or enable path normalizing.
+func (c *Client) SetDisablePathNormalizing(disable bool) *Client {
+	c.disablePathNormalizing = disable
+	return c
+}
+
 // PathParam returns the value of the specified path parameter. Returns an empty string if it does not exist.
 func (c *Client) PathParam(key string) string {
 	if val, ok := (*c.path)[key]; ok {
@@ -529,6 +542,7 @@ func (c *Client) Reset() {
 	c.referer = ""
 	c.retryConfig = nil
 	c.debug = false
+	c.disablePathNormalizing = false
 
 	if c.cookieJar != nil {
 		c.cookieJar.Release()
@@ -545,18 +559,19 @@ func (c *Client) Reset() {
 // JSON is used as the default serialization mechanism. The priority is:
 // Body > FormData > File.
 type Config struct {
-	Ctx          context.Context //nolint:containedctx // It's needed to be stored in the config.
-	Body         any
-	Header       map[string]string
-	Param        map[string]string
-	Cookie       map[string]string
-	PathParam    map[string]string
-	FormData     map[string]string
-	UserAgent    string
-	Referer      string
-	File         []*File
-	Timeout      time.Duration
-	MaxRedirects int
+	Ctx                    context.Context //nolint:containedctx // It's needed to be stored in the config.
+	Body                   any
+	Header                 map[string]string
+	Param                  map[string]string
+	Cookie                 map[string]string
+	PathParam              map[string]string
+	FormData               map[string]string
+	UserAgent              string
+	Referer                string
+	File                   []*File
+	Timeout                time.Duration
+	MaxRedirects           int
+	DisablePathNormalizing bool
 }
 
 // setConfigToRequest sets the parameters passed via Config to the Request.
@@ -600,6 +615,10 @@ func setConfigToRequest(req *Request, config ...Config) {
 
 	if cfg.MaxRedirects != 0 {
 		req.SetMaxRedirects(cfg.MaxRedirects)
+	}
+
+	if cfg.DisablePathNormalizing {
+		req.SetDisablePathNormalizing(true)
 	}
 
 	if cfg.Body != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -38,8 +38,6 @@ type Client struct {
 	cookies *Cookie
 	path    *PathParam
 
-	disablePathNormalizing bool
-
 	jsonMarshal   utils.JSONMarshal
 	jsonUnmarshal utils.JSONUnmarshal
 	xmlMarshal    utils.XMLMarshal
@@ -60,6 +58,7 @@ type Client struct {
 	timeout time.Duration
 	mu      sync.RWMutex
 	debug   bool
+	disablePathNormalizing bool
 }
 
 // R creates a new Request associated with the client.

--- a/client/client.go
+++ b/client/client.go
@@ -55,9 +55,9 @@ type Client struct {
 	userResponseHooks    []ResponseHook
 	builtinResponseHooks []ResponseHook
 
-	timeout time.Duration
-	mu      sync.RWMutex
-	debug   bool
+	timeout                time.Duration
+	mu                     sync.RWMutex
+	debug                  bool
 	disablePathNormalizing bool
 }
 

--- a/client/hooks.go
+++ b/client/hooks.go
@@ -93,7 +93,12 @@ func parserRequestURL(c *Client, req *Request) error {
 	}
 
 	// Set the URI in the raw request.
+	disablePathNormalizing := c.DisablePathNormalizing() || req.DisablePathNormalizing()
 	req.RawRequest.SetRequestURI(uri)
+	req.RawRequest.URI().DisablePathNormalizing = disablePathNormalizing
+	if disablePathNormalizing {
+		req.RawRequest.URI().SetPathBytes(req.RawRequest.URI().PathOriginal())
+	}
 
 	// Merge query parameters.
 	hashSplit := strings.Split(splitURL[1], "#")

--- a/client/hooks_test.go
+++ b/client/hooks_test.go
@@ -207,6 +207,37 @@ func Test_Parser_Request_URL(t *testing.T) {
 		require.True(t, flag2)
 		require.True(t, flag3)
 	})
+
+	t.Run("request disable path normalizing should be respected", func(t *testing.T) {
+		t.Parallel()
+		client := New()
+		req := AcquireRequest().
+			SetURL("https://example.my.host/other.host%2Fpath%2Fto%2Fdata%23123").
+			SetDisablePathNormalizing(true)
+
+		t.Cleanup(func() {
+			ReleaseRequest(req)
+		})
+
+		err := parserRequestURL(client, req)
+		require.NoError(t, err)
+		require.Equal(t, "https://example.my.host/other.host%2Fpath%2Fto%2Fdata%23123", req.RawRequest.URI().String())
+	})
+
+	t.Run("client disable path normalizing should be respected", func(t *testing.T) {
+		t.Parallel()
+		client := New().SetDisablePathNormalizing(true)
+		req := AcquireRequest().
+			SetURL("https://example.my.host/other.host%2Fpath%2Fto%2Fdata%23123")
+
+		t.Cleanup(func() {
+			ReleaseRequest(req)
+		})
+
+		err := parserRequestURL(client, req)
+		require.NoError(t, err)
+		require.Equal(t, "https://example.my.host/other.host%2Fpath%2Fto%2Fdata%23123", req.RawRequest.URI().String())
+	})
 }
 
 func Test_Parser_Request_Header(t *testing.T) {

--- a/client/request.go
+++ b/client/request.go
@@ -68,6 +68,8 @@ type Request struct {
 	maxRedirects int
 
 	bodyType bodyType
+
+	disablePathNormalizing bool
 }
 
 // Method returns the HTTP method set in the Request.
@@ -605,6 +607,18 @@ func (r *Request) SetMaxRedirects(count int) *Request {
 	return r
 }
 
+// DisablePathNormalizing reports whether path normalizing is disabled for the Request.
+func (r *Request) DisablePathNormalizing() bool {
+	return r.disablePathNormalizing
+}
+
+// SetDisablePathNormalizing configures the Request to disable or enable path normalizing.
+func (r *Request) SetDisablePathNormalizing(disable bool) *Request {
+	r.disablePathNormalizing = disable
+	r.RawRequest.URI().DisablePathNormalizing = disable
+	return r
+}
+
 // checkClient ensures that a Client is set. If none is set, it defaults to the global defaultClient.
 func (r *Request) checkClient() {
 	if r.client == nil {
@@ -671,6 +685,7 @@ func (r *Request) Reset() {
 	r.maxRedirects = 0
 	r.bodyType = noBody
 	r.boundary = boundary
+	r.disablePathNormalizing = false
 
 	for len(r.files) != 0 {
 		t := r.files[0]


### PR DESCRIPTION
## Summary
- add client and request options to disable path normalizing and plumb them through request configuration
- update URL parsing to preserve encoded paths when normalization is disabled and add regression tests

Fixes #3096