### PR TITLE
Modernize error handling in UUID functions

### DIFF
--- a/utils/common.go
+++ b/utils/common.go
@@ -48,7 +48,7 @@ func UUID() string {
 	// Setup seed & counter once
 	uuidSetup.Do(func() {
 		if _, err := rand.Read(uuidSeed[:]); err != nil {
-			panic(fmt.Sprintf("utils: failed to seed UUID generator: %v", err))
+			panic(fmt.Errorf("utils: failed to seed UUID generator: %w", err))
 		}
 		uuidCounter = binary.LittleEndian.Uint64(uuidSeed[:8])
 	})
@@ -82,7 +82,7 @@ func UUID() string {
 func UUIDv4() string {
 	token, err := googleuuid.NewRandom()
 	if err != nil {
-		panic(fmt.Sprintf("utils: failed to generate secure UUID: %v", err))
+		panic(fmt.Errorf("utils: failed to generate secure UUID: %w", err))
 	}
 	return token.String()
 }


### PR DESCRIPTION
This PR modernizes error handling in the UUID and UUIDv4 functions by replacing fmt.Sprintf with fmt.Errorf and using %w for proper error wrapping, enabling better error chaining in Go 1.13+.