### PR TITLE
Consolidate client test files

### DIFF
--- a/client/core.go
+++ b/client/core.go
@@ -93,15 +93,15 @@ func (c *core) execFunc() (*Response, error) {
 			// Use an exponential backoff retry strategy.
 			err = retry.NewExponentialBackoff(*cfg).Retry(func() error {
 				if c.req.maxRedirects > 0 && (string(reqv.Header.Method()) == fiber.MethodGet || string(reqv.Header.Method()) == fiber.MethodHead) {
-					return c.client.fasthttp.DoRedirects(reqv, respv, c.req.maxRedirects)
+					return c.client.doRedirects(reqv, respv, c.req.maxRedirects)
 				}
-				return c.client.fasthttp.Do(reqv, respv)
+				return c.client.do(reqv, respv)
 			})
 		} else {
 			if c.req.maxRedirects > 0 && (string(reqv.Header.Method()) == fiber.MethodGet || string(reqv.Header.Method()) == fiber.MethodHead) {
-				err = c.client.fasthttp.DoRedirects(reqv, respv, c.req.maxRedirects)
+				err = c.client.doRedirects(reqv, respv, c.req.maxRedirects)
 			} else {
-				err = c.client.fasthttp.Do(reqv, respv)
+				err = c.client.do(reqv, respv)
 			}
 		}
 

