### PR TITLE
ci(update-version): use PR_TOKEN for push to protected main

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -22,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # PAT with bypass rights for the protected `main` branch.
+          # The default GITHUB_TOKEN cannot push directly to `main`.
+          token: ${{ secrets.PR_TOKEN }}
 
       - name: Determine version
         id: version


### PR DESCRIPTION
The default GITHUB_TOKEN pushes as github-actions[bot], which is not in
the bypass list of `main`'s branch-protection rules, so the push was
rejected. Mirror the dependabot-on-demand workflow and check out with
secrets.PR_TOKEN so the push is authenticated as a bypass-eligible actor.