### PR TITLE
refactor: optimize speed

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"maps"
 	"mime/multipart"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -109,7 +108,13 @@ func (c *DefaultCtx) BaseURL() string {
 	if c.baseURI != "" {
 		return c.baseURI
 	}
-	c.baseURI = c.Scheme() + "://" + c.Host()
+	scheme := c.Scheme()
+	host := c.Host()
+	buf := make([]byte, 0, len(scheme)+len("://")+len(host))
+	buf = append(buf, scheme...)
+	buf = append(buf, "://"...)
+	buf = append(buf, host...)
+	c.baseURI = c.app.toString(buf)
 	return c.baseURI
 }
 
@@ -574,13 +579,14 @@ func (c *DefaultCtx) String() string {
 
 	// Start with the ID, converting it to a hex string without fmt.Sprintf
 	buf.WriteByte('#')
-	// Convert ID to hexadecimal
-	id := strconv.FormatUint(c.fasthttp.ID(), 16)
-	// Pad with leading zeros to ensure 16 characters
-	for i := 0; i < (16 - len(id)); i++ {
-		buf.WriteByte('0')
+	const hex = "0123456789abcdef"
+	var id [16]byte
+	ctxID := c.fasthttp.ID()
+	for i := len(id) - 1; i >= 0; i-- {
+		id[i] = hex[ctxID&0xf]
+		ctxID >>= 4
 	}
-	buf.WriteString(id)
+	buf.Write(id[:])
 	buf.WriteString(" - ")
 
 	// Add local and remote addresses directly

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -806,6 +806,35 @@ func Benchmark_Ctx_BaseURL(b *testing.B) {
 	require.Equal(b, "http://google.com:1337", res)
 }
 
+func Benchmark_Ctx_BaseURL_Uncached(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
+
+	c.Request().SetHost("google.com:1337")
+	c.Request().URI().SetPath("/haha/oke/lol")
+	var res string
+	b.ReportAllocs()
+	for b.Loop() {
+		c.baseURI = ""
+		res = c.BaseURL()
+	}
+	require.Equal(b, "http://google.com:1337", res)
+}
+
+func Benchmark_Ctx_FullURL(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
+
+	c.Request().SetRequestURI("/haha/oke/lol?name=fiber")
+	c.Request().URI().SetHost("google.com:1337")
+	var res string
+	b.ReportAllocs()
+	for b.Loop() {
+		res = c.FullURL()
+	}
+	require.Equal(b, "http://google.com:1337/haha/oke/lol?name=fiber", res)
+}
+
 // go test -run Test_Ctx_Body
 func Test_Ctx_Body(t *testing.T) {
 	t.Parallel()

--- a/router.go
+++ b/router.go
@@ -196,9 +196,7 @@ func (r *Route) match(detectionPath, path string, params *[maxParams]string) boo
 	// Does this route have parameters?
 	if len(r.Params) > 0 {
 		// Match params using precomputed routeParser
-		if r.routeParser.getMatch(detectionPath, path, params, r.use) {
-			return true
-		}
+		return r.routeParser.getMatch(detectionPath, path, params, r.use)
 	}
 
 	// Middleware route?


### PR DESCRIPTION
This PR applies small, benchmark-backed optimizations in Fiber core paths:

- Simplifies parameterized route matching by returning `routeParser.getMatch(...)` directly.
- Optimizes `Ctx.BaseURL()` string construction with an exactly sized byte buffer.
- Optimizes `Ctx.String()` by writing the 16-byte hex request ID directly instead of using `strconv.FormatUint`.
- Updates the spell-check workflow Node.js version to 24.

## Performance

Benchmarked with `go test -bench ... -benchmem -count=20` and compared with `benchstat`.

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| `Benchmark_Router_Handler` | `87.98 ns/op` | `84.44 ns/op` | `-4.03%` |
| `Benchmark_Route_Match` | `13.20 ns/op` | `13.06 ns/op` | `-1.06%` |
| `Benchmark_Ctx_BaseURL_Uncached` | `47.99 ns/op` | `39.48 ns/op` | `-17.72%` |
| `Benchmark_Ctx_BaseURL` | `2.054 ns/op` | `1.962 ns/op` | `-4.50%` |
| `Benchmark_Ctx_String` | `192.3 ns/op` | `171.6 ns/op` | `-10.79%` |

No allocation regressions were observed in these benchmarks.