### PR TITLE
🐛 bug: reject oversized unknown-length adaptor request bodies

### DIFF
--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"reflect"
@@ -251,7 +252,11 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 				http.Error(w, utils.StatusMessage(fiber.StatusRequestEntityTooLarge), fiber.StatusRequestEntityTooLarge)
 				return
 			}
-			limitedReader := io.LimitReader(r.Body, maxBodySize+1)
+			limit := maxBodySize
+			if limit < math.MaxInt64 {
+				limit++
+			}
+			limitedReader := io.LimitReader(r.Body, limit)
 			n, err := io.Copy(req.BodyWriter(), limitedReader)
 			if err != nil {
 				http.Error(w, utils.StatusMessage(fiber.StatusInternalServerError), fiber.StatusInternalServerError)

--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -251,14 +251,19 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 				http.Error(w, utils.StatusMessage(fiber.StatusRequestEntityTooLarge), fiber.StatusRequestEntityTooLarge)
 				return
 			}
-			limitedReader := io.LimitReader(r.Body, maxBodySize)
+			limitedReader := io.LimitReader(r.Body, maxBodySize+1)
 			n, err := io.Copy(req.BodyWriter(), limitedReader)
-			req.Header.SetContentLength(int(n))
-
 			if err != nil {
 				http.Error(w, utils.StatusMessage(fiber.StatusInternalServerError), fiber.StatusInternalServerError)
 				return
 			}
+
+			if n > maxBodySize {
+				http.Error(w, utils.StatusMessage(fiber.StatusRequestEntityTooLarge), fiber.StatusRequestEntityTooLarge)
+				return
+			}
+
+			req.Header.SetContentLength(int(n))
 		}
 		req.Header.SetMethod(r.Method)
 		req.SetRequestURI(r.RequestURI)

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -537,6 +537,7 @@ func Test_FiberHandler_BodyLimit(t *testing.T) {
 		name           string
 		bodyLimit      int
 		bodySize       int
+		unknownLength  bool
 		expectedStatus int
 	}{
 		{
@@ -562,6 +563,13 @@ func Test_FiberHandler_BodyLimit(t *testing.T) {
 			bodySize:       fiber.DefaultBodyLimit - 256,
 			expectedStatus: fiber.StatusOK,
 		},
+		{
+			name:           "UnknownLengthExceededReturns413",
+			bodyLimit:      1 * 1024 * 1024,
+			bodySize:       (1 * 1024 * 1024) + 1,
+			unknownLength:  true,
+			expectedStatus: fiber.StatusRequestEntityTooLarge,
+		},
 	}
 
 	for _, tt := range tests {
@@ -579,7 +587,11 @@ func Test_FiberHandler_BodyLimit(t *testing.T) {
 			handlerFunc := FiberApp(app)
 			body := bytes.Repeat([]byte("a"), tt.bodySize)
 			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
-			req.ContentLength = int64(len(body))
+			if tt.unknownLength {
+				req.ContentLength = -1
+			} else {
+				req.ContentLength = int64(len(body))
+			}
 			resp := httptest.NewRecorder()
 
 			handlerFunc.ServeHTTP(resp, req)


### PR DESCRIPTION
### Motivation
- The net/http -> Fiber adaptor was silently truncating unknown-length (e.g., chunked) request bodies to the app `BodyLimit` and processing the truncated payload instead of rejecting oversized requests.
- This could allow an attacker to send >BodyLimit data with no `Content-Length` and bypass application-level validation or corrupt uploads.

### Description
- Read up to `BodyLimit+1` bytes from the incoming `r.Body` in `handlerFunc`, allowing detection of truncation when the declared length is unknown by using `io.LimitReader(r.Body, maxBodySize+1)` and `io.Copy`.
- Return HTTP 413 (`StatusRequestEntityTooLarge`) when the copied byte count exceeds the configured `BodyLimit` before setting the fasthttp `Content-Length` header.
- Preserve the existing early reject behavior for requests that declare a `Content-Length` larger than the configured limit.
- Add an adaptor test case in `Test_FiberHandler_BodyLimit` that submits an over-limit payload with `ContentLength = -1` (unknown-length) and asserts the handler returns 413.