### PR TITLE
🐛 bug: harden reverse proxy X-Forwarded-For example

### DIFF
--- a/docs/guide/reverse-proxy.md
+++ b/docs/guide/reverse-proxy.md
@@ -114,7 +114,8 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Overwrite untrusted inbound forwarding headers at the edge.
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }

--- a/docs/guide/reverse-proxy.md
+++ b/docs/guide/reverse-proxy.md
@@ -116,6 +116,7 @@ server {
         proxy_set_header Host $host;
         # Overwrite untrusted inbound forwarding headers at the edge.
         proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent copy-pastable documentation that allows client-supplied `X-Forwarded-For` values to control `c.IP()` when Fiber is configured to trust a proxy by ensuring the edge proxy overwrites untrusted inbound forwarding headers.

### Description
- In `docs/guide/reverse-proxy.md` replace `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;` with a hardened example that overwrites the header (`proxy_set_header X-Forwarded-For $remote_addr;`) and add an inline comment explaining the reason.