### PR TITLE
🐛 bug: clear plaintext cookie when encryption fails

### DIFF
--- a/middleware/encryptcookie/encryptcookie.go
+++ b/middleware/encryptcookie/encryptcookie.go
@@ -52,6 +52,7 @@ func New(config ...Config) fiber.Handler {
 				if c.Response().Header.Cookie(&cookieValue) {
 					encryptedValue, encErr := cfg.Encryptor(keyString, string(cookieValue.Value()), cfg.Key)
 					if encErr != nil {
+						c.Response().Header.DelCookieBytes(key)
 						return errors.Join(err, encErr)
 					}
 

--- a/middleware/encryptcookie/encryptcookie.go
+++ b/middleware/encryptcookie/encryptcookie.go
@@ -44,21 +44,32 @@ func New(config ...Config) fiber.Handler {
 		err := c.Next()
 
 		// Encrypt response cookies
+		responseCookieKeys := make([]string, 0, 4)
 		for key := range c.Response().Header.Cookies() {
-			keyString := string(key)
-			if !isDisabled(keyString, cfg.Except) {
-				cookieValue := fasthttp.Cookie{}
-				cookieValue.SetKeyBytes(key)
-				if c.Response().Header.Cookie(&cookieValue) {
-					encryptedValue, encErr := cfg.Encryptor(keyString, string(cookieValue.Value()), cfg.Key)
-					if encErr != nil {
-						c.Response().Header.DelCookieBytes(key)
-						return errors.Join(err, encErr)
+			responseCookieKeys = append(responseCookieKeys, string(key))
+		}
+
+		for _, keyString := range responseCookieKeys {
+			if isDisabled(keyString, cfg.Except) {
+				continue
+			}
+
+			cookieValue := fasthttp.Cookie{}
+			cookieValue.SetKey(keyString)
+			if c.Response().Header.Cookie(&cookieValue) {
+				encryptedValue, encErr := cfg.Encryptor(keyString, string(cookieValue.Value()), cfg.Key)
+				if encErr != nil {
+					for _, responseCookieKey := range responseCookieKeys {
+						if !isDisabled(responseCookieKey, cfg.Except) {
+							c.Response().Header.DelCookie(responseCookieKey)
+						}
 					}
 
-					cookieValue.SetValue(encryptedValue)
-					c.Response().Header.SetCookie(&cookieValue)
+					return errors.Join(err, encErr)
 				}
+
+				cookieValue.SetValue(encryptedValue)
+				c.Response().Header.SetCookie(&cookieValue)
 			}
 		}
 

--- a/middleware/encryptcookie/encryptcookie_test.go
+++ b/middleware/encryptcookie/encryptcookie_test.go
@@ -137,6 +137,10 @@ func Test_Middleware_EncryptionErrorPropagates(t *testing.T) {
 			Name:  "test",
 			Value: "value",
 		})
+		c.Cookie(&fiber.Cookie{
+			Name:  "test2",
+			Value: "value2",
+		})
 		return nil
 	})
 

--- a/middleware/encryptcookie/encryptcookie_test.go
+++ b/middleware/encryptcookie/encryptcookie_test.go
@@ -144,6 +144,7 @@ func Test_Middleware_EncryptionErrorPropagates(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusTeapot, resp.StatusCode)
 	require.ErrorIs(t, captured, expected)
+	require.Empty(t, resp.Header.Values(fiber.HeaderSetCookie))
 }
 
 func Test_Middleware_EncryptionErrorDoesNotMaskNextError(t *testing.T) {


### PR DESCRIPTION
### Motivation
- Prevent plaintext `Set-Cookie` headers from being emitted when `encryptcookie` fails to encrypt a response cookie after the handler returns, which could leak cookie values to the client.

### Description
- Remove the affected response cookie from `c.Response().Header` when `cfg.Encryptor` returns an error before returning the encryption error, and add a regression assertion ensuring no `Set-Cookie` headers are returned on encryption failure in `Test_Middleware_EncryptionErrorPropagates`.