### PR TITLE
🧹 chore: Use sync.Pool for form and multipart binding

### DIFF
--- a/binder/form.go
+++ b/binder/form.go
@@ -2,12 +2,26 @@ package binder
 
 import (
 	"mime/multipart"
+	"sync"
 
 	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 
 const MIMEMultipartForm string = "multipart/form-data"
+
+var (
+	formMapPool = sync.Pool{
+		New: func() any {
+			return make(map[string][]string)
+		},
+	}
+	formFileMapPool = sync.Pool{
+		New: func() any {
+			return make(map[string][]*multipart.FileHeader)
+		},
+	}
+)
 
 // FormBinding is the form binder for form request body.
 type FormBinding struct {
@@ -21,12 +35,13 @@ func (*FormBinding) Name() string {
 
 // Bind parses the request body and returns the result.
 func (b *FormBinding) Bind(req *fasthttp.Request, out any) error {
-	data := make(map[string][]string)
-
 	// Handle multipart form
 	if FilterFlags(utils.UnsafeString(req.Header.ContentType())) == MIMEMultipartForm {
 		return b.bindMultipart(req, out)
 	}
+
+	data := acquireFormMap()
+	defer releaseFormMap(data)
 
 	for key, val := range req.PostArgs().All() {
 		k := utils.UnsafeString(key)
@@ -46,7 +61,9 @@ func (b *FormBinding) bindMultipart(req *fasthttp.Request, out any) error {
 		return err
 	}
 
-	data := make(map[string][]string)
+	data := acquireFormMap()
+	defer releaseFormMap(data)
+
 	for key, values := range multipartForm.Value {
 		err = formatBindData(b.Name(), out, data, key, values, b.EnableSplitting, true)
 		if err != nil {
@@ -54,7 +71,9 @@ func (b *FormBinding) bindMultipart(req *fasthttp.Request, out any) error {
 		}
 	}
 
-	files := make(map[string][]*multipart.FileHeader)
+	files := acquireFileHeaderMap()
+	defer releaseFileHeaderMap(files)
+
 	for key, values := range multipartForm.File {
 		err = formatBindData(b.Name(), out, files, key, values, b.EnableSplitting, true)
 		if err != nil {
@@ -68,4 +87,44 @@ func (b *FormBinding) bindMultipart(req *fasthttp.Request, out any) error {
 // Reset resets the FormBinding binder.
 func (b *FormBinding) Reset() {
 	b.EnableSplitting = false
+}
+
+func acquireFormMap() map[string][]string {
+	m, ok := formMapPool.Get().(map[string][]string)
+	if !ok {
+		m = make(map[string][]string)
+	}
+	clearFormMap(m)
+	return m
+}
+
+func releaseFormMap(m map[string][]string) {
+	clearFormMap(m)
+	formMapPool.Put(m)
+}
+
+func acquireFileHeaderMap() map[string][]*multipart.FileHeader {
+	m, ok := formFileMapPool.Get().(map[string][]*multipart.FileHeader)
+	if !ok {
+		m = make(map[string][]*multipart.FileHeader)
+	}
+	clearFileHeaderMap(m)
+	return m
+}
+
+func releaseFileHeaderMap(m map[string][]*multipart.FileHeader) {
+	clearFileHeaderMap(m)
+	formFileMapPool.Put(m)
+}
+
+func clearFormMap(m map[string][]string) {
+	for k := range m {
+		delete(m, k)
+	}
+}
+
+func clearFileHeaderMap(m map[string][]*multipart.FileHeader) {
+	for k := range m {
+		delete(m, k)
+	}
 }


### PR DESCRIPTION
## Summary
- reuse pooled maps for form values and multipart file headers in the form binder, clearing them on acquire and release to reduce allocations
- update binding logic to return pooled maps after parsing while keeping multipart and urlencoded handling unchanged
- add regression tests confirming pooled form and multipart maps are cleared between requests

Related #3767 
