### PR TITLE
📚 docs(logger): Update logger middleware format constants

### DIFF
--- a/docs/middleware/logger.md
+++ b/docs/middleware/logger.md
@@ -101,19 +101,19 @@ app.Use(logger.New(logger.Config{
 
 // Use predefined formats
 app.Use(logger.New(logger.Config{
-    Format: logger.FormatCommon,
+    Format: logger.CommonFormat,
 }))
 
 app.Use(logger.New(logger.Config{
-    Format: logger.FormatCombined,
+    Format: logger.CombinedFormat,
 }))
 
 app.Use(logger.New(logger.Config{
-    Format: logger.FormatJSON,
+    Format: logger.JSONFormat,
 }))
 
 app.Use(logger.New(logger.Config{
-    Format: logger.FormatECS,
+    Format: logger.ECSFormat,
 }))
 ```
 


### PR DESCRIPTION
The logger documentation referenced non-existent constants (`FormatCommon`, `FormatCombined`, `FormatJSON`, `FormatECS`), while the actual middleware exports `CommonFormat`, `CombinedFormat`, `JSONFormat`, and `ECSFormat`.

This PR updates the examples and the predefined formats table to match the real exported identifiers, preventing copy-paste errors and confusion for users.

# Description

The logger middleware documentation contained incorrect constant names in usage examples and the predefined formats section. These identifiers do not exist in the codebase and result in compile-time errors when users follow the docs.

This change aligns the documentation with the actual exported constants, improving correctness and developer experience without affecting runtime behavior or APIs.

No functional code changes were made.

## Changes introduced

- [ x] Documentation Update: Updated `docs/middleware/logger.md`

## Type of change

- [ x] Documentation update (changes to documentation)