### PR TITLE
🐛 bug: enforce paginate sort allowlist when AllowedSorts is unset

### DIFF
--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -374,7 +374,7 @@ type Ctx interface {
 	// If Config.TrustProxy false, it returns false.
 	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
 	IsProxyTrusted() bool
-	// IsFromLocal will return true if request came from local.
+	// IsFromLocal will return true if request came from a loopback IP.
 	IsFromLocal() bool
 	// IsFromUnixSocket returns true if the request arrived over a Unix domain socket.
 	IsFromUnixSocket() bool

--- a/docs/middleware/paginate.md
+++ b/docs/middleware/paginate.md
@@ -125,7 +125,7 @@ app.Use(paginate.New(paginate.Config{
 | DefaultLimit | `int`                    | Default items per page.                                            | `10`       |
 | SortKey      | `string`                 | Query string key for sort.                                         | `""`       |
 | DefaultSort  | `string`                 | Default sort field.                                                | `"id"`     |
-| AllowedSorts | `[]string`               | Whitelist of allowed sort fields. If nil, all fields are allowed.  | `nil`      |
+| AllowedSorts | `[]string`               | Whitelist of allowed sort fields. If nil or empty, request sort fields are ignored and the default sort is used.  | `nil`      |
 | OffsetKey    | `string`                 | Query string key for offset.                                       | `"offset"` |
 | CursorKey    | `string`                 | Query string key for cursor-based pagination.                      | `"cursor"` |
 | CursorParam  | `string`                 | Optional alias for the cursor query key.                           | `""`       |

--- a/middleware/paginate/paginate.go
+++ b/middleware/paginate/paginate.go
@@ -114,7 +114,7 @@ func parseSortQuery(query string, allowedSorts []string, defaultSort string) []S
 		if field == "" {
 			continue
 		}
-		if len(allowedSorts) == 0 || slices.Contains(allowedSorts, field) {
+		if slices.Contains(allowedSorts, field) {
 			sortFields = append(sortFields, SortField{Field: field, Order: order})
 		}
 	}

--- a/middleware/paginate/paginate_test.go
+++ b/middleware/paginate/paginate_test.go
@@ -783,6 +783,13 @@ func Test_ParseSortQuery(t *testing.T) {
 			[]SortField{{Field: "id", Order: ASC}},
 		},
 		{
+			"Empty AllowedSorts falls back to default sort",
+			"email,-phone",
+			[]string{},
+			"id",
+			[]SortField{{Field: "id", Order: ASC}},
+		},
+		{
 			"Bare dash is skipped",
 			"-",
 			nil,

--- a/middleware/paginate/paginate_test.go
+++ b/middleware/paginate/paginate_test.go
@@ -776,14 +776,11 @@ func Test_ParseSortQuery(t *testing.T) {
 			[]SortField{{Field: "id", Order: ASC}},
 		},
 		{
-			"Nil AllowedSorts allows all fields",
+			"Nil AllowedSorts falls back to default sort",
 			"email,-phone",
 			nil,
 			"id",
-			[]SortField{
-				{Field: "email", Order: ASC},
-				{Field: "phone", Order: DESC},
-			},
+			[]SortField{{Field: "id", Order: ASC}},
 		},
 		{
 			"Bare dash is skipped",
@@ -797,10 +794,7 @@ func Test_ParseSortQuery(t *testing.T) {
 			"name,-,email",
 			nil,
 			"id",
-			[]SortField{
-				{Field: "name", Order: ASC},
-				{Field: "email", Order: ASC},
-			},
+			[]SortField{{Field: "id", Order: ASC}},
 		},
 	}
 

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -185,7 +185,7 @@ type Req interface {
 	// If Config.TrustProxy false, it returns false.
 	// IsProxyTrusted can check remote ip by proxy ranges and ip map.
 	IsProxyTrusted() bool
-	// IsFromLocal will return true if request came from local.
+	// IsFromLocal will return true if request came from a loopback IP.
 	IsFromLocal() bool
 	// IsFromUnixSocket returns true if the request arrived over a Unix domain socket.
 	IsFromUnixSocket() bool


### PR DESCRIPTION
### Motivation
- Restore safe pagination behavior after `parseSortQuery` became permissive when `AllowedSorts` was nil or empty, which allowed attacker-controlled sort text to reach downstream consumers (e.g., SQL ORDER BY) and created an injection risk.
- Ensure the middleware falls back to a safe `DefaultSort` when no whitelist is configured rather than implicitly permitting all client-supplied fields.

### Description
- Reworked `parseSortQuery` in `middleware/paginate/paginate.go` to accept a sort field only when it is explicitly present in `AllowedSorts` (removed the `len(allowedSorts) == 0` permit-all branch). 
- Updated tests in `middleware/paginate/paginate_test.go` so nil/empty `AllowedSorts` falls back to `DefaultSort` and tests assert the safe behavior.
- Clarified `AllowedSorts` semantics in `docs/middleware/paginate.md` to state that nil/empty allowlist causes request sort fields to be ignored and the default sort to be used.
- Regenerated/updated interface artifacts (`ctx_interface_gen.go`, `req_interface_gen.go`) as part of repository checks.