### PR TITLE
🐛 bug: validate and safely apply workflow version updates

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -51,7 +51,10 @@ jobs:
           fi
 
           if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Invalid version '$version'. Expected semantic version like 3.2.0 or 3.2.0-rc.1"
+            escaped_version="${version//'%'/'%25'}"
+            escaped_version="${escaped_version//$'\r'/'%0D'}"
+            escaped_version="${escaped_version//$'\n'/'%0A'}"
+            echo "::error::Invalid version '$escaped_version'. Expected semantic version like 3.2.0 or 3.2.0-rc.1"
             exit 1
           fi
 

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -50,6 +50,11 @@ jobs:
             version="${tag#v}"
           fi
 
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid version '$version'. Expected semantic version like 3.2.0 or 3.2.0-rc.1"
+            exit 1
+          fi
+
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "Resolved version: **${version}**" >> "$GITHUB_STEP_SUMMARY"
 
@@ -67,7 +72,8 @@ jobs:
             exit 0
           fi
 
-          sed -i "s/const Version = \"${current}\"/const Version = \"${VERSION}\"/" app.go
+          escaped_version=$(printf '%s' "$VERSION" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read())[1:-1])')
+          sed -i -E "s|^const Version = \"[^\"]+\"$|const Version = \"${escaped_version}\"|" app.go
           echo "Updated: ${current} → ${VERSION}"
 
           # Verify the change


### PR DESCRIPTION
### Motivation
- Fix a source-code injection vulnerability in `.github/workflows/update-version.yml` where an unvalidated `version` input could break out of the Go string literal in `app.go` and inject arbitrary top-level Go declarations.

### Description
- Add strict semantic-version validation (`^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$`) in the Determine version step and fail fast for invalid inputs.
- Escape the `VERSION` value via `python3` JSON quoting and replace the entire `const Version = "..."` line with a safe `sed -E` pattern to prevent quote-breaking payloads from injecting code into `app.go`.
- Preserve existing behavior for auto-detecting a draft release tag and skipping commits when the version is unchanged.