### PR TITLE
🐛 fix: avoid writing into released Response in core::execFunc()

### DIFF
--- a/client/core.go
+++ b/client/core.go
@@ -258,7 +258,7 @@ var errChanPool = &sync.Pool{
 func acquireErrChan() chan error {
 	ch, ok := errChanPool.Get().(chan error)
 	if !ok {
-		panic(errors.New("failed to type-assert to error"))
+		panic(errors.New("failed to type-assert to chan error"))
 	}
 	return ch
 }

--- a/client/core.go
+++ b/client/core.go
@@ -264,7 +264,7 @@ func acquireErrChan() chan error {
 }
 
 // releaseErrChan returns the error channel to the pool.
-// Its caller's responsibility to ensure that:
+// It's caller's responsibility to ensure that:
 // - the channel is not closed
 // - the channel is drained before returning it
 // - the channel is not reused after returning it

--- a/client/core.go
+++ b/client/core.go
@@ -239,7 +239,7 @@ func acquireResponseChan() chan *Response {
 }
 
 // releaseResponseChan returns the *Response channel to the pool.
-// Its caller's responsibility to ensure that:
+// It's the caller's responsibility to ensure that:
 // - the channel is not closed
 // - the channel is drained before returning it
 // - the channel is not reused after returning it

--- a/client/core.go
+++ b/client/core.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/addon/retry"
@@ -73,25 +72,25 @@ func (c *core) getRetryConfig() *RetryConfig {
 // execFunc is the core logic to send the request and receive the response.
 // It leverages the fasthttp client, optionally with retries or redirects.
 func (c *core) execFunc() (*Response, error) {
-	resp := AcquireResponse()
-	resp.setClient(c.client)
-	resp.setRequest(c.req)
+	// do not close, these will be returned to the pool
+	errChan := acquireErrChan()
+	respChan := acquireResponseChan()
 
-	done := int32(0)
-	errCh, reqv := acquireErrChan(), fasthttp.AcquireRequest()
-	defer releaseErrChan(errCh)
-
-	c.req.RawRequest.CopyTo(reqv)
 	cfg := c.getRetryConfig()
-
-	var err error
 	go func() {
-		respv := fasthttp.AcquireResponse()
-		defer func() {
-			fasthttp.ReleaseRequest(reqv)
-			fasthttp.ReleaseResponse(respv)
-		}()
+		// retain both channels until they are drained
+		defer releaseErrChan(errChan)
+		defer releaseResponseChan(respChan)
 
+		reqv := fasthttp.AcquireRequest()
+		defer fasthttp.ReleaseRequest(reqv)
+
+		respv := fasthttp.AcquireResponse()
+		defer fasthttp.ReleaseResponse(respv)
+
+		c.req.RawRequest.CopyTo(reqv)
+
+		var err error
 		if cfg != nil {
 			// Use an exponential backoff retry strategy.
 			err = retry.NewExponentialBackoff(*cfg).Retry(func() error {
@@ -108,27 +107,31 @@ func (c *core) execFunc() (*Response, error) {
 			}
 		}
 
-		if atomic.CompareAndSwapInt32(&done, 0, 1) {
-			if err != nil {
-				errCh <- err
-				return
-			}
-			respv.CopyTo(resp.RawResponse)
-			errCh <- nil
+		if err != nil {
+			errChan <- err
+			return
 		}
+
+		resp := AcquireResponse()
+		resp.setClient(c.client)
+		resp.setRequest(c.req)
+		respv.CopyTo(resp.RawResponse)
+		respChan <- resp
 	}()
 
 	select {
-	case err := <-errCh:
-		if err != nil {
-			// Release the response if an error occurs.
-			ReleaseResponse(resp)
-			return nil, err
-		}
+	case err := <-errChan:
+		return nil, err
+	case resp := <-respChan:
 		return resp, nil
 	case <-c.ctx.Done():
-		atomic.SwapInt32(&done, 1)
-		ReleaseResponse(resp)
+		go func() { // drain the channels and release the response
+			select {
+			case resp := <-respChan:
+				ReleaseResponse(resp)
+			case <-errChan:
+			}
+		}()
 		return nil, ErrTimeoutOrCancel
 	}
 }
@@ -219,27 +222,52 @@ func (c *core) execute(ctx context.Context, client *Client, req *Request) (*Resp
 	return resp, nil
 }
 
-var errChanPool = &sync.Pool{
+var responseChanPool = &sync.Pool{
 	New: func() any {
-		return make(chan error, 1)
+		return make(chan *Response)
 	},
 }
 
-// acquireErrChan returns an empty error channel from the pool.
-//
-// The returned channel may be returned to the pool with releaseErrChan when no longer needed,
-// reducing GC load.
+// acquireResponseChan returns an empty, non-closed *Response channel from the pool.
+// The returned channel may be returned to the pool with releaseResponseChan
+func acquireResponseChan() chan *Response {
+	ch, ok := responseChanPool.Get().(chan *Response)
+	if !ok {
+		panic(errors.New("failed to type-assert to *Response"))
+	}
+	return ch
+}
+
+// releaseResponseChan returns the *Response channel to the pool.
+// Its caller's responsibility to ensure that:
+// - the channel is not closed
+// - the channel is drained before returning it
+// - the channel is not reused after returning it
+func releaseResponseChan(ch chan *Response) {
+	responseChanPool.Put(ch)
+}
+
+var errChanPool = &sync.Pool{
+	New: func() any {
+		return make(chan error)
+	},
+}
+
+// acquireErrChan returns an empty, non-closed error channel from the pool.
+// The returned channel may be returned to the pool with releaseErrChan
 func acquireErrChan() chan error {
 	ch, ok := errChanPool.Get().(chan error)
 	if !ok {
-		panic(errors.New("failed to type-assert to chan error"))
+		panic(errors.New("failed to type-assert to error"))
 	}
 	return ch
 }
 
 // releaseErrChan returns the error channel to the pool.
-//
-// Do not use the released channel afterward to avoid data races.
+// Its caller's responsibility to ensure that:
+// - the channel is not closed
+// - the channel is drained before returning it
+// - the channel is not reused after returning it
 func releaseErrChan(ch chan error) {
 	errChanPool.Put(ch)
 }

--- a/client/core_test.go
+++ b/client/core_test.go
@@ -354,40 +354,32 @@ func (b *blockingErrTransport) Do(_ *fasthttp.Request, _ *fasthttp.Response) err
 	return b.err
 }
 
-func (b *blockingErrTransport) DoTimeout(req *fasthttp.Request, resp *fasthttp.Response, timeout time.Duration) error {
-	_ = timeout
+func (b *blockingErrTransport) DoTimeout(req *fasthttp.Request, resp *fasthttp.Response, _ time.Duration) error {
 	return b.Do(req, resp)
 }
 
-func (b *blockingErrTransport) DoDeadline(req *fasthttp.Request, resp *fasthttp.Response, deadline time.Time) error {
-	_ = deadline
+func (b *blockingErrTransport) DoDeadline(req *fasthttp.Request, resp *fasthttp.Response, _ time.Time) error {
 	return b.Do(req, resp)
 }
 
-func (b *blockingErrTransport) DoRedirects(req *fasthttp.Request, resp *fasthttp.Response, maxRedirects int) error {
-	_ = maxRedirects
+func (b *blockingErrTransport) DoRedirects(req *fasthttp.Request, resp *fasthttp.Response, _ int) error {
 	return b.Do(req, resp)
 }
 
-func (b *blockingErrTransport) CloseIdleConnections() {
-	_ = b
+func (*blockingErrTransport) CloseIdleConnections() {
 }
 
-func (b *blockingErrTransport) TLSConfig() *tls.Config {
-	_ = b
+func (*blockingErrTransport) TLSConfig() *tls.Config {
 	return nil
 }
 
-func (b *blockingErrTransport) SetTLSConfig(_ *tls.Config) {
-	_ = b
+func (*blockingErrTransport) SetTLSConfig(_ *tls.Config) {
 }
 
-func (b *blockingErrTransport) SetDial(_ fasthttp.DialFunc) {
-	_ = b
+func (*blockingErrTransport) SetDial(_ fasthttp.DialFunc) {
 }
 
-func (b *blockingErrTransport) Client() any {
-	_ = b
+func (*blockingErrTransport) Client() any {
 	return nil
 }
 


### PR DESCRIPTION
# Description

This PR addresses issue in `core::execFunc()` where goroutine can potentially write into `Response` after it has been released back to the pool.

https://github.com/gofiber/fiber/blob/6ef6de5f43f4eb91bef3f7f72c1c84f5ba6d8ad4/client/core.go#L75-L134
On line 111 when `done` is set in the `if` statement:
https://github.com/gofiber/fiber/blob/6ef6de5f43f4eb91bef3f7f72c1c84f5ba6d8ad4/client/core.go#L111
and `context` cancellation happens concurrently at this stage, then  `atomic.SwapInt32(&done, 1)` at line 130:
https://github.com/gofiber/fiber/blob/6ef6de5f43f4eb91bef3f7f72c1c84f5ba6d8ad4/client/core.go#L129-L131
will unconditionally overwrite `done` value and release `Response`. As a result execution at line 112:
https://github.com/gofiber/fiber/blob/6ef6de5f43f4eb91bef3f7f72c1c84f5ba6d8ad4/client/core.go#L116
can still write to Response even when it is returned back to the pool.
Alternatively, if http request fails, then `errCh` will be released back to the pool while goroutine still trying to write into it:
https://github.com/gofiber/fiber/blob/6ef6de5f43f4eb91bef3f7f72c1c84f5ba6d8ad4/client/core.go#L111-L113

Additionally, by removing unneeded `done` atomic I achieved ~3% performance boost in single request benchmark and ~8% in parallel.

```
benchstat old.txt new.txt                                                               
goos: darwin
goarch: arm64
pkg: github.com/gofiber/fiber/v3/client
cpu: Apple M3 Max
                                      │   old.txt   │              new.txt               │
                                      │   sec/op    │   sec/op     vs base               │
_Client_Request-16                      5.008µ ± 0%   4.834µ ± 1%  -3.49% (p=0.000 n=20)
_Client_Request_Parallel-16             2.162µ ± 1%   1.992µ ± 1%  -7.89% (p=0.000 n=20)
_Client_Request_Send_ContextCancel-16   4.652µ ± 1%   5.024µ ± 0%  +7.99% (p=0.000 n=20)
geomean                                 3.693µ        3.643µ       -1.35%

                                      │  old.txt   │              new.txt               │
                                      │    B/op    │    B/op     vs base                │
_Client_Request-16                      217.0 ± 0%   181.0 ± 1%  -16.59% (p=0.000 n=20)
_Client_Request_Parallel-16             218.0 ± 1%   180.0 ± 1%  -17.43% (p=0.000 n=20)
_Client_Request_Send_ContextCancel-16   490.0 ± 0%   479.0 ± 0%   -2.24% (p=0.000 n=20)
geomean                                 285.1        249.9       -12.36%

                                      │  old.txt   │              new.txt               │
                                      │ allocs/op  │ allocs/op   vs base                │
_Client_Request-16                      8.000 ± 0%   6.000 ± 0%  -25.00% (p=0.000 n=20)
_Client_Request_Parallel-16             8.000 ± 0%   6.000 ± 0%  -25.00% (p=0.000 n=20)
_Client_Request_Send_ContextCancel-16   13.00 ± 0%   12.00 ± 0%   -7.69% (p=0.000 n=20)
geomean                                 9.405        7.560       -19.63%
```

Context cancellation path shows slightly degraded performance because now we also correctly drain error chan that was previously missing

## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [x] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [ ] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [ ] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [ ] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [ ] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [ ] Examples: Provide examples demonstrating the new features or changes in action.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [x] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [ ] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [ ] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ ] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
