### PR TITLE
📒 docs: clarify prefork security model and OS-specific socket behavior

### DIFF
--- a/docs/api/fiber.md
+++ b/docs/api/fiber.md
@@ -152,9 +152,9 @@ Prefork is a feature that allows you to spawn multiple Go processes listening on
 app.Listen(":8080", fiber.ListenConfig{EnablePrefork: true})
 ```
 
-This distributes the incoming connections between the spawned processes and allows more requests to be handled simultaneously.
+Depending on the operating system, prefork can distribute incoming connections between the spawned processes and allow more requests to be handled simultaneously.
 
-On Linux, prefork typically relies on the SO_REUSEPORT socket option for kernel-assisted load distribution across workers. On Windows, Fiber falls back to SO_REUSEADDR; this is not a functional equivalent to Linux SO_REUSEPORT as it lacks native load balancing and may allow other processes to bind to the same port. Operators should validate this behavior against their security and availability requirements.
+On Linux, prefork typically relies on the `SO_REUSEPORT` socket option for kernel-assisted load distribution across workers. On Windows, Fiber falls back to `SO_REUSEADDR`; this is not a functional equivalent to Linux `SO_REUSEPORT` as it lacks native load balancing and may allow other processes to bind to the same port. Operators should validate this behavior against their security and availability requirements.
 
 ##### Security Considerations
 

--- a/docs/api/fiber.md
+++ b/docs/api/fiber.md
@@ -154,6 +154,17 @@ app.Listen(":8080", fiber.ListenConfig{EnablePrefork: true})
 
 This distributes the incoming connections between the spawned processes and allows more requests to be handled simultaneously.
 
+On Linux, prefork typically relies on `SO_REUSEPORT` so multiple workers can bind the same port with kernel-assisted distribution. On Windows, Fiber uses a fallback path based on `SO_REUSEADDR`; this is not a drop-in equivalent to Linux `SO_REUSEPORT`, and operators should validate behavior for their threat model.
+
+##### Security Considerations
+
+Prefork changes the port-ownership model from strict single-owner binding to an intentional multi-listener setup. In shared hosts, a local co-resident attacker with sufficient privileges may be able to race for shared binds or receive a portion of traffic, depending on platform behavior and user boundaries.
+
+- Run prefork only within a trusted boundary (same deployment unit / same trust domain).
+- Use a dedicated service account for Fiber workers; avoid broad shared-user deployments.
+- Prefer container or VM isolation and avoid shared host namespaces for unrelated workloads.
+- If strict single-owner port semantics are required, run Fiber without prefork.
+
 #### TLS
 
 Prefer `TLSConfig` for TLS configuration so you can fully control certificates and settings. When `TLSConfig` is set, Fiber ignores `CertFile`, `CertKeyFile`, `CertClientFile`, `TLSMinVersion`, `AutoCertManager`, and `TLSConfigFunc`.

--- a/docs/api/fiber.md
+++ b/docs/api/fiber.md
@@ -154,7 +154,7 @@ app.Listen(":8080", fiber.ListenConfig{EnablePrefork: true})
 
 This distributes the incoming connections between the spawned processes and allows more requests to be handled simultaneously.
 
-On Linux, prefork typically relies on `SO_REUSEPORT` so multiple workers can bind the same port with kernel-assisted distribution. On Windows, Fiber uses a fallback path based on `SO_REUSEADDR`; this is not a drop-in equivalent to Linux `SO_REUSEPORT`, and operators should validate behavior for their threat model.
+On Linux, prefork typically relies on the SO_REUSEPORT socket option for kernel-assisted load distribution across workers. On Windows, Fiber falls back to SO_REUSEADDR; this is not a functional equivalent to Linux SO_REUSEPORT as it lacks native load balancing and may allow other processes to bind to the same port. Operators should validate this behavior against their security and availability requirements.
 
 ##### Security Considerations
 

--- a/docs/extra/internal.md
+++ b/docs/extra/internal.md
@@ -320,7 +320,7 @@ flowchart TD
 #### Explanation
 
 - Preforking improves performance by allowing multiple processes to handle requests concurrently.
-- Linux SO_REUSEPORT and Windows fallback behavior are functionally different; do not assume identical security or scheduling characteristics across operating systems.
+- Linux `SO_REUSEPORT` and Windows fallback behavior are functionally different; do not assume identical security or scheduling characteristics across operating systems.
 - The watchdog routine in each child ensures that they exit if the master process is no longer running, maintaining process integrity.
 
 ### Security Considerations

--- a/docs/extra/internal.md
+++ b/docs/extra/internal.md
@@ -265,7 +265,7 @@ Reusing Context objects significantly reduces garbage collection overhead, ensur
 
 ## Preforking Mechanism
 
-To take full advantage of multi‑core systems, Fiber offers a prefork mode. In this mode, the master process spawns several child processes that listen on the same port using OS features such as SO_REUSEPORT (or fall back to SO_REUSEADDR).
+To take full advantage of multi‑core systems, Fiber offers a prefork mode. In this mode, the master process spawns several child processes that listen on the same port. On Linux, this is typically done with `SO_REUSEPORT`; on Windows, Fiber falls back to a `SO_REUSEADDR`-based behavior that does not provide identical kernel-level load-distribution semantics.
 
 ```mermaid
 flowchart LR
