### PR TITLE
🧹 chore: Fix autolabeler for release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -48,10 +48,6 @@ version-resolver:
       - '⚡️ Performance'
   default: patch
 template: |
-    ## v$RESOLVED_VERSION
-
-    ## What's Changed
-
     $CHANGES
 
     **📒 Documentation**: https://docs.gofiber.io/next/


### PR DESCRIPTION
# Description
- Fix `autolabeler` formatting, the one for release-drafter is different.
- Improve release autogenerated notes.