### PR TITLE
🐛 bug: harden proxy nil client handling in Do/Forward paths

### DIFF
--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -845,6 +845,53 @@ func Test_Proxy_Do_NonNilClientOverride(t *testing.T) {
 	require.Equal(t, "proxied", string(body))
 }
 
+// go test -run Test_Proxy_SelectClient_NilGlobal
+func Test_Proxy_SelectClient_NilGlobal(t *testing.T) {
+	t.Parallel()
+
+	selectedClient, err := selectClient(nil)
+	require.ErrorIs(t, err, errNilGlobalProxyClient)
+	require.Nil(t, selectedClient)
+}
+
+// go test -run Test_Proxy_NilClientOverride_AcrossHelpers
+func Test_Proxy_NilClientOverride_AcrossHelpers(t *testing.T) {
+	t.Parallel()
+
+	_, addr := createProxyTestServerIPv4(t, func(c fiber.Ctx) error {
+		return c.SendString("proxied")
+	})
+
+	tests := map[string]func(c fiber.Ctx) error{
+		"DoRedirects": func(c fiber.Ctx) error {
+			return DoRedirects(c, "http://"+addr, 1, nil)
+		},
+		"DoDeadline": func(c fiber.Ctx) error {
+			return DoDeadline(c, "http://"+addr, time.Now().Add(time.Second), nil)
+		},
+		"DoTimeout": func(c fiber.Ctx) error {
+			return DoTimeout(c, "http://"+addr, time.Second, nil)
+		},
+	}
+
+	for name, run := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			app := fiber.New()
+			app.Get("/test", run)
+
+			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/test", http.NoBody))
+			require.NoError(t, err)
+			require.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.Equal(t, errNilProxyClientOverride.Error(), string(body))
+		})
+	}
+}
+
 // go test -run Test_ProxyBalancer_Custom_Client
 func Test_ProxyBalancer_Custom_Client(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This pull request significantly enhances the robustness of the proxy middleware by implementing comprehensive checks for nil fasthttp.Client instances. It ensures that both globally configured and locally overridden clients are valid before use, preventing unexpected panics and providing clearer, more specific error messages. This change improves the overall stability and predictability of proxy operations within the application.