### PR TITLE
🐛 bug: escape HTML output in Ctx.Format

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -11,6 +11,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"mime/multipart"
 	"net"
@@ -606,7 +607,7 @@ func (c *Ctx) Format(body interface{}) error {
 	// Format based on the accept content type
 	switch accept {
 	case "html":
-		return c.SendString("<p>" + b + "</p>")
+		return c.SendString("<p>" + html.EscapeString(b) + "</p>")
 	case "json":
 		return c.JSON(body)
 	case "txt":

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1218,10 +1218,23 @@ func Test_Ctx_Format(t *testing.T) {
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, "<p>Hello, World!</p>", string(c.Response().Body()))
 
+	c.Request().Header.Set(HeaderAccept, MIMETextHTML)
+	err = c.Format("<script>alert(1)</script>")
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>", string(c.Response().Body()))
+
 	c.Request().Header.Set(HeaderAccept, MIMEApplicationJSON)
 	err = c.Format("Hello, World!")
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, `"Hello, World!"`, string(c.Response().Body()))
+
+	c.Request().Header.Set(HeaderAccept, MIMEApplicationJSON)
+	err = c.Format("<script>alert(1)</script>")
+	utils.AssertEqual(t, nil, err)
+	jsonBody := append([]byte(nil), c.Response().Body()...)
+	err = c.JSON("<script>alert(1)</script>")
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, string(jsonBody), string(c.Response().Body()))
 
 	c.Request().Header.Set(HeaderAccept, MIMETextPlain)
 	err = c.Format(complex(1, 1))
@@ -1232,6 +1245,11 @@ func Test_Ctx_Format(t *testing.T) {
 	err = c.Format("Hello, World!")
 	utils.AssertEqual(t, nil, err)
 	utils.AssertEqual(t, `<string>Hello, World!</string>`, string(c.Response().Body()))
+
+	c.Request().Header.Set(HeaderAccept, MIMEApplicationXML)
+	err = c.Format("<script>alert(1)</script>")
+	utils.AssertEqual(t, nil, err)
+	utils.AssertEqual(t, `<string>&lt;script&gt;alert(1)&lt;/script&gt;</string>`, string(c.Response().Body()))
 
 	err = c.Format(complex(1, 1))
 	utils.AssertEqual(t, true, err != nil)


### PR DESCRIPTION
### Motivation
- Prevent unescaped HTML injection when `Ctx.Format` renders HTML by escaping the formatted string before embedding it in the `<p>` wrapper while keeping JSON/TXT/XML branches RFC-consistent and unchanged.

### Description
- Import `html` and apply `html.EscapeString(b)` in the `html` branch of `func (c *Ctx) Format(body interface{}) error` so content is escaped before wrapping with `<p>...</p>` in `ctx.go`.
- Add/adjust assertions in `Test_Ctx_Format` to verify that HTML mode escapes a `<script>` payload and that JSON/XML behavior remains unchanged by comparing `Format` output to direct `c.JSON`/`c.XML` output where appropriate in `ctx_test.go`.
- Searched for a v3 equivalent (`DefaultRes.AutoFormat` / `res.go`) in this checkout and did not find a matching file or symbol, so no v3-side change was applied here.