### PR TITLE
📒 docs: fix invalid RouteChain method chaining example

### DIFF
--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -2033,7 +2033,7 @@ app.RouteChain("/api").RouteChain("/user/:id?").
     Post(func(c fiber.Ctx) error {
         // Create user
         return c.JSON(fiber.Map{"message": "User created"})
-    });
+    })
 ```
 
 ### 🗺 RebuildTree

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -2025,12 +2025,12 @@ app.Route("/api", func(apiGrp Router) {
 
 ```go
 // After
-app.RouteChain("/api").RouteChain("/user/:id?")
-    .Get(func(c fiber.Ctx) error {
+app.RouteChain("/api").RouteChain("/user/:id?").
+    Get(func(c fiber.Ctx) error {
         // Get user
         return c.JSON(fiber.Map{"message": "Get user", "id": c.Params("id")})
-    })
-    .Post(func(c fiber.Ctx) error {
+    }).
+    Post(func(c fiber.Ctx) error {
         // Create user
         return c.JSON(fiber.Map{"message": "User created"})
     });


### PR DESCRIPTION
### Motivation
- Fix a documentation correctness bug in `docs/whats_new.md` where the `RouteChain` "After" example split method chaining before selector dots, producing invalid Go code due to automatic semicolon insertion.

### Description
- Adjust the `RouteChain` "After" example in `docs/whats_new.md` by moving the selector dots to the end of the preceding lines so the multiline method chain is valid Go syntax while preserving the example behavior.