### PR TITLE
🐛 bug: Fix Early-Data trusted proxy handling

### DIFF
--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -310,7 +310,7 @@ type Ctx interface {
 	// Stale returns the inverse of Fresh, indicating if the client's cached response is considered stale.
 	Stale() bool
 	// IsProxyTrusted checks trustworthiness of remote ip.
-	// If Config.TrustProxy false, it returns true
+	// If Config.TrustProxy false, it returns false.
 	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
 	IsProxyTrusted() bool
 	// IsFromLocal will return true if request came from local.

--- a/docs/middleware/earlydata.md
+++ b/docs/middleware/earlydata.md
@@ -7,6 +7,7 @@ id: earlydata
 The Early Data middleware adds TLS 1.3 "0-RTT" support to [Fiber](https://github.com/gofiber/fiber). When the client and server share a PSK, TLS 1.3 lets the client send data with the first flight and skip the initial round trip.
 
 Enable Fiber's `TrustProxy` option before using this middleware to avoid spoofed client headers.
+When `TrustProxy` is disabled (the default) or the remote address is not trusted by your proxy configuration, requests carrying the `Early-Data` header are rejected with `425 Too Early` to prevent 0-RTT spoofing from direct clients.
 
 Enabling early data in a reverse proxy (for example, `ssl_early_data on;` in nginx) makes requests replayable. Review these resources before proceeding:
 

--- a/middleware/earlydata/earlydata.go
+++ b/middleware/earlydata/earlydata.go
@@ -30,14 +30,14 @@ func New(config ...Config) fiber.Handler {
 			return c.Next()
 		}
 
-		// Abort if we can't trust the early-data header
-		if !c.IsProxyTrusted() {
-			return cfg.Error
-		}
-
 		// Continue stack if request is not an early-data request
 		if !cfg.IsEarlyData(c) {
 			return c.Next()
+		}
+
+		// Abort if we can't trust the early-data header
+		if !c.IsProxyTrusted() {
+			return cfg.Error
 		}
 
 		// Continue stack if we allow early-data for this request

--- a/req.go
+++ b/req.go
@@ -910,12 +910,12 @@ func (r *DefaultReq) Stale() bool {
 }
 
 // IsProxyTrusted checks trustworthiness of remote ip.
-// If Config.TrustProxy false, it returns true
+// If Config.TrustProxy false, it returns false.
 // IsProxyTrusted can check remote ip by proxy ranges and ip map.
 func (r *DefaultReq) IsProxyTrusted() bool {
 	config := r.c.app.config
 	if !config.TrustProxy {
-		return true
+		return false
 	}
 
 	ip := r.c.fasthttp.RemoteIP()

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -178,7 +178,7 @@ type Req interface {
 	// Stale returns the inverse of Fresh, indicating if the client's cached response is considered stale.
 	Stale() bool
 	// IsProxyTrusted checks trustworthiness of remote ip.
-	// If Config.TrustProxy false, it returns true
+	// If Config.TrustProxy false, it returns false.
 	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
 	IsProxyTrusted() bool
 	// IsFromLocal will return true if request came from local.


### PR DESCRIPTION
## Summary
- return false from `IsProxyTrusted` when proxy trust is disabled and adjust early-data middleware to only honor Early-Data headers from trusted clients
- update early-data documentation and regression tests to reject Early-Data headers from untrusted/direct requests by default
- align CSRF and proxy trust tests with the stricter trust model for forwarded headers