### PR TITLE
feat: tag invalidation, conditional requests, and Cache-Control for cache middleware

### DIFF
--- a/middleware/cache/README.md
+++ b/middleware/cache/README.md
@@ -1,0 +1,334 @@
+# Cache Middleware
+
+HTTP response caching middleware for Fiber. Stores responses keyed by request
+path (or a custom key), serves them on subsequent matching requests, and
+provides tag-based invalidation, conditional request validation, and
+Cache-Control header management.
+
+---
+
+## Tag Strategies
+
+Tags associate cache entries with logical groups. Entries sharing a tag can be
+invalidated together, making it possible to flush related content (e.g. all
+pages for a given user or product) with a single call.
+
+### Associating Tags with Entries
+
+Two configuration hooks control tag assignment:
+
+| Hook | When it runs | Signature |
+|---|---|---|
+| `Tags` | Before the handler, using only request data | `func(c fiber.Ctx) []string` |
+| `ResponseTags` | After the handler, with access to the response body | `func(c fiber.Ctx, body []byte) []string` |
+
+Tags from both hooks are merged into a single set and persisted alongside the
+cached entry. Either hook can be omitted.
+
+```go
+app.Use(cache.New(cache.Config{
+    Tags: func(c fiber.Ctx) []string {
+        return []string{"region:" + c.Query("region")}
+    },
+    ResponseTags: func(c fiber.Ctx, body []byte) []string {
+        if strings.Contains(string(body), "draft") {
+            return []string{"draft"}
+        }
+        return nil
+    },
+}))
+```
+
+### Tag Index Backends
+
+The middleware automatically selects the tag index backend based on whether an
+external `Storage` is configured:
+
+| `Config.Storage` | Backend | Scope |
+|---|---|---|
+| `nil` (default) | In-memory `tagIndex` | Single process |
+| non-nil (e.g. Redis) | `distributedTagStore` | Shared across all instances using the same backend |
+
+**In-memory (`tagIndex`)** — a bidirectional map: a forward index
+(`tag → set of cache keys`) supports invalidation lookups and a reverse index
+(`cache key → set of tags`) supports cleanup on eviction or expiry. Both
+directions provide O(1) lookup.
+
+**Distributed (`distributedTagStore`)** — persists the same bidirectional
+index in the shared storage backend using reserved key prefixes:
+
+| Key pattern | Contains |
+|---|---|
+| `__cache_tag__:<tag>` | Forward index: all cache keys under this tag |
+| `__cache_tagrev__:<key>` | Reverse index: all tags for this cache key |
+
+Each instance also maintains a local `tagIndex` as a fast path for the
+`has()` check performed on every cache hit. See
+[Cross-Instance Invalidation](#cross-instance-invalidation) for how this
+affects invalidation semantics.
+
+### Tag Re-population
+
+When an external storage backend is used, a process restart clears the local
+tag index. The middleware recovers transparently: on every cache hit it checks
+whether the key is already tracked locally, and if not, re-adds the tags that
+were persisted with the cached entry. No explicit warm-up step is required.
+
+### Tag Rejection
+
+`RejectTags` is a list of glob patterns. If any tag computed by `Tags` or
+`ResponseTags` matches a reject pattern, the response is **not stored** and the
+middleware reports `X-Cache: unreachable`.
+
+```go
+app.Use(cache.New(cache.Config{
+    Tags: func(c fiber.Ctx) []string { ... },
+    RejectTags: []string{
+        "internal",   // exact match
+        "user:*",     // prefix — matches "user:", "user:42", …
+        "*:secret",   // suffix — matches "api:secret", …
+    },
+}))
+```
+
+Patterns are pre-classified at middleware creation into three runtime-efficient
+buckets:
+
+| Pattern shape | Matching strategy |
+|---|---|
+| No `*` | O(1) map lookup |
+| Single trailing `*` | `strings.HasPrefix` |
+| All other `*` patterns | Full glob match |
+
+The only wildcard character is `*`. It matches any sequence of characters
+including the empty string.
+
+---
+
+## Invalidation Patterns
+
+### Basic Invalidation
+
+`cache.InvalidateTags` removes all cached responses associated with any of the
+provided tags. It must be called from a handler that has the cache middleware in
+its chain.
+
+```go
+app.Post("/flush", func(c fiber.Ctx) error {
+    tag := c.Query("tag")
+    return cache.InvalidateTags(c, tag)
+})
+```
+
+Multiple tags can be passed in a single call. Entries sharing any of the
+listed tags are collected and removed. Duplicate keys — entries that match more
+than one of the provided tags — are deduplicated internally.
+
+### What Happens During Invalidation
+
+1. **Collect keys** — the tag store reads the forward index for each requested
+   tag and merges the results into a unique key set.
+2. **Remove forward entries** — the forward index entries for the invalidated
+   tags are deleted.
+3. **Update reverse entries** — for each collected key, the invalidated tags are
+   stripped from its reverse index entry. Keys whose reverse entry becomes empty
+   are removed entirely.
+4. **Evict from cache** — the middleware removes each collected key from the
+   expiration heap (when `MaxBytes` is configured) and deletes it from storage.
+
+### Partial Invalidation
+
+A cache entry can carry multiple tags. Invalidating one tag removes the entry
+from the cache, but other tags' forward index entries retain the key until those
+tags are invalidated in turn or the entry is re-cached.
+
+```
+Entry "k1" tagged ["product:1", "region:us"]
+
+InvalidateTags(c, "region:us")
+  → k1 is evicted from the cache
+  → forward index for "region:us" is cleared
+  → reverse index for k1 retains ["product:1"]
+```
+
+### Cross-Instance Invalidation
+
+When `Storage` is set, the forward index lives in the shared backend. An
+`InvalidateTags` call on **any** instance reads that shared index and therefore
+discovers keys cached by other instances. Those keys are deleted from the shared
+storage, making the invalidation effective cluster-wide.
+
+Each instance maintains a local tag index for the fast `has()` path. A remote
+invalidation does not update other instances' local indexes; those entries become
+stale. The stale local entries are silently overwritten the next time the same
+key is cached, so no manual synchronisation is required.
+
+### Prerequisite
+
+The cache middleware must be registered on the route or a parent group before
+the handler that calls `InvalidateTags`. If the middleware is absent,
+`InvalidateTags` returns an error:
+
+```
+cache: InvalidateTags requires the cache middleware to be registered on this route
+```
+
+---
+
+## Conditional Requests
+
+The middleware supports RFC 9110 conditional request validation. Conditional
+checks run on both the cache-hit path (using values stored with the cached
+entry) and the cache-miss / revalidation path (using values the handler or
+generators produced during the current request).
+
+### ETag
+
+**Auto-generation** (`EnableETag`, default `true`): when no `ETag` header has
+been set by the handler or by `ETagGenerator`, the middleware computes a strong
+ETag as the hex-encoded SHA-256 hash of the response body.
+
+**Custom generation** (`ETagGenerator`): runs after the handler and before
+auto-generation. When it returns a non-empty string that value is set as the
+`ETag` header; auto-generation is then skipped.
+
+```go
+app.Use(cache.New(cache.Config{
+    ETagGenerator: func(c fiber.Ctx, body []byte) string {
+        return fmt.Sprintf(`"%s-v2"`, myHash(body))
+    },
+}))
+```
+
+**Validation on cache hit**: when a stored entry has an ETag and the request
+carries `If-None-Match`, the middleware performs a weak comparison. A match
+returns `304 Not Modified` without loading the response body from storage.
+
+### Last-Modified
+
+**Auto-generation** (`EnableLastModified`, default `true`): when no
+`Last-Modified` header has been set by the handler or by
+`LastModifiedGenerator`, the middleware sets it to the current time.
+
+**Custom generation** (`LastModifiedGenerator`): runs after the handler. A zero
+`time.Time` is treated as "not set" and does not suppress auto-generation.
+
+```go
+app.Use(cache.New(cache.Config{
+    LastModifiedGenerator: func(c fiber.Ctx) time.Time {
+        return db.LastModifiedForResource(c.Param("id"))
+    },
+}))
+```
+
+**Validation on cache hit**: when a stored entry has a `lastModified` timestamp
+and the request carries `If-Modified-Since`, the middleware compares the two. If
+the stored modification time is not after the client's timestamp, a
+`304 Not Modified` is returned.
+
+### Precedence (RFC 9110 §8.3)
+
+When a request includes both `If-None-Match` and `If-Modified-Since`, only
+`If-None-Match` is evaluated. `If-Modified-Since` is ignored. This rule applies
+on both the cache-hit path and the miss-path conditional checks.
+
+### Miss-Path Conditional Evaluation
+
+On a cache miss or when revalidation forces the handler to re-run, the
+middleware evaluates conditional headers against the ETag and Last-Modified
+values produced during that request (by the handler, a generator, or
+auto-generation). A match still produces `304 Not Modified`, preventing an
+unnecessary body transfer even when the cache entry does not yet exist or has
+just been replaced.
+
+---
+
+## Cache-Control Configuration
+
+### Middleware-Generated Cache-Control
+
+By default (`DisableCacheControl: false`) the middleware writes a
+`Cache-Control` response header whenever the handler has not already set one.
+The generated format is:
+
+```
+public, max-age=<seconds>[, must-revalidate]
+```
+
+- **`max-age`** is the remaining freshness lifetime of the entry in seconds.
+- **`must-revalidate`** is appended only when the original handler response
+  included `must-revalidate` or `proxy-revalidate` in its `Cache-Control`
+  header. The flag is stored with the cached entry and replayed on every
+  subsequent hit.
+
+This header is produced on both the miss path (first response) and the hit path
+(responses served from cache), including `304 Not Modified` replies.
+
+### Handler-Set Cache-Control Is Preserved
+
+When a handler sets its own `Cache-Control` header, the middleware stores the
+raw header bytes with the cached entry and restores them verbatim on cache hits
+and `304` responses. The automatic `public, max-age=…` generation is skipped
+whenever a stored `Cache-Control` value is present.
+
+```go
+app.Get("/custom", func(c fiber.Ctx) error {
+    c.Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=60")
+    return c.SendString("ok")
+})
+// On subsequent hits the exact header above is replayed unchanged.
+```
+
+### Response Directives That Influence Caching Decisions
+
+| Directive | Effect |
+|---|---|
+| `no-store` | Response is not cached. |
+| `no-cache` | Any existing cached entry for this key is deleted. Response is not stored. |
+| `private` | Same effect as `no-cache` in this shared-cache context. |
+| `s-maxage=N` | Sets the cache lifetime to N seconds. Takes priority over `max-age`. |
+| `max-age=N` | Sets the cache lifetime to N seconds when `s-maxage` is absent. |
+| `must-revalidate` | Stored with the entry; appended to middleware-generated `Cache-Control` on hit. Stale entries with this flag trigger revalidation instead of being served. |
+| `proxy-revalidate` | Treated identically to `must-revalidate`. |
+
+### Expires Header
+
+When neither `s-maxage` nor `max-age` is present in the response, the
+middleware falls back to the `Expires` header. The cache lifetime is computed as
+`Expires − now`. A malformed `Expires` value causes the entry to be stored with
+a very short effective TTL; the next request triggers revalidation.
+
+### ExpirationGenerator
+
+`ExpirationGenerator` overrides all other expiration sources (`s-maxage`,
+`max-age`, `Expires`, and `Config.Expiration`). When set, its return value
+becomes the cache lifetime unconditionally.
+
+```go
+app.Use(cache.New(cache.Config{
+    ExpirationGenerator: func(c fiber.Ctx, cfg *cache.Config) time.Duration {
+        if c.Path() == "/static" {
+            return 24 * time.Hour
+        }
+        return cfg.Expiration
+    },
+}))
+```
+
+### Request Directives That Influence Cache Behaviour
+
+| Directive | Effect |
+|---|---|
+| `no-store` | Bypasses the cache entirely — no lookup, no storage. |
+| `no-cache` (or `Pragma: no-cache`) | Cached response is not served; the handler runs. The fresh response may still be stored. |
+| `max-age=N` | A cached entry older than N seconds is not served; the handler re-runs (revalidation). |
+| `min-fresh=N` | A cached entry whose remaining freshness is less than N seconds triggers revalidation. |
+| `max-stale[=N]` | Allows a stale entry to be served. Without a value, any degree of staleness is accepted. |
+| `only-if-cached` | Returns `504 Gateway Timeout` instead of running the handler when no fresh cached response is available. |
+
+### Disabling Cache-Control Generation
+
+Set `DisableCacheControl: true` to suppress all middleware-generated
+`Cache-Control` headers. Handler-set `Cache-Control` values are still stored
+and replayed verbatim — this option only prevents the automatic
+`public, max-age=…` generation.

--- a/middleware/cache/manager.go
+++ b/middleware/cache/manager.go
@@ -23,6 +23,7 @@ type item struct {
 	expires         []byte
 	etag            []byte
 	date            uint64
+	lastModified    uint64
 	status          int
 	age             uint64
 	exp             uint64
@@ -33,6 +34,8 @@ type item struct {
 	private         bool
 	// used for finding the item in an indexed heap
 	heapidx int
+	// tags persisted with the entry so the tag index survives restarts
+	tags []string
 }
 
 type cachedHeader struct {
@@ -90,6 +93,7 @@ func (m *manager) release(e *item) {
 	e.ctype = nil
 	e.cencoding = nil
 	e.date = 0
+	e.lastModified = 0
 	e.status = 0
 	e.age = 0
 	e.exp = 0
@@ -97,6 +101,7 @@ func (m *manager) release(e *item) {
 	e.forceRevalidate = false
 	e.revalidate = false
 	e.headers = nil
+	e.tags = nil
 	e.shareable = false
 	e.private = false
 	e.heapidx = 0

--- a/middleware/cache/manager_msgp.go
+++ b/middleware/cache/manager_msgp.go
@@ -242,6 +242,12 @@ func (z *item) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "date")
 				return
 			}
+		case "lastModified":
+			z.lastModified, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "lastModified")
+				return
+			}
 		case "status":
 			z.status, err = dc.ReadInt()
 			if err != nil {
@@ -296,6 +302,25 @@ func (z *item) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "heapidx")
 				return
 			}
