### PR TITLE
🐛 bug: Fix FIPS-140 compliance for EncryptCookie middleware

### DIFF
--- a/middleware/encryptcookie/utils.go
+++ b/middleware/encryptcookie/utils.go
@@ -80,7 +80,7 @@ func DecryptCookie(name, value, key string) (string, error) {
 		return "", fmt.Errorf("failed to create GCM mode: %w", err)
 	}
 
-	if len(enc) < gcm.Overhead() {
+	if len(enc) < gcm.NonceSize()+gcm.Overhead() {
 		return "", ErrInvalidEncryptedValue
 	}
 


### PR DESCRIPTION
## Summary
- switch encryptcookie to AES-GCM with random nonces using `cipher.NewGCMWithRandomNonce`
- keep ciphertext length validation aligned with the middleware decrypt path and its test coverage

Fixes #3953

## Note:
- Backporting this to `v2` requires golang 1.25 