### PR TITLE
Optimize frequently used hot path methods

### DIFF
--- a/router.go
+++ b/router.go
@@ -96,14 +96,18 @@ func (r *Route) match(detectionPath, path string, params *[maxParams]string) boo
 			if detectionPath != "" && detectionPath[0] == '/' {
 				return true
 			}
-		} else if len(detectionPath) >= plen && detectionPath[:plen] == r.path {
-			if hasPartialMatchBoundary(detectionPath, plen) {
+		} else if len(detectionPath) >= plen {
+			// Optimized: Only compare if lengths allow
+			if detectionPath[:plen] == r.path && hasPartialMatchBoundary(detectionPath, plen) {
 				return true
 			}
 		}
-	} else if len(r.path) == len(detectionPath) && detectionPath == r.path {
-		// Check exact match
-		return true
+	} else {
+		// Optimized: Check length first before string comparison
+		pathLen := len(r.path)
+		if len(detectionPath) == pathLen && detectionPath == r.path {
+			return true
+		}
 	}
 
 	// No match


### PR DESCRIPTION
This commit optimizes frequently used methods in critical hot paths to improve overall framework performance:

**ctx.go - configDependentPaths():**
- Avoid calling TrimRight when path doesn't end with '/'
- Explicitly set treePathHash to 0 for clarity
- Reduce unnecessary function calls on every request

**router.go - Route.match():**
- Check string lengths before comparisons
- Reorder conditional checks for better branch prediction
- Optimize middleware route matching with combined conditions

**path.go - Path matching optimizations:**
- findParamLen(): Check fixed-length segments first (common case)
- findParamLen(): Optimize conditional flow with early returns
- getMatch(): Add fast path for complete matches
- getMatch(): Only check constraints when necessary
- hasPartialMatchBoundary(): Combine boundary checks efficiently

**helpers.go - Header and content negotiation:**
- getOffer(): Optimize wildcard check for */* pattern
- getOffer(): Clean up params pool when skipping quality=0
- joinHeaderValues(): Add fast path for 2-header case to avoid bytes.Join

These micro-optimizations focus on:
- Reducing unnecessary string comparisons
- Adding fast paths for common cases
- Minimizing allocations in hot code paths
- Improving branch prediction with better condition ordering

No functional changes - all optimizations preserve existing behavior.