+		case "tags":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "tags")
+				return
+			}
+			if cap(z.tags) >= int(zb0002) {
+				z.tags = (z.tags)[:zb0002]
+			} else {
+				z.tags = make([]string, zb0002)
+			}
+			for za0001 := range z.tags {
+				z.tags[za0001], err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "tags", za0001)
+					return
+				}
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -309,9 +334,9 @@ func (z *item) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *item) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 17
+	// map header, size 19
 	// write "headers"
-	err = en.Append(0xde, 0x0, 0x11, 0xa7, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72, 0x73)
+	err = en.Append(0xde, 0x0, 0x13, 0xa7, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72, 0x73)
 	if err != nil {
 		return
 	}
@@ -413,6 +438,16 @@ func (z *item) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "date")
 		return
 	}
+	// write "lastModified"
+	err = en.Append(0xac, 0x6c, 0x61, 0x73, 0x74, 0x4d, 0x6f, 0x64, 0x69, 0x66, 0x69, 0x65, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint64(z.lastModified)
+	if err != nil {
+		err = msgp.WrapError(err, "lastModified")
+		return
+	}
 	// write "status"
 	err = en.Append(0xa6, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73)
 	if err != nil {
@@ -503,15 +538,32 @@ func (z *item) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "heapidx")
 		return
 	}
+	// write "tags"
+	err = en.Append(0xa4, 0x74, 0x61, 0x67, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.tags)))
+	if err != nil {
+		err = msgp.WrapError(err, "tags")
+		return
+	}
+	for za0001 := range z.tags {
+		err = en.WriteString(z.tags[za0001])
+		if err != nil {
+			err = msgp.WrapError(err, "tags", za0001)
+			return
+		}
+	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *item) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 17
+	// map header, size 19
 	// string "headers"
-	o = append(o, 0xde, 0x0, 0x11, 0xa7, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72, 0x73)
+	o = append(o, 0xde, 0x0, 0x13, 0xa7, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.headers)))
 	for za0001 := range z.headers {
 		// map header, size 2
@@ -543,6 +595,9 @@ func (z *item) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "date"
 	o = append(o, 0xa4, 0x64, 0x61, 0x74, 0x65)
 	o = msgp.AppendUint64(o, z.date)
+	// string "lastModified"
+	o = append(o, 0xac, 0x6c, 0x61, 0x73, 0x74, 0x4d, 0x6f, 0x64, 0x69, 0x66, 0x69, 0x65, 0x64)
+	o = msgp.AppendUint64(o, z.lastModified)
 	// string "status"
 	o = append(o, 0xa6, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73)
 	o = msgp.AppendInt(o, z.status)
@@ -570,6 +625,12 @@ func (z *item) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "heapidx"
 	o = append(o, 0xa7, 0x68, 0x65, 0x61, 0x70, 0x69, 0x64, 0x78)
 	o = msgp.AppendInt(o, z.heapidx)
+	// string "tags"
+	o = append(o, 0xa4, 0x74, 0x61, 0x67, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.tags)))
+	for za0001 := range z.tags {
+		o = msgp.AppendString(o, z.tags[za0001])
+	}
 	return
 }
 
@@ -681,6 +742,12 @@ func (z *item) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "date")
 				return
 			}
+		case "lastModified":
+			z.lastModified, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "lastModified")
+				return
+			}
 		case "status":
 			z.status, bts, err = msgp.ReadIntBytes(bts)
 			if err != nil {
@@ -735,6 +802,25 @@ func (z *item) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "heapidx")
 				return
 			}
+		case "tags":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "tags")
+				return
+			}
+			if cap(z.tags) >= int(zb0002) {
+				z.tags = (z.tags)[:zb0002]
+			} else {
+				z.tags = make([]string, zb0002)
+			}
+			for za0001 := range z.tags {
+				z.tags[za0001], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "tags", za0001)
+					return
+				}
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -753,6 +839,10 @@ func (z *item) Msgsize() (s int) {
 	for za0001 := range z.headers {
 		s += 1 + 4 + msgp.BytesPrefixSize + len(z.headers[za0001].key) + 6 + msgp.BytesPrefixSize + len(z.headers[za0001].value)
 	}
-	s += 5 + msgp.BytesPrefixSize + len(z.body) + 6 + msgp.BytesPrefixSize + len(z.ctype) + 10 + msgp.BytesPrefixSize + len(z.cencoding) + 13 + msgp.BytesPrefixSize + len(z.cacheControl) + 8 + msgp.BytesPrefixSize + len(z.expires) + 5 + msgp.BytesPrefixSize + len(z.etag) + 5 + msgp.Uint64Size + 7 + msgp.IntSize + 4 + msgp.Uint64Size + 4 + msgp.Uint64Size + 4 + msgp.Uint64Size + 16 + msgp.BoolSize + 11 + msgp.BoolSize + 10 + msgp.BoolSize + 8 + msgp.BoolSize + 8 + msgp.IntSize
+	s += 5 + msgp.BytesPrefixSize + len(z.body) + 6 + msgp.BytesPrefixSize + len(z.ctype) + 10 + msgp.BytesPrefixSize + len(z.cencoding) + 13 + msgp.BytesPrefixSize + len(z.cacheControl) + 8 + msgp.BytesPrefixSize + len(z.expires) + 5 + msgp.BytesPrefixSize + len(z.etag) + 5 + msgp.Uint64Size + 13 + msgp.Uint64Size + 7 + msgp.IntSize + 4 + msgp.Uint64Size + 4 + msgp.Uint64Size + 4 + msgp.Uint64Size + 16 + msgp.BoolSize + 11 + msgp.BoolSize + 10 + msgp.BoolSize + 8 + msgp.BoolSize + 8 + msgp.IntSize
+	s += 5 + msgp.ArrayHeaderSize
+	for za0002 := range z.tags {
+		s += msgp.StringPrefixSize + len(z.tags[za0002])
+	}
 	return
 }

