### PR TITLE
Proposal fix for #4280 with no breaking changes 

### DIFF
--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -45,6 +45,9 @@ type Config struct {
 	// Optional. Default: "csrf_"
 	CookieName string
 
+	// CookieNameFn dynamic cookie name .. overrides CookieName if not nil
+	CookieNameFn func(c fiber.Ctx) string
+
 	// CookieDomain is the domain of the CSRF cookie.
 	//
 	// Optional. Default: ""
@@ -184,17 +187,23 @@ func validateExtractorSecurity(cfg *Config) {
 	if cfg == nil {
 		return
 	}
+
+	cookieName := cfg.CookieName
+	if cfg.CookieNameFn != nil {
+		cookieName = cfg.CookieNameFn(nil)
+	}
+
 	// Check primary extractor
-	if isInsecureCookieExtractor(cfg.Extractor, cfg.CookieName) {
-		panic("CSRF: Extractor reads from the same cookie '" + cfg.CookieName +
+	if isInsecureCookieExtractor(cfg.Extractor, cookieName) {
+		panic("CSRF: Extractor reads from the same cookie '" + cookieName +
 			"' used for token storage. This completely defeats CSRF protection.")
 	}
 
 	// Check chained extractors
 	for i, extractor := range cfg.Extractor.Chain {
-		if isInsecureCookieExtractor(extractor, cfg.CookieName) {
+		if isInsecureCookieExtractor(extractor, cookieName) {
 			panic(fmt.Sprintf("CSRF: Chained extractor #%d reads from the same cookie '%s' "+
-				"used for token storage. This completely defeats CSRF protection.", i+1, cfg.CookieName))
+				"used for token storage. This completely defeats CSRF protection.", i+1, cookieName))
 		}
 	}
 

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -118,11 +118,15 @@ func New(config ...Config) fiber.Handler {
 		fiber.StoreInContext(c, handlerKey, handler)
 
 		var token string
+		cookieName := cfg.CookieName
+		if cfg.CookieNameFn != nil {
+			cookieName = cfg.CookieNameFn(c)
+		}
 
 		// Action depends on the HTTP method
 		switch c.Method() {
 		case fiber.MethodGet, fiber.MethodHead, fiber.MethodOptions, fiber.MethodTrace:
-			cookieToken := c.Cookies(cfg.CookieName)
+			cookieToken := c.Cookies(cookieName)
 
 			if cookieToken != "" {
 				raw, err := getRawFromStorage(c, cookieToken, &cfg, sessionManager, storageManager)
@@ -178,7 +182,7 @@ func New(config ...Config) fiber.Handler {
 			// This prevents CSRF attacks by requiring attackers to know both the cookie AND submit
 			// the same token through a different channel (header, form, etc.)
 			// WARNING: If using a custom extractor that reads from the same cookie, this provides no protection
-			if !compareStrings(extractedToken, c.Cookies(cfg.CookieName)) {
+			if !compareStrings(extractedToken, c.Cookies(cookieName)) {
 				return cfg.ErrorHandler(c, ErrTokenInvalid)
 			}
 
@@ -220,8 +224,15 @@ func New(config ...Config) fiber.Handler {
 		// Tell the browser that a new header value is generated
 		c.Vary(fiber.HeaderCookie)
 
+		var t any
+		if cfg.CookieNameFn == nil {
+			t = tokenKey
+		} else {
+			t = cookieName
+		}
+
 		// Store the token in the context
-		fiber.StoreInContext(c, tokenKey, token)
+		fiber.StoreInContext(c, t, token)
 
 		// Continue stack
 		return c.Next()
@@ -240,8 +251,20 @@ func registerLogContextTags() {
 // TokenFromContext returns the token found in the context.
 // It accepts fiber.CustomCtx, fiber.Ctx, *fasthttp.RequestCtx, and context.Context.
 // It returns an empty string if the token does not exist.
-func TokenFromContext(ctx any) string {
-	if token, ok := fiber.ValueFromContext[string](ctx, tokenKey); ok {
+func TokenFromContext(ctx any, cookieKey ...string) string {
+
+	// variadic function in order not to introduce breaking changes, if cookie name is not sent it uses tokenKey as default
+	var tK any
+	if len(cookieKey) == 1 {
+		tK = cookieKey[0]
+		if tK == "" {
+			tK = tokenKey
+		}
+	} else {
+		tK = tokenKey
+	}
+
+	if token, ok := fiber.ValueFromContext[string](ctx, tK); ok {
 		return token
 	}
 
@@ -306,8 +329,12 @@ func expireCSRFCookie(c fiber.Ctx, cfg *Config) {
 }
 
 func setCSRFCookie(c fiber.Ctx, cfg *Config, token string, expiry time.Duration) {
+	cookieName := cfg.CookieName
+	if cfg.CookieNameFn != nil {
+		cookieName = cfg.CookieNameFn(c)
+	}
 	cookie := &fiber.Cookie{
-		Name:        cfg.CookieName,
+		Name:        cookieName,
 		Value:       token,
 		Domain:      cfg.CookieDomain,
 		Path:        cfg.CookiePath,
@@ -325,8 +352,14 @@ func setCSRFCookie(c fiber.Ctx, cfg *Config, token string, expiry time.Duration)
 // DeleteToken removes the token found in the context from the storage
 // and expires the CSRF cookie
 func (handler *Handler) DeleteToken(c fiber.Ctx) error {
+
+	cookieName := handler.config.CookieName
+	if handler.config.CookieNameFn != nil {
+		cookieName = handler.config.CookieNameFn(c)
+	}
+
 	// Extract token from the client request cookie
-	cookieToken := c.Cookies(handler.config.CookieName)
+	cookieToken := c.Cookies(cookieName)
 	if cookieToken == "" {
 		return handler.config.ErrorHandler(c, ErrTokenNotFound)
 	}


### PR DESCRIPTION
Proposal fix for #4280 with no breaking changes

Added possibility to dynamically control the cookie name and tokenKey using context variable. Rationale is that sometimes csrf token is overridden .. e.g. using SingleUseToken true , and having more then 1 browser windows/tab opened it may happen that all browser sessions use the same csrf token, but on the first post on any window the csrf will be accepted and changed, the other windows will have to be hard refreshed as their token got invalidated. This fix allows control of csrf token on a per window/tab session

# Description

Added possibility to dynamically control the cookie name and tokenKey using context variable. Rationale is that sometimes csrf token is overridden .. 

Fixes # (issue)
e.g. using SingleUseToken true , and having more then 1 browser windows/tab opened it may happen that all browser sessions use the same csrf token, but on the first post on any window the csrf will be accepted and changed, the other windows will have to be hard refreshed as their token got invalidated. This fix allows control of csrf token on a per window/tab session

## Changes introduced

Added CookieNameFn .. if this is used then default CookieName and tokenKey will use this function instead of the default. If not used then CookieName will behave similar. 

- [ ] Examples: Provide examples demonstrating the new features or changes in action.
Setting up configuration :
`
csrfConfig := csrf.Config{
		Session:    store,
		Extractor:  extractors.FromHeader("X-Csrf-Token"), // In this example, we will be using a hidden input field to store the CSRF token
		CookieNameFN: GetCSRFByTabId,                        // set our function
                .................
		SingleUseToken: true,
	}
	return csrfConfig


// Example function that gets the tab id sent from the frontend)
func GetCSRFByTabId(ctx fiber.Ctx) string {

	if ctx == nil {
		return "_csrf"
	}

	//gets it from header
	tabid := ctx.Get("X-Tab-ID")
	if tabid == "" {
		return "_csrf"
	}
	return tabid
}

`



## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [ x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [ x] Ensured that new and existing unit tests pass locally with the changes.
- [ x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [ x] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
