### PR TITLE
🧹 chore: Improve OPTIONS wildcard regression test

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1442,10 +1442,14 @@ func Test_App_OptionsAsterisk(t *testing.T) {
 
 	ln := fasthttputil.NewInmemoryListener()
 	errCh := make(chan error, 1)
+	serverReady := make(chan struct{})
 
 	go func() {
+		serverReady <- struct{}{}
 		errCh <- app.Listener(ln)
 	}()
+
+	<-serverReady
 
 	t.Cleanup(func() {
 		require.NoError(t, app.Shutdown())


### PR DESCRIPTION
## Summary
- add a small helper to write raw OPTIONS requests in `Test_App_OptionsAsterisk`
- assert the wildcard and resource-specific handlers both return zero-length bodies via the `ContentLength` checks