### PR TITLE
docs: update TechEmpower benchmark link and Fiber version to v3.1.0

### DIFF
--- a/docs/extra/benchmarks.md
+++ b/docs/extra/benchmarks.md
@@ -9,11 +9,11 @@ sidebar_position: 2
 
 ## TechEmpower
 
-[TechEmpower](https://www.techempower.com/benchmarks/#section=test&runid=1d5bfc8a-5c4a-4fb2-a792-ad967f1eb138) provides a performance comparison of many web application frameworks that execute fundamental tasks such as JSON serialization, database access, and server-side template rendering.
+[TechEmpower](https://www.techempower.com/benchmarks/#section=test&runid=fd07b64e-47ce-411e-8b9b-b13368e988c6) provides a performance comparison of many web application frameworks that execute fundamental tasks such as JSON serialization, database access, and server-side template rendering.
 
 Each framework runs under a realistic production configuration. Results are recorded on both cloud instances and physical hardware. The test implementations are community contributed and live in the [FrameworkBenchmarks repository](https://github.com/TechEmpower/FrameworkBenchmarks).
 
-* Fiber `v3.0.0`
+* Fiber `v3.1.0`
 * 56 Cores Intel(R) Xeon(R) Gold 6330 CPU @ 2.00GHz (Three homogeneous ProLiant DL360 Gen10 Plus)
 * 64GB RAM
 * Enterprise SSD


### PR DESCRIPTION
## Changes

- Updated TechEmpower benchmark link to Round 23 (run ID: fd07b64e)
- Updated Fiber version reference from v3.0.0 to v3.1.0

## Related Issue

Closes #3346