### PR TITLE
🔥 feat: add BindError type with source and field metadata

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -170,8 +170,9 @@ func (b *Bind) returnErr(err error) error {
 // Use for binding parse failures; use returnErr directly for Custom and validation errors.
 func (b *Bind) returnBindErr(err error, source string) error {
 	if retErr := b.returnErr(err); retErr != nil {
-		if _, ok := retErr.(*Error); ok {
-			return retErr
+		var fiberErr *Error
+		if errors.As(retErr, &fiberErr) {
+			return fiberErr
 		}
 		return newBindError(source, retErr)
 	}

--- a/bind.go
+++ b/bind.go
@@ -215,7 +215,7 @@ func (b *Bind) Custom(name string, dest any) error {
 	binders := b.ctx.App().customBinders
 	for _, customBinder := range binders {
 		if customBinder.Name() == name {
-			return b.returnErr(customBinder.Parse(b.ctx, dest))
+			return b.returnBindErr(customBinder.Parse(b.ctx, dest), name)
 		}
 	}
 

--- a/bind.go
+++ b/bind.go
@@ -1,11 +1,15 @@
 package fiber
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"reflect"
 	"slices"
 	"sync"
 
 	"github.com/gofiber/fiber/v3/binder"
+	"github.com/gofiber/schema"
 	"github.com/gofiber/utils/v2"
 	utilsbytes "github.com/gofiber/utils/v2/bytes"
 )
@@ -31,10 +35,72 @@ var bindPool = sync.Pool{
 }
 
 // Bind provides helper methods for binding request data to Go values.
+// By default (manual mode), parsing failures are returned as *BindError; use errors.As to extract source and field details.
+// With WithAutoHandling(), parsing failures set HTTP 400 and return *Error instead.
 type Bind struct {
 	ctx            Ctx
 	dontHandleErrs bool
 	skipValidation bool
+}
+
+// BindError source constants for BindError.Source.
+const (
+	BindSourceURI        = "uri"
+	BindSourceQuery      = "query"
+	BindSourceHeader     = "header"
+	BindSourceCookie     = "cookie"
+	BindSourceBody       = "body"
+	BindSourceRespHeader = "respHeader"
+)
+
+// BindError wraps a binding failure with the source and field that failed.
+// Use errors.As(err, &be) to extract it when you need to branch on source
+// (e.g. 404 for URI vs 400 for body).
+type BindError struct {
+	Err    error  // underlying error; use errors.As to inspect
+	Source string // binding source: uri, query, body, header, cookie, or respHeader (see BindSource* constants)
+	Field  string // struct field or tag key that failed (best-effort, may be empty)
+}
+
+func (e *BindError) Error() string {
+	if e.Field != "" {
+		return fmt.Sprintf("bind %q from %s: %v", e.Field, e.Source, e.Err)
+	}
+	return fmt.Sprintf("bind from %s: %v", e.Source, e.Err)
+}
+
+func (e *BindError) Unwrap() error {
+	return e.Err
+}
+
+func extractFieldFromError(err error) string {
+	var convErr schema.ConversionError
+	if errors.As(err, &convErr) {
+		return convErr.Key
+	}
+	var unknownKey schema.UnknownKeyError
+	if errors.As(err, &unknownKey) {
+		return unknownKey.Key
+	}
+	var emptyField schema.EmptyFieldError
+	if errors.As(err, &emptyField) {
+		return emptyField.Key
+	}
+	var multiErr schema.MultiError
+	if errors.As(err, &multiErr) {
+		for k := range multiErr {
+			return k
+		}
+	}
+	var unmarshalErr *json.UnmarshalTypeError
+	if errors.As(err, &unmarshalErr) {
+		return unmarshalErr.Field
+	}
+	return ""
+}
+
+func newBindError(source string, raw error) *BindError {
+	return &BindError{Source: source, Field: extractFieldFromError(raw), Err: raw}
 }
 
 // AcquireBind returns Bind reference from bind pool.
@@ -144,6 +210,7 @@ func (b *Bind) Custom(name string, dest any) error {
 }
 
 // Header binds the request header strings into the struct, map[string]string and map[string][]string.
+// Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) Header(out any) error {
 	bind := binder.GetFromThePool[*binder.HeaderBinding](&binder.HeaderBinderPool)
 	bind.EnableSplitting = b.ctx.App().config.EnableSplittingOnParsers
@@ -151,13 +218,18 @@ func (b *Bind) Header(out any) error {
 	defer releasePooledBinder(&binder.HeaderBinderPool, bind)
 
 	if err := b.returnErr(bind.Bind(b.ctx.Request(), out)); err != nil {
-		return err
+		var fiberErr *Error
+		if errors.As(err, &fiberErr) {
+			return err
+		}
+		return newBindError(BindSourceHeader, err)
 	}
 
 	return b.validateStruct(out)
 }
 
 // RespHeader binds the response header strings into the struct, map[string]string and map[string][]string.
+// Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) RespHeader(out any) error {
 	bind := binder.GetFromThePool[*binder.RespHeaderBinding](&binder.RespHeaderBinderPool)
 	bind.EnableSplitting = b.ctx.App().config.EnableSplittingOnParsers
@@ -165,13 +237,18 @@ func (b *Bind) RespHeader(out any) error {
 	defer releasePooledBinder(&binder.RespHeaderBinderPool, bind)
 
 	if err := b.returnErr(bind.Bind(b.ctx.Response(), out)); err != nil {
-		return err
+		var fiberErr *Error
+		if errors.As(err, &fiberErr) {
+			return err
+		}
+		return newBindError(BindSourceRespHeader, err)
 	}
 
 	return b.validateStruct(out)
 }
 
 // Cookie binds the request cookie strings into the struct, map[string]string and map[string][]string.
+// Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 // NOTE: If your cookie is like key=val1,val2; they'll be bound as a slice if your map is map[string][]string. Else, it'll use last element of cookie.
 func (b *Bind) Cookie(out any) error {
 	bind := binder.GetFromThePool[*binder.CookieBinding](&binder.CookieBinderPool)
@@ -180,13 +257,18 @@ func (b *Bind) Cookie(out any) error {
 	defer releasePooledBinder(&binder.CookieBinderPool, bind)
 
 	if err := b.returnErr(bind.Bind(&b.ctx.RequestCtx().Request, out)); err != nil {
-		return err
+		var fiberErr *Error
+		if errors.As(err, &fiberErr) {
+			return err
+		}
+		return newBindError(BindSourceCookie, err)
 	}
 
 	return b.validateStruct(out)
 }
 
 // Query binds the query string into the struct, map[string]string and map[string][]string.
+// Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) Query(out any) error {
 	bind := binder.GetFromThePool[*binder.QueryBinding](&binder.QueryBinderPool)
 	bind.EnableSplitting = b.ctx.App().config.EnableSplittingOnParsers
@@ -194,13 +276,18 @@ func (b *Bind) Query(out any) error {
 	defer releasePooledBinder(&binder.QueryBinderPool, bind)
 
 	if err := b.returnErr(bind.Bind(&b.ctx.RequestCtx().Request, out)); err != nil {
-		return err
+		var fiberErr *Error
+		if errors.As(err, &fiberErr) {
+			return err
+		}
+		return newBindError(BindSourceQuery, err)
 	}
 
 	return b.validateStruct(out)
 }
 
 // JSON binds the body string into the struct.
+// Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) JSON(out any) error {
 	bind := binder.GetFromThePool[*binder.JSONBinding](&binder.JSONBinderPool)
 	bind.JSONDecoder = b.ctx.App().Config().JSONDecoder
@@ -208,13 +295,18 @@ func (b *Bind) JSON(out any) error {
 	defer releasePooledBinder(&binder.JSONBinderPool, bind)
 
 	if err := b.returnErr(bind.Bind(b.ctx.Body(), out)); err != nil {
-		return err
+		var fiberErr *Error
+		if errors.As(err, &fiberErr) {
+			return err
+		}
+		return newBindError(BindSourceBody, err)
 	}
 
 	return b.validateStruct(out)
 }
 
 // CBOR binds the body string into the struct.
+// Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) CBOR(out any) error {
 	bind := binder.GetFromThePool[*binder.CBORBinding](&binder.CBORBinderPool)
 	bind.CBORDecoder = b.ctx.App().Config().CBORDecoder
@@ -222,12 +314,17 @@ func (b *Bind) CBOR(out any) error {
 	defer releasePooledBinder(&binder.CBORBinderPool, bind)
 
 	if err := b.returnErr(bind.Bind(b.ctx.Body(), out)); err != nil {
-		return err
+		var fiberErr *Error
+		if errors.As(err, &fiberErr) {
+			return err
+		}
+		return newBindError(BindSourceBody, err)
 	}
 	return b.validateStruct(out)
 }
 
 // XML binds the body string into the struct.
+// Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) XML(out any) error {
 	bind := binder.GetFromThePool[*binder.XMLBinding](&binder.XMLBinderPool)
 	bind.XMLDecoder = b.ctx.App().config.XMLDecoder
@@ -235,13 +332,18 @@ func (b *Bind) XML(out any) error {
 	defer releasePooledBinder(&binder.XMLBinderPool, bind)
 
 	if err := b.returnErr(bind.Bind(b.ctx.Body(), out)); err != nil {
-		return err
+		var fiberErr *Error
+		if errors.As(err, &fiberErr) {
+			return err
+		}
+		return newBindError(BindSourceBody, err)
 	}
 
 	return b.validateStruct(out)
 }
 
 // Form binds the form into the struct, map[string]string and map[string][]string.
+// Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 // If Content-Type is "application/x-www-form-urlencoded" or "multipart/form-data", it will bind the form values.
 // Multipart file fields are supported using *multipart.FileHeader, []*multipart.FileHeader, or *[]*multipart.FileHeader.
 func (b *Bind) Form(out any) error {
@@ -251,26 +353,36 @@ func (b *Bind) Form(out any) error {
 	defer releasePooledBinder(&binder.FormBinderPool, bind)
 
 	if err := b.returnErr(bind.Bind(&b.ctx.RequestCtx().Request, out)); err != nil {
-		return err
+		var fiberErr *Error
+		if errors.As(err, &fiberErr) {
+			return err
+		}
+		return newBindError(BindSourceBody, err)
 	}
 
 	return b.validateStruct(out)
 }
 
 // URI binds the route parameters into the struct, map[string]string and map[string][]string.
+// Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) URI(out any) error {
 	bind := binder.GetFromThePool[*binder.URIBinding](&binder.URIBinderPool)
 
 	defer releasePooledBinder(&binder.URIBinderPool, bind)
 
 	if err := b.returnErr(bind.Bind(b.ctx.Route().Params, b.ctx.Params, out)); err != nil {
-		return err
+		var fiberErr *Error
+		if errors.As(err, &fiberErr) {
+			return err
+		}
+		return newBindError(BindSourceURI, err)
 	}
 
 	return b.validateStruct(out)
 }
 
 // MsgPack binds the body string into the struct.
+// Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) MsgPack(out any) error {
 	bind := binder.GetFromThePool[*binder.MsgPackBinding](&binder.MsgPackBinderPool)
 	bind.MsgPackDecoder = b.ctx.App().Config().MsgPackDecoder
@@ -278,13 +390,18 @@ func (b *Bind) MsgPack(out any) error {
 	defer releasePooledBinder(&binder.MsgPackBinderPool, bind)
 
 	if err := b.returnErr(bind.Bind(b.ctx.Body(), out)); err != nil {
-		return err
+		var fiberErr *Error
+		if errors.As(err, &fiberErr) {
+			return err
+		}
+		return newBindError(BindSourceBody, err)
 	}
 
 	return b.validateStruct(out)
 }
 
 // Body binds the request body into the struct, map[string]string and map[string][]string.
+// Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 // It supports decoding the following content types based on the Content-Type header:
 // application/json, application/xml, application/x-www-form-urlencoded, multipart/form-data
 // If none of the content types above are matched, it'll take a look custom binders by checking the MIMETypes() method of custom binder.
@@ -298,7 +415,14 @@ func (b *Bind) Body(out any) error {
 	binders := b.ctx.App().customBinders
 	for _, customBinder := range binders {
 		if slices.Contains(customBinder.MIMETypes(), ctype) {
-			return b.returnErr(customBinder.Parse(b.ctx, out))
+			if err := b.returnErr(customBinder.Parse(b.ctx, out)); err != nil {
+				var fiberErr *Error
+				if errors.As(err, &fiberErr) {
+					return err
+				}
+				return newBindError(BindSourceBody, err)
+			}
+			return nil
 		}
 	}
 
@@ -322,6 +446,7 @@ func (b *Bind) Body(out any) error {
 
 // All binds values from URI params, the request body, the query string,
 // headers, and cookies into the provided struct in precedence order.
+// Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) All(out any) error {
 	outVal := reflect.ValueOf(out)
 	if outVal.Kind() != reflect.Ptr || outVal.Elem().Kind() != reflect.Struct {

--- a/bind.go
+++ b/bind.go
@@ -166,6 +166,19 @@ func (b *Bind) returnErr(err error) error {
 	return NewError(StatusBadRequest, "Bad request: "+err.Error())
 }
 
+// returnBindErr runs returnErr and, if the result is not a *Error, wraps it in *BindError.
+// Use for binding parse failures; use returnErr directly for Custom and validation errors.
+func (b *Bind) returnBindErr(err error, source string) error {
+	if retErr := b.returnErr(err); retErr != nil {
+		var fiberErr *Error
+		if errors.As(retErr, &fiberErr) {
+			return retErr
+		}
+		return newBindError(source, err)
+	}
+	return nil
+}
+
 // Struct validation.
 func (b *Bind) validateStruct(out any) error {
 	if b.skipValidation {
@@ -217,12 +230,8 @@ func (b *Bind) Header(out any) error {
 
 	defer releasePooledBinder(&binder.HeaderBinderPool, bind)
 
-	if err := b.returnErr(bind.Bind(b.ctx.Request(), out)); err != nil {
-		var fiberErr *Error
-		if errors.As(err, &fiberErr) {
-			return err
-		}
-		return newBindError(BindSourceHeader, err)
+	if err := b.returnBindErr(bind.Bind(b.ctx.Request(), out), BindSourceHeader); err != nil {
+		return err
 	}
 
 	return b.validateStruct(out)
@@ -236,12 +245,8 @@ func (b *Bind) RespHeader(out any) error {
 
 	defer releasePooledBinder(&binder.RespHeaderBinderPool, bind)
 
-	if err := b.returnErr(bind.Bind(b.ctx.Response(), out)); err != nil {
-		var fiberErr *Error
-		if errors.As(err, &fiberErr) {
-			return err
-		}
-		return newBindError(BindSourceRespHeader, err)
+	if err := b.returnBindErr(bind.Bind(b.ctx.Response(), out), BindSourceRespHeader); err != nil {
+		return err
 	}
 
 	return b.validateStruct(out)
@@ -256,12 +261,8 @@ func (b *Bind) Cookie(out any) error {
 
 	defer releasePooledBinder(&binder.CookieBinderPool, bind)
 
-	if err := b.returnErr(bind.Bind(&b.ctx.RequestCtx().Request, out)); err != nil {
-		var fiberErr *Error
-		if errors.As(err, &fiberErr) {
-			return err
-		}
-		return newBindError(BindSourceCookie, err)
+	if err := b.returnBindErr(bind.Bind(&b.ctx.RequestCtx().Request, out), BindSourceCookie); err != nil {
+		return err
 	}
 
 	return b.validateStruct(out)
@@ -275,12 +276,8 @@ func (b *Bind) Query(out any) error {
 
 	defer releasePooledBinder(&binder.QueryBinderPool, bind)
 
-	if err := b.returnErr(bind.Bind(&b.ctx.RequestCtx().Request, out)); err != nil {
-		var fiberErr *Error
-		if errors.As(err, &fiberErr) {
-			return err
-		}
-		return newBindError(BindSourceQuery, err)
+	if err := b.returnBindErr(bind.Bind(&b.ctx.RequestCtx().Request, out), BindSourceQuery); err != nil {
+		return err
 	}
 
 	return b.validateStruct(out)
@@ -294,12 +291,8 @@ func (b *Bind) JSON(out any) error {
 
 	defer releasePooledBinder(&binder.JSONBinderPool, bind)
 
-	if err := b.returnErr(bind.Bind(b.ctx.Body(), out)); err != nil {
-		var fiberErr *Error
-		if errors.As(err, &fiberErr) {
-			return err
-		}
-		return newBindError(BindSourceBody, err)
+	if err := b.returnBindErr(bind.Bind(b.ctx.Body(), out), BindSourceBody); err != nil {
+		return err
 	}
 
 	return b.validateStruct(out)
@@ -313,12 +306,8 @@ func (b *Bind) CBOR(out any) error {
 
 	defer releasePooledBinder(&binder.CBORBinderPool, bind)
 
-	if err := b.returnErr(bind.Bind(b.ctx.Body(), out)); err != nil {
-		var fiberErr *Error
-		if errors.As(err, &fiberErr) {
-			return err
-		}
-		return newBindError(BindSourceBody, err)
+	if err := b.returnBindErr(bind.Bind(b.ctx.Body(), out), BindSourceBody); err != nil {
+		return err
 	}
 	return b.validateStruct(out)
 }
@@ -331,12 +320,8 @@ func (b *Bind) XML(out any) error {
 
 	defer releasePooledBinder(&binder.XMLBinderPool, bind)
 
-	if err := b.returnErr(bind.Bind(b.ctx.Body(), out)); err != nil {
-		var fiberErr *Error
-		if errors.As(err, &fiberErr) {
-			return err
-		}
-		return newBindError(BindSourceBody, err)
+	if err := b.returnBindErr(bind.Bind(b.ctx.Body(), out), BindSourceBody); err != nil {
+		return err
 	}
 
 	return b.validateStruct(out)
@@ -352,12 +337,8 @@ func (b *Bind) Form(out any) error {
 
 	defer releasePooledBinder(&binder.FormBinderPool, bind)
 
-	if err := b.returnErr(bind.Bind(&b.ctx.RequestCtx().Request, out)); err != nil {
-		var fiberErr *Error
-		if errors.As(err, &fiberErr) {
-			return err
-		}
-		return newBindError(BindSourceBody, err)
+	if err := b.returnBindErr(bind.Bind(&b.ctx.RequestCtx().Request, out), BindSourceBody); err != nil {
+		return err
 	}
 
 	return b.validateStruct(out)
@@ -370,12 +351,8 @@ func (b *Bind) URI(out any) error {
 
 	defer releasePooledBinder(&binder.URIBinderPool, bind)
 
-	if err := b.returnErr(bind.Bind(b.ctx.Route().Params, b.ctx.Params, out)); err != nil {
-		var fiberErr *Error
-		if errors.As(err, &fiberErr) {
-			return err
-		}
-		return newBindError(BindSourceURI, err)
+	if err := b.returnBindErr(bind.Bind(b.ctx.Route().Params, b.ctx.Params, out), BindSourceURI); err != nil {
+		return err
 	}
 
 	return b.validateStruct(out)
@@ -389,12 +366,8 @@ func (b *Bind) MsgPack(out any) error {
 
 	defer releasePooledBinder(&binder.MsgPackBinderPool, bind)
 
-	if err := b.returnErr(bind.Bind(b.ctx.Body(), out)); err != nil {
-		var fiberErr *Error
-		if errors.As(err, &fiberErr) {
-			return err
-		}
-		return newBindError(BindSourceBody, err)
+	if err := b.returnBindErr(bind.Bind(b.ctx.Body(), out), BindSourceBody); err != nil {
+		return err
 	}
 
 	return b.validateStruct(out)
@@ -415,14 +388,7 @@ func (b *Bind) Body(out any) error {
 	binders := b.ctx.App().customBinders
 	for _, customBinder := range binders {
 		if slices.Contains(customBinder.MIMETypes(), ctype) {
-			if err := b.returnErr(customBinder.Parse(b.ctx, out)); err != nil {
-				var fiberErr *Error
-				if errors.As(err, &fiberErr) {
-					return err
-				}
-				return newBindError(BindSourceBody, err)
-			}
-			return nil
+			return b.returnBindErr(customBinder.Parse(b.ctx, out), BindSourceBody)
 		}
 	}
 

--- a/bind.go
+++ b/bind.go
@@ -177,9 +177,6 @@ func (b *Bind) returnBindErr(err error, source string) error {
 	}
 	return nil
 }
-	}
-	return nil
-}
 
 // Struct validation.
 func (b *Bind) validateStruct(out any) error {

--- a/bind.go
+++ b/bind.go
@@ -170,11 +170,13 @@ func (b *Bind) returnErr(err error) error {
 // Use for binding parse failures; use returnErr directly for Custom and validation errors.
 func (b *Bind) returnBindErr(err error, source string) error {
 	if retErr := b.returnErr(err); retErr != nil {
-		var fiberErr *Error
-		if errors.As(retErr, &fiberErr) {
+		if _, ok := retErr.(*Error); ok {
 			return retErr
 		}
-		return newBindError(source, err)
+		return newBindError(source, retErr)
+	}
+	return nil
+}
 	}
 	return nil
 }

--- a/bind_test.go
+++ b/bind_test.go
@@ -177,7 +177,8 @@ func Test_BindError_Sources(t *testing.T) {
 		var be *BindError
 		require.ErrorAs(t, err, &be)
 		require.Equal(t, BindSourceBody, be.Source)
-		require.ErrorAs(t, err, &UnmarshalTypeError{})
+		var unmarshalErr *json.UnmarshalTypeError
+		require.ErrorAs(t, err, &unmarshalErr)
 	})
 }
 

--- a/bind_test.go
+++ b/bind_test.go
@@ -48,6 +48,166 @@ func Test_AcquireReleaseBind(t *testing.T) {
 	ReleaseBind(b2)
 }
 
+// go test -run Test_BindError -v
+
+func Test_BindError_Unwrap(t *testing.T) {
+	t.Parallel()
+	inner := errors.New("inner")
+	be := &BindError{Source: BindSourceQuery, Err: inner}
+	require.ErrorIs(t, be, inner)
+	require.Equal(t, inner, errors.Unwrap(be))
+
+	var extracted *BindError
+	require.ErrorAs(t, be, &extracted)
+	require.Equal(t, BindSourceQuery, extracted.Source)
+}
+
+func Test_BindError_FieldExtraction(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	t.Run("QueryConversionError", func(t *testing.T) {
+		t.Parallel()
+		type Q struct {
+			ID int `query:"id"`
+		}
+		c.Request().URI().SetQueryString("id=notanint")
+		err := c.Bind().Query(new(Q))
+		require.Error(t, err)
+		var be *BindError
+		require.ErrorAs(t, err, &be)
+		require.Equal(t, BindSourceQuery, be.Source)
+		require.Equal(t, "id", be.Field)
+		require.ErrorAs(t, err, &MultiError{})
+	})
+
+	t.Run("JSONUnmarshalTypeError", func(t *testing.T) {
+		t.Parallel()
+		type J struct {
+			Count int `json:"count"`
+		}
+		c.Request().SetBody([]byte(`{"count":"notanint"}`))
+		c.Request().Header.SetContentType(MIMEApplicationJSON)
+		err := c.Bind().Body(new(J))
+		require.Error(t, err)
+		var be *BindError
+		require.ErrorAs(t, err, &be)
+		require.Equal(t, BindSourceBody, be.Source)
+		require.Equal(t, "count", be.Field)
+		require.ErrorAs(t, err, &UnmarshalTypeError{})
+	})
+}
+
+func Test_BindError_Sources(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	t.Run("URI", func(t *testing.T) {
+		t.Parallel()
+		type U struct {
+			ID int `uri:"id"`
+		}
+		c.Request().SetRequestURI("/user/notanint")
+		app.Get("/user/:id", func(ctx Ctx) error {
+			err := ctx.Bind().URI(new(U))
+			require.Error(t, err)
+			var be *BindError
+			require.ErrorAs(t, err, &be)
+			require.Equal(t, BindSourceURI, be.Source)
+			require.ErrorAs(t, err, &MultiError{})
+			return nil
+		})
+		_, err := app.Test(httptest.NewRequest(http.MethodGet, "/user/notanint", http.NoBody))
+		require.NoError(t, err)
+	})
+
+	t.Run("Query", func(t *testing.T) {
+		t.Parallel()
+		type Q struct {
+			ID int `query:"id,required"`
+		}
+		c.Request().URI().SetQueryString("")
+		err := c.Bind().Query(new(Q))
+		require.Error(t, err)
+		var be *BindError
+		require.ErrorAs(t, err, &be)
+		require.Equal(t, BindSourceQuery, be.Source)
+		require.ErrorAs(t, err, &MultiError{})
+	})
+
+	t.Run("Header", func(t *testing.T) {
+		t.Parallel()
+		type H struct {
+			ID int `header:"x-id,required"`
+		}
+		c.Request().Header.Del("X-Id")
+		err := c.Bind().Header(new(H))
+		require.Error(t, err)
+		var be *BindError
+		require.ErrorAs(t, err, &be)
+		require.Equal(t, BindSourceHeader, be.Source)
+		require.ErrorAs(t, err, &MultiError{})
+	})
+
+	t.Run("Cookie", func(t *testing.T) {
+		t.Parallel()
+		type C struct {
+			ID int `cookie:"id,required"`
+		}
+		c.Request().Header.DelCookie("id")
+		err := c.Bind().Cookie(new(C))
+		require.Error(t, err)
+		var be *BindError
+		require.ErrorAs(t, err, &be)
+		require.Equal(t, BindSourceCookie, be.Source)
+		require.ErrorAs(t, err, &MultiError{})
+	})
+
+	t.Run("Body", func(t *testing.T) {
+		t.Parallel()
+		type J struct {
+			X int `json:"x"`
+		}
+		c.Request().SetBody([]byte(`{"x":"bad"}`))
+		c.Request().Header.SetContentType(MIMEApplicationJSON)
+		err := c.Bind().Body(new(J))
+		require.Error(t, err)
+		var be *BindError
+		require.ErrorAs(t, err, &be)
+		require.Equal(t, BindSourceBody, be.Source)
+		require.ErrorAs(t, err, &UnmarshalTypeError{})
+	})
+}
+
+func Test_BindError_All(t *testing.T) {
+	t.Parallel()
+
+	type Req struct {
+		Name string `json:"name"`
+		ID   int    `uri:"id" json:"id"`
+	}
+
+	t.Run("URIFailsFirst", func(t *testing.T) {
+		t.Parallel()
+		app := New()
+		app.Get("/users/:id", func(ctx Ctx) error {
+			err := ctx.Bind().All(new(Req))
+			require.Error(t, err)
+			var be *BindError
+			require.ErrorAs(t, err, &be)
+			require.Equal(t, BindSourceURI, be.Source)
+			require.ErrorAs(t, err, &MultiError{})
+			return nil
+		})
+		req := httptest.NewRequest(http.MethodGet, "/users/notanint", bytes.NewReader([]byte(`{"name":"ok"}`)))
+		req.Header.Set("Content-Type", MIMEApplicationJSON)
+		_, err := app.Test(req)
+		require.NoError(t, err)
+	})
+}
+
 // go test -run Test_Bind_Query -v
 func Test_Bind_Query(t *testing.T) {
 	t.Parallel()
@@ -117,7 +277,10 @@ func Test_Bind_Query(t *testing.T) {
 	}
 	rq := new(RequiredQuery)
 	c.Request().URI().SetQueryString("")
-	require.Equal(t, "bind: name is empty", c.Bind().Query(rq).Error())
+	err := c.Bind().Query(rq)
+	require.Error(t, err)
+	require.Equal(t, "bind \"name\" from query: name is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	type ArrayQuery struct {
 		Data []string
@@ -241,7 +404,10 @@ func Test_Bind_Query_Schema(t *testing.T) {
 
 	c.Request().URI().SetQueryString("namex=tom&nested.age=10")
 	q = new(Query1)
-	require.Equal(t, "bind: name is empty", c.Bind().Query(q).Error())
+	err := c.Bind().Query(q)
+	require.Error(t, err)
+	require.Equal(t, "bind \"name\" from query: name is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	c.Request().URI().SetQueryString("name=tom&nested.agex=10")
 	q = new(Query1)
@@ -249,7 +415,10 @@ func Test_Bind_Query_Schema(t *testing.T) {
 
 	c.Request().URI().SetQueryString("name=tom&test.age=10")
 	q = new(Query1)
-	require.Equal(t, "bind: nested is empty", c.Bind().Query(q).Error())
+	err = c.Bind().Query(q)
+	require.Error(t, err)
+	require.Equal(t, "bind \"nested\" from query: nested is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	type Query2 struct {
 		Name   string `query:"name"`
@@ -267,11 +436,17 @@ func Test_Bind_Query_Schema(t *testing.T) {
 
 	c.Request().URI().SetQueryString("nested.agex=10")
 	q2 = new(Query2)
-	require.Equal(t, "bind: nested.age is empty", c.Bind().Query(q2).Error())
+	err = c.Bind().Query(q2)
+	require.Error(t, err)
+	require.Equal(t, "bind \"nested.age\" from query: nested.age is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	c.Request().URI().SetQueryString("nested.agex=10")
 	q2 = new(Query2)
-	require.Equal(t, "bind: nested.age is empty", c.Bind().Query(q2).Error())
+	err = c.Bind().Query(q2)
+	require.Error(t, err)
+	require.Equal(t, "bind \"nested.age\" from query: nested.age is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	type Node struct {
 		Next  *Node `query:"next,required"`
@@ -285,7 +460,10 @@ func Test_Bind_Query_Schema(t *testing.T) {
 
 	c.Request().URI().SetQueryString("next.val=2")
 	n = new(Node)
-	require.Equal(t, "bind: val is empty", c.Bind().Query(n).Error())
+	err = c.Bind().Query(n)
+	require.Error(t, err)
+	require.Equal(t, "bind \"val\" from query: val is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	c.Request().URI().SetQueryString("val=3&next.value=2")
 	n = new(Node)
@@ -391,7 +569,10 @@ func Test_Bind_Header(t *testing.T) {
 	}
 	rh := new(RequiredHeader)
 	c.Request().Header.Del("name")
-	require.Equal(t, "bind: name is empty", c.Bind().Header(rh).Error())
+	err := c.Bind().Header(rh)
+	require.Error(t, err)
+	require.Equal(t, "bind \"name\" from header: name is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 }
 
 // go test -run Test_Bind_Header_Map -v
@@ -500,7 +681,10 @@ func Test_Bind_Header_Schema(t *testing.T) {
 
 	c.Request().Header.Del("Name")
 	q = new(Header1)
-	require.Equal(t, "bind: Name is empty", c.Bind().Header(q).Error())
+	err := c.Bind().Header(q)
+	require.Error(t, err)
+	require.Equal(t, "bind \"Name\" from header: Name is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	c.Request().Header.Add("Name", "tom")
 	c.Request().Header.Del("Nested.Age")
@@ -510,7 +694,10 @@ func Test_Bind_Header_Schema(t *testing.T) {
 
 	c.Request().Header.Del("Nested.Agex")
 	q = new(Header1)
-	require.Equal(t, "bind: Nested is empty", c.Bind().Header(q).Error())
+	err = c.Bind().Header(q)
+	require.Error(t, err)
+	require.Equal(t, "bind \"Nested\" from header: Nested is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	c.Request().Header.Del("Nested.Agex")
 	c.Request().Header.Del("Name")
@@ -536,7 +723,10 @@ func Test_Bind_Header_Schema(t *testing.T) {
 	c.Request().Header.Del("Nested.Age")
 	c.Request().Header.Add("Nested.Agex", "10")
 	h2 = new(Header2)
-	require.Equal(t, "bind: Nested.age is empty", c.Bind().Header(h2).Error())
+	err = c.Bind().Header(h2)
+	require.Error(t, err)
+	require.Equal(t, "bind \"Nested.age\" from header: Nested.age is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	type Node struct {
 		Next  *Node `header:"Next,required"`
@@ -551,7 +741,10 @@ func Test_Bind_Header_Schema(t *testing.T) {
 
 	c.Request().Header.Del("Val")
 	n = new(Node)
-	require.Equal(t, "bind: Val is empty", c.Bind().Header(n).Error())
+	err = c.Bind().Header(n)
+	require.Error(t, err)
+	require.Equal(t, "bind \"Val\" from header: Val is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	c.Request().Header.Add("Val", "3")
 	c.Request().Header.Del("Next.Val")
@@ -634,7 +827,10 @@ func Test_Bind_RespHeader(t *testing.T) {
 	}
 	rh := new(RequiredHeader)
 	c.Response().Header.Del("name")
-	require.Equal(t, "bind: name is empty", c.Bind().RespHeader(rh).Error())
+	err := c.Bind().RespHeader(rh)
+	require.Error(t, err)
+	require.Equal(t, "bind \"name\" from respHeader: name is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 }
 
 // go test -run Test_Bind_RespHeader_Map -v
@@ -1572,7 +1768,10 @@ func Test_Bind_Cookie(t *testing.T) {
 	}
 	rh := new(RequiredCookie)
 	c.Request().Header.DelCookie("name")
-	require.Equal(t, "bind: name is empty", c.Bind().Cookie(rh).Error())
+	err := c.Bind().Cookie(rh)
+	require.Error(t, err)
+	require.Equal(t, "bind \"name\" from cookie: name is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 }
 
 // go test -run Test_Bind_Cookie_Map -v
@@ -1684,7 +1883,10 @@ func Test_Bind_Cookie_Schema(t *testing.T) {
 
 	c.Request().Header.DelCookie("Name")
 	q = new(Cookie1)
-	require.Equal(t, "bind: Name is empty", c.Bind().Cookie(q).Error())
+	err := c.Bind().Cookie(q)
+	require.Error(t, err)
+	require.Equal(t, "bind \"Name\" from cookie: Name is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	c.Request().Header.SetCookie("Name", "tom")
 	c.Request().Header.DelCookie("Nested.Age")
@@ -1694,7 +1896,10 @@ func Test_Bind_Cookie_Schema(t *testing.T) {
 
 	c.Request().Header.DelCookie("Nested.Agex")
 	q = new(Cookie1)
-	require.Equal(t, "bind: Nested is empty", c.Bind().Cookie(q).Error())
+	err = c.Bind().Cookie(q)
+	require.Error(t, err)
+	require.Equal(t, "bind \"Nested\" from cookie: Nested is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	c.Request().Header.DelCookie("Nested.Agex")
 	c.Request().Header.DelCookie("Name")
@@ -1720,7 +1925,10 @@ func Test_Bind_Cookie_Schema(t *testing.T) {
 	c.Request().Header.DelCookie("Nested.Age")
 	c.Request().Header.SetCookie("Nested.Agex", "10")
 	h2 = new(Cookie2)
-	require.Equal(t, "bind: Nested.Age is empty", c.Bind().Cookie(h2).Error())
+	err = c.Bind().Cookie(h2)
+	require.Error(t, err)
+	require.Equal(t, "bind \"Nested.Age\" from cookie: Nested.Age is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	type Node struct {
 		Next  *Node `cookie:"Next,required"`
@@ -1735,7 +1943,10 @@ func Test_Bind_Cookie_Schema(t *testing.T) {
 
 	c.Request().Header.DelCookie("Val")
 	n = new(Node)
-	require.Equal(t, "bind: Val is empty", c.Bind().Cookie(n).Error())
+	err = c.Bind().Cookie(n)
+	require.Error(t, err)
+	require.Equal(t, "bind \"Val\" from cookie: Val is empty", err.Error())
+	require.ErrorAs(t, err, &MultiError{})
 
 	c.Request().Header.SetCookie("Val", "3")
 	c.Request().Header.DelCookie("Next.Val")
@@ -1849,7 +2060,7 @@ func Test_Bind_WithAutoHandling(t *testing.T) {
 	c.Request().URI().SetQueryString("")
 	err := c.Bind().WithAutoHandling().Query(rq)
 	require.Equal(t, StatusBadRequest, c.Response().StatusCode())
-	require.Equal(t, "Bad request: bind: name is empty", err.Error())
+	require.Equal(t, "Bad request: name is empty", err.Error())
 }
 
 // simple struct validator for testing

--- a/bind_test.go
+++ b/bind_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/gofiber/fiber/v3/binder"
+	"github.com/gofiber/schema"
 	"github.com/shamaton/msgpack/v3"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
@@ -62,6 +63,24 @@ func Test_BindError_Unwrap(t *testing.T) {
 	require.Equal(t, BindSourceQuery, extracted.Source)
 }
 
+func Test_BindError_ErrorFormat(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with field", func(t *testing.T) {
+		t.Parallel()
+		be := &BindError{Source: BindSourceQuery, Field: "id", Err: errors.New("conversion failed")}
+		require.Contains(t, be.Error(), `"id"`)
+		require.Contains(t, be.Error(), "query")
+		require.Contains(t, be.Error(), "conversion failed")
+	})
+
+	t.Run("without field", func(t *testing.T) {
+		t.Parallel()
+		be := &BindError{Source: BindSourceBody, Field: "", Err: errors.New("parse failed")}
+		require.Equal(t, "bind from body: parse failed", be.Error())
+	})
+}
+
 func Test_BindError_FieldExtraction(t *testing.T) {
 	t.Parallel()
 
@@ -83,6 +102,27 @@ func Test_BindError_FieldExtraction(t *testing.T) {
 		require.ErrorAs(t, err, &MultiError{})
 	})
 
+	t.Run("ConversionError", func(t *testing.T) {
+		t.Parallel()
+		convErrBinder := &customBinderReturningError{
+			err:      schema.ConversionError{Key: "count"},
+			mimeType: "application/x-conversion-error-test",
+		}
+		app := New()
+		app.RegisterCustomBinder(convErrBinder)
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
+		c.Request().SetBody([]byte("{}"))
+		c.Request().Header.SetContentType("application/x-conversion-error-test")
+		type D struct{ Name string }
+		err := c.Bind().Body(new(D))
+		require.Error(t, err)
+		var be *BindError
+		require.ErrorAs(t, err, &be)
+		require.Equal(t, BindSourceBody, be.Source)
+		require.Equal(t, "count", be.Field)
+	})
+
 	t.Run("JSONUnmarshalTypeError", func(t *testing.T) {
 		t.Parallel()
 		type J struct {
@@ -101,6 +141,88 @@ func Test_BindError_FieldExtraction(t *testing.T) {
 		require.Equal(t, "count", be.Field)
 		var unmarshalErr *json.UnmarshalTypeError
 		require.ErrorAs(t, err, &unmarshalErr)
+	})
+
+	t.Run("UnknownKeyError", func(t *testing.T) {
+		t.Parallel()
+		unknownKeyBinder := &customBinderReturningError{
+			err:      schema.UnknownKeyError{Key: "extra_field"},
+			mimeType: "application/x-unknown-key-test",
+		}
+		app := New()
+		app.RegisterCustomBinder(unknownKeyBinder)
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
+		c.Request().SetBody([]byte("{}"))
+		c.Request().Header.SetContentType("application/x-unknown-key-test")
+		type D struct{ Name string }
+		err := c.Bind().Body(new(D))
+		require.Error(t, err)
+		var be *BindError
+		require.ErrorAs(t, err, &be)
+		require.Equal(t, BindSourceBody, be.Source)
+		require.Equal(t, "extra_field", be.Field)
+	})
+
+	t.Run("EmptyFieldError", func(t *testing.T) {
+		t.Parallel()
+		emptyFieldBinder := &customBinderReturningError{
+			err:      schema.EmptyFieldError{Key: "required_field"},
+			mimeType: "application/x-empty-field-test",
+		}
+		app := New()
+		app.RegisterCustomBinder(emptyFieldBinder)
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
+		c.Request().SetBody([]byte("{}"))
+		c.Request().Header.SetContentType("application/x-empty-field-test")
+		type D struct{ Name string }
+		err := c.Bind().Body(new(D))
+		require.Error(t, err)
+		var be *BindError
+		require.ErrorAs(t, err, &be)
+		require.Equal(t, BindSourceBody, be.Source)
+		require.Equal(t, "required_field", be.Field)
+	})
+
+	t.Run("MultiError", func(t *testing.T) {
+		t.Parallel()
+		type Q struct {
+			A string `query:"a,required"`
+			B string `query:"b,required"`
+		}
+		app := New()
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
+		c.Request().URI().SetQueryString("")
+		err := c.Bind().Query(new(Q))
+		require.Error(t, err)
+		var be *BindError
+		require.ErrorAs(t, err, &be)
+		require.Equal(t, BindSourceQuery, be.Source)
+		require.Contains(t, []string{"a", "b"}, be.Field)
+		require.ErrorAs(t, err, &MultiError{})
+	})
+
+	t.Run("NoRecognizedErrorType", func(t *testing.T) {
+		t.Parallel()
+		genericErrBinder := &customBinderReturningError{
+			err:      errors.New("generic parse failure"),
+			mimeType: "application/x-generic-error",
+		}
+		app := New()
+		app.RegisterCustomBinder(genericErrBinder)
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
+		c.Request().SetBody([]byte("{}"))
+		c.Request().Header.SetContentType("application/x-generic-error")
+		type D struct{ Name string }
+		err := c.Bind().Body(new(D))
+		require.Error(t, err)
+		var be *BindError
+		require.ErrorAs(t, err, &be)
+		require.Equal(t, BindSourceBody, be.Source)
+		require.Empty(t, be.Field)
 	})
 }
 
@@ -1231,6 +1353,18 @@ func Test_Bind_Body(t *testing.T) {
 		testDecodeParserError(t, "invalid-content-type", "")
 	})
 
+	t.Run("ErrorUnknownContentTypeReturnsUnprocessableEntity", func(t *testing.T) {
+		t.Parallel()
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		c.Request().Header.SetContentType("application/unknown-type")
+		c.Request().SetBody([]byte("some body"))
+		c.Request().Header.SetContentLength(9)
+		d := new(Demo)
+		err := c.Bind().Body(d)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrUnprocessableEntity)
+	})
+
 	t.Run("ErrorMalformedMultipart", func(t *testing.T) {
 		testDecodeParserError(t, MIMEMultipartForm+`;boundary="b"`, "--b")
 	})
@@ -2038,6 +2172,27 @@ func (*customBinder) MIMETypes() []string {
 
 func (*customBinder) Parse(c Ctx, out any) error {
 	return json.Unmarshal(c.Body(), out)
+}
+
+// customBinderReturningError returns a fixed error for testing extractFieldFromError branches.
+type customBinderReturningError struct {
+	err      error
+	mimeType string
+}
+
+func (*customBinderReturningError) Name() string {
+	return "error-binder"
+}
+
+func (b *customBinderReturningError) MIMETypes() []string {
+	if b.mimeType != "" {
+		return []string{b.mimeType}
+	}
+	return []string{"application/x-unknown-key-test", "application/x-empty-field-test"}
+}
+
+func (b *customBinderReturningError) Parse(_ Ctx, _ any) error {
+	return b.err
 }
 
 // go test -run Test_Bind_CustomBinder

--- a/bind_test.go
+++ b/bind_test.go
@@ -64,14 +64,15 @@ func Test_BindError_Unwrap(t *testing.T) {
 
 func Test_BindError_FieldExtraction(t *testing.T) {
 	t.Parallel()
-	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 
 	t.Run("QueryConversionError", func(t *testing.T) {
 		t.Parallel()
 		type Q struct {
 			ID int `query:"id"`
 		}
+		app := New()
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
 		c.Request().URI().SetQueryString("id=notanint")
 		err := c.Bind().Query(new(Q))
 		require.Error(t, err)
@@ -87,6 +88,9 @@ func Test_BindError_FieldExtraction(t *testing.T) {
 		type J struct {
 			Count int `json:"count"`
 		}
+		app := New()
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
 		c.Request().SetBody([]byte(`{"count":"notanint"}`))
 		c.Request().Header.SetContentType(MIMEApplicationJSON)
 		err := c.Bind().Body(new(J))
@@ -102,15 +106,13 @@ func Test_BindError_FieldExtraction(t *testing.T) {
 
 func Test_BindError_Sources(t *testing.T) {
 	t.Parallel()
-	app := New()
-	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 
 	t.Run("URI", func(t *testing.T) {
 		t.Parallel()
 		type U struct {
 			ID int `uri:"id"`
 		}
-		c.Request().SetRequestURI("/user/notanint")
+		app := New()
 		app.Get("/user/:id", func(ctx Ctx) error {
 			err := ctx.Bind().URI(new(U))
 			require.Error(t, err)
@@ -129,6 +131,9 @@ func Test_BindError_Sources(t *testing.T) {
 		type Q struct {
 			ID int `query:"id,required"`
 		}
+		app := New()
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
 		c.Request().URI().SetQueryString("")
 		err := c.Bind().Query(new(Q))
 		require.Error(t, err)
@@ -143,6 +148,9 @@ func Test_BindError_Sources(t *testing.T) {
 		type H struct {
 			ID int `header:"x-id,required"`
 		}
+		app := New()
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
 		c.Request().Header.Del("X-Id")
 		err := c.Bind().Header(new(H))
 		require.Error(t, err)
@@ -157,6 +165,9 @@ func Test_BindError_Sources(t *testing.T) {
 		type C struct {
 			ID int `cookie:"id,required"`
 		}
+		app := New()
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
 		c.Request().Header.DelCookie("id")
 		err := c.Bind().Cookie(new(C))
 		require.Error(t, err)
@@ -171,6 +182,9 @@ func Test_BindError_Sources(t *testing.T) {
 		type J struct {
 			X int `json:"x"`
 		}
+		app := New()
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
 		c.Request().SetBody([]byte(`{"x":"bad"}`))
 		c.Request().Header.SetContentType(MIMEApplicationJSON)
 		err := c.Bind().Body(new(J))

--- a/bind_test.go
+++ b/bind_test.go
@@ -2219,6 +2219,29 @@ func Test_Bind_CustomBinder(t *testing.T) {
 	require.Equal(t, "john", d.Name)
 }
 
+// go test -run Test_Bind_CustomBinder_Source
+func Test_Bind_CustomBinder_Source(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	app.RegisterCustomBinder(&customBinder{})
+
+	type Demo struct {
+		Name string `json:"name"`
+	}
+	c.Request().SetBody([]byte(`{invalid json`))
+	c.Request().Header.SetContentLength(14)
+
+	err := c.Bind().Custom("custom", new(Demo))
+	require.Error(t, err)
+	var be *BindError
+	require.ErrorAs(t, err, &be)
+	require.Equal(t, "custom", be.Source)
+}
+
 // go test -run Test_Bind_WithAutoHandling
 func Test_Bind_WithAutoHandling(t *testing.T) {
 	app := New()

--- a/bind_test.go
+++ b/bind_test.go
@@ -95,7 +95,8 @@ func Test_BindError_FieldExtraction(t *testing.T) {
 		require.ErrorAs(t, err, &be)
 		require.Equal(t, BindSourceBody, be.Source)
 		require.Equal(t, "count", be.Field)
-		require.ErrorAs(t, err, &UnmarshalTypeError{})
+		var unmarshalErr *json.UnmarshalTypeError
+		require.ErrorAs(t, err, &unmarshalErr)
 	})
 }
 

--- a/binder/mapping.go
+++ b/binder/mapping.go
@@ -117,7 +117,7 @@ func parseToStruct(aliasTag string, out any, data map[string][]string, files ...
 	schemaDecoder.SetAliasTag(aliasTag)
 
 	if err := schemaDecoder.Decode(out, data, files...); err != nil {
-		return fmt.Errorf("bind: %w", err)
+		return fmt.Errorf("%w", err)
 	}
 
 	return nil

--- a/binder/mapping_test.go
+++ b/binder/mapping_test.go
@@ -349,7 +349,7 @@ func Test_parseToStruct_MismatchedData(t *testing.T) {
 
 	err := parseToStruct("query", &User{}, data)
 	require.Error(t, err)
-	require.EqualError(t, err, "bind: schema: error converting value for \"age\"")
+	require.EqualError(t, err, "schema: error converting value for \"age\"")
 }
 
 func Test_formatBindData_ErrorCases(t *testing.T) {

--- a/docs/api/bind.md
+++ b/docs/api/bind.md
@@ -50,7 +50,7 @@ The request body is only included as a binding source when the request has both 
 func (b *Bind) All(out any) error
 ```
 
-``` go title="Example"
+```go title="Example"
 type User struct {
     Name      string                `query:"name" json:"name" form:"name"`
     Email     string                `json:"email" form:"email"`
@@ -473,13 +473,13 @@ For more parser settings, please refer to [Config](fiber.md#enablesplittingonpar
 
 Fiber supports several formats for passing array values via query parameters. The following table gives an overview:
 
-| Format | Example | Requires `EnableSplittingOnParsers` |
-| --- | --- | --- |
-| Repeated key | `?colors=red&colors=blue` | No |
-| Bracket notation | `?colors[]=red&colors[]=blue` | No |
-| Comma-separated | `?colors=red,blue` | **Yes** |
-| Indexed bracket notation | `?posts[0][title]=Hello&posts[1][title]=World` | No |
-| Nested bracket notation | `?preferences[tags]=golang,api` | No (comma splitting: **Yes**) |
+| Format                   | Example                                        | Requires `EnableSplittingOnParsers` |
+| ------------------------ | ---------------------------------------------- | ----------------------------------- |
+| Repeated key             | `?colors=red&colors=blue`                      | No                                  |
+| Bracket notation         | `?colors[]=red&colors[]=blue`                  | No                                  |
+| Comma-separated          | `?colors=red,blue`                             | **Yes**                             |
+| Indexed bracket notation | `?posts[0][title]=Hello&posts[1][title]=World` | No                                  |
+| Nested bracket notation  | `?preferences[tags]=golang,api`                | No (comma splitting: **Yes**)       |
 
 ##### Repeated Key
 
@@ -683,6 +683,42 @@ app.Get("/user/:id", func(c fiber.Ctx) error {
     return c.SendString(fmt.Sprintf("User ID: %d", param.ID))
 })
 ```
+
+## BindError
+
+When a bind method fails to parse (e.g. invalid JSON, bad type conversion), it returns a `*BindError` wrapping the underlying error. Use `errors.As` to extract it when you need to branch on the binding source or field.
+
+```go
+type BindError struct {
+    Source string // "uri", "query", "body", "header", "cookie", or "respHeader"
+    Field  string // struct field or tag key that failed (best-effort, may be empty)
+    Err    error  // underlying error; use errors.As to inspect
+}
+```
+
+Source constants: `BindSourceURI`, `BindSourceQuery`, `BindSourceHeader`, `BindSourceCookie`, `BindSourceBody`, `BindSourceRespHeader`.
+
+### Branching on source
+
+Use `errors.As` to extract `*BindError` and branch on `Source` for RFC-correct status codes (e.g. 404 for URI failures vs 400 for body/query):
+
+```go title="Example"
+var req struct {
+    ID   uuid.UUID `uri:"id"`
+    Name string    `json:"name"`
+}
+if err := c.Bind().All(&req); err != nil {
+    var be *fiber.BindError
+    if errors.As(err, &be) && be.Source == fiber.BindSourceURI {
+        return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "not found"})
+    }
+    return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request"})
+}
+```
+
+### Validation vs binding errors
+
+Validation errors (from `StructValidator`) are **not** wrapped in `BindError`. Use `errors.As(err, &be)` to distinguish: it succeeds only for parsing/binding failures, not for validation failures.
 
 ## Custom
 

--- a/docs/api/bind.md
+++ b/docs/api/bind.md
@@ -686,7 +686,7 @@ app.Get("/user/:id", func(c fiber.Ctx) error {
 
 ## BindError
 
-When a bind method fails to parse (e.g. invalid JSON, bad type conversion), it returns a `*BindError` wrapping the underlying error. Use `errors.As` to extract it when you need to branch on the binding source or field.
+When a bind method fails to parse (e.g. invalid JSON, bad type conversion), the behavior depends on the error-handling mode. In **manual handling** (the default), the binder returns a `*BindError` wrapping the underlying error — use `errors.As` to extract it and branch on the binding source or field. In **automatic handling** (enabled via `WithAutoHandling`), parse failures are instead converted to a `*fiber.Error` with HTTP status 400; `*BindError` is never surfaced to the caller in that mode. If you are using `WithAutoHandling`, check for `*fiber.Error` or an HTTP 400 response rather than using `errors.As` for `*BindError`.
 
 ```go
 type BindError struct {

--- a/docs/api/bind.md
+++ b/docs/api/bind.md
@@ -703,9 +703,11 @@ Source constants: `BindSourceURI`, `BindSourceQuery`, `BindSourceHeader`, `BindS
 Use `errors.As` to extract `*BindError` and branch on `Source` for RFC-correct status codes (e.g. 404 for URI failures vs 400 for body/query):
 
 ```go title="Example"
+// With manual handling mode (default behavior)
+// Will not work with WithAutoHandling()
 var req struct {
-    ID   uuid.UUID `uri:"id"`
-    Name string    `json:"name"`
+    ID   int    `uri:"id"`
+    Name string `json:"name"`
 }
 if err := c.Bind().All(&req); err != nil {
     var be *fiber.BindError


### PR DESCRIPTION
## Description

Implements #4118.

All `Bind()` methods now return `*BindError` on parse failure, giving callers the binding source and field that failed as structured data rather than an opaque error string.

Fixes #4118

## Changes introduced

### What changed

**New type and constants in `bind.go`:**

```go
type BindError struct {
    Source string // "uri", "query", "body", "header", "cookie", or "respHeader"
    Field  string // struct field/tag key that failed (best-effort, may be empty)
    Err    error  // underlying error
}

const (
    BindSourceURI        = "uri"
    BindSourceQuery      = "query"
    BindSourceHeader     = "header"
    BindSourceCookie     = "cookie"
    BindSourceBody       = "body"
    BindSourceRespHeader = "respHeader"
)
```

All bind methods (`URI`, `Query`, `Header`, `Cookie`, `RespHeader`, `JSON`, `XML`, `CBOR`, `MsgPack`, `Form`, `Body`, and `All`) now return `*BindError` instead of a raw error when parsing fails. `BindError` implements `Unwrap`, so `errors.As` traverses the full chain — you can extract either the `*BindError` or the underlying error type directly:

```go
if err := c.Bind().All(&req); err != nil {
    var be *fiber.BindError
    if errors.As(err, &be) && be.Source == fiber.BindSourceURI {
        return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "not found"})
    }
    return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request"})
}
```

**`binder/mapping.go`:** Removed the `"bind: "` prefix that `parseToStruct` prepended to schema errors. The field/source context is now carried by `BindError` instead.

### Gotchas

**Validation errors are not bind errors.** Errors from a registered `StructValidator` are returned as-is and not wrapped in `*BindError`. `errors.As(err, &be)` can be used to tell them apart — it succeeds only for parse failures.

**Auto-handling suppresses `BindError`.** With `WithAutoHandling()`, parse failures are converted to an HTTP 400 response and the method returns `*fiber.Error`. `BindError` is only returned in default (manual) mode.

### Breaking change: error message strings

Two error string formats changed:

1. Schema errors from `binder.parseToStruct` lost the `"bind: "` prefix — `"bind: name is empty"` → `"name is empty"`.
2. Errors returned from bind methods gained a structured prefix — bare schema error → `bind "field" from source: underlying error`.

`errors.Is` / `errors.As` chains are unaffected. Code that string-matches `err.Error()` will need updating.

- [x] Benchmarks: no allocations on the happy path; `newBindError` allocates only on error.
- [x] Documentation Update: `docs/api/bind.md` updated with a `BindError` section covering the type, source constants, source-branching example, and validation vs binding error distinction.
- [x] Changelog/What's New: `BindError` type, `BindSource*` constants, structured error metadata on all `Bind()` methods.
- [x] Migration Guide: error string format changed (see above); no API surface changes.
- [x] API Alignment with Express: aligns with express-validator's `location`/`path` fields.
- [x] API Longevity: additive only; `BindError` implements `error` and `Unwrap`, existing code unaffected.
- [x] Examples: see `docs/api/bind.md`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing features and functionality)
- [x] Documentation update (changes to documentation)

## Checklist

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the `/docs/` directory for Fiber's documentation.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.