### PR TITLE
🐛 fix: prefork children exit immediately in Docker containers

### DIFF
--- a/prefork.go
+++ b/prefork.go
@@ -59,7 +59,8 @@ func (app *App) prefork(addr string, tlsConfig *tls.Config, cfg *ListenConfig) e
 		}
 
 		// kill current child proc when master exits
-		go watchMaster()
+		masterPID := os.Getppid()
+		go watchMaster(masterPID)
 
 		// prepare the server for the start
 		app.startupProcess()
@@ -155,24 +156,24 @@ func (app *App) prefork(addr string, tlsConfig *tls.Config, cfg *ListenConfig) e
 
 // watchMaster watches the master process and exits if it dies.
 // It detects master death by checking if the parent PID has changed,
-// which happens when the master exits and the child is reparented to init.
-func watchMaster() {
+// which happens when the master exits and the child is reparented to
+// another process (often init/PID 1, but could be a subreaper).
+func watchMaster(masterPID int) {
 	if runtime.GOOS == windowsOS {
 		// finds parent process,
 		// and waits for it to exit
-		p, err := os.FindProcess(os.Getppid())
+		p, err := os.FindProcess(masterPID)
 		if err == nil {
 			_, _ = p.Wait() //nolint:errcheck // It is fine to ignore the error here
 		}
 		os.Exit(1) //nolint:revive // Calling os.Exit is fine here in the prefork
 	}
-	// Store the original parent PID and watch for changes.
-	// When the master exits, the OS reparents the child to init (PID 1),
-	// causing Getppid() to change. Comparing against the original PID
-	// instead of hardcoding 1 ensures this works correctly when the
-	// master itself is PID 1 (e.g. in Docker containers).
+	// Watch for parent PID changes. When the master exits, the OS
+	// reparents the child to another process, causing Getppid() to change.
+	// Comparing against the original PID instead of hardcoding 1 ensures
+	// this works correctly when the master itself is PID 1 (e.g. in
+	// Docker containers).
 	const watchInterval = 500 * time.Millisecond
-	masterPID := os.Getppid()
 	for range time.NewTicker(watchInterval).C {
 		if os.Getppid() != masterPID {
 			os.Exit(1) //nolint:revive // Calling os.Exit is fine here in the prefork

--- a/prefork.go
+++ b/prefork.go
@@ -153,7 +153,9 @@ func (app *App) prefork(addr string, tlsConfig *tls.Config, cfg *ListenConfig) e
 	return (<-channel).err
 }
 
-// watchMaster watches child procs
+// watchMaster watches the master process and exits if it dies.
+// It detects master death by checking if the parent PID has changed,
+// which happens when the master exits and the child is reparented to init.
 func watchMaster() {
 	if runtime.GOOS == windowsOS {
 		// finds parent process,
@@ -164,11 +166,15 @@ func watchMaster() {
 		}
 		os.Exit(1) //nolint:revive // Calling os.Exit is fine here in the prefork
 	}
-	// if it is equal to 1 (init process ID),
-	// it indicates that the master process has exited
+	// Store the original parent PID and watch for changes.
+	// When the master exits, the OS reparents the child to init (PID 1),
+	// causing Getppid() to change. Comparing against the original PID
+	// instead of hardcoding 1 ensures this works correctly when the
+	// master itself is PID 1 (e.g. in Docker containers).
 	const watchInterval = 500 * time.Millisecond
+	masterPID := os.Getppid()
 	for range time.NewTicker(watchInterval).C {
-		if os.Getppid() == 1 {
+		if os.Getppid() != masterPID {
 			os.Exit(1) //nolint:revive // Calling os.Exit is fine here in the prefork
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #4132

`watchMaster()` kills child processes when `os.Getppid() == 1`, assuming the parent died and the child was reparented to init. In Docker containers, the master process commonly **is** PID 1, so children immediately see `Getppid() == 1` and call `os.Exit(1)` after the first 500ms tick.

### Fix

Store the original parent PID at startup and detect parent death by checking if the parent PID *changed*, rather than comparing against a hardcoded value of 1.

```go
// Before
for range time.NewTicker(watchInterval).C {
    if os.Getppid() == 1 {
        os.Exit(1)
    }
}

// After
masterPID := os.Getppid()
for range time.NewTicker(watchInterval).C {
    if os.Getppid() != masterPID {
        os.Exit(1)
    }
}
```

### Testing

- All existing prefork tests pass
- Verified prefork works in Docker containers without needing an external init process (tini)