### PR TITLE
♻️ refactor: Rename compareConfig to configEqual for clarity

### DIFF
--- a/res.go
+++ b/res.go
@@ -67,11 +67,11 @@ type sendFileStore struct {
 	config            SendFile
 }
 
-// compareConfig compares the current SendFile config with the new one
-// and returns true if they are different.
+// configEqual compares the current SendFile config with the new one
+// and returns true if they are equal.
 //
 // Here we don't use reflect.DeepEqual because it is quite slow compared to manual comparison.
-func (sf *sendFileStore) compareConfig(cfg SendFile) bool {
+func (sf *sendFileStore) configEqual(cfg SendFile) bool {
 	if sf.config.FS != cfg.FS {
 		return false
 	}
@@ -772,7 +772,7 @@ func (r *DefaultRes) SendFile(file string, config ...SendFile) error {
 	app := r.c.app
 	app.sendfilesMutex.RLock()
 	for _, sf := range app.sendfiles {
-		if sf.compareConfig(cfg) {
+		if sf.configEqual(cfg) {
 			fsHandler = sf.handler
 			cacheControlValue = sf.cacheControlValue
 			break


### PR DESCRIPTION
## Summary
- Renamed `sendFileStore.compareConfig` to `configEqual` to accurately reflect its behavior
- The godoc stated "returns true if they are different" but the function actually returns `true` when configs are **equal**
- Updated documentation to match the actual return semantics

## Motivation
The misleading godoc could cause future contributors to misuse the function, potentially introducing bugs in the SendFile caching logic.

## Test plan
- [x] `go build ./...` passes
- [x] Existing `TestSendFile` / `TestDownload` / `TestRes` tests pass
- [x] Single call site updated — no behavior change