### PR TITLE
🚨 test: Fix race condition in TestTimeout_ContextPropagation

### DIFF
--- a/middleware/timeout/timeout_test.go
+++ b/middleware/timeout/timeout_test.go
@@ -90,7 +90,6 @@ func TestTimeout_ContextPropagation(t *testing.T) {
 	errCh := make(chan error, 1)
 
 	app.Get("/context-aware", New(func(c fiber.Ctx) error {
-
 		timer := time.NewTimer(500 * time.Millisecond)
 		defer timer.Stop()
 

--- a/middleware/timeout/timeout_test.go
+++ b/middleware/timeout/timeout_test.go
@@ -110,11 +110,14 @@ func TestTimeout_ContextPropagation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusRequestTimeout, resp.StatusCode)
 
+	safety := time.NewTimer(1 * time.Second)
+	defer safety.Stop()
+
 	select {
 	case handlerErr := <-errCh:
 		require.ErrorIs(t, handlerErr, context.DeadlineExceeded, "handler should report DeadlineExceeded")
 
-	case <-time.After(1 * time.Second):
+	case <-safety.C:
 		t.Fatal("timed out waiting for handler to report context state")
 	}
 }


### PR DESCRIPTION
# Description

Fix a potential race condition in `TestTimeout_ContextPropagation` and strengthen its assertions. The original test used `atomic.Bool` which could be read before the handler goroutine had written to it, since the timeout middleware returns immediately via the Abandon mechanism. This change replaces it with a buffered channel for proper synchronization.

Relates to #3671

### How to reproduce the race (before this fix)

```bash
go test -run TestTimeout_ContextPropagation -count=500 ./middleware/timeout/
```
output
```
--- FAIL: TestTimeout_ContextPropagation (0.05s)
    timeout_test.go:108: 
                Error Trace:./fiber/middleware/timeout/timeout_test.go:108
                Error:      Should be true
                Test:       TestTimeout_ContextPropagation
                Messages:   Handler should have detected context cancelation
FAIL
FAIL    github.com/gofiber/fiber/v3/middleware/timeout   26.277s
FAIL
```


## Changes introduced

List the new features or adjustments introduced in this pull request. Provide details on benchmarks, documentation updates, changelog entries, and if applicable, the migration guide.

- [x] Benchmarks: Describe any performance benchmarks and improvements related to the changes.
- [ ] Documentation Update: Detail the updates made to the documentation and links to the changed files.
- [ ] Changelog/What's New: Include a summary of the additions for the upcoming release notes.
- [ ] Migration Guide: If necessary, provide a guide or steps for users to migrate their existing code to accommodate these changes.
- [ ] API Alignment with Express: Explain how the changes align with the Express API.
- [ ] API Longevity: Discuss the steps taken to ensure that the new or updated APIs are consistent and not prone to breaking changes.
- [ ] Examples: Provide examples demonstrating the new features or changes in action.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
