### PR TITLE
harden numeric constraint parsing and expand route tests

### DIFF
--- a/path.go
+++ b/path.go
@@ -694,8 +694,6 @@ func getParamConstraintType(constraintPart string) TypeConstraint {
 
 // CheckConstraint validates if a param matches the given constraint
 // Returns true if the param passes the constraint check, false otherwise
-//
-//nolint:errcheck // TODO: Properly check _all_ errors in here, log them or immediately return
 func (c *Constraint) CheckConstraint(param string) bool {
 	// First check if there's a custom constraint with the same name
 	// This allows custom constraints to override built-in constraints
@@ -737,47 +735,80 @@ func (c *Constraint) CheckConstraint(param string) bool {
 	case guidConstraint:
 		_, err = uuid.Parse(param)
 	case minLenConstraint:
-		data, _ := strconv.Atoi(c.Data[0])
+		data, parseErr := strconv.Atoi(c.Data[0])
+		if parseErr != nil {
+			return false
+		}
 
 		if len(param) < data {
 			return false
 		}
 	case maxLenConstraint:
-		data, _ := strconv.Atoi(c.Data[0])
+		data, parseErr := strconv.Atoi(c.Data[0])
+		if parseErr != nil {
+			return false
+		}
 
 		if len(param) > data {
 			return false
 		}
 	case lenConstraint:
-		data, _ := strconv.Atoi(c.Data[0])
+		data, parseErr := strconv.Atoi(c.Data[0])
+		if parseErr != nil {
+			return false
+		}
 
 		if len(param) != data {
 			return false
 		}
 	case betweenLenConstraint:
-		data, _ := strconv.Atoi(c.Data[0])
-		data2, _ := strconv.Atoi(c.Data[1])
+		data, parseErr := strconv.Atoi(c.Data[0])
+		if parseErr != nil {
+			return false
+		}
+
+		data2, parseErr := strconv.Atoi(c.Data[1])
+		if parseErr != nil {
+			return false
+		}
+
 		length := len(param)
 		if length < data || length > data2 {
 			return false
 		}
 	case minConstraint:
-		data, _ := strconv.Atoi(c.Data[0])
+		data, parseErr := strconv.Atoi(c.Data[0])
+		if parseErr != nil {
+			return false
+		}
+
 		num, err = strconv.Atoi(param)
 
 		if err != nil || num < data {
 			return false
 		}
 	case maxConstraint:
-		data, _ := strconv.Atoi(c.Data[0])
+		data, parseErr := strconv.Atoi(c.Data[0])
+		if parseErr != nil {
+			return false
+		}
+
 		num, err = strconv.Atoi(param)
 
 		if err != nil || num > data {
 			return false
 		}
 	case rangeConstraint:
-		data, _ := strconv.Atoi(c.Data[0])
-		data2, _ := strconv.Atoi(c.Data[1])
+		data, parseErr := strconv.Atoi(c.Data[0])
+		if parseErr != nil {
+			return false
+		}
+
+		data2, parseErr := strconv.Atoi(c.Data[1])
+		if parseErr != nil {
+			return false
+		}
+
 		num, err = strconv.Atoi(param)
 
 		if err != nil || num < data || num > data2 {

--- a/path_test.go
+++ b/path_test.go
@@ -255,6 +255,69 @@ func Test_Utils_RemoveEscapeChar(t *testing.T) {
 	require.Equal(t, "noEscapeChar", res)
 }
 
+func Test_ConstraintCheckConstraint_InvalidMetadata(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		param      string
+		constraint Constraint
+	}{
+		{
+			name:       "minLen invalid metadata",
+			constraint: Constraint{ID: minLenConstraint, Data: []string{"abc"}},
+			param:      "abcd",
+		},
+		{
+			name:       "maxLen invalid metadata",
+			constraint: Constraint{ID: maxLenConstraint, Data: []string{"abc"}},
+			param:      "abcd",
+		},
+		{
+			name:       "len invalid metadata",
+			constraint: Constraint{ID: lenConstraint, Data: []string{"abc"}},
+			param:      "abcd",
+		},
+		{
+			name:       "betweenLen invalid first metadata",
+			constraint: Constraint{ID: betweenLenConstraint, Data: []string{"abc", "5"}},
+			param:      "abcd",
+		},
+		{
+			name:       "betweenLen invalid second metadata",
+			constraint: Constraint{ID: betweenLenConstraint, Data: []string{"1", "abc"}},
+			param:      "abcd",
+		},
+		{
+			name:       "min invalid metadata",
+			constraint: Constraint{ID: minConstraint, Data: []string{"abc"}},
+			param:      "10",
+		},
+		{
+			name:       "max invalid metadata",
+			constraint: Constraint{ID: maxConstraint, Data: []string{"abc"}},
+			param:      "10",
+		},
+		{
+			name:       "range invalid first metadata",
+			constraint: Constraint{ID: rangeConstraint, Data: []string{"abc", "10"}},
+			param:      "7",
+		},
+		{
+			name:       "range invalid second metadata",
+			constraint: Constraint{ID: rangeConstraint, Data: []string{"1", "abc"}},
+			param:      "7",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			require.False(t, testCase.constraint.CheckConstraint(testCase.param))
+		})
+	}
+}
+
 func Benchmark_Utils_RemoveEscapeChar(b *testing.B) {
 	b.ReportAllocs()
 	var res string

--- a/path_testcases_test.go
+++ b/path_testcases_test.go
@@ -681,6 +681,16 @@ func init() {
 				testCases: []routeTestCase{
 					{url: "/api/v1/entity", params: nil, match: false},
 					{url: "/api/v1/87283827683", params: nil, match: false},
+					{url: "/api/v1/25", params: nil, match: false},
+					{url: "/api/v1/1200", params: nil, match: false},
+					{url: "/api/v1/true", params: nil, match: false},
+				},
+			},
+			{
+				pattern: "/api/v1/:param<range(10,1500)>",
+				testCases: []routeTestCase{
+					{url: "/api/v1/entity", params: nil, match: false},
+					{url: "/api/v1/87283827683", params: nil, match: false},
 					{url: "/api/v1/25", params: []string{"25"}, match: true},
 					{url: "/api/v1/1200", params: []string{"1200"}, match: true},
 					{url: "/api/v1/true", params: nil, match: false},


### PR DESCRIPTION
### Motivation
- Prevent incorrect matches or panics by treating malformed numeric constraint metadata as invalid and failing the constraint check deterministically.
- Restore and expand route test coverage so both malformed/escaped metadata scenarios and valid numeric-range behavior are exercised.
- Make the invalid-metadata test name conform to the project naming convention used elsewhere.

### Description
- In `path.go`, `Constraint.CheckConstraint` now checks `strconv.Atoi` parse errors for numeric metadata-driven constraints (`minLen`, `maxLen`, `len`, `betweenLen`, `min`, `max`, `range`) and returns `false` when metadata cannot be parsed.
- Renamed the test to `Test_ConstraintCheckConstraint_InvalidMetadata` and added explicit cases for invalid numeric metadata in `path_test.go` covering `minLen`, `maxLen`, `len`, `betweenLen`, `min`, `max`, and `range`.
- Restored/added route testcases in `path_testcases_test.go` to keep the malformed escaped-comma `range(10\,30,1500)` checks and add a separate valid `range(10,1500)` case that matches numeric parameters like `25` and `1200`.
- Applied minor formatting/housekeeping as part of test additions and validation steps.