### PR TITLE
docs: add reverse proxy guide for HTTP/2 support

### DIFF
--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -2174,8 +2174,9 @@ before the final response. This allows the browser to start preloading
 resources while the server prepares the full response.
 
 :::caution
-This feature requires HTTP/2 or newer. Some legacy HTTP/1.1 clients may not
-Early Hints (`103` responses) are supported in HTTP/2 and newer. Older HTTP/1.1 clients may ignore these interim responses or misbehave when receiving them.
+This feature requires HTTP/2 or newer. Early Hints (`103` responses) are supported in HTTP/2 and newer protocols. Older HTTP/1.1 clients may ignore these interim responses or misbehave when receiving them.
+
+To enable HTTP/2 support for your Fiber application, see the [Reverse Proxy Configuration](../guide/reverse-proxy.md) guide.
 :::
 
 ```go title="Signature"

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -2176,7 +2176,7 @@ resources while the server prepares the full response.
 :::caution
 This feature requires HTTP/2 or newer protocols. Early Hints (`103` responses) may be ignored by older HTTP/1.1 clients or cause them to misbehave.
 
-To enable HTTP/2 support for your Fiber application, see the [Reverse Proxy Configuration](../guide/reverse-proxy.md) guide.
+To use Early Hints, ensure your Fiber application is served over HTTP/2. You can enable HTTP/2 support by using a [reverse proxy](../guide/reverse-proxy.md) that supports HTTP/2.
 :::
 
 ```go title="Signature"

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -2174,7 +2174,7 @@ before the final response. This allows the browser to start preloading
 resources while the server prepares the full response.
 
 :::caution
-This feature requires HTTP/2 or newer. Early Hints (`103` responses) are supported in HTTP/2 and newer protocols. Older HTTP/1.1 clients may ignore these interim responses or misbehave when receiving them.
+This feature requires HTTP/2 or newer protocols. Early Hints (`103` responses) may be ignored by older HTTP/1.1 clients or cause them to misbehave.
 
 To enable HTTP/2 support for your Fiber application, see the [Reverse Proxy Configuration](../guide/reverse-proxy.md) guide.
 :::

