### PR TITLE
Enable manual workflow dispatch for CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,7 @@
 name: "CodeQL"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,6 +1,7 @@
 name: golangci-lint
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,6 +1,7 @@
 name: markdownlint
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/modernize.yml
+++ b/.github/workflows/modernize.yml
@@ -1,6 +1,7 @@
 name: Modernize Lint
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,6 +1,7 @@
 name: Spell check
 
 on:
+  workflow_dispatch:
   pull_request:
     types:
       - opened

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,6 +1,7 @@
 name: "Sync docs"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -1,6 +1,7 @@
 name: Run govulncheck
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- enable manual `workflow_dispatch` triggers for the benchmark, CodeQL, lint, markdown, modernize, spell-check, docs sync, test, and govulncheck workflows so they can be run on demand

## Testing
- `make audit` *(fails: govulncheck cannot download vulnerability data in this environment)*
- `make generate`
- `make betteralign`
- `make modernize`
- `make format`
- `make test` *(fails: Test_App_BodyLimit_LargerThanDefault times out in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dbd6120f88326bca4b80790630db0)