### PR TITLE
📚 doc: Key Value Expectation Notice (KeyAuth Middleware)

### DIFF
--- a/docs/middleware/keyauth.md
+++ b/docs/middleware/keyauth.md
@@ -169,7 +169,7 @@ curl --cookie "access_token=correct horse battery staple" http://localhost:3000/
 ### Apply middleware in the handler
 
 You can apply the middleware to specific routes or groups instead of globally. This example uses the default extractor (`FromAuthHeader`).
-- FromAuthHeader expects a complaint [RFC 7235 Token68](https://datatracker.ietf.org/doc/html/rfc7235#:~:text=token%20/%20quoted%2Dstring%20)-,token68,-%3D%201*(%20ALPHA%20/%20DIGIT) key value.
+- FromAuthHeader expects a compliant [RFC 7235 Token68](https://datatracker.ietf.org/doc/html/rfc7235#:~:text=token%20/%20quoted%2Dstring%20)-,token68,-%3D%201*(%20ALPHA%20/%20DIGIT) key value.
 
 ```go
 package main

--- a/docs/middleware/keyauth.md
+++ b/docs/middleware/keyauth.md
@@ -169,6 +169,7 @@ curl --cookie "access_token=correct horse battery staple" http://localhost:3000/
 ### Apply middleware in the handler
 
 You can apply the middleware to specific routes or groups instead of globally. This example uses the default extractor (`FromAuthHeader`).
+
 - `FromAuthHeader` expects a compliant [RFC 7235 `token68`](https://datatracker.ietf.org/doc/html/rfc7235#section-2.1) key value.
 
 ```go

--- a/docs/middleware/keyauth.md
+++ b/docs/middleware/keyauth.md
@@ -169,7 +169,7 @@ curl --cookie "access_token=correct horse battery staple" http://localhost:3000/
 ### Apply middleware in the handler
 
 You can apply the middleware to specific routes or groups instead of globally. This example uses the default extractor (`FromAuthHeader`).
-- FromAuthHeader expects a compliant [RFC 7235 Token68](https://datatracker.ietf.org/doc/html/rfc7235#:~:text=token%20/%20quoted%2Dstring%20)-,token68,-%3D%201*(%20ALPHA%20/%20DIGIT) key value.
+- `FromAuthHeader` expects a compliant [RFC 7235 `token68`](https://datatracker.ietf.org/doc/html/rfc7235#section-2.1) key value.
 
 ```go
 package main

--- a/docs/middleware/keyauth.md
+++ b/docs/middleware/keyauth.md
@@ -169,6 +169,7 @@ curl --cookie "access_token=correct horse battery staple" http://localhost:3000/
 ### Apply middleware in the handler
 
 You can apply the middleware to specific routes or groups instead of globally. This example uses the default extractor (`FromAuthHeader`).
+- FromAuthHeader expects a complaint [RFC 7235 Token68](https://datatracker.ietf.org/doc/html/rfc7235#:~:text=token%20/%20quoted%2Dstring%20)-,token68,-%3D%201*(%20ALPHA%20/%20DIGIT) key value.
 
 ```go
 package main


### PR DESCRIPTION
# Description

1. Extractor: extractors.FromAuthHeader("Bearer") expects a specific type of key value.
2. it un-noted leading to situations where the the Validator is skipped entirely in the key.
3. The error handler is not clear on this as well.

This fix adds a little note stating the expectations with a link to the RFC docs on it - so readers can easily see where to go.

I spent some minutes trying to debug - my hope is others dont because of it.

Fixes # (issue)

## Changes introduced
- [x] Documentation Update:  Added this little note:
- FromAuthHeader expects a complaint [RFC 7235 Token68](https://datatracker.ietf.org/doc/html/rfc7235#:~:text=token%20/%20quoted%2Dstring%20)-,token68,-%3D%201*(%20ALPHA%20/%20DIGIT) key value.


## Type of change
- [x] Documentation update (changes to documentation)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:
- [x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).