### PR TITLE
🐛 bug: add nil-safety to response decode helpers

### DIFF
--- a/client/core.go
+++ b/client/core.go
@@ -301,5 +301,4 @@ var (
 	ErrBodyType             = errors.New("the body type should be []byte")
 	ErrNotSupportSaveMethod = errors.New("only file paths and io.Writer are supported")
 	ErrBodyTypeNotSupported = errors.New("the body type is not supported")
-	ErrResponseClientNil    = errors.New("response client cannot be nil")
 )

--- a/client/response.go
+++ b/client/response.go
@@ -113,7 +113,7 @@ func (r *Response) String() string {
 // JSON unmarshal the response body into the given interface{} using JSON.
 func (r *Response) JSON(v any) error {
 	if r.client == nil {
-		return ErrResponseClientNil
+		return ErrClientNil
 	}
 
 	return r.client.jsonUnmarshal(r.Body(), v)
@@ -122,7 +122,7 @@ func (r *Response) JSON(v any) error {
 // CBOR unmarshal the response body into the given interface{} using CBOR.
 func (r *Response) CBOR(v any) error {
 	if r.client == nil {
-		return ErrResponseClientNil
+		return ErrClientNil
 	}
 
 	return r.client.cborUnmarshal(r.Body(), v)
@@ -131,7 +131,7 @@ func (r *Response) CBOR(v any) error {
 // XML unmarshal the response body into the given interface{} using XML.
 func (r *Response) XML(v any) error {
 	if r.client == nil {
-		return ErrResponseClientNil
+		return ErrClientNil
 	}
 
 	return r.client.xmlUnmarshal(r.Body(), v)

--- a/client/response_test.go
+++ b/client/response_test.go
@@ -474,7 +474,7 @@ func Test_Response_DecodeHelpers_ClientNilSafety(t *testing.T) {
 			decoded := payload{}
 			require.NotPanics(t, func() {
 				err := resp.JSON(&decoded)
-				require.ErrorIs(t, err, ErrResponseClientNil)
+				require.ErrorIs(t, err, ErrClientNil)
 			})
 		})
 
@@ -490,7 +490,7 @@ func Test_Response_DecodeHelpers_ClientNilSafety(t *testing.T) {
 			decoded := payload{}
 			require.NotPanics(t, func() {
 				err := resp.XML(&decoded)
-				require.ErrorIs(t, err, ErrResponseClientNil)
+				require.ErrorIs(t, err, ErrClientNil)
 			})
 		})
 
@@ -506,7 +506,7 @@ func Test_Response_DecodeHelpers_ClientNilSafety(t *testing.T) {
 			decoded := payload{}
 			require.NotPanics(t, func() {
 				err := resp.CBOR(&decoded)
-				require.ErrorIs(t, err, ErrResponseClientNil)
+				require.ErrorIs(t, err, ErrClientNil)
 			})
 		})
 	})


### PR DESCRIPTION
### Motivation

- Response decode helpers (`JSON`, `CBOR`, `XML`) could panic when used on a pooled `Response` without an attached `Client`, producing unpredictable behavior.
- Introduce a stable exported error to make the API predictable and easier to handle by callers.
- Harden response helper behavior so decode helpers are safe to call even when `Client` was not set.

### Description

- Add a new exported error `ErrResponseClientNil` in `client/core.go`.
- Guard `Response.JSON`, `Response.CBOR`, and `Response.XML` in `client/response.go` to check `r.client == nil` and return `ErrResponseClientNil` instead of dereferencing a nil `client`.
- Add `Test_Response_DecodeHelpers_ClientNilSafety` in `client/response_test.go` to assert there is no panic and that the exported error is returned when client is nil, and to verify normal decode still works when a `Client` is attached.