--- a/docs/guide/reverse-proxy.md
+++ b/docs/guide/reverse-proxy.md
@@ -1,0 +1,310 @@
+---
+id: reverse-proxy
+title: 🔄 Reverse Proxy Configuration
+description: Configure reverse proxies to enable HTTP/2 and HTTP/3 support for your Fiber applications
+sidebar_position: 12
+---
+
+Many Fiber features like `SendEarlyHints` require HTTP/2 or newer protocols to function properly. Since Go's standard HTTP server has limitations with HTTP/2 in certain configurations, using a reverse proxy is often the most practical solution to enable these modern protocol features.
+
+## Why Use a Reverse Proxy?
+
+- **Protocol Upgrade**: Convert HTTP/1.1 connections to HTTP/2 or HTTP/3
+- **TLS Termination**: Handle SSL/TLS certificates and encryption
+- **Load Balancing**: Distribute traffic across multiple Fiber instances
+- **Caching**: Improve performance with reverse proxy caching
+- **Security**: Add additional security layers and request filtering
+
+## Popular Reverse Proxies
+
+### Nginx
+
+Nginx is a widely used reverse proxy that provides excellent HTTP/2 and HTTP/3 support.
+
+#### Basic HTTP/2 Configuration
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name your-domain.com;
+
+    ssl_certificate /path/to/your/certificate.crt;
+    ssl_certificate_key /path/to/your/private.key;
+
+    # Modern SSL configuration
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512;
+    ssl_prefer_server_ciphers off;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+```
+
+#### HTTP/3 Configuration (Experimental)
+
+```nginx
+server {
+    listen 443 ssl http2;
+    listen 443 quic reuseport;
+    
+    server_name your-domain.com;
+    
+    ssl_certificate /path/to/your/certificate.crt;
+    ssl_certificate_key /path/to/your/private.key;
+    
+    # HTTP/3 specific settings
+    ssl_early_data on;
+    ssl_protocols TLSv1.3;
+    
+    # Add Alt-Svc header for HTTP/3 discovery
+    add_header Alt-Svc 'h3=":443"; ma=86400';
+    
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+```
+
+### Traefik
+
+Traefik is a modern reverse proxy with automatic service discovery and excellent HTTP/2 support.
+
+#### Docker Compose Configuration
+
+```yaml
+version: '3.8'
+
+services:
+  traefik:
+    image: traefik:v3.0
+    command:
+      - --api.dashboard=true
+      - --entrypoints.websecure.address=:443
+      - --entrypoints.websecure.http.tls=true
+      - --entrypoints.websecure.http2.maxConcurrentStreams=250
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --certificatesresolvers.letsencrypt.acme.email=your-email@domain.com
+      - --certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json
+      - --certificatesresolvers.letsencrypt.acme.tlschallenge=true
+    ports:
+      - "443:443"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./letsencrypt:/letsencrypt
+
+  fiber-app:
+    image: your-fiber-app:latest
+    expose:
+      - "3000"
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.fiber.rule=Host(`your-domain.com`)
+      - traefik.http.routers.fiber.entrypoints=websecure
+      - traefik.http.routers.fiber.tls.certresolver=letsencrypt
+      - traefik.http.services.fiber.loadbalancer.server.port=3000
+```
+
+#### File-based Configuration
+
+```yaml
+# traefik.yml
+api:
+  dashboard: true
+
+entryPoints:
+  websecure:
+    address: ":443"
+    http:
+      tls: {}
+      middlewares:
+        - security-headers@file
+    http2:
+      maxConcurrentStreams: 250
+
+providers:
+  file:
+    filename: /etc/traefik/dynamic.yml
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: your-email@domain.com
+      storage: /letsencrypt/acme.json
+      tlsChallenge: {}
+```
+
+```yaml
+# dynamic.yml
+http:
+  middlewares:
+    security-headers:
+      headers:
+        customRequestHeaders:
+          X-Forwarded-Proto: "https"
+        customResponseHeaders:
+          X-Frame-Options: "DENY"
+          X-Content-Type-Options: "nosniff"
+
+  routers:
+    fiber-router:
+      rule: "Host(`your-domain.com`)"
+      entryPoints:
+        - websecure
+      service: fiber-service
+      tls:
+        certResolver: letsencrypt
+
+  services:
+    fiber-service:
+      loadBalancer:
+        servers:
+          - url: "http://127.0.0.1:3000"
+```
+
+### Caddy
+
+Caddy automatically handles HTTPS and HTTP/2, making it one of the simplest options for enabling modern protocols.
+
+#### Basic Caddyfile
+
+```caddy
+your-domain.com {
+    reverse_proxy 127.0.0.1:3000
+    
+    # Automatically enables HTTP/2 and HTTPS
+    # HTTP/3 is experimental but can be enabled:
+    # protocols h1 h2 h3
+}
+```
+
+#### Advanced Configuration
+
+```caddy
+your-domain.com {
+    # Enable HTTP/3 (experimental)
+    protocols h1 h2 h3
+    
+    # Custom headers for Fiber
+    reverse_proxy 127.0.0.1:3000 {
+        header_up Host {host}
+        header_up X-Real-IP {remote_host}
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Forwarded-Proto {scheme}
+    }
+    
+    # Additional security headers
+    header {
+        # Security headers
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        Referrer-Policy "strict-origin-when-cross-origin"
+    }
+}
+```
+
+## Configuring Fiber for Reverse Proxy
+
+When using a reverse proxy, configure your Fiber application to trust proxy headers:
+
+```go
+package main
+
+import (
+    "github.com/gofiber/fiber/v3"
+)
+
+func main() {
+    app := fiber.New(fiber.Config{
+        // Trust proxy headers
+        EnableTrustedProxyCheck: true,
+        TrustedProxies: []string{
+            "127.0.0.1",
+            "10.0.0.0/8",
+            "172.16.0.0/12",
+            "192.168.0.0/16",
+        },
+        ProxyHeader: fiber.HeaderXForwardedFor,
+    })
+
+    // Your routes here
+    app.Get("/", func(c fiber.Ctx) error {
+        return c.SendString("Hello, World!")
+    })
+
+    // Example using SendEarlyHints (requires HTTP/2)
+    app.Get("/early-hints", func(c fiber.Ctx) error {
+        hints := []string{
+            "<https://cdn.example.com/app.js>; rel=preload; as=script",
+            "<https://cdn.example.com/style.css>; rel=preload; as=style",
+        }
+        
+        if err := c.SendEarlyHints(hints); err != nil {
+            return err
+        }
+        
+        return c.SendString("Page with early hints")
+    })
+
+    app.Listen(":3000")
+}
+```
+
+## Testing HTTP/2 Configuration
+
+You can verify that HTTP/2 is working correctly using curl or browser developer tools:
+
+```bash
+# Test with curl
+curl -I --http2 https://your-domain.com
+
+# Check protocol version
+curl -w "%{http_version}\n" -o /dev/null -s https://your-domain.com
+```
+
+Look for the HTTP/2 protocol indicator in the response or browser network tab.
+
+## Performance Considerations
+
+- **Connection Multiplexing**: HTTP/2 allows multiple requests over a single connection
+- **Server Push**: Some reverse proxies support HTTP/2 server push
+- **Compression**: Enable compression at the reverse proxy level for better performance
+- **Keep-Alive**: Configure appropriate keep-alive settings for persistent connections
+
+## Security Notes
+
+When using reverse proxies:
+
+1. **Always validate trusted proxy ranges** to prevent IP spoofing
+2. **Use TLS between proxy and Fiber** in production environments
+3. **Configure proper timeout values** to prevent resource exhaustion
+4. **Monitor proxy logs** for suspicious activity
+5. **Keep proxy software updated** for security patches
+
+## References
+
+- [Nginx HTTP/2 Module](https://nginx.org/en/docs/http/ngx_http_v2_module.html)
+- [Nginx HTTP/3 Support](https://nginx.org/en/docs/http/ngx_http_v3_module.html)
+- [Traefik HTTP/2 Configuration](https://doc.traefik.io/traefik/routing/entrypoints/#http2)
+- [Traefik HTTP/3 Support](https://doc.traefik.io/traefik/routing/entrypoints/#http3)
+- [Caddy Reverse Proxy](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy)


### PR DESCRIPTION
# Description

This PR adds comprehensive reverse proxy documentation to help users enable HTTP/2 support for Fiber applications. The `SendEarlyHints` feature and other HTTP/2-dependent functionality require proper proxy configuration, which was previously undocumented.

Fixes #3735

## Changes introduced

- [x] Documentation Update: Updated `SendEarlyHints` section in `docs/api/ctx.md` to reference the new proxy guide
- [x] Documentation Update: Added new reverse proxy guide at `docs/guide/reverse-proxy.md` with configuration examples for Nginx, Traefik, and Caddy
- [x] Examples: Provided production-ready configuration examples for all major reverse proxies
- [x] Migration Guide: Included Fiber application configuration steps for proxy environments
- [ ] Benchmarks: Not applicable for documentation changes
- [ ] Changelog/What's New: Documentation enhancement for HTTP/2 support
- [ ] API Alignment with Express: Not applicable for documentation changes
- [ ] API Longevity: Not applicable for documentation changes

## Type of change

- [x] Documentation update (changes to documentation)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features. (Not applicable for documentation)
- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage. (Not applicable for documentation)
- [ ] Aimed for optimal performance with minimal allocations in the new code. (Not applicable for documentation)
- [ ] Provided benchmarks for the new code to analyze and improve upon. (Not applicable for documentation)