### PR TITLE
🐛 bug: reject empty normalized host before dynamic matching

### DIFF
--- a/middleware/hostauthorization/hostauthorization.go
+++ b/middleware/hostauthorization/hostauthorization.go
@@ -155,6 +155,9 @@ func New(config ...Config) fiber.Handler {
 		}
 
 		host := normalizeHost(c.Hostname())
+		if host == "" {
+			return cfg.ErrorHandler(c, ErrForbiddenHost)
+		}
 
 		if matchHost(host, parsed, cfg.AllowedHostsFunc) {
 			return c.Next()

--- a/middleware/hostauthorization/hostauthorization_test.go
+++ b/middleware/hostauthorization/hostauthorization_test.go
@@ -392,6 +392,31 @@ func Test_HostAuthorization_SubdomainWildcard_BareDomainRejected(t *testing.T) {
 	require.Equal(t, fiber.StatusForbidden, resp.StatusCode)
 }
 
+func Test_HostAuthorization_AllowedHostsFunc_EmptyHostRejectedBeforeCallback(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	called := false
+	app.Use(New(Config{
+		AllowedHostsFunc: func(_ string) bool {
+			called = true
+			return true
+		},
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("OK")
+	})
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Host = ":443"
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+	require.False(t, called)
+}
+
 func Test_HostAuthorization_AllowedHostsFunc_Allowed(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()


### PR DESCRIPTION
### Motivation
- A recent change removed the unconditional rejection of an empty normalized Host, allowing empty or malformed effective hosts (e.g. `Host: :443`, missing Host header, empty trusted `X-Forwarded-Host` first element) to reach `AllowedHostsFunc`, which can cause authorization bypasses or panics. 
- Restore the previous RFC-compliant behavior that rejects requests with missing/empty host before invoking any dynamic validator.

### Description
- Reintroduced an explicit empty-host guard in `middleware/hostauthorization.New` that calls `cfg.ErrorHandler(c, ErrForbiddenHost)` when `normalizeHost(c.Hostname())` is empty. 
- Added a regression test `Test_HostAuthorization_AllowedHostsFunc_EmptyHostRejectedBeforeCallback` that asserts `Host: :443` is rejected with `403` and that `AllowedHostsFunc` is not invoked. 
- Files changed: `middleware/hostauthorization/hostauthorization.go` and `middleware/hostauthorization/hostauthorization_test.go`.