### PR TITLE
🐛 bug: avoid panic for non-struct listeners in TLS config discovery

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -109,6 +109,9 @@ func getTLSConfig(ln net.Listener) *tls.Config {
 	if !val.IsValid() {
 		return nil
 	}
+	if val.Kind() != reflect.Struct {
+		return nil
+	}
 
 	field := val.FieldByName("config")
 	if !field.IsValid() {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -157,6 +157,12 @@ func (ln *configMethodListener) Config() *tls.Config {
 	return ln.cfg
 }
 
+type nonStructListener int
+
+func (nonStructListener) Accept() (net.Conn, error) { return nil, net.ErrClosed }
+func (nonStructListener) Close() error              { return nil }
+func (nonStructListener) Addr() net.Addr            { return &net.TCPAddr{} }
+
 func Test_GetTLSConfig(t *testing.T) {
 	t.Parallel()
 
@@ -222,6 +228,15 @@ func Test_GetTLSConfig(t *testing.T) {
 		})
 
 		require.Nil(t, getTLSConfig(base), "plain listeners should not report TLS config")
+	})
+
+	t.Run("non-struct listener", func(t *testing.T) {
+		t.Parallel()
+
+		ln := nonStructListener(7)
+		require.NotPanics(t, func() {
+			require.Nil(t, getTLSConfig(ln), "non-struct listeners should not panic and should not report TLS config")
+		})
 	})
 }
 


### PR DESCRIPTION
### Motivation
- Prevent a startup panic when `App.Listener` calls `getTLSConfig` with a legally valid non-struct `net.Listener` implementation, where the reflection fallback previously called `FieldByName` on a non-struct value.

### Description
- Add a `reflect.Struct` kind guard (`if val.Kind() != reflect.Struct { return nil }`) before calling `FieldByName("config")` in `getTLSConfig` to avoid panics for non-struct listener types.
- Add a regression test `non-struct listener` in `Test_GetTLSConfig` using a named non-struct `net.Listener` type to assert `getTLSConfig` does not panic and returns `nil`.
- The patch is minimal and preserves existing TLS discovery behavior for `TLSConfig()` and `Config()` provider methods and the existing struct reflection fallback.