### PR TITLE
Doc: Documented reverse proxy workaround for SendEarlyHints

### DIFF
--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -2176,6 +2176,7 @@ resources while the server prepares the full response.
 :::caution
 This feature requires HTTP/2 or newer. Some legacy HTTP/1.1 clients may not
 Early Hints (`103` responses) are supported in HTTP/2 and newer. Older HTTP/1.1 clients may ignore these interim responses or misbehave when receiving them.
+See [Enabling HTTP/2](../guide/enabling-http2.md) for instructions on how to use a reverse proxy (e.g. Nginx or Traefik) to enable HTTP/2 support.
 :::
 
 ```go title="Signature"

--- a/docs/guide/enabling-http2.md
+++ b/docs/guide/enabling-http2.md
@@ -1,0 +1,72 @@
+---
+id: enabling-http2
+title: Enabling HTTP/2
+description: >-
+  Learn how to enable HTTP/2 (and optionally HTTP/3) in Fiber using reverse
+  proxies like Nginx or Traefik. Required for features such as SendEarlyHints
+  and other modern HTTP capabilities.
+sidebar_position: 4
+---
+
+## Enabling HTTP/2
+Some features in Fiber, such as SendEarlyHints, require HTTP/2 or newer.
+If your app is served directly over HTTP/1.1, certain features may be ignored or not function as expected.
+
+To enable HTTP/2 in production, you can run Fiber behind a reverse proxy that upgrades connections.
+Popular choices include Nginx and Traefik.
+
+Example for Nginx
+```go title="Example"
+server {
+    listen 443 ssl http2;
+    server_name example.com;
+
+    ssl_certificate     /etc/ssl/certs/example.crt;
+    ssl_certificate_key /etc/ssl/private/example.key;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+    }
+}
+```
+This configuration enables HTTP/2 with TLS and proxies requests to your Fiber app on port 3000.
+
+Example of Traefik
+```go title="Example"
+entryPoints:
+  websecure:
+    address: ":443"
+
+http:
+  routers:
+    app:
+      rule: "Host(`example.com`)"
+      entryPoints:
+        - websecure
+      service: app
+      tls: {}
+
+  services:
+    app:
+      loadBalancer:
+        servers:
+          - url: "http://127.0.0.1:3000"
+```
+With this configuration, Traefik terminates TLS and serves your app over HTTP/2.
+
+## HTTP/3 (QUIC) Support
+While Early Hints (103 responses) are officially part of HTTP/2 and newer, many reverse proxies also support HTTP/3 (QUIC).
+
+Nginx: Requires a recent build with QUIC/HTTP3 patches.
+Traefik: Supports HTTP/3 via its entryPoint configuration.
+
+Enabling HTTP/3 is optional but can provide lower latency and improved performance for clients that support it. If you enable HTTP/3, your Early Hints responses will still work as expected.
+
+For more details, see the official documentation:
+
+- [Nginx HTTP/2 Module](https://nginx.org/en/docs/http/ngx_http_v2_module.html)  
+- [Nginx QUIC / HTTP/3](https://nginx.org/en/docs/quic.html)  
+- [Traefik HTTP/3](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#http3)


### PR DESCRIPTION
# Description

This PR adds documentation to guide users on enabling HTTP/2 (and optionally HTTP/3) in Fiber applications using reverse proxies such as Nginx and Traefik.
The new page docs/guide/enabling-http2.md provides example configurations and references to official proxy documentation.
Additionally, the SendEarlyHints section in docs/api/ctx.md has been updated to link to this guide, helping users understand how to properly enable required protocols.

Fixes # (issue)

## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [ ] Documentation Update: 
   - Added new guide: docs/guide/enabling-http2.md
   - Updated docs/api/ctx.md
- [ ] Examples: Included Nginx and Traefik config snippets for enabling HTTP/2. 

## Type of change

- [ ] Documentation update (changes to documentation)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [ ] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] No Unit tests required(documentation only). 
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.
