### PR TITLE
🐛 bug: preserve mounted sub-app regex handler during mount prefixing

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -421,7 +421,9 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	wrapperApp := New(Config{
 		CaseSensitive: subApp.config.CaseSensitive,
 		StrictRouting: subApp.config.StrictRouting,
+		RegexHandler:  subApp.config.RegexHandler,
 	})
+	wrapperApp.customConstraints = subApp.customConstraints
 
 	// Clone routes from the sub-app with domain-wrapped handlers.
 	// Lock the sub-app while reading to prevent data races with concurrent

--- a/mount.go
+++ b/mount.go
@@ -202,7 +202,7 @@ func (app *App) processSubAppsRoutes() {
 				subAppRouteClone := app.copyRoute(subAppRoute)
 
 				// Add the parent route's path as a prefix to the sub-app's route
-				app.addPrefixToRoute(route.path, subAppRouteClone)
+				app.addPrefixToRoute(route.path, subAppRouteClone, route.group.app.config.RegexHandler, route.group.app.customConstraints...)
 
 				// Add the cloned sub-app's route to the slice of sub-app routes
 				subRoutes[j] = subAppRouteClone

--- a/mount_test.go
+++ b/mount_test.go
@@ -9,10 +9,40 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func Test_App_Mount_PreservesSubAppRegexHandler(t *testing.T) {
+	t.Parallel()
+
+	parent := New(Config{
+		CaseSensitive: true,
+		RegexHandler: func(pattern string) *matchOnlyRegexCompiler {
+			return &matchOnlyRegexCompiler{re: regexp.MustCompile("(?i)" + pattern)}
+		},
+	})
+
+	sub := New(Config{
+		CaseSensitive: true,
+		RegexHandler:  regexp.MustCompile,
+	})
+	sub.Get("/resource/:id<regex(ALLOW)>", func(c Ctx) error {
+		return c.SendStatus(StatusOK)
+	})
+
+	parent.Use("/mounted", sub)
+
+	resp, err := sub.Test(httptest.NewRequest(MethodGet, "/resource/allow", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+
+	resp, err = parent.Test(httptest.NewRequest(MethodGet, "/mounted/resource/allow", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
 
 // go test -run Test_App_Mount
 func Test_App_Mount(t *testing.T) {

--- a/mount_test.go
+++ b/mount_test.go
@@ -35,7 +35,15 @@ func Test_App_Mount_PreservesSubAppRegexHandler(t *testing.T) {
 
 	parent.Use("/mounted", sub)
 
-	resp, err := sub.Test(httptest.NewRequest(MethodGet, "/resource/allow", http.NoBody))
+	resp, err := sub.Test(httptest.NewRequest(MethodGet, "/resource/ALLOW", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+
+	resp, err = parent.Test(httptest.NewRequest(MethodGet, "/mounted/resource/ALLOW", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+
+	resp, err = sub.Test(httptest.NewRequest(MethodGet, "/resource/allow", http.NoBody))
 	require.NoError(t, err)
 	require.Equal(t, StatusNotFound, resp.StatusCode)
 

--- a/router.go
+++ b/router.go
@@ -474,7 +474,7 @@ func (app *App) customRequestHandler(rctx *fasthttp.RequestCtx) {
 	}
 }
 
-func (app *App) addPrefixToRoute(prefix string, route *Route) *Route {
+func (app *App) addPrefixToRoute(prefix string, route *Route, regexHandler any, customConstraints ...CustomConstraint) *Route {
 	prefixedPath := getGroupPath(prefix, route.Path)
 	prettyPath := prefixedPath
 	// Case-sensitive routing, all to lowercase
@@ -488,7 +488,7 @@ func (app *App) addPrefixToRoute(prefix string, route *Route) *Route {
 
 	route.Path = prefixedPath
 	route.path = RemoveEscapeChar(prettyPath)
-	route.routeParser = parseRoute(prettyPath, app.config.RegexHandler, app.customConstraints...)
+	route.routeParser = parseRoute(prettyPath, regexHandler, customConstraints...)
 	route.root = false
 	route.star = false
 	route.caseSensitive = app.config.CaseSensitive


### PR DESCRIPTION
### Motivation
- Mounted sub-app routes were being reparsed using the parent app's regex handler when the mount prefix was added, which can change route constraint semantics and break security-sensitive regex behavior.
- The change ensures per-App `RegexHandler` semantics are preserved for routes cloned from mounted sub-apps so a sub-app's constraints are not silently recompiled under a different engine.

### Description
- Changed `addPrefixToRoute` signature to accept an explicit `regexHandler` and variadic `customConstraints` and use them when reparsing the prefixed path.
- Updated mount processing to pass the sub-app's `config.RegexHandler` and `customConstraints` when cloning and prefixing sub-app routes so the sub-app's regex configuration is preserved.
- Added `Test_App_Mount_PreservesSubAppRegexHandler` to `mount_test.go` which verifies a mounted route retains the sub-app's regex behavior when the parent uses a different handler.