### PR TITLE
🐛 Backport defensive copying fixes from #3828 and #3829 to v2

### DIFF
--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -1,5 +1,19 @@
-// Package memory Is a slight copy of the memory storage, but far from the storage interface it can not only work with bytes
-// but directly store any kind of data without having to encode it each time, which gives a huge speed advantage
+// Package memory provides a high-performance in-memory storage that can store
+// any type without encoding overhead. Unlike the standard storage interface,
+// this storage works directly with Go types for maximum speed.
+//
+// # Safety Considerations
+//
+// This storage automatically performs defensive copying for:
+//   - String keys: Copied to prevent corruption from pooled buffers
+//   - []byte values: Copied on both Set and Get to prevent external mutation
+//
+// For other types (structs, ints, etc.), Go's value semantics provide natural
+// protection. However, if storing pointers or slices of non-byte types,
+// callers are responsible for not mutating the underlying data.
+//
+// This storage is primarily used internally by middleware for performance-
+// critical operations where the stored data types are known and controlled.
 package memory
 
 import (
@@ -16,9 +30,9 @@ type Storage struct {
 }
 
 type item struct {
-	// max value is 4294967295 -> Sun Feb 07 2106 06:28:15 GMT+0000
-	e uint32      // exp
 	v interface{} // val
+	// max value is 4294967295 -> Sun Feb 07 2106 06:28:15 GMT+0000
+	e uint32 // exp
 }
 
 func New() *Storage {
@@ -30,7 +44,11 @@ func New() *Storage {
 	return store
 }
 
-// Get value by key
+// Get retrieves the value stored under key, returning nil when the entry does
+// not exist or has expired.
+//
+// For []byte values, this returns a defensive copy to prevent callers from
+// mutating the stored data. Other types are returned as-is.
 func (s *Storage) Get(key string) interface{} {
 	s.RLock()
 	v, ok := s.data[key]
@@ -38,29 +56,49 @@ func (s *Storage) Get(key string) interface{} {
 	if !ok || v.e != 0 && v.e <= atomic.LoadUint32(&utils.Timestamp) {
 		return nil
 	}
+
+	// Defensive copy for byte slices to prevent external mutation
+	if b, ok := v.v.([]byte); ok {
+		return utils.CopyBytes(b)
+	}
+
 	return v.v
 }
 
-// Set key with value
+// Set stores val under key and applies the optional ttl before expiring the
+// entry. A non-positive ttl keeps the item forever.
+//
+// String keys are defensively copied to prevent corruption from pooled buffers.
+// []byte values are also copied to prevent external mutation of stored data.
+// Other types are stored as-is (structs are copied by value automatically).
 func (s *Storage) Set(key string, val interface{}, ttl time.Duration) {
 	var exp uint32
 	if ttl > 0 {
 		exp = uint32(ttl.Seconds()) + atomic.LoadUint32(&utils.Timestamp)
 	}
-	i := item{exp, val}
+
+	// Defensive copies to prevent unsafe reuse from sync.Pool
+	keyCopy := utils.CopyString(key)
+
+	// Copy byte slices to prevent external mutation
+	if b, ok := val.([]byte); ok {
+		val = utils.CopyBytes(b)
+	}
+
+	i := item{v: val, e: exp}
 	s.Lock()
-	s.data[key] = i
+	s.data[keyCopy] = i
 	s.Unlock()
 }
 
-// Delete key by key
+// Delete removes key and its associated value from the storage.
 func (s *Storage) Delete(key string) {
 	s.Lock()
 	delete(s.data, key)
 	s.Unlock()
 }
 
-// Reset all keys
+// Reset clears the storage by dropping every stored key.
 func (s *Storage) Reset() {
 	nd := make(map[string]item)
 	s.Lock()
@@ -83,6 +121,12 @@ func (s *Storage) gc(sleep time.Duration) {
 			}
 		}
 		s.RUnlock()
+
+		if len(expired) == 0 {
+			// avoid locking if nothing to delete
+			continue
+		}
+
 		s.Lock()
 		// Double-checked locking.
 		// We might have replaced the item in the meantime.

--- a/middleware/csrf/storage_manager.go
+++ b/middleware/csrf/storage_manager.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/internal/memory"
-	"github.com/gofiber/fiber/v2/utils"
 )
 
 // go:generate msgp
@@ -55,8 +54,8 @@ func (m *storageManager) setRaw(key string, raw []byte, exp time.Duration) {
 	if m.storage != nil {
 		_ = m.storage.Set(key, raw, exp) //nolint:errcheck // TODO: Do not ignore error
 	} else {
-		// the key is crucial in crsf and sometimes a reference to another value which can be reused later(pool/unsafe values concept), so a copy is made here
-		m.memory.Set(utils.CopyString(key), raw, exp)
+		// Storage layer handles defensive copying of keys and values
+		m.memory.Set(key, raw, exp)
 	}
 }
 

--- a/middleware/idempotency/idempotency.go
+++ b/middleware/idempotency/idempotency.go
@@ -117,7 +117,7 @@ func New(config ...Config) fiber.Handler {
 		res := &response{
 			StatusCode: c.Response().StatusCode(),
 
-			Body: utils.CopyBytes(c.Response().Body()),
+			Body: c.Response().Body(),
 		}
 		{
 			headers := c.GetRespHeaders()


### PR DESCRIPTION
## Description

This PR backports the defensive copying fixes from PR #3828 and #3829 to the v2 branch to prevent memory corruption from pooled buffers.

## Background

PR #3828 and #3829 fixed critical memory corruption issues in the main branch where strings or byte slices backed by `sync.Pool` buffers were stored in maps without copying, causing intermittent data corruption when buffers were reused.

## Changes

### 1. `internal/memory/memory.go`
- Added defensive copying for string keys to prevent corruption from `sync.Pool`
- Added defensive copying for `[]byte` values on both `Set` and `Get`
- Enhanced package documentation explaining safety guarantees
- Optimized GC to skip locking when no items to delete

### 2. `internal/storage/memory/memory.go`
- Added defensive copying for string keys and `[]byte` values in `Set`
- Added defensive copying in `Get` to prevent external mutation
- Updated method comments for clarity
- Optimized GC to skip locking when no items to delete

### 3. `middleware/csrf/storage_manager.go`
- Removed redundant `utils.CopyString` since storage layer now handles it
- Storage layer automatically handles defensive copying

### 4. `middleware/idempotency/idempotency.go`
- Removed redundant `utils.CopyBytes` before marshaling
- Marshaling already creates new bytes, so pre-copy was redundant

## Why This Matters

### The Problem
Fiber uses `sync.Pool` for buffer reuse. When strings or `[]byte` slices backed by pooled buffers are stored directly in maps without copying:
1. The map holds references to pooled memory
2. When buffers return to the pool and get reused
3. Map keys/values become corrupted
4. Results in intermittent data loss and failures

### The Solution
Defensive copying at the storage layer ensures:
- All stored data is independent of pooled buffers
- Middleware doesn't need to worry about pooling safety
- Centralized fix prevents future issues

## Performance Impact
- Minimal: Only affects string keys and `[]byte` values
- Structs, integers, and other types remain zero-copy
- Trade-off: Small allocation overhead for correctness and safety

## Testing
✅ All memory storage tests pass (`internal/memory` and `internal/storage/memory`)
✅ All CSRF middleware tests pass
✅ All idempotency middleware tests pass

## Related PRs
- #3828 - Fix: Prevent memory corruption in internal memory storage from pooled buffers
- #3829 - bug: fix copying of key/values in internal/memory

## Breaking Changes
None - this is a bug fix that makes storage implementations behave correctly.