### PR TITLE
🐛 bug: skip non-string state keys during iteration

### DIFF
--- a/state.go
+++ b/state.go
@@ -75,7 +75,7 @@ func (s *State) Keys() []string {
 	s.dependencies.Range(func(key, _ any) bool {
 		keyStr, ok := key.(string)
 		if !ok {
-			return false
+			return true
 		}
 
 		keys = append(keys, keyStr)
@@ -261,7 +261,7 @@ func (s *State) serviceKeys() []string {
 	s.dependencies.Range(func(key, _ any) bool {
 		keyStr, ok := key.(string)
 		if !ok {
-			return false
+			return true
 		}
 
 		if !strings.HasPrefix(keyStr, s.servicePrefix) {


### PR DESCRIPTION
### Motivation
- Prevent iteration over the internal `State.dependencies` `sync.Map` from aborting when encountering non-`string` keys so valid string keys and service entries are always discovered.
- Ensure service discovery and key enumeration remain correct when the backing map contains mixed-type entries and when string keys are inserted before and after non-string keys.

### Description
- Change `Keys()` to continue iterating (return `true`) when a `sync.Map` key is not a `string` instead of stopping the iteration.
- Change `serviceKeys()` to continue iterating when a `sync.Map` key is not a `string` so non-string entries don't interrupt service discovery.
- Add test `TestState_Keys_SkipsNonStringKeys_WithMixedOrder` to verify string keys inserted before and after a non-string key are still returned, and extend service-key tests with `with-non-string-key` and `with-non-service-keys` scenarios to cover mixed-type entries.