### PR TITLE
📒 docs: refine v3 migration guide and align listen/hooks docs

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -128,7 +128,7 @@ func (h *Hooks) OnGroupName(handler ...OnGroupNameHandler)
 
 ## OnListen
 
-Runs when the app starts listening via `Listen`, `ListenTLS`, or `Listener`.
+Runs when the app starts listening via `Listen` or `Listener`.
 
 ```go title="Signature"
 func (h *Hooks) OnListen(handler ...OnListenHandler)
@@ -310,7 +310,7 @@ func main() {
         return nil
     })
 
-    app.Mount("/sub", subApp)
+    app.Use("/sub", subApp)
 }
 
 func testSimpleHandler(c fiber.Ctx) error {

--- a/docs/extra/internal.md
+++ b/docs/extra/internal.md
@@ -180,7 +180,7 @@ Middleware are executed in the order they are registered. This sequential design
 
 Fiber allows mounting sub‑applications (or sub‑routers) under specific path prefixes. This enables modular design of large APIs. The mounting process works as follows:
 
-1. Defining a Mount Point: A parent application calls `App.Mount()` or a Group calls its own `mount()` method.
+1. Defining a Mount Point: A parent application (or group) calls `Use` with a sub-app, which triggers the internal mount path logic.
 2. Merging Mount Fields: The sub‑app’s mount fields are updated with the prefix of the parent, and its routes are integrated into the parent’s routing structure.
 3. Processing Sub‑App Routes: During startup, the parent app collects routes from mounted sub‑apps and builds a unified route tree.
 

--- a/hooks.go
+++ b/hooks.go
@@ -272,7 +272,7 @@ func (h *Hooks) OnGroupName(handler ...OnGroupNameHandler) {
 	h.app.mutex.Unlock()
 }
 
-// OnListen is a hook to execute user functions on Listen, ListenTLS, Listener.
+// OnListen is a hook to execute user functions on Listen or Listener.
 func (h *Hooks) OnListen(handler ...OnListenHandler) {
 	h.app.mutex.Lock()
 	h.onListen = append(h.onListen, handler...)


### PR DESCRIPTION
### Motivation
- Clarify v3 migration guidance and minimum toolchain by stating the Go `1.25+` requirement. 
- Ensure documentation reflects current listener and hook APIs (use `ListenConfig`, prefer `TLSConfig`, consolidate shutdown hooks). 
- Fix examples and wording for sub-app mounting, filesystem vs static middleware, and logger helper text so docs match the implementation.

### Description
- Updated `docs/whats_new.md` to require Go `1.25+`, standardize examples to `fiber.ListenConfig`, clarify TLS/listen migration, reword filesystem removal and logger helper phrasing, and replace legacy shutdown callbacks example with the `OnPostShutdown` hook example. 
- Updated `docs/api/hooks.md` to remove the obsolete `ListenTLS` mention from the `OnListen` description and replaced the sub-app mount example to use `app.Use` with a sub-app. 
- Updated `docs/extra/internal.md` to align the sub-application mounting wording to describe `Use` semantics and mounting behavior. 
- Adjusted `hooks.go` comment to reflect current listener APIs by removing `ListenTLS` from the `OnListen` hook comment.