### PR TITLE
🐛 bug: Improve suffix range normalization

### DIFF
--- a/req.go
+++ b/req.go
@@ -798,7 +798,7 @@ func (r *DefaultReq) Range(size int64) (Range, error) {
 			return rangeData, ErrRangeMalformed
 		}
 		if startErr != nil { // -nnn
-			start = size - end
+			start = max(size-end, 0)
 			end = size - 1
 		} else if endErr != nil { // nnn-
 			end = size - 1


### PR DESCRIPTION
## Summary
- clamp oversized suffix range starts using max() for clearer normalization
- consolidate suffix range normalization coverage into ctx_test.go while validating status codes and Content-Range headers for suffix and unsatisfiable requests