--- a/middleware/cache/tags.go
+++ b/middleware/cache/tags.go
@@ -1,0 +1,217 @@
+package cache
+
+import (
+	"strings"
+	"sync"
+)
+
+// tagStore abstracts the tag↔cache-key index. When no external storage is
+// configured the lightweight in-memory tagIndex is used. When the middleware
+// shares an external storage backend (e.g. Redis) a distributedTagStore
+// persists the index there so that InvalidateTags propagates across every
+// instance that uses the same backend.
+type tagStore interface {
+	// add registers key under the given tags.
+	add(key string, tags []string)
+	// remove deletes key from every tag it belongs to.
+	remove(key string)
+	// has reports whether key is currently tracked.
+	has(key string) bool
+	// invalidate collects all keys associated with the given tags, removes the
+	// tag entries, and returns the collected keys so the caller can delete them
+	// from the cache.
+	invalidate(tags []string) []string
+}
+
+// tagIndex maintains a bidirectional mapping between tags and cache keys,
+// enabling O(1) lookup of all keys for a given tag. The forward index
+// (tags → keys) supports invalidation; the reverse index (keys → tags)
+// supports cleanup when entries are evicted or expire.
+type tagIndex struct {
+	mu sync.Mutex
+	// tag name → set of cache keys
+	tags map[string]map[string]struct{}
+	// cache key → set of tag names (reverse index for cleanup on eviction)
+	keys map[string]map[string]struct{}
+}
+
+func newTagIndex() *tagIndex {
+	return &tagIndex{
+		tags: make(map[string]map[string]struct{}),
+		keys: make(map[string]map[string]struct{}),
+	}
+}
+
+// add registers a cache key under the given tags and records the reverse mapping.
+func (ti *tagIndex) add(key string, tags []string) {
+	if len(tags) == 0 {
+		return
+	}
+	ti.mu.Lock()
+	defer ti.mu.Unlock()
+
+	for _, tag := range tags {
+		if ti.tags[tag] == nil {
+			ti.tags[tag] = make(map[string]struct{})
+		}
+		ti.tags[tag][key] = struct{}{}
+	}
+	if ti.keys[key] == nil {
+		ti.keys[key] = make(map[string]struct{}, len(tags))
+	}
+	for _, tag := range tags {
+		ti.keys[key][tag] = struct{}{}
+	}
+}
+
+// has reports whether key is already tracked in the reverse index.
+func (ti *tagIndex) has(key string) bool {
+	ti.mu.Lock()
+	defer ti.mu.Unlock()
+	_, ok := ti.keys[key]
+	return ok
+}
+
+// remove deletes a cache key from all tags it belongs to. Called during
+// eviction or expiration to keep the index consistent.
+func (ti *tagIndex) remove(key string) {
+	ti.mu.Lock()
+	defer ti.mu.Unlock()
+
+	tags, ok := ti.keys[key]
+	if !ok {
+		return
+	}
+	for tag := range tags {
+		if keySet := ti.tags[tag]; keySet != nil {
+			delete(keySet, key)
+			if len(keySet) == 0 {
+				delete(ti.tags, tag)
+			}
+		}
+	}
+	delete(ti.keys, key)
+}
+
+// invalidate collects all cache keys associated with any of the given tags,
+// removes those tag entries from the forward index, and cleans up the
+// reverse index for keys that have no remaining tags. It acquires and
+// releases its own lock; callers must not hold mux simultaneously.
+func (ti *tagIndex) invalidate(tags []string) []string {
+	ti.mu.Lock()
+	defer ti.mu.Unlock()
+
+	// Collect unique keys across all requested tags
+	seen := make(map[string]struct{})
+	for _, tag := range tags {
+		for key := range ti.tags[tag] {
+			seen[key] = struct{}{}
+		}
+		delete(ti.tags, tag)
+	}
+
+	// Build result slice and clean up reverse index
+	tagSet := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		tagSet[tag] = struct{}{}
+	}
+
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+		if keyTags := ti.keys[key]; keyTags != nil {
+			for tag := range tagSet {
+				delete(keyTags, tag)
+			}
+			if len(keyTags) == 0 {
+				delete(ti.keys, key)
+			}
+		}
+	}
+	return keys
+}
+
+// rejectMatcher pre-classifies tag reject patterns into three buckets
+// for efficient runtime matching: exact strings use a map (O(1)),
+// single trailing-* patterns use prefix checks, and everything else
+// falls back to full glob matching.
+type rejectMatcher struct {
+	exact   map[string]struct{} // no wildcards
+	prefix  []string            // single trailing *, stored without the *
+	general []string            // all other glob patterns
+}
+
+func newRejectMatcher(patterns []string) *rejectMatcher {
+	m := &rejectMatcher{
+		exact: make(map[string]struct{}),
+	}
+	for _, p := range patterns {
+		switch {
+		case !strings.Contains(p, "*"):
+			m.exact[p] = struct{}{}
+		case strings.Count(p, "*") == 1 && p[len(p)-1] == '*':
+			m.prefix = append(m.prefix, p[:len(p)-1])
+		default:
+			m.general = append(m.general, p)
+		}
+	}
+	return m
+}
+
+// matches reports whether tag matches any reject pattern.
+func (m *rejectMatcher) matches(tag string) bool {
+	if _, ok := m.exact[tag]; ok {
+		return true
+	}
+	for _, prefix := range m.prefix {
+		if strings.HasPrefix(tag, prefix) {
+			return true
+		}
+	}
+	for _, pattern := range m.general {
+		if globMatch(pattern, tag) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesAny reports whether any tag in the slice matches a reject pattern.
+func (m *rejectMatcher) matchesAny(tags []string) bool {
+	for _, tag := range tags {
+		if m.matches(tag) {
+			return true
+		}
+	}
+	return false
+}
+
+// globMatch reports whether s matches the glob pattern.
+// '*' matches any sequence of characters (including none).
+// All other characters match literally.
+func globMatch(pattern, s string) bool {
+	for len(pattern) > 0 {
+		if pattern[0] == '*' {
+			// Collapse consecutive stars
+			for len(pattern) > 0 && pattern[0] == '*' {
+				pattern = pattern[1:]
+			}
+			if len(pattern) == 0 {
+				return true // trailing * matches everything remaining
+			}
+			// Try matching the rest of the pattern at every position in s
+			for i := range len(s) + 1 {
+				if globMatch(pattern, s[i:]) {
+					return true
+				}
+			}
+			return false
+		}
+		if len(s) == 0 || pattern[0] != s[0] {
+			return false
+		}
+		pattern = pattern[1:]
+		s = s[1:]
+	}
+	return len(s) == 0
+}

--- a/middleware/cache/tags_bench_test.go
+++ b/middleware/cache/tags_bench_test.go
@@ -1,0 +1,229 @@
+package cache
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3/internal/storage/memory"
+)
+
+// ---------------------------------------------------------------------------
+// tagIndex benchmarks
+// ---------------------------------------------------------------------------
+
+// BenchmarkTagIndex_Has measures the has() fast path with varying index sizes.
+// has() is called on every cache hit to decide whether the tag index needs
+// re-population; it must stay O(1) regardless of index size.
+func BenchmarkTagIndex_Has(b *testing.B) {
+	for _, n := range []int{10, 100, 1_000, 10_000} {
+		b.Run(fmt.Sprintf("keys=%d", n), func(b *testing.B) {
+			ti := newTagIndex()
+			for i := range n {
+				ti.add(fmt.Sprintf("key:%d", i), []string{fmt.Sprintf("tag:%d", i%10)})
+			}
+			target := fmt.Sprintf("key:%d", n/2)
+			b.ResetTimer()
+			for range b.N {
+				ti.has(target)
+			}
+		})
+	}
+}
+
+// BenchmarkTagIndex_Has_Parallel stress-tests has() under concurrent readers,
+// matching the real request-handling workload.
+func BenchmarkTagIndex_Has_Parallel(b *testing.B) {
+	ti := newTagIndex()
+	for i := range 10_000 {
+		ti.add(fmt.Sprintf("key:%d", i), []string{fmt.Sprintf("tag:%d", i%100)})
+	}
+	target := "key:5000"
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			ti.has(target)
+		}
+	})
+}
+
+// BenchmarkTagIndex_Add measures the cost of registering a key under a varying
+// number of tags. Both the forward and reverse indexes are updated.
+func BenchmarkTagIndex_Add(b *testing.B) {
+	for _, tc := range []int{1, 5, 10} {
+		b.Run(fmt.Sprintf("tags=%d", tc), func(b *testing.B) {
+			ti := newTagIndex()
+			tags := make([]string, tc)
+			for i := range tc {
+				tags[i] = fmt.Sprintf("tag:%d", i)
+			}
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := range b.N {
+				ti.add(fmt.Sprintf("key:%d", i), tags)
+			}
+		})
+	}
+}
+
+// BenchmarkTagIndex_Invalidate measures invalidation of a single tag that
+// covers a varying number of keys. Setup (index population) runs outside the
+// timed window; only the invalidate call itself is measured.
+func BenchmarkTagIndex_Invalidate(b *testing.B) {
+	for _, kpt := range []int{10, 100, 1_000} {
+		b.Run(fmt.Sprintf("keysPerTag=%d", kpt), func(b *testing.B) {
+			// Pre-generate keys and per-key tag slices so setup allocations
+			// are not charged to the timed portion.
+			keys := make([]string, kpt)
+			tags := make([][]string, kpt)
+			for j := range kpt {
+				keys[j] = fmt.Sprintf("key:%d", j)
+				tags[j] = []string{"target", fmt.Sprintf("other:%d", j)}
+			}
+			b.ReportAllocs()
+			for range b.N {
+				b.StopTimer()
+				ti := newTagIndex()
+				for j := range kpt {
+					ti.add(keys[j], tags[j])
+				}
+				b.StartTimer()
+
+				ti.invalidate([]string{"target"})
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// distributedTagStore benchmarks
+// ---------------------------------------------------------------------------
+
+// BenchmarkDistributedTagStore_Has measures the distributed store's has() path.
+// It delegates directly to the local tagIndex, so the cost should be identical
+// to BenchmarkTagIndex_Has; this benchmark confirms no overhead is added by the
+// distributed wrapper.
+func BenchmarkDistributedTagStore_Has(b *testing.B) {
+	store := memory.New()
+	defer store.Close()
+	d := newDistributedTagStore(store, 5*time.Minute)
+	for i := range 10_000 {
+		d.add(fmt.Sprintf("key:%d", i), []string{fmt.Sprintf("tag:%d", i%10)})
+	}
+	target := "key:5000"
+	b.ResetTimer()
+	for range b.N {
+		d.has(target)
+	}
+}
+
+// BenchmarkDistributedTagStore_Has_Parallel confirms the distributed has() path
+// remains contention-free under concurrent readers.
+func BenchmarkDistributedTagStore_Has_Parallel(b *testing.B) {
+	store := memory.New()
+	defer store.Close()
+	d := newDistributedTagStore(store, 5*time.Minute)
+	for i := range 10_000 {
+		d.add(fmt.Sprintf("key:%d", i), []string{fmt.Sprintf("tag:%d", i%10)})
+	}
+	target := "key:5000"
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			d.has(target)
+		}
+	})
+}
+
+// BenchmarkDistributedTagStore_Add measures the cost of add(), which writes to
+// both the local index and the shared backend. Each add performs one read-modify-
+// write cycle per tag on the forward index plus one on the reverse index.
+func BenchmarkDistributedTagStore_Add(b *testing.B) {
+	for _, tc := range []int{1, 5, 10} {
+		b.Run(fmt.Sprintf("tags=%d", tc), func(b *testing.B) {
+			store := memory.New()
+			defer store.Close()
+			d := newDistributedTagStore(store, 5*time.Minute)
+			tags := make([]string, tc)
+			for i := range tc {
+				tags[i] = fmt.Sprintf("tag:%d", i)
+			}
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := range b.N {
+				d.add(fmt.Sprintf("key:%d", i), tags)
+			}
+		})
+	}
+}
+
+// BenchmarkDistributedTagStore_Invalidate measures invalidation against the
+// shared backend. Each iteration resets the shared storage and re-populates
+// it so that invalidate() always operates on a freshly populated index. Only
+// the invalidate call is timed.
+func BenchmarkDistributedTagStore_Invalidate(b *testing.B) {
+	for _, kpt := range []int{10, 100, 1_000} {
+		b.Run(fmt.Sprintf("keysPerTag=%d", kpt), func(b *testing.B) {
+			store := memory.New()
+			defer store.Close()
+			keys := make([]string, kpt)
+			tags := make([][]string, kpt)
+			for j := range kpt {
+				keys[j] = fmt.Sprintf("key:%d", j)
+				tags[j] = []string{"target", fmt.Sprintf("other:%d", j)}
+			}
+			b.ReportAllocs()
+			for range b.N {
+				b.StopTimer()
+				_ = store.Reset()
+				d := newDistributedTagStore(store, 5*time.Minute)
+				for j := range kpt {
+					d.add(keys[j], tags[j])
+				}
+				b.StartTimer()
+
+				d.invalidate([]string{"target"})
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Encoding benchmarks
+// ---------------------------------------------------------------------------
+
+// BenchmarkEncodeStringSet measures the serialization cost for the binary
+// format used by distributedTagStore to persist sets in shared storage.
+// This is on the hot path of every shared-storage read and write.
+func BenchmarkEncodeStringSet(b *testing.B) {
+	for _, n := range []int{1, 5, 10, 50} {
+		b.Run(fmt.Sprintf("strings=%d", n), func(b *testing.B) {
+			ss := make([]string, n)
+			for i := range n {
+				ss[i] = fmt.Sprintf("tag:%d", i)
+			}
+			b.ResetTimer()
+			b.ReportAllocs()
+			for range b.N {
+				encodeStringSet(ss)
+			}
+		})
+	}
+}
+
+// BenchmarkDecodeStringSet measures the deserialization cost; called once per
+// shared-storage read.
+func BenchmarkDecodeStringSet(b *testing.B) {
+	for _, n := range []int{1, 5, 10, 50} {
+		b.Run(fmt.Sprintf("strings=%d", n), func(b *testing.B) {
+			ss := make([]string, n)
+			for i := range n {
+				ss[i] = fmt.Sprintf("tag:%d", i)
+			}
+			data := encodeStringSet(ss)
+			b.ResetTimer()
+			b.ReportAllocs()
+			for range b.N {
+				decodeStringSet(data)
+			}
+		})
+	}
+}

--- a/middleware/cache/tags_distributed.go
+++ b/middleware/cache/tags_distributed.go
@@ -1,0 +1,209 @@
+package cache
+
+import (
+	"encoding/binary"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+const (
+	tagKeyPrefix    = "__cache_tag__:"
+	tagRevKeyPrefix = "__cache_tagrev__:"
+)
+
+// distributedTagStore backs the tag↔key index in a shared external storage
+// (e.g. Redis) so that InvalidateTags propagates across every middleware
+// instance that shares the same backend. A local tagIndex is kept in sync
+// for the fast has() path used on cache hit.
+type distributedTagStore struct {
+	local   *tagIndex
+	storage fiber.Storage
+	mu      sync.Mutex    // serialises read-modify-write cycles on shared storage
+	ttl     time.Duration // TTL for tag index entries in shared storage
+}
+
+func newDistributedTagStore(storage fiber.Storage, ttl time.Duration) *distributedTagStore {
+	return &distributedTagStore{
+		local:   newTagIndex(),
+		storage: storage,
+		ttl:     ttl,
+	}
+}
+
+// add registers key under the given tags in both the local index and the
+// shared storage backend.
+func (d *distributedTagStore) add(key string, tags []string) {
+	if len(tags) == 0 {
+		return
+	}
+	d.local.add(key, tags)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for _, tag := range tags {
+		fwdKey := tagKeyPrefix + tag
+		fwd := d.readSet(fwdKey)
+		if !sliceContains(fwd, key) {
+			d.writeSet(fwdKey, append(fwd, key))
+		}
+	}
+	revKey := tagRevKeyPrefix + key
+	rev := d.readSet(revKey)
+	for _, tag := range tags {
+		if !sliceContains(rev, tag) {
+			rev = append(rev, tag)
+		}
+	}
+	d.writeSet(revKey, rev)
+}
+
+// remove deletes key from all tags in both the local index and shared storage.
+func (d *distributedTagStore) remove(key string) {
+	d.local.remove(key)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	revKey := tagRevKeyPrefix + key
+	rev := d.readSet(revKey)
+	if len(rev) == 0 {
+		return
+	}
+	for _, tag := range rev {
+		fwdKey := tagKeyPrefix + tag
+		fwd := d.readSet(fwdKey)
+		d.writeSet(fwdKey, sliceRemove(fwd, key))
+	}
+	_ = d.storage.Delete(revKey)
+}
+
+// has reports whether key is tracked locally. This is the fast-path check
+// used by the middleware's cache-hit re-population guard.
+func (d *distributedTagStore) has(key string) bool {
+	return d.local.has(key)
+}
+
+// invalidate reads the authoritative forward index from shared storage,
+// collects all keys for the requested tags, cleans up both shared and local
+// indexes, and returns the collected keys so the caller can evict them.
+func (d *distributedTagStore) invalidate(tags []string) []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	seen := make(map[string]struct{})
+	for _, tag := range tags {
+		fwdKey := tagKeyPrefix + tag
+		for _, k := range d.readSet(fwdKey) {
+			seen[k] = struct{}{}
+		}
+		_ = d.storage.Delete(fwdKey)
+	}
+
+	tagSet := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		tagSet[tag] = struct{}{}
+	}
+
+	result := make([]string, 0, len(seen))
+	for key := range seen {
+		result = append(result, key)
+		revKey := tagRevKeyPrefix + key
+		rev := d.readSet(revKey)
+		filtered := make([]string, 0, len(rev))
+		for _, t := range rev {
+			if _, ok := tagSet[t]; !ok {
+				filtered = append(filtered, t)
+			}
+		}
+		d.writeSet(revKey, filtered)
+		d.local.remove(key)
+	}
+	return result
+}
+
+// readSet reads a string set from shared storage. Returns nil when the key
+// does not exist.
+func (d *distributedTagStore) readSet(key string) []string {
+	raw, err := d.storage.Get(key)
+	if err != nil || raw == nil {
+		return nil
+	}
+	return decodeStringSet(raw)
+}
+
+// writeSet persists a string set to shared storage. An empty slice causes the
+// key to be deleted.
+func (d *distributedTagStore) writeSet(key string, ss []string) {
+	if len(ss) == 0 {
+		_ = d.storage.Delete(key)
+		return
+	}
+	_ = d.storage.Set(key, encodeStringSet(ss), d.ttl)
+}
+
+// encodeStringSet serialises a string slice into a compact binary format:
+// [count uint32 LE] ([len uint32 LE] [bytes])*
+func encodeStringSet(ss []string) []byte {
+	size := 4
+	for _, s := range ss {
+		size += 4 + len(s)
+	}
+	buf := make([]byte, size)
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(len(ss)))
+	off := 4
+	for _, s := range ss {
+		binary.LittleEndian.PutUint32(buf[off:off+4], uint32(len(s)))
+		off += 4
+		copy(buf[off:], s)
+		off += len(s)
+	}
+	return buf
+}
+
+// decodeStringSet deserialises a []byte produced by encodeStringSet. Returns
+// nil when data is nil or too short to contain a valid header.
+func decodeStringSet(data []byte) []string {
+	if len(data) < 4 {
+		return nil
+	}
+	count := binary.LittleEndian.Uint32(data[0:4])
+	ss := make([]string, 0, count)
+	off := 4
+	for i := uint32(0); i < count; i++ {
+		if off+4 > len(data) {
+			return ss
+		}
+		n := int(binary.LittleEndian.Uint32(data[off : off+4]))
+		off += 4
+		if off+n > len(data) {
+			return ss
+		}
+		ss = append(ss, string(data[off:off+n]))
+		off += n
+	}
+	return ss
+}
+
+func sliceContains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// sliceRemove returns ss with all occurrences of s removed.
+func sliceRemove(ss []string, s string) []string {
+	n := 0
+	for _, v := range ss {
+		if v != s {
+			ss[n] = v
+			n++
+		}
+	}
+	return ss[:n]
+}

--- a/middleware/cache/tags_distributed_test.go
+++ b/middleware/cache/tags_distributed_test.go
@@ -1,0 +1,272 @@
+package cache
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3/internal/storage/memory"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Encoding round-trip
+// ---------------------------------------------------------------------------
+
+func Test_encodeDecodeStringSet_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := [][]string{
+		nil,
+		{},
+		{"single"},
+		{"a", "b", "c"},
+		{"", "empty-first"},
+		{"user:123", "product:456", "region:us-east-1"},
+	}
+	for _, input := range cases {
+		got := decodeStringSet(encodeStringSet(input))
+		if len(input) == 0 {
+			require.Empty(t, got)
+		} else {
+			require.Equal(t, input, got)
+		}
+	}
+}
+
+func Test_decodeStringSet_Truncated(t *testing.T) {
+	t.Parallel()
+
+	full := encodeStringSet([]string{"hello", "world"})
+	// Truncate at every byte boundary; must never panic
+	for i := range len(full) {
+		got := decodeStringSet(full[:i])
+		require.LessOrEqual(t, len(got), 2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// distributedTagStore unit tests
+// ---------------------------------------------------------------------------
+
+func Test_distributedTagStore_AddAndHas(t *testing.T) {
+	t.Parallel()
+
+	store := memory.New()
+	defer store.Close()
+	d := newDistributedTagStore(store, 5*time.Minute)
+
+	require.False(t, d.has("k1"))
+	d.add("k1", []string{"a", "b"})
+	require.True(t, d.has("k1"))
+
+	// Forward and reverse indexes persisted in shared storage
+	require.Contains(t, d.readSet(tagKeyPrefix+"a"), "k1")
+	require.Contains(t, d.readSet(tagKeyPrefix+"b"), "k1")
+	require.ElementsMatch(t, []string{"a", "b"}, d.readSet(tagRevKeyPrefix+"k1"))
+
+	// Idempotent: second add does not duplicate entries
+	d.add("k1", []string{"a", "b"})
+	require.Equal(t, []string{"k1"}, d.readSet(tagKeyPrefix+"a"))
+
+	// Empty tags is a no-op
+	d.add("k2", nil)
+	require.False(t, d.has("k2"))
+}
+
+func Test_distributedTagStore_Remove(t *testing.T) {
+	t.Parallel()
+
+	store := memory.New()
+	defer store.Close()
+	d := newDistributedTagStore(store, 5*time.Minute)
+
+	d.add("k1", []string{"a", "b"})
+	d.add("k2", []string{"a"})
+
+	d.remove("k1")
+	require.False(t, d.has("k1"))
+
+	// "a" forward still contains k2; "b" forward is deleted (empty set)
+	require.Equal(t, []string{"k2"}, d.readSet(tagKeyPrefix+"a"))
+	require.Nil(t, d.readSet(tagKeyPrefix+"b"))
+	// Reverse index for k1 is gone
+	require.Nil(t, d.readSet(tagRevKeyPrefix+"k1"))
+
+	// Removing a non-existent key is a safe no-op
+	d.remove("nonexistent")
+}
+
+func Test_distributedTagStore_Invalidate(t *testing.T) {
+	t.Parallel()
+
+	store := memory.New()
+	defer store.Close()
+	d := newDistributedTagStore(store, 5*time.Minute)
+
+	d.add("k1", []string{"a", "b"})
+	d.add("k2", []string{"b", "c"})
+	d.add("k3", []string{"c"})
+
+	keys := d.invalidate([]string{"b"})
+	sort.Strings(keys)
+	require.Equal(t, []string{"k1", "k2"}, keys)
+
+	// Affected keys removed from local index
+	require.False(t, d.has("k1"))
+	require.False(t, d.has("k2"))
+	// Unaffected key still tracked
+	require.True(t, d.has("k3"))
+
+	// Shared reverse indexes: only the invalidated tag stripped
+	require.Equal(t, []string{"a"}, d.readSet(tagRevKeyPrefix+"k1"))
+	require.Equal(t, []string{"c"}, d.readSet(tagRevKeyPrefix+"k2"))
+	// Forward index for "b" deleted; others intact
+	require.Nil(t, d.readSet(tagKeyPrefix+"b"))
+	require.Contains(t, d.readSet(tagKeyPrefix+"a"), "k1")
+	require.Contains(t, d.readSet(tagKeyPrefix+"c"), "k2")
+	require.Contains(t, d.readSet(tagKeyPrefix+"c"), "k3")
+}
+
+func Test_distributedTagStore_InvalidateMultipleTags(t *testing.T) {
+	t.Parallel()
+
+	store := memory.New()
+	defer store.Close()
+	d := newDistributedTagStore(store, 5*time.Minute)
+
+	d.add("k1", []string{"a", "b"})
+	d.add("k2", []string{"b", "c"})
+	d.add("k3", []string{"c", "d"})
+
+	keys := d.invalidate([]string{"a", "c"})
+	sort.Strings(keys)
+	require.Equal(t, []string{"k1", "k2", "k3"}, keys)
+
+	// All affected keys gone from local
+	require.False(t, d.has("k1"))
+	require.False(t, d.has("k2"))
+	require.False(t, d.has("k3"))
+
+	// Only the invalidated tags stripped from reverse indexes
+	require.Equal(t, []string{"b"}, d.readSet(tagRevKeyPrefix+"k1"))
+	require.Equal(t, []string{"b"}, d.readSet(tagRevKeyPrefix+"k2"))
+	require.Equal(t, []string{"d"}, d.readSet(tagRevKeyPrefix+"k3"))
+
+	// Forward indexes for "a" and "c" deleted; "b" and "d" intact
+	require.Nil(t, d.readSet(tagKeyPrefix+"a"))
+	require.Nil(t, d.readSet(tagKeyPrefix+"c"))
+	require.ElementsMatch(t, []string{"k1", "k2"}, d.readSet(tagKeyPrefix+"b"))
+	require.Equal(t, []string{"k3"}, d.readSet(tagKeyPrefix+"d"))
+}
+
+// ---------------------------------------------------------------------------
+// Cross-instance coordination
+// ---------------------------------------------------------------------------
+
+func Test_distributedTagStore_CrossInstance(t *testing.T) {
+	t.Parallel()
+
+	shared := memory.New()
+	defer shared.Close()
+
+	d1 := newDistributedTagStore(shared, 5*time.Minute)
+	d2 := newDistributedTagStore(shared, 5*time.Minute)
+
+	// Instance 1 populates the shared index
+	d1.add("k1", []string{"user:1"})
+	d1.add("k2", []string{"user:1", "product:x"})
+
+	// Instance 2 invalidates – finds keys written by instance 1
+	keys := d2.invalidate([]string{"user:1"})
+	sort.Strings(keys)
+	require.Equal(t, []string{"k1", "k2"}, keys)
+
+	// Shared forward index for "user:1" is gone
+	require.Nil(t, d2.readSet(tagKeyPrefix+"user:1"))
+
+	// k2 still has "product:x" in its shared reverse index
+	require.Equal(t, []string{"product:x"}, d2.readSet(tagRevKeyPrefix+"k2"))
+
+	// Instance 1's local index is stale (it doesn't know about the remote
+	// invalidation until it re-populates on the next cache hit)
+	require.True(t, d1.has("k1"))
+	require.True(t, d1.has("k2"))
+}
+
+func Test_distributedTagStore_CrossInstanceBothDirections(t *testing.T) {
+	t.Parallel()
+
+	shared := memory.New()
+	defer shared.Close()
+
+	d1 := newDistributedTagStore(shared, 5*time.Minute)
+	d2 := newDistributedTagStore(shared, 5*time.Minute)
+
+	// Each instance adds entries under the same tag
+	d1.add("k1", []string{"shared-tag"})
+	d2.add("k2", []string{"shared-tag"})
+
+	// Either instance sees both keys in the shared forward index
+	fwd := d1.readSet(tagKeyPrefix + "shared-tag")
+	require.ElementsMatch(t, []string{"k1", "k2"}, fwd)
+
+	// Instance 1 invalidates and collects keys from both instances
+	keys := d1.invalidate([]string{"shared-tag"})
+	sort.Strings(keys)
+	require.Equal(t, []string{"k1", "k2"}, keys)
+
+	// Shared forward index is cleared
+	require.Nil(t, d1.readSet(tagKeyPrefix+"shared-tag"))
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent access
+// ---------------------------------------------------------------------------
+
+func Test_distributedTagStore_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	store := memory.New()
+	defer store.Close()
+	d := newDistributedTagStore(store, 5*time.Minute)
+
+	const n = 100
+	var wg sync.WaitGroup
+
+	// Concurrent adds with 10 shared tags
+	wg.Add(n)
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			d.add(fmt.Sprintf("key:%d", i), []string{fmt.Sprintf("tag:%d", i%10)})
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range n {
+		require.True(t, d.has(fmt.Sprintf("key:%d", i)))
+	}
+
+	// Concurrently invalidate tags 0–4
+	wg.Add(5)
+	for i := range 5 {
+		go func(i int) {
+			defer wg.Done()
+			d.invalidate([]string{fmt.Sprintf("tag:%d", i)})
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range n {
+		if i%10 < 5 {
+			require.False(t, d.has(fmt.Sprintf("key:%d", i)),
+				"key:%d under tag %d should be invalidated", i, i%10)
+		} else {
+			require.True(t, d.has(fmt.Sprintf("key:%d", i)),
+				"key:%d under tag %d should still exist", i, i%10)
+		}
+	}
+}

--- a/middleware/cache/tags_test.go
+++ b/middleware/cache/tags_test.go
@@ -1,0 +1,1001 @@
+package cache
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/internal/storage/memory"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// tagIndex unit tests
+// ---------------------------------------------------------------------------
+
+func Test_tagIndex_AddAndHas(t *testing.T) {
+	t.Parallel()
+
+	ti := newTagIndex()
+
+	require.False(t, ti.has("k1"))
+	ti.add("k1", []string{"a", "b"})
+	require.True(t, ti.has("k1"))
+
+	// Adding empty tags is a no-op
+	ti.add("k2", nil)
+	require.False(t, ti.has("k2"))
+}
+
+func Test_tagIndex_Remove(t *testing.T) {
+	t.Parallel()
+
+	ti := newTagIndex()
+	ti.add("k1", []string{"a", "b"})
+	ti.add("k2", []string{"b", "c"})
+
+	ti.remove("k1")
+	require.False(t, ti.has("k1"))
+	// "b" still mapped to k2
+	require.True(t, ti.has("k2"))
+
+	// Removing unknown key is safe
+	ti.remove("nonexistent")
+}
+
+func Test_tagIndex_Invalidate(t *testing.T) {
+	t.Parallel()
+
+	ti := newTagIndex()
+	ti.add("k1", []string{"a", "b"})
+	ti.add("k2", []string{"b", "c"})
+	ti.add("k3", []string{"c", "d"})
+
+	// Invalidate tag "b" → should return k1 and k2
+	keys := ti.invalidate([]string{"b"})
+	require.ElementsMatch(t, []string{"k1", "k2"}, keys)
+
+	// k1 still has tag "a" (only "b" was invalidated), so it remains in reverse index
+	require.True(t, ti.has("k1"))
+	// k2 still has tag "c"
+	require.True(t, ti.has("k2"))
+
+	// Invalidate "a" → removes k1's last remaining tag
+	keys = ti.invalidate([]string{"a"})
+	require.ElementsMatch(t, []string{"k1"}, keys)
+	require.False(t, ti.has("k1"))
+
+	// Invalidate tags "c" and "d" → should return k2 and k3
+	keys = ti.invalidate([]string{"c", "d"})
+	require.ElementsMatch(t, []string{"k2", "k3"}, keys)
+	require.False(t, ti.has("k2"))
+	require.False(t, ti.has("k3"))
+
+	// Invalidating already-gone tags returns nothing
+	keys = ti.invalidate([]string{"a", "b", "c"})
+	require.Empty(t, keys)
+}
+
+func Test_tagIndex_InvalidateMultipleTags(t *testing.T) {
+	t.Parallel()
+
+	ti := newTagIndex()
+	// k1 shares both tags being invalidated – should appear only once in result
+	ti.add("k1", []string{"x", "y"})
+	ti.add("k2", []string{"x"})
+	ti.add("k3", []string{"y"})
+
+	keys := ti.invalidate([]string{"x", "y"})
+	require.ElementsMatch(t, []string{"k1", "k2", "k3"}, keys)
+}
+
+// ---------------------------------------------------------------------------
+// rejectMatcher unit tests
+// ---------------------------------------------------------------------------
+
+func Test_rejectMatcher_Exact(t *testing.T) {
+	t.Parallel()
+	m := newRejectMatcher([]string{"internal", "secret"})
+
+	require.True(t, m.matches("internal"))
+	require.True(t, m.matches("secret"))
+	require.False(t, m.matches("public"))
+	require.False(t, m.matches("internal2")) // not a prefix match
+}
+
+func Test_rejectMatcher_Prefix(t *testing.T) {
+	t.Parallel()
+	m := newRejectMatcher([]string{"user:*"})
+
+	require.True(t, m.matches("user:"))
+	require.True(t, m.matches("user:123"))
+	require.True(t, m.matches("user:abc:def"))
+	require.False(t, m.matches("User:1")) // case-sensitive
+	require.False(t, m.matches("admin:1"))
+}
+
+func Test_rejectMatcher_Suffix(t *testing.T) {
+	t.Parallel()
+	m := newRejectMatcher([]string{"*:secret"})
+
+	require.True(t, m.matches("data:secret"))
+	require.True(t, m.matches(":secret"))
+	require.False(t, m.matches("data:public"))
+}
+
+func Test_rejectMatcher_General(t *testing.T) {
+	t.Parallel()
+	m := newRejectMatcher([]string{"a*b*c"})
+
+	require.True(t, m.matches("abc"))
+	require.True(t, m.matches("aXbYc"))
+	require.True(t, m.matches("a123b456c"))
+	require.False(t, m.matches("abX"))
+}
+
+func Test_rejectMatcher_MatchesAny(t *testing.T) {
+	t.Parallel()
+	m := newRejectMatcher([]string{"bad", "evil:*"})
+
+	require.True(t, m.matchesAny([]string{"good", "bad"}))
+	require.True(t, m.matchesAny([]string{"evil:tag"}))
+	require.False(t, m.matchesAny([]string{"good", "fine"}))
+	require.False(t, m.matchesAny(nil))
+}
+
+func Test_globMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		pattern string
+		s       string
+		want    bool
+	}{
+		{"*", "", true},
+		{"*", "anything", true},
+		{"abc", "abc", true},
+		{"abc", "ab", false},
+		{"a*c", "ac", true},
+		{"a*c", "abc", true},
+		{"a*c", "aXYZc", true},
+		{"a*c", "aXYZ", false},
+		{"**", "hello", true},  // consecutive stars collapse
+		{"a**b", "aXb", true},  // consecutive stars collapse
+		{"", "", true},
+		{"", "x", false},
+		{"*a*", "bab", true},
+		{"*a*", "bbb", false},
+	}
+
+	for _, tc := range tests {
+		got := globMatch(tc.pattern, tc.s)
+		require.Equal(t, tc.want, got, "globMatch(%q, %q)", tc.pattern, tc.s)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: tag association, invalidation, and rejection via middleware
+// ---------------------------------------------------------------------------
+
+func Test_Cache_TagAssociationAndInvalidation(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration: 10 * time.Second,
+		Storage:    memory.New(),
+		Tags: func(c fiber.Ctx) []string {
+			// Use the last path segment as the tag
+			p := c.Path()
+			if len(p) > 1 {
+				return []string{p[1:]} // strip leading /
+			}
+			return []string{"root"}
+		},
+	}))
+
+	// Two distinct paths → distinct cache keys and tags
+	app.Get("/alpha", func(c fiber.Ctx) error {
+		return c.SendString("alpha")
+	})
+	app.Get("/beta", func(c fiber.Ctx) error {
+		return c.SendString("beta")
+	})
+	// POST routes so they are not cached themselves (only GET/HEAD are cached by default)
+	app.Post("/invalidate-alpha", func(c fiber.Ctx) error {
+		return InvalidateTags(c, "alpha")
+	})
+
+	// Seed two tagged entries
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/alpha", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/beta", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+
+	// Both should be cached hits now
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/alpha", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/beta", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+
+	// Invalidate only "alpha" via POST
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodPost, "/invalidate-alpha", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	// alpha is gone → miss; beta untouched → hit
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/alpha", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/beta", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+}
+
+func Test_Cache_ResponseTagsMergedWithRequestTags(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration: 10 * time.Second,
+		Tags: func(c fiber.Ctx) []string {
+			return []string{"req"}
+		},
+		ResponseTags: func(_ fiber.Ctx, body []byte) []string {
+			return []string{"resp:" + string(body)}
+		},
+	}))
+
+	app.Get("/data", func(c fiber.Ctx) error {
+		return c.SendString("hello")
+	})
+	// POST so it is not cached itself
+	app.Post("/invalidate-resp-hello", func(c fiber.Ctx) error {
+		return InvalidateTags(c, "resp:hello")
+	})
+
+	// Seed
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/data", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+
+	// Cached
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/data", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+
+	// Invalidating the response-derived tag evicts the entry
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodPost, "/invalidate-resp-hello", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/data", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+}
+
+func Test_Cache_RejectTagsPreventsStorage(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration: 10 * time.Second,
+		Tags: func(c fiber.Ctx) []string {
+			return []string{fiber.Query(c, "tag", "ok")}
+		},
+		RejectTags: []string{"internal", "secret:*"},
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("body")
+	})
+
+	// Exact match rejection
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/?tag=internal", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheUnreachable, resp.Header.Get("X-Cache"))
+
+	// Prefix wildcard rejection
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/?tag=secret:key1", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheUnreachable, resp.Header.Get("X-Cache"))
+
+	// Non-rejected tag → normal caching
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/?tag=public", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/?tag=public", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+}
+
+func Test_Cache_InvalidateTagsWithoutMiddlewareReturnsError(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	// No cache middleware registered
+	app.Get("/", func(c fiber.Ctx) error {
+		err := InvalidateTags(c, "anything")
+		if err != nil {
+			return c.SendString(err.Error())
+		}
+		return c.SendString("ok")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	// The error message should indicate middleware is required
+	body := make([]byte, resp.ContentLength)
+	_, _ = resp.Body.Read(body)
+	require.Contains(t, string(body), "requires the cache middleware")
+}
+
+// ---------------------------------------------------------------------------
+// Conditional requests: ETag (If-None-Match) and Last-Modified (If-Modified-Since)
+// ---------------------------------------------------------------------------
+
+func Test_Cache_ETagAutoGeneration(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration: 10 * time.Second,
+		EnableETag: true,
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("etag-body")
+	})
+
+	// First request → miss, ETag should be generated
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+	etag := resp.Header.Get(fiber.HeaderETag)
+	require.NotEmpty(t, etag, "ETag must be auto-generated on miss")
+	// Strong ETag: quoted hex
+	require.True(t, len(etag) > 2 && etag[0] == '"' && etag[len(etag)-1] == '"')
+
+	// Second request → hit, same ETag
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+	require.Equal(t, etag, resp.Header.Get(fiber.HeaderETag))
+}
+
+func Test_Cache_ETagConditional304(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration: 10 * time.Second,
+		EnableETag: true,
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("conditional-body")
+	})
+
+	// Seed the cache
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	etag := resp.Header.Get(fiber.HeaderETag)
+	require.NotEmpty(t, etag)
+
+	// Send If-None-Match with matching ETag → 304
+	req := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Header.Set(fiber.HeaderIfNoneMatch, etag)
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusNotModified, resp.StatusCode)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+
+	// Non-matching ETag → 200 hit with body
+	req = httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Header.Set(fiber.HeaderIfNoneMatch, `"0000000000000000000000000000000000000000000000000000000000000000"`)
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+}
+
+func Test_Cache_ETagStar304(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration: 10 * time.Second,
+		EnableETag: true,
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("star-body")
+	})
+
+	// Seed
+	_, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+
+	// If-None-Match: * matches any stored ETag
+	req := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Header.Set(fiber.HeaderIfNoneMatch, "*")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusNotModified, resp.StatusCode)
+}
+
+func Test_Cache_LastModifiedAutoGeneration(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration:         10 * time.Second,
+		EnableETag:         false,
+		EnableLastModified: true,
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("lm-body")
+	})
+
+	// Miss → Last-Modified should be set
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+	lm := resp.Header.Get(fiber.HeaderLastModified)
+	require.NotEmpty(t, lm, "Last-Modified must be auto-generated on miss")
+
+	// Hit → same Last-Modified
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+	require.Equal(t, lm, resp.Header.Get(fiber.HeaderLastModified))
+}
+
+func Test_Cache_LastModifiedConditional304(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration:         10 * time.Second,
+		EnableETag:         false,
+		EnableLastModified: true,
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("lm-conditional")
+	})
+
+	// Seed
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	lm := resp.Header.Get(fiber.HeaderLastModified)
+	require.NotEmpty(t, lm)
+
+	// If-Modified-Since equal to Last-Modified → 304
+	req := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Header.Set(fiber.HeaderIfModifiedSince, lm)
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusNotModified, resp.StatusCode)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+
+	// If-Modified-Since in the future → 304 (resource hasn't changed since then)
+	req = httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Header.Set(fiber.HeaderIfModifiedSince, time.Now().Add(1*time.Hour).UTC().Format(http.TimeFormat))
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusNotModified, resp.StatusCode)
+
+	// If-Modified-Since far in the past → 200 (resource modified after that)
+	req = httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Header.Set(fiber.HeaderIfModifiedSince, time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).Format(http.TimeFormat))
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+}
+
+func Test_Cache_RFC9110_ETagTakesPrecedenceOverLastModified(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration:         10 * time.Second,
+		EnableETag:         true,
+		EnableLastModified: true,
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("precedence-body")
+	})
+
+	// Seed
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	etag := resp.Header.Get(fiber.HeaderETag)
+	require.NotEmpty(t, etag)
+
+	// Send BOTH If-None-Match (non-matching) and If-Modified-Since (far past).
+	// Per RFC 9110 §8.3, If-None-Match takes precedence: non-match → 200.
+	// If If-Modified-Since were evaluated, the past date would also yield 200,
+	// so we use a matching ETag with a past If-Modified-Since to confirm
+	// that ETag match triggers 304 regardless of the date.
+	req := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Header.Set(fiber.HeaderIfNoneMatch, etag)
+	req.Header.Set(fiber.HeaderIfModifiedSince, time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).Format(http.TimeFormat))
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	// ETag matches → 304; If-Modified-Since is ignored per §8.3
+	require.Equal(t, fiber.StatusNotModified, resp.StatusCode)
+
+	// Non-matching ETag + future If-Modified-Since: ETag non-match → 200
+	// (If-Modified-Since is never consulted)
+	req = httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Header.Set(fiber.HeaderIfNoneMatch, `"0000000000000000000000000000000000000000000000000000000000000000"`)
+	req.Header.Set(fiber.HeaderIfModifiedSince, time.Now().Add(1*time.Hour).UTC().Format(http.TimeFormat))
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+}
+
+func Test_Cache_CustomETagGenerator(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration: 10 * time.Second,
+		ETagGenerator: func(_ fiber.Ctx, body []byte) string {
+			return `"custom-` + string(body) + `"`
+		},
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("myval")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, `"custom-myval"`, resp.Header.Get(fiber.HeaderETag))
+
+	// Conditional match with custom ETag → 304
+	req := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Header.Set(fiber.HeaderIfNoneMatch, `"custom-myval"`)
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusNotModified, resp.StatusCode)
+}
+
+func Test_Cache_CustomLastModifiedGenerator(t *testing.T) {
+	t.Parallel()
+
+	fixedTime := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration:            10 * time.Second,
+		EnableETag:            false,
+		EnableLastModified:    true,
+		LastModifiedGenerator: func(_ fiber.Ctx) time.Time { return fixedTime },
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("fixed-lm")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fixedTime.Format(http.TimeFormat), resp.Header.Get(fiber.HeaderLastModified))
+
+	// If-Modified-Since equal to fixed time → 304
+	req := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Header.Set(fiber.HeaderIfModifiedSince, fixedTime.Format(http.TimeFormat))
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusNotModified, resp.StatusCode)
+}
+
+// ---------------------------------------------------------------------------
+// Cache-Control response header generation
+// ---------------------------------------------------------------------------
+
+func Test_Cache_CacheControlOnMiss(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{Expiration: 30 * time.Second}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("miss-cc")
+	})
+
+	// First request is a miss → Cache-Control should be generated
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+	cc := resp.Header.Get(fiber.HeaderCacheControl)
+	require.NotEmpty(t, cc, "Cache-Control must be generated on miss")
+	require.Contains(t, cc, "public")
+	require.Contains(t, cc, "max-age=")
+}
+
+func Test_Cache_CacheControlOnHit(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{Expiration: 60 * time.Second}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("hit-cc")
+	})
+
+	// Seed
+	_, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+
+	// Hit → Cache-Control with decreasing max-age
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+	cc := resp.Header.Get(fiber.HeaderCacheControl)
+	require.Contains(t, cc, "public, max-age=")
+}
+
+func Test_Cache_CacheControlMustRevalidateOnMiss(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{Expiration: 30 * time.Second}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderCacheControl, "public, max-age=30, must-revalidate")
+		return c.SendString("must-reval")
+	})
+
+	// Miss: handler sets must-revalidate; the middleware should not overwrite it
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+	require.Equal(t, "public, max-age=30, must-revalidate", resp.Header.Get(fiber.HeaderCacheControl))
+}
+
+func Test_Cache_CacheControlMustRevalidateOnHit(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{Expiration: 60 * time.Second}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderCacheControl, "public, max-age=60, must-revalidate")
+		return c.SendString("reval-hit")
+	})
+
+	// Seed (miss stores must-revalidate flag in item)
+	_, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+
+	// Hit → generated Cache-Control must include must-revalidate
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+	cc := resp.Header.Get(fiber.HeaderCacheControl)
+	require.Contains(t, cc, "must-revalidate")
+	require.Contains(t, cc, "public, max-age=")
+}
+
+func Test_Cache_CacheControlMustRevalidateOn304(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration: 60 * time.Second,
+		EnableETag: true,
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderCacheControl, "public, max-age=60, must-revalidate")
+		return c.SendString("reval-304")
+	})
+
+	// Seed
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	etag := resp.Header.Get(fiber.HeaderETag)
+	require.NotEmpty(t, etag)
+
+	// Conditional hit → 304 with must-revalidate in Cache-Control
+	req := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Header.Set(fiber.HeaderIfNoneMatch, etag)
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusNotModified, resp.StatusCode)
+	cc := resp.Header.Get(fiber.HeaderCacheControl)
+	require.Contains(t, cc, "must-revalidate")
+}
+
+func Test_Cache_CacheControlDisabledNoHeaderGenerated(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration:          10 * time.Second,
+		DisableCacheControl: true,
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("no-cc")
+	})
+
+	// Miss
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Empty(t, resp.Header.Get(fiber.HeaderCacheControl))
+
+	// Hit
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+	require.Empty(t, resp.Header.Get(fiber.HeaderCacheControl))
+}
+
+func Test_Cache_HandlerSetCacheControlPreservedOnHit(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration:           10 * time.Second,
+		StoreResponseHeaders: true,
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderCacheControl, "no-store")
+		return c.SendString("handler-cc")
+	})
+
+	// Handler sets no-store → entry is not cached
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheUnreachable, resp.Header.Get("X-Cache"))
+	require.Equal(t, "no-store", resp.Header.Get(fiber.HeaderCacheControl))
+}
+
+func Test_Cache_ProxyRevalidatePreservedOnHit(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{Expiration: 60 * time.Second}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderCacheControl, "public, max-age=60, proxy-revalidate")
+		return c.SendString("proxy-reval")
+	})
+
+	// Seed
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+	// Handler's Cache-Control preserved on miss (middleware skips generation when handler sets one)
+	require.Equal(t, "public, max-age=60, proxy-revalidate", resp.Header.Get(fiber.HeaderCacheControl))
+
+	// Hit → stored Cache-Control (including proxy-revalidate) restored verbatim
+	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+	require.Equal(t, "public, max-age=60, proxy-revalidate", resp.Header.Get(fiber.HeaderCacheControl))
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent access
+// ---------------------------------------------------------------------------
+
+func Test_Cache_ConcurrentTagOperations(t *testing.T) {
+	t.Parallel()
+
+	ti := newTagIndex()
+	const n = 100
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			key := fmt.Sprintf("key-%d", i)
+			tag := fmt.Sprintf("tag-%d", i%10)
+			ti.add(key, []string{tag})
+		}()
+	}
+	wg.Wait()
+
+	// All keys should be present
+	for i := 0; i < n; i++ {
+		require.True(t, ti.has(fmt.Sprintf("key-%d", i)))
+	}
+
+	// Concurrent invalidations of all 10 tag buckets
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			ti.invalidate([]string{fmt.Sprintf("tag-%d", i)})
+		}()
+	}
+	wg.Wait()
+
+	// Each key had exactly one tag (tag-N); after invalidating all buckets
+	// every key's tag set is empty and the key is removed from the reverse index
+	for i := 0; i < n; i++ {
+		require.False(t, ti.has(fmt.Sprintf("key-%d", i)))
+	}
+}
+
+func Test_Cache_ConcurrentRequestsWithTags(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration: 10 * time.Second,
+		Tags: func(c fiber.Ctx) []string {
+			return []string{fiber.Query(c, "group", "default")}
+		},
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("group=" + fiber.Query(c, "group", "default"))
+	})
+	app.Get("/invalidate", func(c fiber.Ctx) error {
+		return InvalidateTags(c, fiber.Query[string](c, "group"))
+	})
+
+	const groups = 5
+	const perGroup = 10
+	var wg sync.WaitGroup
+
+	// Seed all groups concurrently
+	wg.Add(groups * perGroup)
+	for g := 0; g < groups; g++ {
+		for i := 0; i < perGroup; i++ {
+			g, i := g, i
+			go func() {
+				defer wg.Done()
+				path := fmt.Sprintf("/?group=g%d&i=%d", g, i)
+				_, _ = app.Test(httptest.NewRequest(fiber.MethodGet, path, http.NoBody))
+			}()
+		}
+	}
+	wg.Wait()
+
+	// Concurrent invalidations of different groups
+	wg.Add(groups)
+	for g := 0; g < groups; g++ {
+		g := g
+		go func() {
+			defer wg.Done()
+			path := fmt.Sprintf("/invalidate?group=g%d", g)
+			_, _ = app.Test(httptest.NewRequest(fiber.MethodGet, path, http.NoBody))
+		}()
+	}
+	wg.Wait()
+	// Test passes if no race conditions or panics detected by -race flag
+}
+
+func Test_Cache_ConcurrentConditionalRequests(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration:         10 * time.Second,
+		EnableETag:         true,
+		EnableLastModified: true,
+	}))
+
+	app.Get("/*", func(c fiber.Ctx) error {
+		return c.SendString("path=" + c.Path())
+	})
+
+	const paths = 10
+	const rounds = 5
+
+	// Seed all paths
+	etags := make([]string, paths)
+	for i := 0; i < paths; i++ {
+		path := fmt.Sprintf("/item-%d", i)
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, path, http.NoBody))
+		require.NoError(t, err)
+		etags[i] = resp.Header.Get(fiber.HeaderETag)
+		require.NotEmpty(t, etags[i])
+	}
+
+	// Fire concurrent conditional requests across all paths
+	var wg sync.WaitGroup
+	errCh := make(chan error, paths*rounds)
+
+	wg.Add(paths * rounds)
+	for i := 0; i < paths; i++ {
+		for r := 0; r < rounds; r++ {
+			i, r := i, r
+			go func() {
+				defer wg.Done()
+				path := fmt.Sprintf("/item-%d", i)
+				req := httptest.NewRequest(fiber.MethodGet, path, http.NoBody)
+				if r%2 == 0 {
+					// Even rounds: conditional with matching ETag → expect 304
+					req.Header.Set(fiber.HeaderIfNoneMatch, etags[i])
+				}
+				resp, err := app.Test(req)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if r%2 == 0 && resp.StatusCode != fiber.StatusNotModified {
+					errCh <- fmt.Errorf("path %s round %d: expected 304, got %d", path, r, resp.StatusCode)
+				}
+				if r%2 != 0 && resp.StatusCode != fiber.StatusOK {
+					errCh <- fmt.Errorf("path %s round %d: expected 200, got %d", path, r, resp.StatusCode)
+				}
+			}()
+		}
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+}
+
+func Test_Cache_ConcurrentMixedWriteAndInvalidate(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration: 10 * time.Second,
+		Tags: func(c fiber.Ctx) []string {
+			return []string{fiber.Query(c, "tag", "default")}
+		},
+	}))
+
+	app.Get("/write", func(c fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+	app.Get("/invalidate", func(c fiber.Ctx) error {
+		return InvalidateTags(c, fiber.Query[string](c, "tag"))
+	})
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			tag := fmt.Sprintf("t%d", i%5)
+			if i%3 == 0 {
+				// Invalidate
+				path := fmt.Sprintf("/invalidate?tag=%s", tag)
+				_, _ = app.Test(httptest.NewRequest(fiber.MethodGet, path, http.NoBody))
+			} else {
+				// Write
+				path := fmt.Sprintf("/write?tag=%s&id=%d", tag, i)
+				_, _ = app.Test(httptest.NewRequest(fiber.MethodGet, path, http.NoBody))
+			}
+		}()
+	}
+	wg.Wait()
+	// Passes if no race conditions or panics; -race flag validates
+}


