### PR TITLE
🐛 bug: fix regex route constraint parsing with literal >

### DIFF
--- a/path.go
+++ b/path.go
@@ -370,7 +370,7 @@ func (parser *routeParser) analyseParameterPart(pattern string, customConstraint
 				paramConstraintStartPosition = i + 1
 				continue
 			}
-			if search[i] == paramConstraintEnd && (i == 0 || search[i-1] != escapeChar) {
+if paramConstraintStartPosition != -1 && search[i] == paramConstraintEnd && (i == 0 || search[i-1] != escapeChar) {
 				paramConstraintEndPosition = i + 1
 				continue
 			}

--- a/path.go
+++ b/path.go
@@ -370,7 +370,7 @@ func (parser *routeParser) analyseParameterPart(pattern string, customConstraint
 				paramConstraintStartPosition = i + 1
 				continue
 			}
-if paramConstraintStartPosition != -1 && search[i] == paramConstraintEnd && (i == 0 || search[i-1] != escapeChar) {
+			if paramConstraintStartPosition != -1 && search[i] == paramConstraintEnd && (i == 0 || search[i-1] != escapeChar) {
 				paramConstraintEndPosition = i + 1
 				continue
 			}

--- a/path.go
+++ b/path.go
@@ -370,7 +370,7 @@ func (parser *routeParser) analyseParameterPart(pattern string, customConstraint
 				paramConstraintStartPosition = i + 1
 				continue
 			}
-			if paramConstraintEndPosition == -1 && search[i] == paramConstraintEnd && (i == 0 || search[i-1] != escapeChar) {
+			if search[i] == paramConstraintEnd && (i == 0 || search[i-1] != escapeChar) {
 				paramConstraintEndPosition = i + 1
 				continue
 			}

--- a/path_testcases_test.go
+++ b/path_testcases_test.go
@@ -624,6 +624,13 @@ func init() {
 				},
 			},
 			{
+				pattern: "/api/v1/:param<regex(^[^>]+$)>",
+				testCases: []routeTestCase{
+					{url: "/api/v1/safe-value", params: []string{"safe-value"}, match: true},
+					{url: "/api/v1/bad>value", params: nil, match: false},
+				},
+			},
+			{
 				pattern: `/api/v1/:param<regex(\d{4}-\d{2}-\d{2})}>`,
 				testCases: []routeTestCase{
 					{url: "/api/v1/ent", params: nil, match: false},


### PR DESCRIPTION
### Motivation
- Fix a regression in the parameter parser where the first unescaped `>` inside a parameter constraint was recorded as the constraint terminator, which truncated regex constraints containing literal `>` and could degrade them into a no-op `noConstraint` allowing unintended matches.

### Description
- Update `analyseParameterPart` in `path.go` so `paramConstraintEndPosition` is updated for every unescaped `>` found, ensuring the closing delimiter of the full constraint is used rather than the first `>` inside constraint data.
- Add a regression test in `path_testcases_test.go` for the pattern `/:param<regex(^[^>]+$)>` to assert a safe value matches and a value containing `>` is rejected.
- Changes affect `path.go` and `path_testcases_test.go` and preserve existing parser behavior for all other cases.