### PR TITLE
🐛 bug: keep IsFromLocal loopback-only and add unix-socket helper

### DIFF
--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -376,6 +376,8 @@ type Ctx interface {
 	IsProxyTrusted() bool
 	// IsFromLocal will return true if request came from local.
 	IsFromLocal() bool
+	// IsFromUnixSocket returns true if the request arrived over a Unix domain socket.
+	IsFromUnixSocket() bool
 	getBody() []byte
 	// Append the specified value to the HTTP response header field.
 	// If the header is not already set, it creates the header with the specified value.

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -8424,7 +8424,7 @@ func Test_Ctx_IsFromLocal_RemoteAddr(t *testing.T) {
 		require.False(t, c.IsFromLocal())
 	}
 	// Test for the case fasthttp remoteAddr is set to a Unix socket.
-	// Unix sockets are inherently local - only processes on the same host can connect.
+	// IsFromLocal only treats loopback IPs as local.
 	{
 		app := New()
 		fastCtx := &fasthttp.RequestCtx{}
@@ -8432,7 +8432,32 @@ func Test_Ctx_IsFromLocal_RemoteAddr(t *testing.T) {
 		fastCtx.SetRemoteAddr(unixAddr)
 		c := app.AcquireCtx(fastCtx)
 		defer app.ReleaseCtx(c)
-		require.True(t, c.IsFromLocal())
+		require.False(t, c.IsFromLocal())
+	}
+}
+
+// go test -run Test_Ctx_IsFromUnixSocket_RemoteAddr
+func Test_Ctx_IsFromUnixSocket_RemoteAddr(t *testing.T) {
+	t.Parallel()
+
+	{
+		app := New()
+		fastCtx := &fasthttp.RequestCtx{}
+		fastCtx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
+		c := app.AcquireCtx(fastCtx)
+		defer app.ReleaseCtx(c)
+		require.False(t, c.IsFromUnixSocket())
+		require.False(t, c.Req().IsFromUnixSocket())
+	}
+
+	{
+		app := New()
+		fastCtx := &fasthttp.RequestCtx{}
+		fastCtx.SetRemoteAddr(&net.UnixAddr{Name: "/tmp/fiber.sock", Net: "unix"})
+		c := app.AcquireCtx(fastCtx)
+		defer app.ReleaseCtx(c)
+		require.True(t, c.IsFromUnixSocket())
+		require.True(t, c.Req().IsFromUnixSocket())
 	}
 }
 

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -1264,6 +1264,21 @@ app.Get("/", func(c fiber.Ctx) error {
 })
 ```
 
+### IsFromUnixSocket
+
+Returns `true` if the request came in over a Unix domain socket.
+
+```go title="Signature"
+func (c fiber.Ctx) IsFromUnixSocket() bool
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  c.IsFromUnixSocket()
+  return nil
+})
+```
+
 ### IsJSON
 
 Reports whether the `Content-Type` header is JSON.

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -1274,8 +1274,10 @@ func (c fiber.Ctx) IsFromUnixSocket() bool
 
 ```go title="Example"
 app.Get("/", func(c fiber.Ctx) error {
-  c.IsFromUnixSocket()
-  return nil
+  if c.IsFromUnixSocket() {
+    return c.SendString("Connected via Unix socket")
+  }
+  return c.SendString("Connected via TCP")
 })
 ```
 

--- a/req.go
+++ b/req.go
@@ -1151,16 +1151,16 @@ func (r *DefaultReq) IsProxyTrusted() bool {
 
 // IsFromLocal will return true if request came from local.
 func (r *DefaultReq) IsFromLocal() bool {
-	// Unix sockets are inherently local - only processes on the same host can connect.
-	remoteAddr := r.c.fasthttp.RemoteAddr()
-	if _, ok := remoteAddr.(*net.UnixAddr); ok {
-		return true
-	}
-
 	if ip := r.c.fasthttp.RemoteIP(); ip != nil {
 		return ip.IsLoopback()
 	}
 	return false
+}
+
+// IsFromUnixSocket returns true if the request arrived over a Unix domain socket.
+func (r *DefaultReq) IsFromUnixSocket() bool {
+	_, ok := r.c.fasthttp.RemoteAddr().(*net.UnixAddr)
+	return ok
 }
 
 func (r *DefaultReq) getBody() []byte {

--- a/req.go
+++ b/req.go
@@ -1149,7 +1149,7 @@ func (r *DefaultReq) IsProxyTrusted() bool {
 	return false
 }
 
-// IsFromLocal will return true if request came from local.
+// IsFromLocal will return true if request came from a loopback IP.
 func (r *DefaultReq) IsFromLocal() bool {
 	if ip := r.c.fasthttp.RemoteIP(); ip != nil {
 		return ip.IsLoopback()

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -187,5 +187,7 @@ type Req interface {
 	IsProxyTrusted() bool
 	// IsFromLocal will return true if request came from local.
 	IsFromLocal() bool
+	// IsFromUnixSocket returns true if the request arrived over a Unix domain socket.
+	IsFromUnixSocket() bool
 	getBody() []byte
 }


### PR DESCRIPTION
### Motivation
- Fix an authentication/authorization bypass where requests arriving over Unix domain sockets were treated as local by `IsFromLocal()`, enabling external requests forwarded by a public reverse proxy to be mistaken for localhost.
- Preserve an explicit opt-in model for trusting Unix-socket proxies while still allowing apps to detect Unix-socket transport if they intend to.
- Provide a clear API for consumers to make an explicit, auditable decision when handling Unix-socket connections.

### Description
- Reverted the unconditional `*net.UnixAddr` => `true` branch from `IsFromLocal()` so it only returns `true` for loopback IPs (`req.go`).
- Added a new helper `IsFromUnixSocket()` on `Req` that returns `true` when the remote address is a Unix domain socket (`req.go`).
- Exported the new method in generated interfaces (`req_interface_gen.go`, `ctx_interface_gen.go`) and added documentation for `IsFromUnixSocket()` in `docs/api/ctx.md`.
- Updated tests in `ctx_test.go` to assert Unix-socket addresses are no longer treated as local and added `Test_Ctx_IsFromUnixSocket_RemoteAddr` to validate the new helper on both `Ctx` and `Req`.