### PR TITLE
⚡ perf: Improve performance of RebuildTree() by 68%

### DIFF
--- a/router.go
+++ b/router.go
@@ -710,52 +710,47 @@ func (app *App) buildTree() *App {
 
 	// 1) First loop: determine all possible 3-char prefixes ("treePaths") for each method
 	for method := range app.config.RequestMethods {
-		prefixSet := map[int]struct{}{
-			0: {},
-		}
-		for _, route := range app.stack[method] {
+		routes := app.stack[method]
+		treePaths := make([]int, len(routes))
+
+		globalCount := 0
+		prefixCounts := make(map[int]int, len(routes))
+
+		for i, route := range routes {
 			if len(route.routeParser.segs) > 0 && len(route.routeParser.segs[0].Const) >= maxDetectionPaths {
-				prefix := int(route.routeParser.segs[0].Const[0])<<16 |
+				treePaths[i] = int(route.routeParser.segs[0].Const[0])<<16 |
 					int(route.routeParser.segs[0].Const[1])<<8 |
 					int(route.routeParser.segs[0].Const[2])
-				prefixSet[prefix] = struct{}{}
 			}
+
+			if treePaths[i] == 0 {
+				globalCount++
+				continue
+			}
+
+			prefixCounts[treePaths[i]]++
 		}
-		tsMap := make(map[int][]*Route, len(prefixSet))
-		for prefix := range prefixSet {
-			tsMap[prefix] = nil
+
+		tsMap := make(map[int][]*Route, len(prefixCounts)+1)
+		tsMap[0] = make([]*Route, 0, globalCount)
+		for treePath, count := range prefixCounts {
+			tsMap[treePath] = make([]*Route, 0, count+globalCount)
 		}
+
+		for i, route := range routes {
+			treePath := treePaths[i]
+
+			if treePath == 0 {
+				for bucket := range tsMap {
+					tsMap[bucket] = append(tsMap[bucket], route)
+				}
+				continue
+			}
+
+			tsMap[treePath] = append(tsMap[treePath], route)
+		}
+
 		app.treeStack[method] = tsMap
-	}
-
-	// 2) Second loop: for each method and each discovered treePath, assign matching routes
-	for method := range app.config.RequestMethods {
-		// get the map of buckets for this method
-		tsMap := app.treeStack[method]
-
-		// for every treePath key (including the empty one)
-		for treePath := range tsMap {
-			// iterate all routes of this method
-			for _, route := range app.stack[method] {
-				// compute this route's own prefix ("" or first 3 chars)
-				routePath := 0
-				if len(route.routeParser.segs) > 0 && len(route.routeParser.segs[0].Const) >= 3 {
-					routePath = int(route.routeParser.segs[0].Const[0])<<16 |
-						int(route.routeParser.segs[0].Const[1])<<8 |
-						int(route.routeParser.segs[0].Const[2])
-				}
-
-				// if it's a global route, assign to every bucket
-				// If the route path is 0 (global route) or matches the current tree path,
-				// append this route to the current bucket
-				if routePath == 0 || routePath == treePath {
-					tsMap[treePath] = append(tsMap[treePath], route)
-				}
-			}
-
-			// after collecting, dedupe the bucket if it's not the global one
-			tsMap[treePath] = uniqueRouteStack(tsMap[treePath])
-		}
 	}
 
 	// reset the flag and return

--- a/router_test.go
+++ b/router_test.go
@@ -1454,6 +1454,20 @@ func registerDummyRoutes(app *App) {
 	}
 }
 
+// go test -v -run=^$ -bench=Benchmark_App_RebuildTree -benchmem -count=4
+func Benchmark_App_RebuildTree(b *testing.B) {
+	app := New()
+	registerDummyRoutes(app)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		app.routesRefreshed = true
+		app.RebuildTree()
+	}
+}
+
 // go test -v -run=^$ -bench=Benchmark_App_MethodNotAllowed -benchmem -count=4
 func Benchmark_App_MethodNotAllowed(b *testing.B) {
 	app := New()


### PR DESCRIPTION
## Summary
- This pull request focuses on improving the efficiency and memory management of the routing tree construction within the application. It refactors the buildTree function to simplify bucket allocation and ensure precise preallocation of data structures. Additionally, a new benchmark is added to track the performance of the tree rebuilding operation, providing a baseline for future optimizations.

### Before

```console
goos: linux
goarch: amd64
pkg: github.com/gofiber/fiber/v3
cpu: AMD Ryzen 7 7800X3D 8-Core Processor           
Benchmark_App_RebuildTree
Benchmark_App_RebuildTree-4   	   32095	     37059 ns/op	   26768 B/op	     290 allocs/op
Benchmark_App_RebuildTree-4   	   32386	     37005 ns/op	   26768 B/op	     290 allocs/op
Benchmark_App_RebuildTree-4   	   33099	     36389 ns/op	   26768 B/op	     290 allocs/op
Benchmark_App_RebuildTree-4   	   31860	     36865 ns/op	   26768 B/op	     290 allocs/op
Benchmark_App_RebuildTree-4   	   32568	     37237 ns/op	   26768 B/op	     290 allocs/op
Benchmark_App_RebuildTree-4   	   32446	     36411 ns/op	   26768 B/op	     290 allocs/op
Benchmark_App_RebuildTree-4   	   33307	     36342 ns/op	   26768 B/op	     290 allocs/op
Benchmark_App_RebuildTree-4   	   32185	     36923 ns/op	   26768 B/op	     290 allocs/op
Benchmark_App_RebuildTree-4   	   33567	     36420 ns/op	   26768 B/op	     290 allocs/op
Benchmark_App_RebuildTree-4   	   31746	     36938 ns/op	   26768 B/op	     290 allocs/op
PASS
ok  	github.com/gofiber/fiber/v3	11.972s
```

### After

```console
goos: linux
goarch: amd64
pkg: github.com/gofiber/fiber/v3
cpu: AMD Ryzen 7 7800X3D 8-Core Processor           
Benchmark_App_RebuildTree
Benchmark_App_RebuildTree-4   	   88698	     13380 ns/op	   17952 B/op	      93 allocs/op
Benchmark_App_RebuildTree-4   	   87627	     13122 ns/op	   17952 B/op	      93 allocs/op
Benchmark_App_RebuildTree-4   	   89563	     13367 ns/op	   17952 B/op	      93 allocs/op
Benchmark_App_RebuildTree-4   	   90487	     13846 ns/op	   17952 B/op	      93 allocs/op
Benchmark_App_RebuildTree-4   	   83514	     14268 ns/op	   17952 B/op	      93 allocs/op
Benchmark_App_RebuildTree-4   	   81895	     13929 ns/op	   17952 B/op	      93 allocs/op
Benchmark_App_RebuildTree-4   	   84560	     14110 ns/op	   17952 B/op	      93 allocs/op
Benchmark_App_RebuildTree-4   	   81997	     13364 ns/op	   17952 B/op	      93 allocs/op
Benchmark_App_RebuildTree-4   	   87638	     13045 ns/op	   17952 B/op	      93 allocs/op
Benchmark_App_RebuildTree-4   	   91272	     13427 ns/op	   17952 B/op	      93 allocs/op
PASS
ok  	github.com/gofiber/fiber/v3	11.795s
```

### Benchstat

```console
$ go run golang.org/x/perf/cmd/benchstat@latest old.txt new.txt 
goos: linux
goarch: amd64
pkg: github.com/gofiber/fiber/v3
cpu: AMD Ryzen 7 7800X3D 8-Core Processor           
                   │   old.txt   │               new.txt               │
                   │   sec/op    │   sec/op     vs base                │
_App_RebuildTree-4   36.89µ ± 1%   13.40µ ± 5%  -63.67% (p=0.000 n=10)

                   │   old.txt    │               new.txt                │
                   │     B/op     │     B/op      vs base                │
_App_RebuildTree-4   26.14Ki ± 0%   17.53Ki ± 0%  -32.93% (p=0.000 n=10)

                   │   old.txt   │              new.txt               │
                   │  allocs/op  │ allocs/op   vs base                │
_App_RebuildTree-4   290.00 ± 0%   93.00 ± 0%  -67.93% (p=0.000 n=10)
```
