### PR TITLE
🐛 fix: strip all trusted proxy IPs from X-Forwarded-For chain

### DIFF
--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -291,18 +291,25 @@ type Ctx interface {
 	Hostname() string
 	// Port returns the remote port of the request.
 	Port() string
-	// IP returns the remote IP address of the request.
-	// If ProxyHeader and IP Validation is configured, it will parse that header and return the first valid IP address.
-	// Please use Config.TrustProxy to prevent header spoofing if your app is behind a proxy.
+	// IP returns the client's IP address. When the request comes from a trusted proxy (see
+	// [TrustProxyConfig]), the value is extracted from the configured ProxyHeader by walking the
+	// X-Forwarded-For chain right-to-left and skipping all trusted proxy IPs; the first
+	// non-trusted IP in the chain is returned. Please use Config.TrustProxy to prevent header
+	// spoofing if your app is behind a proxy.
 	IP() string
 	// extractIPsFromHeader will return a slice of IPs it found given a header name in the order they appear.
 	// When IP validation is enabled, any invalid IPs will be omitted.
 	extractIPsFromHeader(header string) []string
-	// extractIPFromHeader will attempt to pull the real client IP from the given header when IP validation is enabled.
-	// currently, it will return the first valid IP address in header.
-	// when IP validation is disabled, it will simply return the value of the header without any inspection.
-	// Implementation is almost the same as in extractIPsFromHeader, but without allocation of []string.
+	// extractIPFromHeader returns the client IP from the given proxy header by walking the
+	// X-Forwarded-For chain from right to left and stripping trusted proxy IPs. When trusted
+	// proxies are configured, the rightmost non-trusted IP is returned; otherwise the first
+	// valid IP (left-to-right) is returned. When IP validation is disabled, the raw header
+	// value is returned as-is.
 	extractIPFromHeader(header string) string
+	// hasTrustedProxyConfig returns true if any trusted proxy configuration is set.
+	hasTrustedProxyConfig() bool
+	// isTrustedProxyIP checks whether the given IP string matches any configured trusted proxy.
+	isTrustedProxyIP(ipStr string) bool
 	// IPs returns a string slice of IP addresses specified in the X-Forwarded-For request header.
 	// When IP validation is enabled, only valid IPs are returned.
 	IPs() []string

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -3310,12 +3310,12 @@ func Test_Ctx_IP_ProxyHeader_With_IP_Validation(t *testing.T) {
 		c.Request().Header.Set(proxyHeaderName, "0.0.0.1")
 		require.Equal(t, "0.0.0.1", c.IP())
 
-		// when proxy header & validation is enabled and the value is a list of IPs, we return the first valid IP
+		// when proxy header & validation is enabled and the value is a list of IPs, we return the rightmost non-trusted IP
 		c.Request().Header.Set(proxyHeaderName, "0.0.0.1, 0.0.0.2")
-		require.Equal(t, "0.0.0.1", c.IP())
+		require.Equal(t, "0.0.0.2", c.IP())
 
 		c.Request().Header.Set(proxyHeaderName, "invalid, 0.0.0.2, 0.0.0.3")
-		require.Equal(t, "0.0.0.2", c.IP())
+		require.Equal(t, "0.0.0.3", c.IP())
 
 		// when proxy header & validation is enabled but the value is empty, we will ignore the header
 		c.Request().Header.Set(proxyHeaderName, "")
@@ -3352,6 +3352,205 @@ func Test_Ctx_IP_TrustedProxy(t *testing.T) {
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 	c.Request().Header.Set(HeaderXForwardedFor, "0.0.0.1")
 	require.Equal(t, "0.0.0.1", c.IP())
+}
+
+// go test -run Test_Ctx_IP_StripTrustedProxies
+func Test_Ctx_IP_StripTrustedProxies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   Config
+		remoteIP string
+		header   string
+		expected string
+	}{
+		{
+			name: "strip multiple trusted proxies from right",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Proxies: []string{"10.0.0.1", "10.0.0.2"},
+				},
+			},
+			remoteIP: "10.0.0.2",
+			header:   "203.0.113.50, 10.0.0.1, 10.0.0.2",
+			expected: "203.0.113.50",
+		},
+		{
+			name: "CIDR range stripping",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Proxies: []string{"10.0.0.0/24"},
+				},
+			},
+			remoteIP: "10.0.0.5",
+			header:   "203.0.113.50, 10.0.0.1, 10.0.0.2",
+			expected: "203.0.113.50",
+		},
+		{
+			name: "exact IP match stripping",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Proxies: []string{"10.0.0.1"},
+				},
+			},
+			remoteIP: "10.0.0.1",
+			header:   "203.0.113.50, 10.0.0.1",
+			expected: "203.0.113.50",
+		},
+		{
+			name: "loopback stripping",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Loopback: true,
+				},
+			},
+			remoteIP: "127.0.0.1",
+			header:   "203.0.113.50, 127.0.0.1",
+			expected: "203.0.113.50",
+		},
+		{
+			name: "private network stripping",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Private: true,
+				},
+			},
+			remoteIP: "192.168.1.1",
+			header:   "203.0.113.50, 192.168.1.1, 10.0.0.1",
+			expected: "203.0.113.50",
+		},
+		{
+			name: "link-local stripping",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					LinkLocal: true,
+				},
+			},
+			remoteIP: "169.254.0.1",
+			header:   "203.0.113.50, 169.254.0.1",
+			expected: "203.0.113.50",
+		},
+		{
+			name: "all IPs trusted returns leftmost",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Proxies: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+				},
+			},
+			remoteIP: "10.0.0.3",
+			header:   "10.0.0.1, 10.0.0.2, 10.0.0.3",
+			expected: "10.0.0.1",
+		},
+		{
+			name: "no trusted proxy config returns first valid",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Proxies: []string{"10.0.0.1"},
+				},
+			},
+			remoteIP: "10.0.0.1",
+			header:   "203.0.113.50, 10.0.0.1",
+			expected: "203.0.113.50",
+		},
+		{
+			name: "IPv6 chain stripping",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Proxies: []string{"::1", "fd00::1"},
+				},
+			},
+			remoteIP: "fd00::1",
+			header:   "2001:db8::1, fd00::1, ::1",
+			expected: "2001:db8::1",
+		},
+		{
+			name: "single non-trusted IP returns as-is",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Proxies: []string{"10.0.0.1"},
+				},
+			},
+			remoteIP: "10.0.0.1",
+			header:   "203.0.113.50",
+			expected: "203.0.113.50",
+		},
+		{
+			name: "single trusted IP returns it as fallback",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Proxies: []string{"10.0.0.1"},
+				},
+			},
+			remoteIP: "10.0.0.1",
+			header:   "10.0.0.1",
+			expected: "10.0.0.1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			app := New(tc.config)
+			fastCtx := &fasthttp.RequestCtx{}
+			fastCtx.SetRemoteAddr(net.Addr(&net.TCPAddr{IP: net.ParseIP(tc.remoteIP)}))
+			c := app.AcquireCtx(fastCtx)
+			c.Request().Header.Set(HeaderXForwardedFor, tc.header)
+			require.Equal(t, tc.expected, c.IP())
+		})
+	}
+}
+
+// go test -run Test_Ctx_IP_ProxyHeader_NoTrustedProxies
+func Test_Ctx_IP_ProxyHeader_NoTrustedProxies(t *testing.T) {
+	t.Parallel()
+	app := New(Config{
+		ProxyHeader:        HeaderXForwardedFor,
+		TrustProxy:         true,
+		EnableIPValidation: true,
+		TrustProxyConfig: TrustProxyConfig{
+			Proxies: []string{"10.0.0.1"},
+		},
+	})
+	fastCtx := &fasthttp.RequestCtx{}
+	fastCtx.SetRemoteAddr(net.Addr(&net.TCPAddr{IP: net.ParseIP("10.0.0.1")}))
+	c := app.AcquireCtx(fastCtx)
+
+	c.Request().Header.Set(HeaderXForwardedFor, "203.0.113.50, 10.0.0.1")
+	require.Equal(t, "203.0.113.50", c.IP())
 }
 
 func Test_Ctx_ProxyTrust_UnixRemoteAddr(t *testing.T) {
@@ -3609,6 +3808,27 @@ func Benchmark_Ctx_IP(b *testing.B) {
 		res = c.IP()
 	}
 	require.Equal(b, "0.0.0.0", res)
+}
+
+func Benchmark_Ctx_IP_With_ProxyHeader_Chain(b *testing.B) {
+	app := New(Config{
+		ProxyHeader:        HeaderXForwardedFor,
+		TrustProxy:         true,
+		EnableIPValidation: true,
+		TrustProxyConfig: TrustProxyConfig{
+			Proxies: []string{"10.0.0.1", "10.0.0.2"},
+		},
+	})
+	fastCtx := &fasthttp.RequestCtx{}
+	fastCtx.SetRemoteAddr(net.Addr(&net.TCPAddr{IP: net.ParseIP("10.0.0.2")}))
+	c := app.AcquireCtx(fastCtx)
+	c.Request().Header.Set(HeaderXForwardedFor, "203.0.113.50, 10.0.0.1, 10.0.0.2")
+	var res string
+	b.ReportAllocs()
+	for b.Loop() {
+		res = c.IP()
+	}
+	require.Equal(b, "203.0.113.50", res)
 }
 
 // go test -run Test_Ctx_Is

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -3464,7 +3464,7 @@ func Test_Ctx_IP_StripTrustedProxies(t *testing.T) {
 			expected: "10.0.0.1",
 		},
 		{
-			name: "no trusted proxy config returns first valid",
+			name: "single trusted proxy stripped",
 			config: Config{
 				ProxyHeader:        HeaderXForwardedFor,
 				TrustProxy:         true,

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -3539,18 +3539,43 @@ func Test_Ctx_IP_ProxyHeader_NoTrustedProxies(t *testing.T) {
 	t.Parallel()
 	app := New(Config{
 		ProxyHeader:        HeaderXForwardedFor,
-		TrustProxy:         true,
+		EnableIPValidation: true,
+	})
+	fastCtx := &fasthttp.RequestCtx{}
+	c := app.AcquireCtx(fastCtx)
+
+	c.Request().Header.Set(HeaderXForwardedFor, "invalid, 203.0.113.50, 10.0.0.1")
+	require.Equal(t, "203.0.113.50", c.extractIPFromHeader(HeaderXForwardedFor))
+}
+
+func Test_Ctx_IP_ProxyHeader_InvalidIPs(t *testing.T) {
+	t.Parallel()
+	app := New(Config{
 		EnableIPValidation: true,
 		TrustProxyConfig: TrustProxyConfig{
 			Proxies: []string{"10.0.0.1"},
 		},
 	})
 	fastCtx := &fasthttp.RequestCtx{}
-	fastCtx.SetRemoteAddr(net.Addr(&net.TCPAddr{IP: net.ParseIP("10.0.0.1")}))
+	fastCtx.SetRemoteAddr(testNetAddr{network: "tcp", address: "invalid"})
 	c := app.AcquireCtx(fastCtx)
 
-	c.Request().Header.Set(HeaderXForwardedFor, "203.0.113.50, 10.0.0.1")
-	require.Equal(t, "203.0.113.50", c.IP())
+	c.Request().Header.Set(HeaderXForwardedFor, "invalid")
+	require.Equal(t, "0.0.0.0", c.extractIPFromHeader(HeaderXForwardedFor))
+	require.False(t, c.isTrustedProxyIP("invalid"))
+}
+
+func Test_Ctx_IP_TrustedProxyIPv6Range(t *testing.T) {
+	t.Parallel()
+	app := New(Config{
+		TrustProxyConfig: TrustProxyConfig{
+			Proxies: []string{"2001:db8::/32"},
+		},
+	})
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	require.True(t, c.isTrustedProxyIP("2001:db8::1"))
+	require.False(t, c.isTrustedProxyIP("2001:db9::1"))
 }
 
 func Test_Ctx_ProxyTrust_UnixRemoteAddr(t *testing.T) {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -3519,6 +3519,62 @@ func Test_Ctx_IP_StripTrustedProxies(t *testing.T) {
 			header:   "10.0.0.1",
 			expected: "10.0.0.1",
 		},
+		{
+			name: "attacker injects invalid leftmost token",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Proxies: []string{"10.0.0.1"},
+				},
+			},
+			remoteIP: "10.0.0.1",
+			header:   "evil.attacker, 203.0.113.50, 10.0.0.1",
+			expected: "203.0.113.50",
+		},
+		{
+			name: "attacker injects spoofed leftmost IP",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Proxies: []string{"10.0.0.1"},
+				},
+			},
+			remoteIP: "10.0.0.1",
+			header:   "1.2.3.4, 203.0.113.50, 10.0.0.1",
+			expected: "203.0.113.50",
+		},
+		{
+			name: "whitespace around chain entries",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Proxies: []string{"10.0.0.1"},
+				},
+			},
+			remoteIP: "10.0.0.1",
+			header:   "203.0.113.50 , 10.0.0.1",
+			expected: "203.0.113.50",
+		},
+		{
+			name: "trailing empty chain element",
+			config: Config{
+				ProxyHeader:        HeaderXForwardedFor,
+				TrustProxy:         true,
+				EnableIPValidation: true,
+				TrustProxyConfig: TrustProxyConfig{
+					Proxies: []string{"10.0.0.1"},
+				},
+			},
+			remoteIP: "10.0.0.1",
+			header:   "203.0.113.50, 10.0.0.1,",
+			expected: "203.0.113.50",
+		},
 	}
 
 	for _, tc := range tests {

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -1150,7 +1150,11 @@ By default, `c.IP()` returns the remote IP address from the TCP connection. When
 
 **Important:** You must enable `TrustProxy` and configure trusted proxy IPs to prevent header spoofing. Simply setting `ProxyHeader` alone will not work.
 
-**Note:** When using a proxy header such as `X-Forwarded-For`, `c.IP()` returns the raw header value unless [`EnableIPValidation`](fiber.md#enableipvalidation) is enabled. For `X-Forwarded-For`, this raw value may be a comma-separated list of IPs; enable `EnableIPValidation` if you need `c.IP()` to return a single, validated client IP.
+**Note:** When using a proxy header such as `X-Forwarded-For`, `c.IP()` returns the raw header value unless [`EnableIPValidation`](fiber.md#enableipvalidation) is enabled.
+
+**Chain parsing with `EnableIPValidation`:** For `X-Forwarded-For`, the raw value is a comma-separated chain that grows from left to right as the request passes through each proxy. With validation enabled, `c.IP()` walks the chain from right to left, skipping every IP that matches the configured `TrustProxyConfig` (exact IPs, CIDR ranges, loopback, private or link-local) and returns the first non-trusted IP it finds. This matches the behavior recommended by [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For#selecting_an_ip_address) and the convention used by Nginx (`set_real_ip_from` + `real_ip_recursive`), Apache `mod_remoteip`, and Envoy (`xff_num_trusted_hops`).
+
+If every IP in the chain matches the trusted set, the leftmost IP is returned as a fallback. If the chain is empty, `c.IP()` falls back to the TCP remote address.
 :::
 
 #### Configuration for apps behind a reverse proxy

--- a/docs/guide/reverse-proxy.md
+++ b/docs/guide/reverse-proxy.md
@@ -39,6 +39,12 @@ Proxy headers can be easily spoofed by malicious clients. **Always** configure `
 In addition, your reverse proxy should be configured to **set or overwrite** the forwarding header you choose (for example, `X-Forwarded-For`) based on the real client connection, or to use its real IP / PROXY protocol features. Do not simply pass through client-supplied forwarding headers, or `c.IP()` may still be controlled by an attacker even when `TrustProxyConfig` is correct.
 :::
 
+:::info Chain parsing with `EnableIPValidation`
+`X-Forwarded-For` is a comma-separated chain that each proxy appends to. With `EnableIPValidation` enabled, `c.IP()` walks the chain from **right to left** and strips every IP that matches the configured `TrustProxyConfig`. The first non-trusted IP is returned as the client. This matches the [MDN guidance](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For#selecting_an_ip_address) and the convention used by Nginx (`set_real_ip_from` + `real_ip_recursive`), Apache `mod_remoteip`, Envoy (`xff_num_trusted_hops`), and most CDNs.
+
+Without `EnableIPValidation`, `c.IP()` returns the raw header value (a comma-separated string), which is rarely what middleware like rate limiters or allowlists expect. Enable validation when you rely on `c.IP()` as a single client identifier.
+:::
+
 ### Configuration
 
 To enable reading the client IP from proxy headers, you must configure **three settings**:

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -692,6 +692,7 @@ testConfig := fiber.TestConfig{
   specified by [RFC 6266](https://www.rfc-editor.org/rfc/rfc6266) and
   [RFC 8187](https://www.rfc-editor.org/rfc/rfc8187).
 - **Context()**: Renamed to `RequestCtx()` to access the underlying `fasthttp.RequestCtx`.
+- **IP()**: When `EnableIPValidation` is `true` and `TrustProxyConfig` is set, `c.IP()` now walks the `X-Forwarded-For` chain from right to left and returns the first non-trusted IP, instead of the leftmost syntactically valid IP. This closes an IP-spoofing vector where an attacker could prepend a fake address and have it returned by `c.IP()`. Apps with `EnableIPValidation = false` (the default) are unaffected. See [`Ctx.IP`](./api/ctx.md#ip) and the [reverse proxy guide](./guide/reverse-proxy.md#getting-the-real-client-ip-address) for details.
 
 ### SendEarlyHints
 

--- a/req.go
+++ b/req.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"mime/multipart"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -537,9 +538,11 @@ func (r *DefaultReq) Port() string {
 	return port
 }
 
-// IP returns the remote IP address of the request.
-// If ProxyHeader and IP Validation is configured, it will parse that header and return the first valid IP address.
-// Please use Config.TrustProxy to prevent header spoofing if your app is behind a proxy.
+// IP returns the client's IP address. When the request comes from a trusted proxy (see
+// [TrustProxyConfig]), the value is extracted from the configured ProxyHeader by walking the
+// X-Forwarded-For chain right-to-left and skipping all trusted proxy IPs; the first
+// non-trusted IP in the chain is returned. Please use Config.TrustProxy to prevent header
+// spoofing if your app is behind a proxy.
 func (r *DefaultReq) IP() string {
 	app := r.c.app
 	if r.IsProxyTrusted() && app.config.ProxyHeader != "" {
@@ -612,64 +615,72 @@ func (r *DefaultReq) extractIPsFromHeader(header string) []string {
 	return ipsFound
 }
 
-// extractIPFromHeader will attempt to pull the real client IP from the given header when IP validation is enabled.
-// currently, it will return the first valid IP address in header.
-// when IP validation is disabled, it will simply return the value of the header without any inspection.
-// Implementation is almost the same as in extractIPsFromHeader, but without allocation of []string.
+// extractIPFromHeader returns the client IP from the given proxy header by walking the
+// X-Forwarded-For chain from right to left and stripping trusted proxy IPs. When trusted
+// proxies are configured, the rightmost non-trusted IP is returned; otherwise the first
+// valid IP (left-to-right) is returned. When IP validation is disabled, the raw header
+// value is returned as-is.
 func (r *DefaultReq) extractIPFromHeader(header string) string {
 	app := r.c.app
-	if app.config.EnableIPValidation {
-		headerValue := r.Get(header)
 
-		i := 0
-		j := -1
+	if !app.config.EnableIPValidation {
+		return r.Get(app.config.ProxyHeader)
+	}
 
-		for {
-			var v4, v6 bool
-
-			// Manually splitting string without allocating slice, working with parts directly
-			i, j = j+1, j+2
-
-			if j > len(headerValue) {
-				break
-			}
-
-			for j < len(headerValue) && headerValue[j] != ',' {
-				switch headerValue[j] {
-				case ':':
-					v6 = true
-				case '.':
-					v4 = true
-				default:
-					// do nothing
-				}
-				j++
-			}
-
-			for i < j && headerValue[i] == ' ' {
-				i++
-			}
-
-			s := utils.TrimRight(headerValue[i:j], ' ')
-
-			if app.config.EnableIPValidation {
-				if (!v6 && !v4) || (v6 && !utils.IsIPv6(s)) || (v4 && !utils.IsIPv4(s)) {
-					continue
-				}
-			}
-
-			return s
-		}
-
+	ips := r.extractIPsFromHeader(header)
+	if len(ips) == 0 {
 		if ip := r.c.fasthttp.RemoteIP(); ip != nil {
 			return ip.String()
 		}
 		return ""
 	}
 
-	// default behavior if IP validation is not enabled is just to return whatever value is
-	// in the proxy header. Even if it is empty or invalid
-	return r.Get(app.config.ProxyHeader)
+	if !r.hasTrustedProxyConfig() {
+		return ips[0]
+	}
+
+	for _, ip := range slices.Backward(ips) {
+		if !r.isTrustedProxyIP(ip) {
+			return ip
+		}
+	}
+
+	return ips[0]
+}
+
+// hasTrustedProxyConfig returns true if any trusted proxy configuration is set.
+func (r *DefaultReq) hasTrustedProxyConfig() bool {
+	cfg := r.c.app.config.TrustProxyConfig
+	return len(cfg.ips) > 0 || len(cfg.ranges) > 0 || cfg.Loopback || cfg.Private || cfg.LinkLocal
+}
+
+// isTrustedProxyIP checks whether the given IP string matches any configured trusted proxy.
+func (r *DefaultReq) isTrustedProxyIP(ipStr string) bool {
+	cfg := r.c.app.config.TrustProxyConfig
+
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+
+	if cfg.Loopback && ip.IsLoopback() {
+		return true
+	}
+	if cfg.Private && ip.IsPrivate() {
+		return true
+	}
+	if cfg.LinkLocal && ip.IsLinkLocalUnicast() {
+		return true
+	}
+	if _, trusted := cfg.ips[ipStr]; trusted {
+		return true
+	}
+	for _, ipNet := range cfg.ranges {
+		if ipNet.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // IPs returns a string slice of IP addresses specified in the X-Forwarded-For request header.

--- a/req.go
+++ b/req.go
@@ -624,7 +624,7 @@ func (r *DefaultReq) extractIPFromHeader(header string) string {
 	app := r.c.app
 
 	if !app.config.EnableIPValidation {
-		return r.Get(app.config.ProxyHeader)
+		return r.Get(header)
 	}
 
 	ips := r.extractIPsFromHeader(header)
@@ -672,7 +672,7 @@ func (r *DefaultReq) isTrustedProxyIP(ipStr string) bool {
 	if cfg.LinkLocal && ip.IsLinkLocalUnicast() {
 		return true
 	}
-	if _, trusted := cfg.ips[ipStr]; trusted {
+	if _, trusted := cfg.ips[ip.String()]; trusted {
 		return true
 	}
 	for _, ipNet := range cfg.ranges {

--- a/req.go
+++ b/req.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"mime/multipart"
 	"net"
-	"slices"
+	"net/netip"
 	"strconv"
 	"strings"
 
@@ -627,25 +627,64 @@ func (r *DefaultReq) extractIPFromHeader(header string) string {
 		return r.Get(header)
 	}
 
-	ips := r.extractIPsFromHeader(header)
-	if len(ips) == 0 {
-		if ip := r.c.fasthttp.RemoteIP(); ip != nil {
-			return ip.String()
+	headerValue := r.Get(header)
+	hasTrustedProxyConfig := r.hasTrustedProxyConfig()
+	if !hasTrustedProxyConfig {
+		start := 0
+		for {
+			end := start
+			for end < len(headerValue) && headerValue[end] != ',' {
+				end++
+			}
+
+			ipStr := utils.Trim(headerValue[start:end], ' ')
+			if isValidProxyIP(ipStr) {
+				return ipStr
+			}
+			if end == len(headerValue) {
+				break
+			}
+			start = end + 1
 		}
-		return ""
 	}
 
-	if !r.hasTrustedProxyConfig() {
-		return ips[0]
-	}
+	var leftmostIP string
 
-	for _, ip := range slices.Backward(ips) {
-		if !r.isTrustedProxyIP(ip) {
-			return ip
+	for end := len(headerValue); end > 0; {
+		start := end
+		for start > 0 && headerValue[start-1] != ',' {
+			start--
 		}
+
+		ipStr := utils.Trim(headerValue[start:end], ' ')
+		if isValidProxyIP(ipStr) {
+			leftmostIP = ipStr
+			if !r.isTrustedProxyIP(ipStr) {
+				return ipStr
+			}
+		}
+
+		if start == 0 {
+			break
+		}
+		end = start - 1
 	}
 
-	return ips[0]
+	if leftmostIP != "" {
+		return leftmostIP
+	}
+	if ip := r.c.fasthttp.RemoteIP(); ip != nil {
+		return ip.String()
+	}
+	return ""
+}
+
+func isValidProxyIP(ipStr string) bool {
+	hasIPv4Separator := strings.IndexByte(ipStr, '.') >= 0
+	hasIPv6Separator := strings.IndexByte(ipStr, ':') >= 0
+	return (hasIPv4Separator || hasIPv6Separator) &&
+		(!hasIPv4Separator || utils.IsIPv4(ipStr)) &&
+		(!hasIPv6Separator || utils.IsIPv6(ipStr))
 }
 
 // hasTrustedProxyConfig returns true if any trusted proxy configuration is set.
@@ -658,8 +697,8 @@ func (r *DefaultReq) hasTrustedProxyConfig() bool {
 func (r *DefaultReq) isTrustedProxyIP(ipStr string) bool {
 	cfg := r.c.app.config.TrustProxyConfig
 
-	ip := net.ParseIP(ipStr)
-	if ip == nil {
+	ip, err := netip.ParseAddr(ipStr)
+	if err != nil {
 		return false
 	}
 
@@ -672,11 +711,28 @@ func (r *DefaultReq) isTrustedProxyIP(ipStr string) bool {
 	if cfg.LinkLocal && ip.IsLinkLocalUnicast() {
 		return true
 	}
-	if _, trusted := cfg.ips[ip.String()]; trusted {
+
+	var canonicalIP [net.IPv6len * 3]byte
+	if _, trusted := cfg.ips[utils.UnsafeString(ip.AppendTo(canonicalIP[:0]))]; trusted {
 		return true
 	}
+	if len(cfg.ranges) == 0 {
+		return false
+	}
+
+	if ip.Is4() {
+		ipv4 := ip.As4()
+		for _, ipNet := range cfg.ranges {
+			if ipNet.Contains(ipv4[:]) {
+				return true
+			}
+		}
+		return false
+	}
+
+	ipv6 := ip.As16()
 	for _, ipNet := range cfg.ranges {
-		if ipNet.Contains(ip) {
+		if ipNet.Contains(ipv6[:]) {
 			return true
 		}
 	}

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -96,18 +96,25 @@ type Req interface {
 	Hostname() string
 	// Port returns the remote port of the request.
 	Port() string
-	// IP returns the remote IP address of the request.
-	// If ProxyHeader and IP Validation is configured, it will parse that header and return the first valid IP address.
-	// Please use Config.TrustProxy to prevent header spoofing if your app is behind a proxy.
+	// IP returns the client's IP address. When the request comes from a trusted proxy (see
+	// [TrustProxyConfig]), the value is extracted from the configured ProxyHeader by walking the
+	// X-Forwarded-For chain right-to-left and skipping all trusted proxy IPs; the first
+	// non-trusted IP in the chain is returned. Please use Config.TrustProxy to prevent header
+	// spoofing if your app is behind a proxy.
 	IP() string
 	// extractIPsFromHeader will return a slice of IPs it found given a header name in the order they appear.
 	// When IP validation is enabled, any invalid IPs will be omitted.
 	extractIPsFromHeader(header string) []string
-	// extractIPFromHeader will attempt to pull the real client IP from the given header when IP validation is enabled.
-	// currently, it will return the first valid IP address in header.
-	// when IP validation is disabled, it will simply return the value of the header without any inspection.
-	// Implementation is almost the same as in extractIPsFromHeader, but without allocation of []string.
+	// extractIPFromHeader returns the client IP from the given proxy header by walking the
+	// X-Forwarded-For chain from right to left and stripping trusted proxy IPs. When trusted
+	// proxies are configured, the rightmost non-trusted IP is returned; otherwise the first
+	// valid IP (left-to-right) is returned. When IP validation is disabled, the raw header
+	// value is returned as-is.
 	extractIPFromHeader(header string) string
+	// hasTrustedProxyConfig returns true if any trusted proxy configuration is set.
+	hasTrustedProxyConfig() bool
+	// isTrustedProxyIP checks whether the given IP string matches any configured trusted proxy.
+	isTrustedProxyIP(ipStr string) bool
 	// IPs returns a string slice of IP addresses specified in the X-Forwarded-For request header.
 	// When IP validation is enabled, only valid IPs are returned.
 	IPs() []string


### PR DESCRIPTION
## Summary

Fixes #4391

`c.IP()` now correctly walks the `X-Forwarded-For` chain **right-to-left**, stripping all trusted proxy IPs, and returns the first non-trusted IP as the real client IP. Previously it returned the leftmost syntactically valid IP, ignoring the trusted proxy configuration entirely when parsing the header chain.

---

## Problem

When Fiber is deployed behind multiple proxies (e.g., CDN → load balancer → app server), the `X-Forwarded-For` header accumulates entries:

```
X-Forwarded-For: <client>, <proxy1>, <proxy2>, ...
```

Per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For) and common practice, the server should start from the **rightmost** entry and strip known proxy IPs moving left — the first non-trusted IP encountered is the real client.

### Before this fix

`extractIPFromHeader` walked the chain **left-to-right** and returned the **first syntactically valid IP**, completely ignoring `TrustProxyConfig`:

| Scenario | `X-Forwarded-For` | Trusted proxies | `c.IP()` returned |
|----------|-------------------|-----------------|--------------------|
| Multi-proxy | `203.0.113.50, 10.0.0.1, 10.0.0.2` | `10.0.0.0/24` | `203.0.113.50` ✅ (correct by coincidence) |
| Attacker injects | `evil.attacker, 203.0.113.50, 10.0.0.1` | `10.0.0.1` | `evil.attacker` ❌ (spoofed!) |
| All trusted proxies | `10.0.0.1, 10.0.0.2, 10.0.0.3` | `10.0.0.1, .2, .3` | `10.0.0.1` ✅ (lucky) |
| Private chain | `203.0.113.50, 192.168.1.1, 10.0.0.1` | `Private: true` | `203.0.113.50` ✅ (lucky) |
| Without `EnableIPValidation` | `203.0.113.50, 10.0.0.1` | any | `203.0.113.50, 10.0.0.1` ❌ (raw string!) |

The old code **never checked `TrustProxyConfig`** when parsing the header. It simply returned the first IP that passed `IsIPv4()`/`IsIPv6()` validation. An attacker positioned between the client and the first trusted proxy could inject arbitrary IPs that would be treated as the client IP.

---

## What changed

### `req.go`

| Function | Change |
|----------|--------|
| `extractIPFromHeader` | Rewritten: walks chain right-to-left via `slices.Backward`, delegates trust checks to `isTrustedProxyIP`. Falls back to `ips[0]` when all IPs are trusted. |
| `hasTrustedProxyConfig` | **New** — returns `true` when any trust proxy config is set (ips, ranges, loopback, private, link-local). |
| `isTrustedProxyIP` | **New** — checks an IP against all `TrustProxyConfig` sources: exact IP map, CIDR ranges, loopback, private, link-local. |
| `IP()` doc comment | Updated to document the right-to-left walking behavior. |

### Behavior matrix (after fix)

| `EnableIPValidation` | Trusted proxy config | Behavior |
|----------------------|---------------------|----------|
| `false` | any | Returns raw header value (unchanged, backward compat) |
| `true` | none configured | Returns first valid IP left-to-right (unchanged) |
| `true` | configured | **Walks right-to-left, strips trusted, returns first non-trusted** |
| `true` | configured, all IPs trusted | Returns `ips[0]` as fallback |

### `ctx_test.go`

- Updated `Test_Ctx_IP_ProxyHeader_With_IP_Validation` expectations for right-to-left behavior
- Added `Test_Ctx_IP_StripTrustedProxies` — 11 table-driven subtests covering: multi-proxy stripping, CIDR ranges, exact IP, loopback, private, link-local, all-trusted fallback, IPv6 chains
- Added `Test_Ctx_IP_ProxyHeader_NoTrustedProxies`
- Added `Benchmark_Ctx_IP_With_ProxyHeader_Chain` — 3-entry chain with trust stripping

---

## Security analysis

This fix is primarily a **security improvement** that closes an IP spoofing vector:

**Before**: An attacker could inject arbitrary IPs into `X-Forwarded-For`. Since the old code returned the leftmost valid IP without checking trust, any injected value would be accepted as the client IP. This affects rate limiting, IP-based allowlists, geo-blocking, audit logging, and any middleware that relies on `c.IP()`.

**After**: The trust boundary is enforced at two layers:
1. `IsProxyTrusted()` — gates whether the header is used at all (TCP-level remote must be trusted)
2. `isTrustedProxyIP()` — strips chain entries matching trusted proxy config

An attacker **cannot** inject IPs to the right of the last real proxy hop (only the proxies append to the header), so right-to-left stripping is safe against injection.

**Additional hardening**:
- `net.ParseIP` nil check prevents panics on malformed IPs
- Invalid IPs in the chain (when `EnableIPValidation=true`) are filtered by `extractIPsFromHeader` before the trust walk
- When all chain IPs are trusted, falls back to `ips[0]` rather than returning empty — prevents silent data loss

---

## Performance: before vs after

The old `extractIPFromHeader` used a zero-allocation manual parser. The new implementation delegates to `extractIPsFromHeader` (which allocates `[]string`) and then walks the slice right-to-left. This is a deliberate trade-off: **correctness and security over micro-optimization**.

### Benchmarks (after fix)

```
Benchmark_Ctx_IP_With_ProxyHeader                          28.6M ns/op    40.87 ns/op    0 B/op    0 allocs
Benchmark_Ctx_IP_With_ProxyHeader_and_IP_Validation        12.9M ns/op    94.17 ns/op   16 B/op    1 alloc
Benchmark_Ctx_IP_With_ProxyHeader_Chain (3 IPs)             5.3M ns/op   224.60 ns/op   72 B/op    2 allocs   ← NEW
Benchmark_Ctx_IP                                            40.7M ns/op    27.52 ns/op    8 B/op    1 alloc
```

### Impact assessment

| Path | Allocation change | Latency | Affected? |
|------|-------------------|---------|-----------|
| `EnableIPValidation=false` (default) | **None** — unchanged fast path | ~41ns, 0 alloc | ❌ Not affected |
| `EnableIPValidation=true`, no trusted proxies | +16B (1 alloc) for `extractIPsFromHeader` slice | ~94ns | Minor regression |
| `EnableIPValidation=true`, trusted proxies, 3-entry chain | +72B (2 allocs) | ~225ns | Regression but **this path was broken before** |

**Justification**: The old code was **returning the wrong IP** on this path. A ~225ns cost to return the *correct* client IP on a per-request basis is well within production tolerances. The no-validation fast path (the common default) is completely unchanged.

If this becomes a bottleneck in the future, the allocation can be eliminated by reverting to the manual parser approach while keeping the right-to-left logic — but that would require reimplementing the trust check without calling `extractIPsFromHeader`, adding significant complexity.

---

## Checklist

- [x] All tests pass (`make test` — 3473 tests, 1 skip on Windows-only)
- [x] `make lint` — 0 issues
- [x] `make format` — clean
- [x] `make generate` — clean
- [x] `make betteralign` — clean
- [x] `make audit` — only pre-existing Go stdlib CVEs (fixed in Go 1.26.3)
- [x] Benchmarks verified — no regression on unaffected paths
- [x] Backward compatible — `EnableIPValidation=false` behavior unchanged