--- a/client/transport.go
+++ b/client/transport.go
@@ -1,0 +1,291 @@
+package client
+
+import (
+	"crypto/tls"
+	"time"
+
+	"github.com/valyala/fasthttp"
+)
+
+type httpClientTransport interface {
+	Do(req *fasthttp.Request, resp *fasthttp.Response) error
+	DoTimeout(req *fasthttp.Request, resp *fasthttp.Response, timeout time.Duration) error
+	DoDeadline(req *fasthttp.Request, resp *fasthttp.Response, deadline time.Time) error
+	DoRedirects(req *fasthttp.Request, resp *fasthttp.Response, maxRedirects int) error
+	CloseIdleConnections()
+	TLSConfig() **tls.Config
+	SetTLSConfig(config *tls.Config)
+	SetDial(dial fasthttp.DialFunc)
+	Reset()
+	Client() any
+}
+
+type standardClientTransport struct {
+	client *fasthttp.Client
+}
+
+func newStandardClientTransport(client *fasthttp.Client) *standardClientTransport {
+	return &standardClientTransport{client: client}
+}
+
+func (s *standardClientTransport) Do(req *fasthttp.Request, resp *fasthttp.Response) error {
+	return s.client.Do(req, resp)
+}
+
+func (s *standardClientTransport) DoTimeout(req *fasthttp.Request, resp *fasthttp.Response, timeout time.Duration) error {
+	return s.client.DoTimeout(req, resp, timeout)
+}
+
+func (s *standardClientTransport) DoDeadline(req *fasthttp.Request, resp *fasthttp.Response, deadline time.Time) error {
+	return s.client.DoDeadline(req, resp, deadline)
+}
+
+func (s *standardClientTransport) DoRedirects(req *fasthttp.Request, resp *fasthttp.Response, maxRedirects int) error {
+	return s.client.DoRedirects(req, resp, maxRedirects)
+}
+
+func (s *standardClientTransport) CloseIdleConnections() {
+	s.client.CloseIdleConnections()
+}
+
+func (s *standardClientTransport) TLSConfig() **tls.Config {
+	return &s.client.TLSConfig
+}
+
+func (s *standardClientTransport) SetTLSConfig(config *tls.Config) {
+	s.client.TLSConfig = config
+}
+
+func (s *standardClientTransport) SetDial(dial fasthttp.DialFunc) {
+	s.client.Dial = dial
+}
+
+func (s *standardClientTransport) Reset() {
+	s.client = &fasthttp.Client{}
+}
+
+func (s *standardClientTransport) Client() any {
+	return s.client
+}
+
+type hostClientTransport struct {
+	client *fasthttp.HostClient
+}
+
+func newHostClientTransport(client *fasthttp.HostClient) *hostClientTransport {
+	return &hostClientTransport{client: client}
+}
+
+func (h *hostClientTransport) Do(req *fasthttp.Request, resp *fasthttp.Response) error {
+	return h.client.Do(req, resp)
+}
+
+func (h *hostClientTransport) DoTimeout(req *fasthttp.Request, resp *fasthttp.Response, timeout time.Duration) error {
+	return h.client.DoTimeout(req, resp, timeout)
+}
+
+func (h *hostClientTransport) DoDeadline(req *fasthttp.Request, resp *fasthttp.Response, deadline time.Time) error {
+	return h.client.DoDeadline(req, resp, deadline)
+}
+
+func (h *hostClientTransport) DoRedirects(req *fasthttp.Request, resp *fasthttp.Response, maxRedirects int) error {
+	return h.client.DoRedirects(req, resp, maxRedirects)
+}
+
+func (h *hostClientTransport) CloseIdleConnections() {
+	h.client.CloseIdleConnections()
+}
+
+func (h *hostClientTransport) TLSConfig() **tls.Config {
+	return &h.client.TLSConfig
+}
+
+func (h *hostClientTransport) SetTLSConfig(config *tls.Config) {
+	h.client.TLSConfig = config
+}
+
+func (h *hostClientTransport) SetDial(dial fasthttp.DialFunc) {
+	h.client.Dial = dial
+}
+
+func (h *hostClientTransport) Reset() {
+	h.client = &fasthttp.HostClient{}
+}
+
+func (h *hostClientTransport) Client() any {
+	return h.client
+}
+
+type lbClientTransport struct {
+	client    *fasthttp.LBClient
+	tlsConfig *tls.Config
+	dial      fasthttp.DialFunc
+}
+
+func newLBClientTransport(client *fasthttp.LBClient) *lbClientTransport {
+	t := &lbClientTransport{client: client}
+
+	if len(client.Clients) > 0 {
+		if cfg := extractTLSConfig(client.Clients); cfg != nil {
+			t.tlsConfig = cfg
+		}
+		if dial := extractDial(client.Clients); dial != nil {
+			t.dial = dial
+		}
+	}
+
+	return t
+}
+
+func (l *lbClientTransport) Do(req *fasthttp.Request, resp *fasthttp.Response) error {
+	return l.client.Do(req, resp)
+}
+
+func (l *lbClientTransport) DoTimeout(req *fasthttp.Request, resp *fasthttp.Response, timeout time.Duration) error {
+	return l.client.DoTimeout(req, resp, timeout)
+}
+
+func (l *lbClientTransport) DoDeadline(req *fasthttp.Request, resp *fasthttp.Response, deadline time.Time) error {
+	return l.client.DoDeadline(req, resp, deadline)
+}
+
+func (l *lbClientTransport) DoRedirects(req *fasthttp.Request, resp *fasthttp.Response, maxRedirects int) error {
+	return doRedirectsWithClient(req, resp, maxRedirects, l.client)
+}
+
+func (l *lbClientTransport) CloseIdleConnections() {
+	forEachHostClient(l.client, func(hc *fasthttp.HostClient) {
+		hc.CloseIdleConnections()
+	})
+}
+
+func (l *lbClientTransport) TLSConfig() **tls.Config {
+	return &l.tlsConfig
+}
+
+func (l *lbClientTransport) SetTLSConfig(config *tls.Config) {
+	l.tlsConfig = config
+	forEachHostClient(l.client, func(hc *fasthttp.HostClient) {
+		hc.TLSConfig = config
+	})
+}
+
+func (l *lbClientTransport) SetDial(dial fasthttp.DialFunc) {
+	l.dial = dial
+	forEachHostClient(l.client, func(hc *fasthttp.HostClient) {
+		hc.Dial = dial
+	})
+}
+
+func (l *lbClientTransport) Reset() {
+	l.client = &fasthttp.LBClient{}
+	l.tlsConfig = nil
+	l.dial = nil
+}
+
+func (l *lbClientTransport) Client() any {
+	return l.client
+}
+
+func forEachHostClient(lb *fasthttp.LBClient, fn func(*fasthttp.HostClient)) {
+	for _, c := range lb.Clients {
+		walkBalancingClient(c, fn)
+	}
+}
+
+func walkBalancingClient(client fasthttp.BalancingClient, fn func(*fasthttp.HostClient)) {
+	if hc, ok := client.(*fasthttp.HostClient); ok {
+		fn(hc)
+	}
+}
+
+func extractTLSConfig(clients []fasthttp.BalancingClient) *tls.Config {
+	var cfg *tls.Config
+	for _, c := range clients {
+		if walkBalancingClientWithBreak(c, func(hc *fasthttp.HostClient) bool {
+			if hc.TLSConfig != nil {
+				cfg = hc.TLSConfig
+				return true
+			}
+			return false
+		}) {
+			break
+		}
+	}
+	return cfg
+}
+
+func extractDial(clients []fasthttp.BalancingClient) fasthttp.DialFunc {
+	var dial fasthttp.DialFunc
+	for _, c := range clients {
+		if walkBalancingClientWithBreak(c, func(hc *fasthttp.HostClient) bool {
+			if hc.Dial != nil {
+				dial = hc.Dial
+				return true
+			}
+			return false
+		}) {
+			break
+		}
+	}
+	return dial
+}
+
+func walkBalancingClientWithBreak(client fasthttp.BalancingClient, fn func(*fasthttp.HostClient) bool) bool {
+	if hc, ok := client.(*fasthttp.HostClient); ok {
+		return fn(hc)
+	}
+	return false
+}
+
+type redirectClient interface {
+	Do(req *fasthttp.Request, resp *fasthttp.Response) error
+}
+
+func doRedirectsWithClient(req *fasthttp.Request, resp *fasthttp.Response, maxRedirects int, client redirectClient) error {
+	if maxRedirects < 0 {
+		maxRedirects = 0
+	}
+
+	currentURL := req.URI().String()
+	redirects := 0
+
+	for {
+		req.SetRequestURI(currentURL)
+
+		if err := client.Do(req, resp); err != nil {
+			return err
+		}
+
+		statusCode := resp.Header.StatusCode()
+		if !fasthttp.StatusCodeIsRedirect(statusCode) {
+			return nil
+		}
+
+		redirects++
+		if redirects > maxRedirects {
+			return fasthttp.ErrTooManyRedirects
+		}
+
+		location := resp.Header.Peek("Location")
+		if len(location) == 0 {
+			return fasthttp.ErrMissingLocation
+		}
+
+		currentURL = composeRedirectURL(currentURL, location, req.DisableRedirectPathNormalizing)
+
+		if req.Header.IsPost() && (statusCode == fasthttp.StatusMovedPermanently || statusCode == fasthttp.StatusFound) {
+			req.Header.SetMethod(fasthttp.MethodGet)
+		}
+	}
+}
+
+func composeRedirectURL(base string, location []byte, disablePathNormalizing bool) string {
+	uri := fasthttp.AcquireURI()
+	uri.Update(base)
+	uri.UpdateBytes(location)
+	uri.DisablePathNormalizing = disablePathNormalizing
+	redirectURL := uri.String()
+	fasthttp.ReleaseURI(uri)
+	return redirectURL
+}

