### PR TITLE
📚 Doc: correct fasthttpctx Done semantics in context guide

### DIFF
--- a/docs/guide/context.md
+++ b/docs/guide/context.md
@@ -98,10 +98,14 @@ app.Get("/raw", func(c fiber.Ctx) error {
 ```
 
 `fasthttpctx` enables `fasthttp` to satisfy the `context.Context` interface.
-`Deadline` always reports no deadline, `Done` is closed when the client
-connection ends, and once it fires `Err` reports `context.Canceled`. This
-means handlers can detect client disconnects while still passing
-`c.RequestCtx()` into APIs that expect a `context.Context`.
+`Deadline` always reports no deadline. `Done` closes only when the server
+shuts down, and `Err` then returns `context.Canceled`.
+
+:::caution
+`Done` does not fire when an individual client disconnects. To stop a
+long-running handler at a deadline, wrap the request with
+`context.WithTimeout` as shown below.
+:::
 
 ## Context Helpers
 
@@ -216,7 +220,7 @@ When starting asynchronous work inside a handler, Fiber does not cancel the base
 By wrapping the request context with `context.WithTimeout`, you can create a derived context that honors deadlines and cancellation signals.
 
 The goroutine checks `ctx.Done()` before sending a result.
-If the request times out or the client disconnects the goroutine exits early and avoids leaking resources.
+If the deadline elapses, the goroutine exits early and avoids leaking resources.
 
 The handler then waits for either:
 
@@ -260,8 +264,8 @@ This approach provides safe cancellation semantics for goroutine-based work whil
 
 - `fiber.Ctx` satisfies `context.Context` but its `Deadline`, `Done`, and `Err`
   methods are currently no-ops.
-- `RequestCtx` exposes the raw `fasthttp` context, whose `Done` channel closes
-  when the client connection ends.
+- `RequestCtx` exposes the raw `fasthttp` context. Its `Done` channel
+  closes only on server shutdown, not on client disconnect.
 - Use `fiber.StoreInContext(c, key, value)` to store request-scoped values in both
   `c.Locals()` and `c.Context()` when values must be available through either API.
 - Middleware helpers like `requestid.FromContext` or `session.FromContext`


### PR DESCRIPTION
# Description

The "Working with `RequestCtx` and `fasthttpctx`" section in `docs/guide/context.md` (introduced in #3677) currently tells readers that `RequestCtx.Done` closes when the client connection ends and that "handlers can detect client disconnects" via this channel. That is not what fasthttp actually does:

- [fasthttp `server.go` `RequestCtx.Done`](https://github.com/valyala/fasthttp/blob/master/server.go) carries the explicit comment **"`RequestCtx.s.done` is only closed when the server is shutting down"** — `s.done` is the shared server-wide channel, allocated once in `Server.Serve` and closed once in `Server.Shutdown`. There is no per-connection cancellation signal.
- valyala/fasthttp#468 — *"this is not possible and would be really hard to add"*
- valyala/fasthttp#965 — *"fasthttp doesn't do any operations on the socket while your handler is running, this is impossible for us to implement"*
- gofiber/fiber#805 — @Fenny: *"I'm afraid that is not possible nor efficient with fasthttp sync.pool design"*
- gofiber/fiber#1718 — same Q&A, closed in 2022 with the same answer
- gofiber/fiber#4145 — **open** proposal asking Fiber to *add* per-connection disconnect detection. Its existence is direct evidence that the capability the docs already advertised does not exist.

So the docs paragraph contradicts (a) the fasthttp source code, (b) two upstream fasthttp maintainers, (c) a four-year-old Fiber maintainer Q&A answer, and (d) an open Fiber proposal asking for the very capability the docs claim is already there.

Fixes #4263

## Changes introduced

Three spots in `docs/guide/context.md`:

1. The `fasthttpctx` paragraph (~L100): now describes the actual semantics (server-shutdown-only, shared channel, no client-disconnect signal) and points readers to `context.WithTimeout` or `Flush`-error detection for long handlers.
2. The "Context Cancellation with Goroutines" paragraph (~L219): drops the misleading "or the client disconnects" phrasing and clarifies that the timeout (not a client-side cancellation) is what bounds the work.
3. The Summary bullet (~L263): matches the corrected description.

No code changes; no API changes.

- [ ] Benchmarks: n/a
- [x] Documentation Update: `docs/guide/context.md` — three passages corrected, no new sections.
- [ ] Changelog/What's New: n/a (corrects an inaccurate claim, no behavior change)
- [ ] Migration Guide: n/a
- [ ] API Alignment with Express: n/a
- [ ] API Longevity: n/a (docs only)
- [ ] Examples: n/a

## Type of change

- [x] Documentation update (changes to documentation)

## Checklist

- [x] Conducted a self-review of the changes.
- [x] Updated the documentation in the `/docs/` directory.
- [ ] Added or updated unit tests — n/a, docs only.
- [x] Verified the wording against the fasthttp source and the linked issues.