### PR TITLE
🧹 chore: Replace strings.TrimSpace with utils.TrimSpace

### DIFF
--- a/client/response.go
+++ b/client/response.go
@@ -91,7 +91,7 @@ func (r *Response) Body() []byte {
 
 // String returns the response body as a trimmed string.
 func (r *Response) String() string {
-	return utils.Trim(string(r.Body()), ' ')
+	return utils.TrimSpace(string(r.Body()))
 }
 
 // JSON unmarshal the response body into the given interface{} using JSON.

--- a/ctx.go
+++ b/ctx.go
@@ -404,12 +404,12 @@ func hasTransferEncodingBody(hdr *fasthttp.RequestHeader) bool {
 
 	hasEncoding := false
 	for raw := range strings.SplitSeq(te, ",") {
-		token := strings.TrimSpace(raw)
+		token := utils.TrimSpace(raw)
 		if token == "" {
 			continue
 		}
 		if idx := strings.IndexByte(token, ';'); idx >= 0 {
-			token = strings.TrimSpace(token[:idx])
+			token = utils.TrimSpace(token[:idx])
 		}
 		if token == "" {
 			continue
@@ -428,7 +428,7 @@ func (c *DefaultCtx) IsWebSocket() bool {
 	conn := c.fasthttp.Request.Header.Peek(HeaderConnection)
 	var isUpgrade bool
 	for v := range strings.SplitSeq(utils.UnsafeString(conn), ",") {
-		if utils.EqualFold(utils.Trim(v, ' '), "upgrade") {
+		if utils.EqualFold(utils.TrimSpace(v), "upgrade") {
 			isUpgrade = true
 			break
 		}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -708,7 +708,7 @@ func Test_Ctx_Body_With_Compression(t *testing.T) {
 
 			encs := strings.SplitSeq(tCase.contentEncoding, ",")
 			for enc := range encs {
-				enc = strings.TrimSpace(enc)
+				enc = utils.TrimSpace(enc)
 				if strings.Contains(tCase.name, "invalid_deflate") && enc == StrDeflate {
 					continue
 				}
@@ -942,7 +942,7 @@ func Test_Ctx_Body_With_Compression_Immutable(t *testing.T) {
 
 			encs := strings.SplitSeq(tCase.contentEncoding, ",")
 			for enc := range encs {
-				enc = strings.TrimSpace(enc)
+				enc = utils.TrimSpace(enc)
 				if strings.Contains(tCase.name, "invalid_deflate") && enc == StrDeflate {
 					continue
 				}

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -2221,9 +2221,9 @@ import (
 )
 
 func demo() {
-    b := utils.Trim([]byte(" fiber "))
+    s := utils.TrimSpace(" fiber ")
     id := utils.UUIDv4()
-    s := utils.ToString([]byte("foo"))
+    str := utils.ToString([]byte("foo"))
     t := strings.TrimRight("bar  ", " ")
 }
 ```

--- a/helpers.go
+++ b/helpers.go
@@ -536,7 +536,7 @@ func getOffer(header []byte, isAccepted func(spec, offer string, specParams head
 			}
 		}
 
-		spec = utils.Trim(spec, ' ')
+		spec = utils.TrimSpace(spec)
 
 		// Determine specificity
 		var specificity int
@@ -660,7 +660,7 @@ func matchEtagStrong(s, etag string) bool {
 // weak as defined by RFC 9110 §8.8.3.2.
 func (app *App) isEtagStale(etag string, noneMatchBytes []byte) bool {
 	var start, end int
-	header := utils.Trim(app.toString(noneMatchBytes), ' ')
+	header := utils.TrimSpace(app.toString(noneMatchBytes))
 
 	// Short-circuit the wildcard case: "*" never counts as stale.
 	if header == "*" {
@@ -695,7 +695,7 @@ func parseAddr(raw string) (host, port string) { //nolint:nonamedreturns // gocr
 		return "", ""
 	}
 
-	raw = utils.Trim(raw, ' ')
+	raw = utils.TrimSpace(raw)
 
 	// Handle IPv6 addresses enclosed in brackets as defined by RFC 3986
 	if strings.HasPrefix(raw, "[") {

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -426,7 +426,7 @@ func cacheBodyFetchError(mask func(string) string, key string, err error) error 
 // parseMaxAge extracts the max-age directive from a Cache-Control header.
 func parseMaxAge(cc string) (time.Duration, bool) {
 	for part := range strings.SplitSeq(cc, ",") {
-		part = utils.Trim(utils.ToLower(part), ' ')
+		part = utils.TrimSpace(utils.ToLower(part))
 		if after, ok := strings.CutPrefix(part, "max-age="); ok {
 			if sec, err := strconv.Atoi(after); err == nil {
 				return time.Duration(sec) * time.Second, true
@@ -440,7 +440,7 @@ func allowsSharedCache(cc string) bool {
 	shareable := false
 
 	for part := range strings.SplitSeq(cc, ",") {
-		part = strings.TrimSpace(utils.ToLower(part))
+		part = utils.TrimSpace(utils.ToLower(part))
 		switch {
 		case part == "":
 			continue

--- a/middleware/compress/compress.go
+++ b/middleware/compress/compress.go
@@ -11,7 +11,7 @@ import (
 
 func hasToken(header, token string) bool {
 	for part := range strings.SplitSeq(header, ",") {
-		if utils.EqualFold(utils.Trim(part, ' '), token) {
+		if utils.EqualFold(utils.TrimSpace(part), token) {
 			return true
 		}
 	}

--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -54,7 +54,7 @@ func New(config ...Config) fiber.Handler {
 			break
 		}
 
-		trimmedOrigin := utils.Trim(origin, ' ')
+		trimmedOrigin := utils.TrimSpace(origin)
 		if i := strings.Index(trimmedOrigin, "://*."); i != -1 {
 			withoutWildcard := trimmedOrigin[:i+len("://")] + trimmedOrigin[i+len("://*."):]
 			isValid, normalizedOrigin := normalizeOrigin(withoutWildcard)

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -71,7 +71,7 @@ func New(config ...Config) fiber.Handler {
 	trustedSubOrigins := []subdomain{}
 
 	for _, origin := range cfg.TrustedOrigins {
-		trimmedOrigin := utils.Trim(origin, ' ')
+		trimmedOrigin := utils.TrimSpace(origin)
 		if i := strings.Index(trimmedOrigin, "://*."); i != -1 {
 			withoutWildcard := trimmedOrigin[:i+len("://")] + trimmedOrigin[i+len("://*."):]
 			isValid, normalizedOrigin := normalizeOrigin(withoutWildcard)

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -304,7 +304,7 @@ func Test_CSRF_WithSession(t *testing.T) {
 		h(ctx)
 		token := string(ctx.Response.Header.Peek(fiber.HeaderSetCookie))
 		for header := range strings.SplitSeq(token, ";") {
-			if strings.Split(utils.Trim(header, ' '), "=")[0] == ConfigDefault.CookieName {
+			if strings.Split(utils.TrimSpace(header), "=")[0] == ConfigDefault.CookieName {
 				token = strings.Split(header, "=")[1]
 				break
 			}
@@ -476,7 +476,7 @@ func Test_CSRF_ExpiredToken_WithSession(t *testing.T) {
 	h(ctx)
 	token := string(ctx.Response.Header.Peek(fiber.HeaderSetCookie))
 	for header := range strings.SplitSeq(token, ";") {
-		if strings.Split(utils.Trim(header, ' '), "=")[0] == ConfigDefault.CookieName {
+		if strings.Split(utils.TrimSpace(header), "=")[0] == ConfigDefault.CookieName {
 			token = strings.Split(header, "=")[1]
 			break
 		}

--- a/middleware/session/middleware_test.go
+++ b/middleware/session/middleware_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/extractors"
+	"github.com/gofiber/utils/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 )
@@ -131,7 +132,7 @@ func Test_Session_Middleware(t *testing.T) {
 		// get a value from the body
 		value := c.FormValue("keys")
 		for rawKey := range strings.SplitSeq(value, ",") {
-			key := strings.TrimSpace(rawKey)
+			key := utils.TrimSpace(rawKey)
 			if key == "" {
 				continue
 			}

--- a/req.go
+++ b/req.go
@@ -496,7 +496,7 @@ func (r *DefaultReq) Is(extension string) bool {
 	if i := strings.IndexByte(ct, ';'); i != -1 {
 		ct = ct[:i]
 	}
-	ct = utils.Trim(ct, ' ')
+	ct = utils.TrimSpace(ct)
 	return utils.EqualFold(ct, extensionHeader)
 }
 
@@ -744,7 +744,7 @@ func (r *DefaultReq) Range(size int64) (Range, error) {
 		rangeData Range
 		ranges    string
 	)
-	rangeStr := utils.Trim(r.Get(HeaderRange), ' ')
+	rangeStr := utils.TrimSpace(r.Get(HeaderRange))
 
 	parseBound := func(value string) (int64, error) {
 		parsed, err := utils.ParseUint(value)
@@ -761,11 +761,11 @@ func (r *DefaultReq) Range(size int64) (Range, error) {
 	if i == -1 || strings.Contains(rangeStr[i+1:], "=") {
 		return rangeData, ErrRangeMalformed
 	}
-	rangeData.Type = utils.ToLower(utils.Trim(rangeStr[:i], ' '))
+	rangeData.Type = utils.ToLower(utils.TrimSpace(rangeStr[:i]))
 	if rangeData.Type != "bytes" {
 		return rangeData, ErrRangeMalformed
 	}
-	ranges = utils.Trim(rangeStr[i+1:], ' ')
+	ranges = utils.TrimSpace(rangeStr[i+1:])
 
 	var (
 		singleRange string
@@ -775,12 +775,12 @@ func (r *DefaultReq) Range(size int64) (Range, error) {
 		singleRange = moreRanges
 		if i := strings.IndexByte(moreRanges, ','); i >= 0 {
 			singleRange = moreRanges[:i]
-			moreRanges = utils.Trim(moreRanges[i+1:], ' ')
+			moreRanges = utils.TrimSpace(moreRanges[i+1:])
 		} else {
 			moreRanges = ""
 		}
 
-		singleRange = utils.Trim(singleRange, ' ')
+		singleRange = utils.TrimSpace(singleRange)
 
 		var (
 			startStr, endStr string
@@ -789,8 +789,8 @@ func (r *DefaultReq) Range(size int64) (Range, error) {
 		if i = strings.IndexByte(singleRange, '-'); i == -1 {
 			return rangeData, ErrRangeMalformed
 		}
-		startStr = utils.Trim(singleRange[:i], ' ')
-		endStr = utils.Trim(singleRange[i+1:], ' ')
+		startStr = utils.TrimSpace(singleRange[:i])
+		endStr = utils.TrimSpace(singleRange[i+1:])
 
 		start, startErr := parseBound(startStr)
 		end, endErr := parseBound(endStr)


### PR DESCRIPTION
## Summary
- This pull request focuses on enhancing code consistency and clarity by migrating all relevant string trimming operations to use the utils.TrimSpace function. This change ensures a unified approach to handling whitespace removal and includes an update to the documentation's v3 migration example to reflect this new standard and resolve variable shadowing issues.