### PR TITLE
🐛 bug: trim only one trailing dot in host normalization

### DIFF
--- a/middleware/hostauthorization/hostauthorization.go
+++ b/middleware/hostauthorization/hostauthorization.go
@@ -86,7 +86,7 @@ func validateHostLength(host string) {
 func normalizeHost(host string) string {
 	// Fast path for plain hostnames — avoids net.SplitHostPort's error allocation.
 	if host != "" && host[0] != '[' && strings.IndexByte(host, ':') < 0 {
-		host = utils.TrimRight(host, '.')
+		host = trimOneTrailingDot(host)
 		host = utilsstrings.ToLower(host)
 		return toPunycode(host)
 	}
@@ -98,9 +98,17 @@ func normalizeHost(host string) string {
 		host = utils.TrimRight(host, ']')
 	}
 
-	host = utils.TrimRight(host, '.')
+	host = trimOneTrailingDot(host)
 	host = utilsstrings.ToLower(host)
 	return toPunycode(host)
+}
+
+func trimOneTrailingDot(host string) string {
+	if host != "" && host[len(host)-1] == '.' {
+		return host[:len(host)-1]
+	}
+
+	return host
 }
 
 func toPunycode(host string) string {

--- a/middleware/hostauthorization/hostauthorization_test.go
+++ b/middleware/hostauthorization/hostauthorization_test.go
@@ -115,6 +115,7 @@ func Test_NormalizeHost(t *testing.T) {
 		{"plain host", "example.com", "example.com"},
 		{"uppercase", "EXAMPLE.COM", "example.com"},
 		{"trailing dot", "example.com.", "example.com"},
+		{"multiple trailing dots only trims one", "example.com..", "example.com."},
 		{"host with port", "example.com:8080", "example.com"},
 		{"uppercase host with port", "EXAMPLE.COM:8080", "example.com"},
 		{"ipv4", "192.168.1.1", "192.168.1.1"},
@@ -146,6 +147,7 @@ func Test_ParseNormalizedAuthority(t *testing.T) {
 	}{
 		{name: "plain host", input: "example.com", expected: "example.com", expectOK: true},
 		{name: "host with valid port", input: "example.com:8080", expected: "example.com", expectOK: true},
+		{name: "multiple trailing dots with port only trims one", input: "api.example.com...:443", expected: "api.example.com..", expectOK: true},
 		{name: "ipv6 with port", input: "[::1]:443", expected: "::1", expectOK: true},
 		{name: "ipv6 without port", input: "[::1]", expected: "::1", expectOK: true},
 		{name: "empty port", input: "example.com:", expectOK: false},


### PR DESCRIPTION
### Motivation
- Restore the intended FQDN canonicalization semantics so that only a single trailing root-label dot is removed from hosts, preventing malformed multi-dot authorities (e.g. `example.com..`) from being silently accepted and matched against allowlist entries.

### Description
- Replace calls to `utils.TrimRight(host, '.')` with a new `trimOneTrailingDot(host string) string` helper that removes at most one trailing `.` from the hostname in `middleware/hostauthorization/hostauthorization.go`.
- Update `normalizeHost` to use `trimOneTrailingDot` on both the fast path and the general path before lowercasing and punycode conversion.
- Add focused regression tests in `middleware/hostauthorization/hostauthorization_test.go` to assert that multiple trailing dots are only trimmed once for both plain hosts and authority strings with ports.