### PR TITLE
🚀 perf: Inline Request state wrappers

### DIFF
--- a/client/hooks_test.go
+++ b/client/hooks_test.go
@@ -793,7 +793,7 @@ func Benchmark_Parser_Request_Body_File(b *testing.B) {
 func newBenchmarkRequest(formValues map[string]string, fileContents [][]byte) *Request {
 	req := &Request{
 		boundary:   "FiberBenchmarkBoundary",
-		formData:   &FormData{Args: fasthttp.AcquireArgs()},
+		formData:   FormData{Args: fasthttp.AcquireArgs()},
 		RawRequest: fasthttp.AcquireRequest(),
 		files:      make([]*File, len(fileContents)),
 	}

--- a/client/request.go
+++ b/client/request.go
@@ -363,7 +363,7 @@ func (r *Request) DelCookies(key ...string) *Request {
 // PathParam returns the value of a named path parameter.
 // If the parameter does not exist, an empty string is returned.
 func (r *Request) PathParam(key string) string {
-	if val, ok := (r.path)[key]; ok {
+	if val, ok := r.path[key]; ok {
 		return val
 	}
 	return ""

--- a/client/request.go
+++ b/client/request.go
@@ -47,14 +47,14 @@ type Request struct {
 	ctx context.Context //nolint:containedctx // Context is needed to be stored in the request.
 
 	body    any
-	header  *Header
-	params  *QueryParam
-	cookies *Cookie
-	path    *PathParam
+	header  Header
+	params  QueryParam
+	cookies Cookie
+	path    PathParam
 
 	client *Client
 
-	formData *FormData
+	formData FormData
 
 	RawRequest *fasthttp.Request
 	url        string
@@ -324,7 +324,7 @@ func (r *Request) SetReferer(referer string) *Request {
 // Cookie returns the value of a named cookie.
 // If the cookie does not exist, an empty string is returned.
 func (r *Request) Cookie(key string) string {
-	if val, ok := (*r.cookies)[key]; ok {
+	if val, ok := (r.cookies)[key]; ok {
 		return val
 	}
 	return ""
@@ -363,7 +363,7 @@ func (r *Request) DelCookies(key ...string) *Request {
 // PathParam returns the value of a named path parameter.
 // If the parameter does not exist, an empty string is returned.
 func (r *Request) PathParam(key string) string {
-	if val, ok := (*r.path)[key]; ok {
+	if val, ok := (r.path)[key]; ok {
 		return val
 	}
 	return ""
@@ -967,12 +967,12 @@ func (f *File) Reset() {
 var requestPool = &sync.Pool{
 	New: func() any {
 		return &Request{
-			header:     &Header{RequestHeader: &fasthttp.RequestHeader{}},
-			params:     &QueryParam{Args: fasthttp.AcquireArgs()},
-			cookies:    &Cookie{},
-			path:       &PathParam{},
+			header:     Header{RequestHeader: &fasthttp.RequestHeader{}},
+			params:     QueryParam{Args: fasthttp.AcquireArgs()},
+			cookies:    Cookie{},
+			path:       PathParam{},
 			boundary:   boundary,
-			formData:   &FormData{Args: fasthttp.AcquireArgs()},
+			formData:   FormData{Args: fasthttp.AcquireArgs()},
 			files:      make([]*File, 0),
 			RawRequest: fasthttp.AcquireRequest(),
 		}

--- a/client/request.go
+++ b/client/request.go
@@ -324,7 +324,7 @@ func (r *Request) SetReferer(referer string) *Request {
 // Cookie returns the value of a named cookie.
 // If the cookie does not exist, an empty string is returned.
 func (r *Request) Cookie(key string) string {
-	if val, ok := (r.cookies)[key]; ok {
+	if val, ok := r.cookies[key]; ok {
 		return val
 	}
 	return ""

--- a/client/request_bench_test.go
+++ b/client/request_bench_test.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"runtime"
+	"runtime/metrics"
+	"strconv"
+	"testing"
+)
+
+// BenchmarkRequestHeapScan measures how much heap memory the GC needs to scan
+// when a batch of requests is created and released.
+func BenchmarkRequestHeapScan(b *testing.B) {
+	samples := []metrics.Sample{
+		{Name: "/gc/scan/heap:bytes"},
+		{Name: "/gc/scan/total:bytes"},
+	}
+
+	b.ReportAllocs()
+	b.StopTimer()
+	b.ResetTimer()
+
+	const batchSize = 512
+	var totalScanHeap, totalScanAll uint64
+	for i := 0; i < b.N; i++ {
+		reqs := make([]*Request, batchSize)
+		runtime.GC()
+		metrics.Read(samples)
+		startScanHeap := samples[0].Value.Uint64()
+		startScanAll := samples[1].Value.Uint64()
+
+		b.StartTimer()
+		for j := range reqs {
+			req := AcquireRequest()
+			req.SetHeader("X-Benchmark", "value")
+			req.SetCookie("session", strconv.Itoa(j))
+			req.SetPathParam("id", strconv.Itoa(j))
+			req.SetParam("page", strconv.Itoa(j))
+			reqs[j] = req
+		}
+		b.StopTimer()
+
+		runtime.GC()
+		metrics.Read(samples)
+		totalScanHeap += samples[0].Value.Uint64() - startScanHeap
+		totalScanAll += samples[1].Value.Uint64() - startScanAll
+
+		for _, req := range reqs {
+			ReleaseRequest(req)
+		}
+	}
+
+	if b.N > 0 {
+		b.ReportMetric(float64(totalScanHeap)/float64(b.N), "scan-bytes-heap/op")
+		b.ReportMetric(float64(totalScanAll)/float64(b.N), "scan-bytes-total/op")
+	}
+}

--- a/client/request_bench_test.go
+++ b/client/request_bench_test.go
@@ -23,7 +23,7 @@ func BenchmarkRequestHeapScan(b *testing.B) {
 	var totalScanHeap, totalScanAll uint64
 	for i := 0; i < b.N; i++ {
 		reqs := make([]*Request, batchSize)
-		// revive:disable-next-line:call-to-gc // ensure consistent heap state before measuring scan metrics
+		// revive:disable-next-line:call-to-gc // Ensure consistent heap state before measuring scan metrics
 		runtime.GC()
 		metrics.Read(samples)
 		startScanHeap := samples[0].Value.Uint64()

--- a/client/request_bench_test.go
+++ b/client/request_bench_test.go
@@ -40,7 +40,7 @@ func BenchmarkRequestHeapScan(b *testing.B) {
 		}
 		b.StopTimer()
 
-		// revive:disable-next-line:call-to-gc // force GC to capture post-benchmark scan metrics
+		// revive:disable-next-line:call-to-gc // Force GC to capture post-benchmark scan metrics
 		runtime.GC()
 		metrics.Read(samples)
 		totalScanHeap += samples[0].Value.Uint64() - startScanHeap

--- a/client/request_bench_test.go
+++ b/client/request_bench_test.go
@@ -23,6 +23,7 @@ func BenchmarkRequestHeapScan(b *testing.B) {
 	var totalScanHeap, totalScanAll uint64
 	for i := 0; i < b.N; i++ {
 		reqs := make([]*Request, batchSize)
+		// revive:disable-next-line:call-to-gc // ensure consistent heap state before measuring scan metrics
 		runtime.GC()
 		metrics.Read(samples)
 		startScanHeap := samples[0].Value.Uint64()
@@ -39,6 +40,7 @@ func BenchmarkRequestHeapScan(b *testing.B) {
 		}
 		b.StopTimer()
 
+		// revive:disable-next-line:call-to-gc // force GC to capture post-benchmark scan metrics
 		runtime.GC()
 		metrics.Read(samples)
 		totalScanHeap += samples[0].Value.Uint64() - startScanHeap


### PR DESCRIPTION
# Description

This PR drops unneeded pointers in the `Request`. This change doesn't affect `Request`'s public API.
As a result GC now needs to scan 2.5% less bytes, also now new `Request` instantiation is 4% faster

```
╰─⠠⠵ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/gofiber/fiber/v3/client
cpu: Apple M3 Max
                   │   old.txt   │              new.txt               │
                   │   sec/op    │   sec/op     vs base               │
RequestHeapScan-16   183.1µ ± 1%   175.8µ ± 1%  -3.98% (p=0.000 n=20)

                   │      old.txt       │                  new.txt                  │
                   │ scan-bytes-heap/op │ scan-bytes-heap/op  vs base               │
RequestHeapScan-16        2222.7Ti ± 1%        2166.9Ti ± 1%  -2.51% (p=0.000 n=20)

                   │       old.txt       │                  new.txt                   │
                   │ scan-bytes-total/op │ scan-bytes-total/op  vs base               │
RequestHeapScan-16         2222.7Ti ± 1%         2166.9Ti ± 1%  -2.51% (p=0.000 n=20)

                   │   old.txt    │            new.txt             │
                   │     B/op     │     B/op      vs base          │
RequestHeapScan-16   10.77Ki ± 0%   10.76Ki ± 0%  ~ (p=0.311 n=20)

                   │   old.txt   │              new.txt               │
                   │  allocs/op  │  allocs/op   vs base               │
RequestHeapScan-16   1.256k ± 0%   1.252k ± 0%  -0.32% (p=0.000 n=20)
```

## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [x] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [ ] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [ ] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [ ] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [ ] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [ ] Examples: Provide examples demonstrating the new features or changes in action.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [x] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [ ] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [ ] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
