### PR TITLE
🩹 bug: Fprint to use format instead of fmtArgs

### DIFF
--- a/log/default.go
+++ b/log/default.go
@@ -55,7 +55,7 @@ func (l *defaultLogger) privateLogf(lv Level, format string, fmtArgs []any) {
 	if len(fmtArgs) > 0 {
 		_, _ = fmt.Fprintf(buf, format, fmtArgs...)
 	} else {
-		_, _ = fmt.Fprint(buf, fmtArgs...)
+		_, _ = fmt.Fprint(buf, format)
 	}
 
 	_ = l.stdlog.Output(l.depth, buf.String()) //nolint:errcheck // It is fine to ignore the error


### PR DESCRIPTION
same bug of https://github.com/gofiber/fiber/pull/3924

# Description

When you use `log.Errrof(message)`, it logs just `[Error]` and message  isn't logged.
Current implementation discards `format` and uses 0 length `fmtArgs`.