### PR TITLE
🐛 bug: prevent panic when CBOR is not explicitly configured

### DIFF
--- a/binder/cbor.go
+++ b/binder/cbor.go
@@ -1,6 +1,8 @@
 package binder
 
 import (
+	"errors"
+
 	"github.com/gofiber/utils/v2"
 )
 
@@ -24,14 +26,16 @@ func (b *CBORBinding) Reset() {
 	b.CBORDecoder = nil
 }
 
-// UnimplementedCborMarshal panics to signal that a CBOR marshaler must be
-// configured before CBOR support can be used.
+var errUnimplementedCBOR = errors.New("must explicitly setup CBOR, please check docs: https://docs.gofiber.io/next/guide/advance-format#cbor")
+
+// UnimplementedCborMarshal returns an error to signal that a CBOR marshaler
+// must be configured before CBOR support can be used.
 func UnimplementedCborMarshal(_ any) ([]byte, error) {
-	panic("Must explicitly setup CBOR, please check docs: https://docs.gofiber.io/next/guide/advance-format#cbor")
+	return nil, errUnimplementedCBOR
 }
 
-// UnimplementedCborUnmarshal panics to signal that a CBOR unmarshaler must be
-// configured before CBOR support can be used.
+// UnimplementedCborUnmarshal returns an error to signal that a CBOR unmarshaler
+// must be configured before CBOR support can be used.
 func UnimplementedCborUnmarshal(_ []byte, _ any) error {
-	panic("Must explicitly setup CBOR, please check docs: https://docs.gofiber.io/next/guide/advance-format#cbor")
+	return errUnimplementedCBOR
 }