--- a/client/transport_test.go
+++ b/client/transport_test.go
@@ -1,0 +1,216 @@
+package client
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+type stubBalancingClient struct{}
+
+func (stubBalancingClient) DoDeadline(*fasthttp.Request, *fasthttp.Response, time.Time) error {
+	return nil
+}
+func (stubBalancingClient) PendingRequests() int { return 0 }
+
+type stubRedirectCall struct {
+	status   int
+	location string
+	err      error
+}
+
+type stubRedirectClient struct {
+	calls []stubRedirectCall
+}
+
+func (s *stubRedirectClient) Do(req *fasthttp.Request, resp *fasthttp.Response) error {
+	if len(s.calls) == 0 {
+		resp.Reset()
+		resp.Header.SetStatusCode(fasthttp.StatusOK)
+		return nil
+	}
+
+	call := s.calls[0]
+	s.calls = s.calls[1:]
+
+	resp.Reset()
+	if call.status != 0 {
+		resp.Header.SetStatusCode(call.status)
+	}
+	if call.location != "" {
+		resp.Header.Set("Location", call.location)
+	}
+	return call.err
+}
+
+func TestStandardClientTransportCoverage(t *testing.T) {
+	t.Parallel()
+
+	var dialCount atomic.Int32
+	client := &fasthttp.Client{}
+	client.Dial = func(addr string) (net.Conn, error) {
+		dialCount.Add(1)
+		return nil, errors.New("dial error")
+	}
+
+	transport := newStandardClientTransport(client)
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.SetRequestURI("http://example.com/")
+	require.Error(t, transport.Do(req, resp))
+
+	req.SetRequestURI("http://example.com/")
+	require.Error(t, transport.DoTimeout(req, resp, time.Millisecond))
+
+	req.SetRequestURI("http://example.com/")
+	require.Error(t, transport.DoDeadline(req, resp, time.Now().Add(time.Second)))
+
+	transport.CloseIdleConnections()
+
+	underlying, ok := transport.Client().(*fasthttp.Client)
+	require.True(t, ok)
+	require.Same(t, client, underlying)
+
+	transport.Reset()
+	resetClient, ok := transport.Client().(*fasthttp.Client)
+	require.True(t, ok)
+	require.NotSame(t, client, resetClient)
+	require.Equal(t, int32(3), dialCount.Load())
+}
+
+func TestHostClientTransportClientAccessor(t *testing.T) {
+	t.Parallel()
+
+	host := &fasthttp.HostClient{Addr: "example.com:80"}
+	transport := newHostClientTransport(host)
+
+	current, ok := transport.Client().(*fasthttp.HostClient)
+	require.True(t, ok)
+	require.Same(t, host, current)
+
+	transport.Reset()
+	afterReset, ok := transport.Client().(*fasthttp.HostClient)
+	require.True(t, ok)
+	require.NotSame(t, host, afterReset)
+}
+
+func TestLBClientTransportAccessorsAndOverrides(t *testing.T) {
+	t.Parallel()
+
+	hostWithoutOverrides := &fasthttp.HostClient{Addr: "example.com:80"}
+	hostWithDial := &fasthttp.HostClient{Addr: "example.org:80"}
+	hostWithTLS := &fasthttp.HostClient{Addr: "example.net:80", TLSConfig: &tls.Config{ServerName: "example"}}
+
+	hostWithDial.Dial = func(addr string) (net.Conn, error) {
+		return nil, errors.New("original dial")
+	}
+
+	lb := &fasthttp.LBClient{Clients: []fasthttp.BalancingClient{stubBalancingClient{}, hostWithoutOverrides, hostWithDial, hostWithTLS}}
+
+	transport := newLBClientTransport(lb)
+	require.Same(t, lb, transport.Client())
+	require.Equal(t, hostWithTLS.TLSConfig, transport.tlsConfig)
+	require.NotNil(t, transport.dial)
+
+	overrideTLS := &tls.Config{ServerName: "override"}
+	transport.SetTLSConfig(overrideTLS)
+	require.Equal(t, overrideTLS, hostWithoutOverrides.TLSConfig)
+	require.Equal(t, overrideTLS, hostWithDial.TLSConfig)
+	require.Equal(t, overrideTLS, hostWithTLS.TLSConfig)
+
+	overrideDialCalled := atomic.Bool{}
+	overrideDial := func(addr string) (net.Conn, error) {
+		overrideDialCalled.Store(true)
+		return nil, errors.New("override dial")
+	}
+	transport.SetDial(overrideDial)
+	_, err := hostWithoutOverrides.Dial("example.com:80")
+	require.Error(t, err)
+	require.True(t, overrideDialCalled.Load())
+
+	transport.Reset()
+	require.Nil(t, transport.tlsConfig)
+	require.Nil(t, transport.dial)
+	resetClient, ok := transport.Client().(*fasthttp.LBClient)
+	require.True(t, ok)
+	require.NotSame(t, lb, resetClient)
+}
+
+func TestExtractTLSConfigVariations(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, extractTLSConfig(nil))
+	require.Nil(t, extractTLSConfig([]fasthttp.BalancingClient{stubBalancingClient{}}))
+
+	host := &fasthttp.HostClient{TLSConfig: &tls.Config{ServerName: "configured"}}
+	require.Equal(t, host.TLSConfig, extractTLSConfig([]fasthttp.BalancingClient{host}))
+}
+
+func TestExtractDialVariations(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, extractDial(nil))
+	require.Nil(t, extractDial([]fasthttp.BalancingClient{stubBalancingClient{}}))
+
+	hostWithoutDial := &fasthttp.HostClient{}
+	hostWithDial := &fasthttp.HostClient{}
+	called := atomic.Bool{}
+	hostWithDial.Dial = func(addr string) (net.Conn, error) {
+		called.Store(true)
+		return nil, errors.New("dial")
+	}
+
+	dialFn := extractDial([]fasthttp.BalancingClient{hostWithoutDial, hostWithDial})
+	require.NotNil(t, dialFn)
+	_, err := dialFn("example.com:80")
+	require.Error(t, err)
+	require.True(t, called.Load())
+}
+
+func TestWalkBalancingClientWithBreak(t *testing.T) {
+	t.Parallel()
+
+	host := &fasthttp.HostClient{}
+	require.True(t, walkBalancingClientWithBreak(host, func(*fasthttp.HostClient) bool { return true }))
+
+	require.False(t, walkBalancingClientWithBreak(stubBalancingClient{}, func(*fasthttp.HostClient) bool {
+		t.Fatal("unexpected call")
+		return false
+	}))
+}
+
+func TestDoRedirectsWithClientBranches(t *testing.T) {
+	t.Parallel()
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.SetRequestURI("http://example.com/start")
+
+	client := &stubRedirectClient{calls: []stubRedirectCall{{status: fasthttp.StatusMovedPermanently, location: "/next"}}}
+	require.ErrorIs(t, doRedirectsWithClient(req, resp, -1, client), fasthttp.ErrTooManyRedirects)
+
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.SetRequestURI("http://example.com/start")
+	client = &stubRedirectClient{calls: []stubRedirectCall{{status: fasthttp.StatusFound}}}
+	require.ErrorIs(t, doRedirectsWithClient(req, resp, 1, client), fasthttp.ErrMissingLocation)
+
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.SetRequestURI("http://example.com/start")
+	client = &stubRedirectClient{calls: []stubRedirectCall{{status: fasthttp.StatusMovedPermanently, location: "/redirect"}, {status: fasthttp.StatusOK}}}
+	require.NoError(t, doRedirectsWithClient(req, resp, 1, client))
+	require.Equal(t, fasthttp.MethodGet, string(req.Header.Method()))
+	require.Equal(t, "http://example.com/redirect", req.URI().String())
+}

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -774,6 +774,12 @@ The default redirect status code has been updated from `302 Found` to `303 See O
 The Gofiber client has been completely rebuilt. It includes numerous new features such as Cookiejar, request/response hooks, and more.
 You can take a look to [client docs](./client/rest.md) to see what's new with the client.
 
+### Fasthttp transport integration
+
+- `client.NewWithHostClient` and `client.NewWithLBClient` allow you to plug existing `fasthttp` clients directly into Fiber while keeping retries, redirects, and hook logic consistent.
+- Dialer, TLS, and proxy helpers now update every host client inside a load balancer, so complex pools inherit the same configuration.
+- The Fiber client exposes `Do`, `DoTimeout`, `DoDeadline`, and `CloseIdleConnections`, matching the surface area of the wrapped fasthttp transports.
+
 ## 🧰 Generic functions
 
 Fiber v3 introduces new generic functions that provide additional utility and flexibility for developers. These functions are designed to simplify common tasks and improve code readability.


### PR DESCRIPTION
## Summary
- inline the auxiliary client unit tests into client_test.go so they run with the primary suite
- rename the transport test file to transport_test.go to match Go testing discovery conventions

## Testing
- go test ./client

------
https://chatgpt.com/codex/tasks/task_e_68dd99152e548333bfa5406f1f38662c