### PR TITLE
🐛 bug: harden DefaultRes.Format against nil handler panics

### DIFF
--- a/res.go
+++ b/res.go
@@ -382,6 +382,12 @@ func (r *DefaultRes) Format(handlers ...ResFmt) error {
 		return ErrNoHandlers
 	}
 
+	for i, h := range handlers {
+		if h.Handler == nil {
+			return fmt.Errorf("format handler is nil for media type %q at index %d", h.MediaType, i)
+		}
+	}
+
 	r.Vary(HeaderAccept)
 
 	if r.c.DefaultReq.Get(HeaderAccept) == "" {


### PR DESCRIPTION
### Motivation
- Prevent runtime panics when user-provided `ResFmt.Handler` entries are nil by validating handlers before running content negotiation and make debugging easier by returning a descriptive error that includes the media type and handler index.

### Description
- Added an upfront validation loop in `DefaultRes.Format` that returns `fmt.Errorf("format handler is nil for media type %q at index %d", ...)` when any `ResFmt.Handler` is nil, performed before `Vary`/Accept negotiation so existing flow is preserved (matching, default fallback, 406 behavior).
- Kept the existing content-negotiation behavior unchanged once validation passes, including the existing default handler and `StatusNotAcceptable` fallback.
- Added `Test_Ctx_Format_NilHandler` in `ctx_test.go` with three subtests that assert (and use `require.NotPanics`) for: nil handler in the first entry, nil handler in the matched media type, and nil default handler.