### PR TITLE
🐛 bug: close BodyStream in adaptor FiberHandler streaming path

### DIFF
--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -312,6 +312,10 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 			return
 		}
 
+		defer func() {
+			_ = fctx.Response.CloseBodyStream() //nolint:errcheck // not needed
+		}()
+
 		// Stream fctx.Response.BodyStream() -> w
 		// in chunks.
 		bufPtr, ok := bufferPool.Get().(*[bufferSize]byte)

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1057,6 +1058,75 @@ func Test_FiberHandler_WithSendStreamWriter(t *testing.T) {
 	require.Equal(t, fiber.StatusTeapot, w.StatusCode())
 	require.Equal(t, "Hello World!", string(w.body))
 }
+
+func Test_FiberHandler_ClosesBodyStream(t *testing.T) {
+	t.Parallel()
+
+	closed := &atomic.Bool{}
+	body := &closeTrackingReader{
+		ReadCloser: io.NopCloser(strings.NewReader("streamed body")),
+		closed:     closed,
+	}
+
+	fiberH := func(c fiber.Ctx) error {
+		return c.SendStream(body)
+	}
+	handlerFunc := FiberHandlerFunc(fiberH)
+
+	r := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	w := httptest.NewRecorder()
+
+	handlerFunc.ServeHTTP(w, r)
+	require.True(t, closed.Load())
+}
+
+func Test_FiberHandler_ClosesBodyStreamOnWriteError(t *testing.T) {
+	t.Parallel()
+
+	closed := &atomic.Bool{}
+	body := &closeTrackingReader{
+		ReadCloser: io.NopCloser(strings.NewReader("streamed body")),
+		closed:     closed,
+	}
+
+	fiberH := func(c fiber.Ctx) error {
+		return c.SendStream(body)
+	}
+	handlerFunc := FiberHandlerFunc(fiberH)
+
+	r := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	w := &failingStreamWriter{header: make(http.Header)}
+
+	handlerFunc.ServeHTTP(w, r)
+	require.True(t, closed.Load())
+}
+
+type closeTrackingReader struct {
+	io.ReadCloser
+	closed *atomic.Bool
+}
+
+func (r *closeTrackingReader) Close() error {
+	r.closed.Store(true)
+	_ = r.ReadCloser.Close() //nolint:errcheck // not needed
+	return nil
+}
+
+type failingStreamWriter struct {
+	header http.Header
+}
+
+func (f *failingStreamWriter) Header() http.Header {
+	return f.header
+}
+
+func (f *failingStreamWriter) Write([]byte) (int, error) {
+	return 0, errors.New("simulated write error")
+}
+
+func (f *failingStreamWriter) WriteHeader(int) {}
+
+func (f *failingStreamWriter) Flush() {}
 
 func Test_FiberHandler_WithInterruptedSendStreamWriter(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
### Motivation
- The adaptor streaming path forwarded `fasthttp` `BodyStream()` data to a `net/http` `ResponseWriter` but did not close the underlying fasthttp body stream, which can leak resources and enable DoS via repeated disconnects.

### Description
- Ensure `fctx.Response.CloseBodyStream()` is always called when the streaming branch is taken by adding a deferred close in `middleware/adaptor/adaptor.go` so streams are released on EOF, read errors, or downstream write errors.
- Add regression tests in `middleware/adaptor/adaptor_test.go` that assert streamed `io.ReadCloser` instances are closed after normal completion and after a simulated downstream write error using a close-tracking reader and a failing `ResponseWriter`.
- Files changed: `middleware/adaptor/adaptor.go` and `middleware/adaptor/adaptor_test.go`.