### PR TITLE
🐛 bug: copy FullURL string before returning pooled buffer

### DIFF
--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -374,7 +374,7 @@ type Ctx interface {
 	// If Config.TrustProxy false, it returns false.
 	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
 	IsProxyTrusted() bool
-	// IsFromLocal will return true if request came from local.
+	// IsFromLocal will return true if request came from a loopback IP.
 	IsFromLocal() bool
 	// IsFromUnixSocket returns true if the request arrived over a Unix domain socket.
 	IsFromUnixSocket() bool

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -264,6 +264,8 @@ func Test_Ctx_HeaderHelpers(t *testing.T) {
 func Test_Ctx_FullURL_DoesNotAliasPooledBuffer(t *testing.T) {
 	t.Parallel()
 
+	const bufferPoolReuseAttempts = 128
+
 	app := New()
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 
@@ -273,7 +275,7 @@ func Test_Ctx_FullURL_DoesNotAliasPooledBuffer(t *testing.T) {
 	fullURL := c.FullURL()
 	require.Equal(t, "http://example.com/search?q=fiber", fullURL)
 
-	for range 128 {
+	for range bufferPoolReuseAttempts {
 		buf := bytebufferpool.Get()
 		buf.Reset()
 		buf.WriteString("https://mutated.example/rewritten")

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -260,6 +260,29 @@ func Test_Ctx_HeaderHelpers(t *testing.T) {
 	require.False(t, c.HasHeader("X-Trace-Id"))
 }
 
+// go test -run Test_Ctx_FullURL_DoesNotAliasPooledBuffer
+func Test_Ctx_FullURL_DoesNotAliasPooledBuffer(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	c.Request().Header.SetHost("example.com")
+	c.Request().SetRequestURI("/search?q=fiber")
+
+	fullURL := c.FullURL()
+	require.Equal(t, "http://example.com/search?q=fiber", fullURL)
+
+	for range 128 {
+		buf := bytebufferpool.Get()
+		buf.Reset()
+		buf.WriteString("https://mutated.example/rewritten")
+		bytebufferpool.Put(buf)
+	}
+
+	require.Equal(t, "http://example.com/search?q=fiber", fullURL)
+}
+
 // go test -run Test_Ctx_TypedParsingDefaults
 func Test_Ctx_TypedParsingDefaults(t *testing.T) {
 	t.Parallel()

--- a/req.go
+++ b/req.go
@@ -215,7 +215,7 @@ func (c *DefaultCtx) FullURL() string {
 	buf.WriteString(c.Host())
 	buf.WriteString(c.OriginalURL())
 
-	return c.app.toString(buf.Bytes())
+	return buf.String()
 }
 
 // UserAgent returns the User-Agent request header.

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -185,7 +185,7 @@ type Req interface {
 	// If Config.TrustProxy false, it returns false.
 	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
 	IsProxyTrusted() bool
-	// IsFromLocal will return true if request came from local.
+	// IsFromLocal will return true if request came from a loopback IP.
 	IsFromLocal() bool
 	// IsFromUnixSocket returns true if the request arrived over a Unix domain socket.
 	IsFromUnixSocket() bool


### PR DESCRIPTION
### Motivation
- Fix a use-after-pool/aliasing vulnerability in `DefaultCtx.FullURL()` where the method returned a string that could alias memory from a pooled `bytebufferpool` buffer that was returned to the pool before the caller could safely use the string.

### Description
- Change `DefaultCtx.FullURL()` to return a safe copy using `buf.String()` instead of returning `c.app.toString(buf.Bytes())`, preventing returned strings from referencing pooled memory that is recycled immediately. (see `req.go`).
- Regenerate related generated interface files that updated method comments/signatures formatting (`ctx_interface_gen.go`, `req_interface_gen.go`).