### PR DESCRIPTION
## Summary

- Tag-based cache invalidation with in-memory and distributed (shared-storage) backends
- RFC 9110 conditional request validation (ETag / Last-Modified / 304)
- Automatic Cache-Control header generation with handler-override preservation
- Full test coverage including concurrent and cross-instance scenarios
- Benchmarks for all tag operations and encoding paths
- README documenting tag strategies, invalidation, conditional requests, and Cache-Control

## Test plan

- [ ] `go test -race ./middleware/cache/` passes clean
- [ ] Tag association and invalidation via `InvalidateTags` works end-to-end
- [ ] Cross-instance invalidation: two `distributedTagStore` instances sharing one storage backend; invalidation on one finds keys written by the other
- [ ] Conditional 304 responses: ETag auto-generation, custom generator, If-None-Match; Last-Modified auto-generation, custom generator, If-Modified-Since
- [ ] RFC 9110 §8.3 precedence: If-None-Match takes priority when both conditional headers are present
- [ ] Cache-Control: middleware-generated header on miss and hit; handler-set header preserved verbatim; DisableCacheControl suppresses generation
- [ ] RejectTags prevents storage for matching tag patterns (exact, prefix, general glob)
- [ ] Benchmarks: `has()` is O(1) across index sizes; distributed `has()` matches in-memory cost; invalidation scales linearly with keys per tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)