### PR TITLE
🐛 bug: Trim values from getSplicedStrList

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -380,20 +380,13 @@ func getSplicedStrList(headerValue string, dst []string) []string {
 
 	dst = dst[:0]
 	segmentStart := 0
-	isLeadingSpace := true
 	for i, c := range headerValue {
-		switch {
-		case c == ',':
-			dst = append(dst, headerValue[segmentStart:i])
+		if c == ',' {
+			dst = append(dst, utils.TrimSpace(headerValue[segmentStart:i]))
 			segmentStart = i + 1
-			isLeadingSpace = true
-		case c == ' ' && isLeadingSpace:
-			segmentStart = i + 1
-		default:
-			isLeadingSpace = false
 		}
 	}
-	dst = append(dst, headerValue[segmentStart:])
+	dst = append(dst, utils.TrimSpace(headerValue[segmentStart:]))
 
 	return dst
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -346,6 +346,16 @@ func Test_Utils_GetSplicedStrList(t *testing.T) {
 			expectedList: []string{"gzip", "deflate", "br", "zip"},
 		},
 		{
+			description:  "comma with trailing spaces around values",
+			headerValue:  "gzip , br",
+			expectedList: []string{"gzip", "br"},
+		},
+		{
+			description:  "comma with tabbed whitespace",
+			headerValue:  "gzip\t,br",
+			expectedList: []string{"gzip", "br"},
+		},
+		{
 			description:  "headerValue is empty",
 			headerValue:  "",
 			expectedList: nil,


### PR DESCRIPTION
### Motivation
- Ensure each element returned by `getSplicedStrList` is trimmed of leading/trailing OWS so header values like `gzip , br` and `gzip\t,br` parse correctly.

### Description
- Update `getSplicedStrList` to call `utils.TrimSpace` on each extracted segment and the final tail segment instead of preserving surrounding whitespace. 
- Add tests in `Test_Utils_GetSplicedStrList` to cover trailing-space and tabbed-whitespace cases such as `"gzip , br"` and `"gzip\t,br"`.