### PR TITLE
🐛 bug: preserve idempotency replay protection for oversized responses

### DIFF
--- a/middleware/idempotency/idempotency.go
+++ b/middleware/idempotency/idempotency.go
@@ -164,12 +164,6 @@ func New(config ...Config) fiber.Handler {
 			}
 		}
 
-		bodyLimit := c.App().Config().BodyLimit
-		if bodyLimit > 0 && len(res.Body) > bodyLimit {
-			_ = c.Locals(localsKeyWasPutToCache, false)
-			return nil
-		}
-
 		// Marshal response
 		bs, err := res.MarshalMsg(nil)
 		if err != nil {

--- a/middleware/idempotency/idempotency_test.go
+++ b/middleware/idempotency/idempotency_test.go
@@ -339,7 +339,7 @@ func Test_New_StoreRetrieve_FilterHeaders(t *testing.T) {
 	require.Equal(t, 1, s.setCount)
 }
 
-func Test_New_SkipCache_WhenBodyTooLarge(t *testing.T) {
+func Test_New_Cache_WhenBodyTooLarge(t *testing.T) {
 	t.Parallel()
 	bodyLimit := 8
 	app := fiber.New(fiber.Config{BodyLimit: bodyLimit})
@@ -374,10 +374,10 @@ func Test_New_SkipCache_WhenBodyTooLarge(t *testing.T) {
 	require.Equal(t, fiber.StatusOK, resp2.StatusCode)
 	require.Equal(t, oversized, body2)
 
-	require.Equal(t, 2, count)
-	require.Equal(t, 0, s.setCount)
+	require.Equal(t, 1, count)
+	require.Equal(t, 1, s.setCount)
 	require.Len(t, wasPut, 2)
-	require.False(t, wasPut[0])
+	require.True(t, wasPut[0])
 	require.False(t, wasPut[1])
 }
 


### PR DESCRIPTION
### Motivation
- Fix a regression where the idempotency middleware skipped persisting responses larger than `BodyLimit` after the unsafe handler ran, allowing retries with the same idempotency key to re-execute side effects.
- Restore the middleware guarantee that duplicate requests with the same idempotency key do not trigger the same server action twice.

### Description
- Removed the `BodyLimit`-based early return in `middleware/idempotency/idempotency.go` so successful handler responses are always marshaled and stored for idempotency replay protection.
- Updated the regression test `Test_New_SkipCache_WhenBodyTooLarge` → `Test_New_Cache_WhenBodyTooLarge` in `middleware/idempotency/idempotency_test.go` to assert oversized responses are cached and replayed (asserts `count == 1`, `s.setCount == 1`, and `WasPutToCache` is true for the initial request).
- The change is minimal and preserves existing behavior for handler errors and lock/storage error paths.