--- a/binder/cbor.go
+++ b/binder/cbor.go
@@ -28,7 +28,7 @@ func (b *CBORBinding) Reset() {
 
 // ErrUnimplementedCBOR signals that CBOR support must be explicitly configured
 // before it can be used.
-var ErrUnimplementedCBOR = errors.New("must explicitly set up CBOR, please check docs: https://docs.gofiber.io/next/guide/advance-format#cbor")
+var ErrUnimplementedCBOR = errors.New("binder: must explicitly set up CBOR, please check docs: https://docs.gofiber.io/next/guide/advance-format#cbor")
 
 // UnimplementedCborMarshal returns an error to signal that a CBOR marshaler
 // must be configured before CBOR support can be used.

--- a/binder/cbor.go
+++ b/binder/cbor.go
@@ -26,16 +26,18 @@ func (b *CBORBinding) Reset() {
 	b.CBORDecoder = nil
 }
 
-var errUnimplementedCBOR = errors.New("must explicitly set up CBOR, please check docs: https://docs.gofiber.io/next/guide/advance-format#cbor")
+// ErrUnimplementedCBOR signals that CBOR support must be explicitly configured
+// before it can be used.
+var ErrUnimplementedCBOR = errors.New("must explicitly set up CBOR, please check docs: https://docs.gofiber.io/next/guide/advance-format#cbor")
 
 // UnimplementedCborMarshal returns an error to signal that a CBOR marshaler
 // must be configured before CBOR support can be used.
 func UnimplementedCborMarshal(_ any) ([]byte, error) {
-	return nil, errUnimplementedCBOR
+	return nil, ErrUnimplementedCBOR
 }
 
 // UnimplementedCborUnmarshal returns an error to signal that a CBOR unmarshaler
 // must be configured before CBOR support can be used.
 func UnimplementedCborUnmarshal(_ []byte, _ any) error {
-	return errUnimplementedCBOR
+	return ErrUnimplementedCBOR
 }

--- a/binder/cbor.go
+++ b/binder/cbor.go
@@ -26,7 +26,7 @@ func (b *CBORBinding) Reset() {
 	b.CBORDecoder = nil
 }
 
-var errUnimplementedCBOR = errors.New("must explicitly setup CBOR, please check docs: https://docs.gofiber.io/next/guide/advance-format#cbor")
+var errUnimplementedCBOR = errors.New("must explicitly set up CBOR, please check docs: https://docs.gofiber.io/next/guide/advance-format#cbor")
 
 // UnimplementedCborMarshal returns an error to signal that a CBOR marshaler
 // must be configured before CBOR support can be used.

--- a/binder/cbor_test.go
+++ b/binder/cbor_test.go
@@ -94,7 +94,7 @@ func Test_UnimplementedCborMarshal_ReturnsError(t *testing.T) {
 	t.Parallel()
 
 	_, err := UnimplementedCborMarshal(struct{ Name string }{Name: "test"})
-	require.EqualError(t, err, "must explicitly setup CBOR, please check docs: https://docs.gofiber.io/next/guide/advance-format#cbor")
+	require.ErrorIs(t, err, errUnimplementedCBOR)
 }
 
 func Test_UnimplementedCborUnmarshal_ReturnsError(t *testing.T) {
@@ -102,5 +102,5 @@ func Test_UnimplementedCborUnmarshal_ReturnsError(t *testing.T) {
 
 	var out any
 	err := UnimplementedCborUnmarshal([]byte{0xa0}, &out)
-	require.EqualError(t, err, "must explicitly setup CBOR, please check docs: https://docs.gofiber.io/next/guide/advance-format#cbor")
+	require.ErrorIs(t, err, errUnimplementedCBOR)
 }

--- a/binder/cbor_test.go
+++ b/binder/cbor_test.go
@@ -94,7 +94,7 @@ func Test_UnimplementedCborMarshal_ReturnsError(t *testing.T) {
 	t.Parallel()
 
 	_, err := UnimplementedCborMarshal(struct{ Name string }{Name: "test"})
-	require.ErrorIs(t, err, errUnimplementedCBOR)
+	require.ErrorIs(t, err, ErrUnimplementedCBOR)
 }
 
 func Test_UnimplementedCborUnmarshal_ReturnsError(t *testing.T) {
@@ -102,5 +102,5 @@ func Test_UnimplementedCborUnmarshal_ReturnsError(t *testing.T) {
 
 	var out any
 	err := UnimplementedCborUnmarshal([]byte{0xa0}, &out)
-	require.ErrorIs(t, err, errUnimplementedCBOR)
+	require.ErrorIs(t, err, ErrUnimplementedCBOR)
 }

--- a/binder/cbor_test.go
+++ b/binder/cbor_test.go
@@ -90,42 +90,17 @@ func Benchmark_CBORBinder_Bind(b *testing.B) {
 	require.Equal(b, 42, user.Age)
 }
 
-func Test_UnimplementedCborMarshal_Panics(t *testing.T) {
+func Test_UnimplementedCborMarshal_ReturnsError(t *testing.T) {
 	t.Parallel()
 
-	require.Panics(t, func() {
-		_, _ = UnimplementedCborMarshal(struct{ Name string }{Name: "test"}) //nolint:errcheck // this is just a test to trigger the panic
-	})
+	_, err := UnimplementedCborMarshal(struct{ Name string }{Name: "test"})
+	require.EqualError(t, err, "must explicitly setup CBOR, please check docs: https://docs.gofiber.io/next/guide/advance-format#cbor")
 }
 
-func Test_UnimplementedCborUnmarshal_Panics(t *testing.T) {
+func Test_UnimplementedCborUnmarshal_ReturnsError(t *testing.T) {
 	t.Parallel()
 
-	require.Panics(t, func() {
-		var out any
-		_ = UnimplementedCborUnmarshal([]byte{0xa0}, &out) //nolint:errcheck // this is just a test to trigger the panic
-	})
-}
-
-func Test_UnimplementedCborMarshal_PanicMessage(t *testing.T) {
-	t.Parallel()
-
-	defer func() {
-		if r := recover(); r != nil {
-			require.Contains(t, r, "Must explicitly setup CBOR")
-		}
-	}()
-	_, _ = UnimplementedCborMarshal(struct{ Name string }{Name: "test"}) //nolint:errcheck // this is just a test to trigger the panic
-}
-
-func Test_UnimplementedCborUnmarshal_PanicMessage(t *testing.T) {
-	t.Parallel()
-
-	defer func() {
-		if r := recover(); r != nil {
-			require.Contains(t, r, "Must explicitly setup CBOR")
-		}
-	}()
 	var out any
-	_ = UnimplementedCborUnmarshal([]byte{0xa0}, &out) //nolint:errcheck // this is just a test to trigger the panic
+	err := UnimplementedCborUnmarshal([]byte{0xa0}, &out)
+	require.EqualError(t, err, "must explicitly setup CBOR, please check docs: https://docs.gofiber.io/next/guide/advance-format#cbor")
 }


### PR DESCRIPTION
### Motivation
- A previous refactor replaced the default CBOR marshal/unmarshal with panic-only stubs which made `Bind().Body` reachable panic via an attacker-controlled `Content-Type: application/cbor` header.  
- The change preserves CBOR as opt-in but must not allow a panic to be triggered from normal request dispatch paths.  

### Description
- Replace panic stubs in `binder/cbor.go` with an `errUnimplementedCBOR` error and make `UnimplementedCborMarshal`/`UnimplementedCborUnmarshal` return that error instead of calling `panic`.  
- Update `binder/cbor_test.go` to assert error-return behavior for the unimplemented CBOR helpers rather than expecting panics.  
- This is a minimal remediation that preserves opt-in semantics while ensuring failures propagate as errors handled by existing Fiber error paths.