### PR TITLE
📒 docs: update cache migration guidance

### DIFF
--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -2311,7 +2311,7 @@ Combine multiple sources with `keyauth.Chain()` when needed.
 The deprecated `Store` and `Key` fields were removed. Use `Storage` and
 `KeyGenerator` instead to configure caching backends and cache keys.
 
-Defaults also changed: the middleware now emits `Cache-Control` headers, the default `Expiration` increased to `5 minutes` (from `1 minute`), and a `MaxBytes` limit of `1 MB` now caps cached payloads.
+Defaults also changed: the middleware now emits `Cache-Control` headers, the default `Expiration` increased to `5 minutes` (from `1 minute`), and a new `MaxBytes` limit of `1 MB` (previously unlimited) now caps cached payloads.
 
 To restore v2 behavior:
 


### PR DESCRIPTION
## Summary
- remove inline cache migration notes from the main Cache section while retaining the behavioral change description
- add cache migration steps to the migration guide for restoring v2 Cache-Control behavior, expiration defaults, and cache size limits

## Testing
- make audit *(fails: govulncheck forbidden when fetching vulnerability index)*
- make generate
- make betteralign
- make modernize
- make format
- make lint
- make test *(fails: Test_App_BodyLimit_Zero timeout; see log)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b1c603ed08326b7ac892beb5ccae5)