### PR TITLE
🐛 bug: prevent SharedState namespace key collisions

### DIFF
--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -374,7 +374,7 @@ type Ctx interface {
 	// If Config.TrustProxy false, it returns false.
 	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
 	IsProxyTrusted() bool
-	// IsFromLocal will return true if request came from local.
+	// IsFromLocal will return true if request came from a loopback IP.
 	IsFromLocal() bool
 	// IsFromUnixSocket returns true if the request arrived over a Unix domain socket.
 	IsFromUnixSocket() bool

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -185,7 +185,7 @@ type Req interface {
 	// If Config.TrustProxy false, it returns false.
 	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
 	IsProxyTrusted() bool
-	// IsFromLocal will return true if request came from local.
+	// IsFromLocal will return true if request came from a loopback IP.
 	IsFromLocal() bool
 	// IsFromUnixSocket returns true if the request arrived over a Unix domain socket.
 	IsFromUnixSocket() bool

--- a/shared_state.go
+++ b/shared_state.go
@@ -413,5 +413,5 @@ func (s *SharedState) storageKey(key string) (string, bool) {
 		return "", false
 	}
 
-return s.prefix + hex.EncodeToString(utils.UnsafeBytes(key)), true
+	return s.prefix + hex.EncodeToString(utils.UnsafeBytes(key)), true
 }

--- a/shared_state.go
+++ b/shared_state.go
@@ -2,6 +2,7 @@ package fiber
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -412,5 +413,5 @@ func (s *SharedState) storageKey(key string) (string, bool) {
 		return "", false
 	}
 
-	return s.prefix + key, true
+	return utils.CopyString(s.prefix + hex.EncodeToString(utils.UnsafeBytes(key))), true
 }

--- a/shared_state.go
+++ b/shared_state.go
@@ -413,5 +413,5 @@ func (s *SharedState) storageKey(key string) (string, bool) {
 		return "", false
 	}
 
-	return utils.CopyString(s.prefix + hex.EncodeToString(utils.UnsafeBytes(key))), true
+return s.prefix + hex.EncodeToString(utils.UnsafeBytes(key)), true
 }

--- a/shared_state_test.go
+++ b/shared_state_test.go
@@ -282,6 +282,25 @@ func TestSharedState_KeyNamespacing(t *testing.T) {
 	require.Equal(t, 2, outTwo["app"])
 }
 
+func TestSharedState_KeyNamespacingWithOverlappingPrefixes(t *testing.T) {
+	t.Parallel()
+
+	store := newSharedStateMemoryStorage(t)
+	shortPrefixApp := New(Config{AppName: "app", SharedStorage: store})
+	longPrefixApp := New(Config{AppName: "app-one", SharedStorage: store})
+
+	err := longPrefixApp.SharedState().Set("session:123", []byte("victim-secret"), time.Minute)
+	require.NoError(t, err)
+
+	err = shortPrefixApp.SharedState().Set("one-session:123", []byte("attacker-value"), time.Minute)
+	require.NoError(t, err)
+
+	data, found, err := longPrefixApp.SharedState().Get("session:123")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, []byte("victim-secret"), data)
+}
+
 func TestSharedState_StorageErrorsArePropagated(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Motivation
- A recent change stopped hex-encoding caller-supplied keys before concatenating them with the SharedState prefix, making namespace prefixes and keys ambiguous and enabling cross-namespace collisions on shared backends. 
- Restore an unambiguous storage-key derivation to prevent a crafted key in one app from reading/writing/deleting state from another app sharing the same backend.

### Description
- Restore hex-encoding of the caller key in `SharedState.storageKey`, now returning `utils.CopyString(s.prefix + hex.EncodeToString(utils.UnsafeBytes(key)))` to preserve a clear namespace delimiter. 
- Add `TestSharedState_KeyNamespacingWithOverlappingPrefixes` that reproduces the overlapping-prefix scenario (`app` vs `app-one`) and verifies namespaces remain isolated. 
- Update generated interface comment text via `make generate` which updated `ctx_interface_gen.go` and `req_interface_gen.go` as part of the repository generation workflow.