### PR TITLE
Add automation for v3 label assignments

### DIFF
--- a/.github/workflows/v3-label-automation.yml
+++ b/.github/workflows/v3-label-automation.yml
@@ -25,7 +25,7 @@ jobs:
           project-url: https://github.com/orgs/gofiber/projects/1
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Assign v3 milestone
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary
- add a workflow that watches for the `v3` label on issues and pull requests
- automatically add labeled items to the configurable v3 project using actions/add-to-project
- assign the matching milestone through a GitHub Script step

## Testing
- make audit *(fails: govulncheck cannot reach vuln.go.dev)*
- make generate
- make betteralign
- make modernize
- make format
- make test

------
https://chatgpt.com/codex/tasks/task_e_690ca17e7fec8326be1e971f56a0c978