### PR TITLE
docs(logger): clarify ${bytesSent} behavior in logger middleware

### DIFF
--- a/docs/middleware/logger.md
+++ b/docs/middleware/logger.md
@@ -206,6 +206,8 @@ Logger provides predefined formats that you can use by name or directly by speci
 | `JSONFormat` | `"{time: ${time}, ip: ${ip}, method: ${method}, url: ${url}, status: ${status}, bytesSent: ${bytesSent}}\n"` | JSON format for structured logging. |
 | `ECSFormat` | `"{\"@timestamp\":\"${time}\",\"ecs\":{\"version\":\"1.6.0\"},\"client\":{\"ip\":\"${ip}\"},\"http\":{\"request\":{\"method\":\"${method}\",\"url\":\"${url}\",\"protocol\":\"${protocol}\"},\"response\":{\"status_code\":${status},\"body\":{\"bytes\":${bytesSent}}}},\"log\":{\"level\":\"INFO\",\"logger\":\"fiber\"},\"message\":\"${method} ${url} responded with ${status}\"}\n"` | Elastic Common Schema (ECS) format for structured logging. |
 
+`${bytesSent}` returns the number of bytes sent to the client based on the `Content-Length` response header. If `Content-Length` is not set, the value may be `0`. For streaming responses, the value may be `-1`. Fiber does not calculate the actual response body size for performance reasons.
+
 ## Constants
 
 ```go

--- a/docs/middleware/logger.md
+++ b/docs/middleware/logger.md
@@ -206,7 +206,9 @@ Logger provides predefined formats that you can use by name or directly by speci
 | `JSONFormat` | `"{time: ${time}, ip: ${ip}, method: ${method}, url: ${url}, status: ${status}, bytesSent: ${bytesSent}}\n"` | JSON format for structured logging. |
 | `ECSFormat` | `"{\"@timestamp\":\"${time}\",\"ecs\":{\"version\":\"1.6.0\"},\"client\":{\"ip\":\"${ip}\"},\"http\":{\"request\":{\"method\":\"${method}\",\"url\":\"${url}\",\"protocol\":\"${protocol}\"},\"response\":{\"status_code\":${status},\"body\":{\"bytes\":${bytesSent}}}},\"log\":{\"level\":\"INFO\",\"logger\":\"fiber\"},\"message\":\"${method} ${url} responded with ${status}\"}\n"` | Elastic Common Schema (ECS) format for structured logging. |
 
-`${bytesSent}` returns the number of bytes sent to the client based on the `Content-Length` response header. If `Content-Length` is not set, the value may be `0`. For streaming responses, the value may be `-1`. Fiber does not calculate the actual response body size for performance reasons.
+:::tip
+`${bytesSent}` returns the value of the `Content-Length` response header. If the header is missing or the response is streaming (e.g., chunked encoding), the value will be `-1`. Fiber does not calculate the actual response body size for performance reasons.
+:::
 
 ## Constants
 


### PR DESCRIPTION
## Summary

Clarifies the behavior of the `${bytesSent}` logger tag in the middleware documentation.

## Changes

- document that `${bytesSent}` is based on the `Content-Length` response header
- mention that it may be `0` when `Content-Length` is not set
- mention that it may be `-1` for streaming responses
- clarify that Fiber does not calculate the actual response body size for performance reasons

## Notes

- documentation-only change
- no runtime behavior changed

## Validation

- reviewed the logger middleware documentation location for `${bytesSent}`
- confirmed the behavior from issue #4226 discussion
- no code or runtime logic changed
