### PR TITLE
🐛 bug: prevent negative paginate start overflow

### DIFF
--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -374,7 +374,7 @@ type Ctx interface {
 	// If Config.TrustProxy false, it returns false.
 	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
 	IsProxyTrusted() bool
-	// IsFromLocal will return true if request came from local.
+	// IsFromLocal will return true if request came from a loopback IP.
 	IsFromLocal() bool
 	// IsFromUnixSocket returns true if the request arrived over a Unix domain socket.
 	IsFromUnixSocket() bool

--- a/middleware/paginate/page_info.go
+++ b/middleware/paginate/page_info.go
@@ -69,7 +69,7 @@ func (p *PageInfo) Start() int {
 	}
 
 	const maxInt = int(^uint(0) >> 1)
-	if p.Page > (maxInt/p.Limit)+1 {
+	if p.Page-1 > maxInt/p.Limit {
 		return maxInt
 	}
 

--- a/middleware/paginate/page_info.go
+++ b/middleware/paginate/page_info.go
@@ -64,9 +64,15 @@ func (p *PageInfo) Start() int {
 	if p.Offset > 0 {
 		return p.Offset
 	}
-	if p.Page < 1 {
+	if p.Page < 1 || p.Limit < 1 {
 		return 0
 	}
+
+	const maxInt = int(^uint(0) >> 1)
+	if p.Page > (maxInt/p.Limit)+1 {
+		return maxInt
+	}
+
 	return (p.Page - 1) * p.Limit
 }
 

--- a/middleware/paginate/paginate_test.go
+++ b/middleware/paginate/paginate_test.go
@@ -121,7 +121,9 @@ func Test_PageInfoStart(t *testing.T) {
 		expected int
 	}{
 		{"Page 1, limit 10", PageInfo{Page: 1, Limit: 10}, 0},
+		{"Page 1, limit 1", PageInfo{Page: 1, Limit: 1}, 0},
 		{"Page 2, limit 10", PageInfo{Page: 2, Limit: 10}, 10},
+		{"Page 2, limit 1", PageInfo{Page: 2, Limit: 1}, 1},
 		{"Page 3, limit 20", PageInfo{Page: 3, Limit: 20}, 40},
 		{"With offset", PageInfo{Page: 2, Limit: 10, Offset: 25}, 25},
 		{"Zero page", PageInfo{Page: 0, Limit: 10}, 0},

--- a/middleware/paginate/paginate_test.go
+++ b/middleware/paginate/paginate_test.go
@@ -124,6 +124,8 @@ func Test_PageInfoStart(t *testing.T) {
 		{"Page 2, limit 10", PageInfo{Page: 2, Limit: 10}, 10},
 		{"Page 3, limit 20", PageInfo{Page: 3, Limit: 20}, 40},
 		{"With offset", PageInfo{Page: 2, Limit: 10, Offset: 25}, 25},
+		{"Zero page", PageInfo{Page: 0, Limit: 10}, 0},
+		{"Overflow clamps to MaxInt", PageInfo{Page: int(^uint(0) >> 1), Limit: 100}, int(^uint(0) >> 1)},
 	}
 
 	for _, tt := range tests {

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -185,7 +185,7 @@ type Req interface {
 	// If Config.TrustProxy false, it returns false.
 	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
 	IsProxyTrusted() bool
-	// IsFromLocal will return true if request came from local.
+	// IsFromLocal will return true if request came from a loopback IP.
 	IsFromLocal() bool
 	// IsFromUnixSocket returns true if the request arrived over a Unix domain socket.
 	IsFromUnixSocket() bool


### PR DESCRIPTION
### Motivation
- Prevent PageInfo.Start() from returning negative offsets when cursor mode leaves `Page` unset or when extremely large `page` values overflow the multiplication. 
- The middleware previously capped only `limit` while `page` and `offset` could be attacker-controlled and produce negative or wrapped results used as slice/SQL offsets. 
- Cursor support being enabled by default meant a crafted `cursor` could trigger the bug in handlers that follow the documented `pageInfo.Start()` usage.

### Description
- Harden `PageInfo.Start()` to return `0` if `Page < 1` or `Limit < 1` and to clamp extremely large page-based starts to `MaxInt` to avoid integer overflow. 
- Preserve existing behavior for normal page/offset values while preventing negative/wrapped results from untrusted inputs. 
- Add test cases to `Test_PageInfoStart` covering `Page = 0` (cursor mode) and an overflow-scale `Page` value. 
- Include updated generated interface files (`ctx_interface_gen.go` and `req_interface_gen.go`) produced by repository tooling.