### PR TITLE
Fix recover middleware panic output formatting

### DIFF
--- a/middleware/recover/recover.go
+++ b/middleware/recover/recover.go
@@ -9,7 +9,7 @@ import (
 )
 
 func defaultStackTraceHandler(_ *fiber.Ctx, e interface{}) {
-	_, _ = os.Stderr.WriteString(fmt.Sprintf("panic: %v\n%s\n", e, debug.Stack())) //nolint:errcheck // This will never fail
+	_, _ = os.Stderr.WriteString(fmt.Sprintf("panic: %v\n\n%s\n", e, debug.Stack())) //nolint:errcheck // This will never fail
 }
 
 // New creates a new middleware handler


### PR DESCRIPTION
## Summary
- remove the recover middleware stack trace formatting regression test while keeping the blank-line output fix

## Testing
- go test -mod=mod ./...


------
https://chatgpt.com/codex/tasks/task_e_68fb3b2974a083268aa5e0b111f876e9