@@ -293,7 +293,9 @@ Fiber’s prefork mode uses OS‑level mechanisms to allow multiple processes to
 
 1. Master Process Spawning: The master process detects the number of CPU cores and spawns that many child processes.
 2. Child Process Initialization: Each child process sets GOMAXPROCS(1) so that it runs on a single core.
-3. Binding to Port: Child processes use packages like reuseport to bind to the same address and port.
+3. Binding to Port:
+   - Linux: child processes use `SO_REUSEPORT` (for example through reuseport helpers) so multiple workers can bind the same address/port with kernel-level distribution.
+   - Windows: Fiber uses a `SO_REUSEADDR` fallback path; behavior is platform-dependent and should not be treated as equivalent to Linux `SO_REUSEPORT`.
 4. Parent Monitoring: Each child runs a watchdog function (watchMaster()) to monitor the master process; if the master terminates, children exit.
 5. Request Handling: Each child independently handles incoming HTTP requests.
 
@@ -318,8 +320,17 @@ flowchart TD
 #### Explanation
 
 - Preforking improves performance by allowing multiple processes to handle requests concurrently.
-- Using reuseport (or a fallback) ensures that all child processes can listen on the same port without conflicts.
+- Linux `SO_REUSEPORT` and Windows fallback behavior are intentionally different; do not assume identical security or scheduling characteristics across operating systems.
 - The watchdog routine in each child ensures that they exit if the master process is no longer running, maintaining process integrity.
+
+### Security Considerations
+
+Prefork intentionally relaxes strict single-owner assumptions on a listening socket. In multi-tenant or shared-host environments, a local co-resident attacker with sufficient local privileges may attempt to bind to the same address/port and compete for or observe traffic, depending on OS behavior, account boundaries, and deployment configuration.
+
+- **Privilege and user-boundary assumptions:** Prefork is safest when all participating workers run under the same dedicated service identity and within an isolated trust boundary.
+- **Linux vs Windows behavior:** Linux `SO_REUSEPORT` provides explicit multi-listener semantics; Windows fallback behavior differs and should be evaluated carefully before enabling prefork in sensitive environments.
+- **Strict ownership requirement:** If you require strict single-owner port semantics, run Fiber **without** prefork.
+- **Hardening guidance:** Prefer a dedicated service user, strong container/VM isolation, and avoid shared host namespaces between unrelated workloads.
 
 ## Redirection & Flash Messages
 

--- a/docs/extra/internal.md
+++ b/docs/extra/internal.md
@@ -320,7 +320,7 @@ flowchart TD
 #### Explanation
 
 - Preforking improves performance by allowing multiple processes to handle requests concurrently.
-- Linux `SO_REUSEPORT` and Windows fallback behavior are intentionally different; do not assume identical security or scheduling characteristics across operating systems.
+- Linux SO_REUSEPORT and Windows fallback behavior are functionally different; do not assume identical security or scheduling characteristics across operating systems.
 - The watchdog routine in each child ensures that they exit if the master process is no longer running, maintaining process integrity.
 
 ### Security Considerations


### PR DESCRIPTION
### Motivation

- Make prefork documentation explicit about differing OS socket semantics so operators understand platform and threat-model differences.  
- Surface risk that prefork relaxes single-owner port assumptions and can expose traffic or binding races in shared-host/multi-tenant environments.  
- Provide actionable operator guidance (service account, container/VM isolation, avoid shared namespaces) and a clear recommendation to disable prefork when strict single-owner port semantics are required.

### Description

- Updated `docs/extra/internal.md` to distinguish Linux `SO_REUSEPORT` semantics from Windows `SO_REUSEADDR` fallback and clarified platform-dependent binding behavior.  
- Added a new `Security Considerations` subsection in `docs/extra/internal.md` describing local co-resident attacker risk, privilege/user-boundary assumptions, and deployment hardening guidance.  
- Mirrored the OS distinction and security/hardening guidance in `docs/api/fiber.md` under the Prefork section and added an explicit recommendation to run without prefork if strict single-owner port semantics are required.  
- Small wording/flow updates to the prefork workflow to call out Linux vs Windows behavior and operator responsibilities.

### Testing

- Ran `make generate` and it completed successfully.  
- Ran `make betteralign`, `make modernize`, and `make format` and each completed successfully.  
- Ran `make lint` and it completed successfully.  
- Ran `make test` and the full test suite completed successfully (`PASS` for all tests except 1 skipped).  
- Ran `make audit` and it failed due to `govulncheck` findings in the Go standard library for the toolchain `go1.25.1` (multiple standard-library vulnerabilities were reported by the vulnerability scanner), which are unrelated to this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3d5e2fb083339f47931a7c83af92)