### PR TITLE
🐛 bug: Fix recover middleware panic output formatting

### DIFF
--- a/middleware/recover/recover.go
+++ b/middleware/recover/recover.go
@@ -9,7 +9,7 @@ import (
 )
 
 func defaultStackTraceHandler(_ fiber.Ctx, e any) {
-	fmt.Fprintf(os.Stderr, "panic: %v\n%s\n", e, debug.Stack())
+	fmt.Fprintf(os.Stderr, "panic: %v\n\n%s\n", e, debug.Stack())
 }
 
 // New creates a new middleware handler


### PR DESCRIPTION
## Summary
- add the missing blank line between the panic header and stack trace in the recover middleware output so it matches Go's native panic format

Fixes #3815

------
https://chatgpt.com/codex/tasks/task_e_68fb25aadb048333b92ef5e0212e54ec