### PR TITLE
🔥 feat: unify internal and custom constraints into single interface

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -103,7 +103,20 @@ func newConstraint(handler ConstraintHandler, data []string) *Constraint {
 
 // matchConstraint checks if a parameter value satisfies the constraint.
 func (c *Constraint) matchConstraint(param string) bool {
-	return c.handler.Execute(param, c.Data, c.precompiled)
+	handler := c.handler
+	precompiled := c.precompiled
+	if handler == nil {
+		handler = findConstraintHandler(resolveConstraintName(c.Name), nil)
+		if handler == nil {
+			return true
+		}
+		if analyser, ok := handler.(ConstraintAnalyzer); ok {
+			if pre, err := analyser.Analyze(c.Data); err == nil {
+				precompiled = pre
+			}
+		}
+	}
+	return handler.Execute(param, c.Data, precompiled)
 }
 
 // --- Built-in constraint types ---

--- a/constraint.go
+++ b/constraint.go
@@ -3,6 +3,7 @@ package fiber
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -11,6 +12,58 @@ import (
 
 	"github.com/google/uuid"
 )
+
+type regexMatcher interface {
+	MatchString(s string) bool
+}
+
+var (
+	regexMatcherType = reflect.TypeFor[regexMatcher]()
+	stringType       = reflect.TypeFor[string]()
+)
+
+func isNilRegexMatcher(matcher regexMatcher) bool {
+	if matcher == nil {
+		return true
+	}
+	matcherValue := reflect.ValueOf(matcher)
+	switch matcherValue.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return matcherValue.IsNil()
+	default:
+		return false
+	}
+}
+
+func compileRegex(handler any, pattern string) regexMatcher {
+	result := reflect.ValueOf(handler).Call([]reflect.Value{reflect.ValueOf(pattern)})
+	matcher, ok := result[0].Interface().(regexMatcher)
+	if !ok {
+		panic("fiber: Config.RegexHandler return type must support MatchString(string) bool")
+	}
+	if isNilRegexMatcher(matcher) {
+		panic("fiber: Config.RegexHandler must not return nil")
+	}
+	return matcher
+}
+
+func validateRegexHandler(handler any) any {
+	if handler == nil {
+		return regexp.MustCompile
+	}
+	handlerValue := reflect.ValueOf(handler)
+	handlerType := handlerValue.Type()
+	if handlerType.Kind() != reflect.Func || handlerValue.IsNil() {
+		panic("fiber: Config.RegexHandler must be a non-nil function")
+	}
+	if handlerType.NumIn() != 1 || handlerType.In(0) != stringType || handlerType.NumOut() != 1 {
+		panic("fiber: Config.RegexHandler must have signature func(string) T")
+	}
+	if !handlerType.Out(0).Implements(regexMatcherType) {
+		panic("fiber: Config.RegexHandler return type must support MatchString(string) bool")
+	}
+	return handler
+}
 
 // ConstraintHandler is the interface that all constraints must implement.
 // Built-in and custom constraints are treated uniformly through this interface.
@@ -45,6 +98,10 @@ type customConstraintWrapper struct {
 	CustomConstraint
 }
 
+func (*customConstraintWrapper) Analyze(args []string) ([]any, error) {
+	return stringArgsToAny(parseConstraintArgs(args)), nil
+}
+
 func (w *customConstraintWrapper) Execute(param string, data []any) bool {
 	args := make([]string, len(data))
 	for i, d := range data {
@@ -53,6 +110,28 @@ func (w *customConstraintWrapper) Execute(param string, data []any) bool {
 		}
 	}
 	return w.CustomConstraint.Execute(param, args...)
+}
+
+func stringArgsToAny(args []string) []any {
+	raw := make([]any, len(args))
+	for i, a := range args {
+		raw[i] = a
+	}
+	return raw
+}
+
+func parseConstraintArgs(args []string) []string {
+	if len(args) != 1 {
+		return args
+	}
+	parsed := splitNonEscaped(args[0], paramConstraintDataSeparator)
+	if len(parsed) == 1 {
+		parsed[0] = RemoveEscapeChar(parsed[0])
+	} else if len(parsed) == 2 {
+		parsed[0] = RemoveEscapeChar(parsed[0])
+		parsed[1] = RemoveEscapeChar(parsed[1])
+	}
+	return parsed
 }
 
 // builtinConstraints is the registry of all built-in constraint handlers.
@@ -70,16 +149,18 @@ var builtinConstraints = []ConstraintHandler{
 	minConstraintType{},
 	maxConstraintType{},
 	rangeConstraintType{},
-	regexConstraintType{},
 }
 
 // findConstraintHandler looks up a constraint handler by name from the merged
 // list of custom and built-in constraints. Custom constraints take priority.
-func findConstraintHandler(name string, customs []CustomConstraint) ConstraintHandler {
+func findConstraintHandler(name string, regexHandler any, customs []CustomConstraint) ConstraintHandler {
 	for _, cc := range customs {
 		if cc.Name() == name {
 			return &customConstraintWrapper{CustomConstraint: cc}
 		}
+	}
+	if name == ConstraintRegex {
+		return regexConstraintType{regexHandler: regexHandler}
 	}
 	for _, bc := range builtinConstraints {
 		if bc.Name() == name {
@@ -101,18 +182,10 @@ func newConstraint(handler ConstraintHandler, args []string) *Constraint {
 			c.Data = typed
 		} else {
 			// Store raw strings as fallback for invalid data.
-			raw := make([]any, len(args))
-			for i, a := range args {
-				raw[i] = a
-			}
-			c.Data = raw
+			c.Data = stringArgsToAny(args)
 		}
 	} else {
-		raw := make([]any, len(args))
-		for i, a := range args {
-			raw[i] = a
-		}
-		c.Data = raw
+		c.Data = stringArgsToAny(args)
 	}
 	return c
 }
@@ -122,7 +195,7 @@ func (c *Constraint) matchConstraint(param string) bool {
 	handler := c.handler
 	data := c.Data
 	if handler == nil {
-		handler = findConstraintHandler(resolveConstraintName(c.Name), nil)
+		handler = findConstraintHandler(resolveConstraintName(c.Name), nil, nil)
 		if handler == nil {
 			return true
 		}
@@ -192,6 +265,7 @@ type datetimeConstraintType struct{}
 
 func (datetimeConstraintType) Name() string { return ConstraintDatetime }
 func (datetimeConstraintType) Analyze(args []string) ([]any, error) {
+	args = parseConstraintArgs(args)
 	if len(args) == 0 {
 		return nil, errors.New("datetime constraint requires a layout argument")
 	}
@@ -214,6 +288,7 @@ type minLenConstraintType struct{}
 
 func (minLenConstraintType) Name() string { return ConstraintMinLen }
 func (minLenConstraintType) Analyze(args []string) ([]any, error) {
+	args = parseConstraintArgs(args)
 	if len(args) == 0 {
 		return nil, errors.New("minLen constraint requires an argument")
 	}
@@ -239,6 +314,7 @@ type maxLenConstraintType struct{}
 
 func (maxLenConstraintType) Name() string { return ConstraintMaxLen }
 func (maxLenConstraintType) Analyze(args []string) ([]any, error) {
+	args = parseConstraintArgs(args)
 	if len(args) == 0 {
 		return nil, errors.New("maxLen constraint requires an argument")
 	}
@@ -264,6 +340,7 @@ type lenConstraintType struct{}
 
 func (lenConstraintType) Name() string { return ConstraintLen }
 func (lenConstraintType) Analyze(args []string) ([]any, error) {
+	args = parseConstraintArgs(args)
 	if len(args) == 0 {
 		return nil, errors.New("len constraint requires an argument")
 	}
@@ -289,6 +366,7 @@ type betweenLenConstraintType struct{}
 
 func (betweenLenConstraintType) Name() string { return ConstraintBetweenLen }
 func (betweenLenConstraintType) Analyze(args []string) ([]any, error) {
+	args = parseConstraintArgs(args)
 	if len(args) < 2 {
 		return nil, errors.New("betweenLen constraint requires two arguments")
 	}
@@ -323,6 +401,7 @@ type minConstraintType struct{}
 
 func (minConstraintType) Name() string { return ConstraintMin }
 func (minConstraintType) Analyze(args []string) ([]any, error) {
+	args = parseConstraintArgs(args)
 	if len(args) == 0 {
 		return nil, errors.New("min constraint requires an argument")
 	}
@@ -349,6 +428,7 @@ type maxConstraintType struct{}
 
 func (maxConstraintType) Name() string { return ConstraintMax }
 func (maxConstraintType) Analyze(args []string) ([]any, error) {
+	args = parseConstraintArgs(args)
 	if len(args) == 0 {
 		return nil, errors.New("max constraint requires an argument")
 	}
@@ -375,6 +455,7 @@ type rangeConstraintType struct{}
 
 func (rangeConstraintType) Name() string { return ConstraintRange }
 func (rangeConstraintType) Analyze(args []string) ([]any, error) {
+	args = parseConstraintArgs(args)
 	if len(args) < 2 {
 		return nil, errors.New("range constraint requires two arguments")
 	}
@@ -405,29 +486,35 @@ func (rangeConstraintType) Execute(param string, data []any) bool {
 	return err == nil && num >= lo && num <= hi
 }
 
-type regexConstraintType struct{}
+type regexConstraintType struct {
+	regexHandler any
+}
 
 func (regexConstraintType) Name() string { return ConstraintRegex }
-func (regexConstraintType) Analyze(args []string) ([]any, error) {
+func (r regexConstraintType) Analyze(args []string) ([]any, error) {
 	if len(args) == 0 {
 		return nil, errors.New("regex constraint requires a pattern argument")
 	}
-	re, err := regexp.Compile(args[0])
-	if err != nil {
-		return nil, fmt.Errorf("parse constraint arg: %w", err)
+	if r.regexHandler == nil {
+		re, err := regexp.Compile(args[0])
+		if err != nil {
+			return nil, fmt.Errorf("parse constraint arg: %w", err)
+		}
+		return []any{re}, nil
 	}
-	return []any{re}, nil
+	matcher := compileRegex(r.regexHandler, args[0])
+	return []any{matcher}, nil
 }
 
 func (regexConstraintType) Execute(param string, data []any) bool {
 	if len(data) == 0 {
 		return false
 	}
-	re, ok := data[0].(*regexp.Regexp)
-	if !ok || re == nil {
+	matcher, ok := data[0].(regexMatcher)
+	if !ok || matcher == nil {
 		return false
 	}
-	return re.MatchString(param)
+	return matcher.MatchString(param)
 }
 
 // resolveConstraintName handles case-insensitive and alias matching for constraint names.

--- a/constraint.go
+++ b/constraint.go
@@ -1,0 +1,384 @@
+package fiber
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/google/uuid"
+)
+
+// ConstraintHandler is the interface that all constraints must implement.
+// Built-in and custom constraints are treated uniformly through this interface.
+type ConstraintHandler interface {
+	// Name returns the constraint identifier used in route patterns (e.g. "int", "minLen", "regex").
+	Name() string
+
+	// Execute validates a request parameter value against the constraint.
+	// param is the request parameter value to check.
+	// args are the constraint arguments from the route pattern.
+	// precompiled is data produced by Analyze() at registration time (may be nil).
+	Execute(param string, args []string, precompiled any) bool
+}
+
+// ConstraintAnalyzer is an optional interface that constraints can implement
+// to preprocess data at route registration time. The returned value is stored
+// and passed to Execute() on every request, avoiding repeated parsing.
+type ConstraintAnalyzer interface {
+	// Analyze preprocesses constraint data at route registration time.
+	// Returns an opaque value that will be passed to Execute().
+	Analyze(args []string) (any, error)
+}
+
+// CustomConstraint is the legacy interface for user-defined constraints.
+// It is kept for backward compatibility. CustomConstraint implementations
+// are automatically wrapped to satisfy the ConstraintHandler interface.
+type CustomConstraint interface {
+	Name() string
+	Execute(param string, args ...string) bool
+}
+
+type customConstraintWrapper struct {
+	CustomConstraint
+}
+
+func (w *customConstraintWrapper) Execute(param string, args []string, _ any) bool {
+	return w.CustomConstraint.Execute(param, args...)
+}
+
+// builtinConstraints is the registry of all built-in constraint handlers.
+var builtinConstraints = []ConstraintHandler{
+	intConstraintType{},
+	boolConstraintType{},
+	floatConstraintType{},
+	alphaConstraintType{},
+	datetimeConstraintType{},
+	guidConstraintType{},
+	minLenConstraintType{},
+	maxLenConstraintType{},
+	lenConstraintType{},
+	betweenLenConstraintType{},
+	minConstraintType{},
+	maxConstraintType{},
+	rangeConstraintType{},
+	regexConstraintType{},
+}
+
+// findConstraintHandler looks up a constraint handler by name from the merged
+// list of custom and built-in constraints. Custom constraints take priority.
+func findConstraintHandler(name string, customs []CustomConstraint) ConstraintHandler {
+	for _, cc := range customs {
+		if cc.Name() == name {
+			return &customConstraintWrapper{CustomConstraint: cc}
+		}
+	}
+	for _, bc := range builtinConstraints {
+		if bc.Name() == name {
+			return bc
+		}
+	}
+	return nil
+}
+
+// newConstraint creates a Constraint with the given handler and data,
+// calling Analyze() if the handler implements ConstraintAnalyzer.
+func newConstraint(handler ConstraintHandler, data []string) *Constraint {
+	c := &Constraint{
+		Name:    handler.Name(),
+		Data:    data,
+		handler: handler,
+	}
+	if analyser, ok := handler.(ConstraintAnalyzer); ok {
+		pre, err := analyser.Analyze(data)
+		if err == nil {
+			c.precompiled = pre
+		}
+	}
+	return c
+}
+
+// matchConstraint checks if a parameter value satisfies the constraint.
+func (c *Constraint) matchConstraint(param string) bool {
+	return c.handler.Execute(param, c.Data, c.precompiled)
+}
+
+// --- Built-in constraint types ---
+
+type intConstraintType struct{}
+
+func (intConstraintType) Name() string { return ConstraintInt }
+func (intConstraintType) Execute(param string, _ []string, _ any) bool {
+	_, err := strconv.Atoi(param)
+	return err == nil
+}
+
+type boolConstraintType struct{}
+
+func (boolConstraintType) Name() string { return ConstraintBool }
+func (boolConstraintType) Execute(param string, _ []string, _ any) bool {
+	_, err := strconv.ParseBool(param)
+	return err == nil
+}
+
+type floatConstraintType struct{}
+
+func (floatConstraintType) Name() string { return ConstraintFloat }
+func (floatConstraintType) Execute(param string, _ []string, _ any) bool {
+	_, err := strconv.ParseFloat(param, 32)
+	return err == nil
+}
+
+type alphaConstraintType struct{}
+
+func (alphaConstraintType) Name() string { return ConstraintAlpha }
+func (alphaConstraintType) Execute(param string, _ []string, _ any) bool {
+	for _, r := range param {
+		if !unicode.IsLetter(r) {
+			return false
+		}
+	}
+	return true
+}
+
+type guidConstraintType struct{}
+
+func (guidConstraintType) Name() string { return ConstraintGUID }
+func (guidConstraintType) Execute(param string, _ []string, _ any) bool {
+	_, err := uuid.Parse(param)
+	return err == nil
+}
+
+type datetimeConstraintType struct{}
+
+func (datetimeConstraintType) Name() string { return ConstraintDatetime }
+func (datetimeConstraintType) Analyze(args []string) (any, error) {
+	if len(args) == 0 {
+		return nil, errors.New("datetime constraint requires a layout argument")
+	}
+	return args[0], nil
+}
+
+func (datetimeConstraintType) Execute(param string, _ []string, precompiled any) bool {
+	layout, ok := precompiled.(string)
+	if !ok || layout == "" {
+		return false
+	}
+	_, err := time.Parse(layout, param)
+	return err == nil
+}
+
+type minLenConstraintType struct{}
+
+func (minLenConstraintType) Name() string { return ConstraintMinLen }
+func (minLenConstraintType) Analyze(args []string) (any, error) {
+	if len(args) == 0 {
+		return nil, errors.New("minLen constraint requires an argument")
+	}
+	n, err := strconv.Atoi(args[0])
+	if err != nil {
+		return 0, fmt.Errorf("parse constraint arg: %w", err)
+	}
+	return n, nil
+}
+
+func (minLenConstraintType) Execute(param string, _ []string, precompiled any) bool {
+	limit, ok := precompiled.(int)
+	if !ok {
+		return false
+	}
+	return len(param) >= limit
+}
+
+type maxLenConstraintType struct{}
+
+func (maxLenConstraintType) Name() string { return ConstraintMaxLen }
+func (maxLenConstraintType) Analyze(args []string) (any, error) {
+	if len(args) == 0 {
+		return nil, errors.New("maxLen constraint requires an argument")
+	}
+	n, err := strconv.Atoi(args[0])
+	if err != nil {
+		return 0, fmt.Errorf("parse constraint arg: %w", err)
+	}
+	return n, nil
+}
+
+func (maxLenConstraintType) Execute(param string, _ []string, precompiled any) bool {
+	limit, ok := precompiled.(int)
+	if !ok {
+		return false
+	}
+	return len(param) <= limit
+}
+
+type lenConstraintType struct{}
+
+func (lenConstraintType) Name() string { return ConstraintLen }
+func (lenConstraintType) Analyze(args []string) (any, error) {
+	if len(args) == 0 {
+		return nil, errors.New("len constraint requires an argument")
+	}
+	n, err := strconv.Atoi(args[0])
+	if err != nil {
+		return 0, fmt.Errorf("parse constraint arg: %w", err)
+	}
+	return n, nil
+}
+
+func (lenConstraintType) Execute(param string, _ []string, precompiled any) bool {
+	limit, ok := precompiled.(int)
+	if !ok {
+		return false
+	}
+	return len(param) == limit
+}
+
+type betweenLenPrecompiled struct {
+	lo int
+	hi int
+}
+
+type betweenLenConstraintType struct{}
+
+func (betweenLenConstraintType) Name() string { return ConstraintBetweenLen }
+func (betweenLenConstraintType) Analyze(args []string) (any, error) {
+	if len(args) < 2 {
+		return nil, errors.New("betweenLen constraint requires two arguments")
+	}
+	lo, err := strconv.Atoi(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("parse constraint arg: %w", err)
+	}
+	hi, err := strconv.Atoi(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("parse constraint arg: %w", err)
+	}
+	return betweenLenPrecompiled{lo: lo, hi: hi}, nil
+}
+
+func (betweenLenConstraintType) Execute(param string, _ []string, precompiled any) bool {
+	pre, ok := precompiled.(betweenLenPrecompiled)
+	if !ok {
+		return false
+	}
+	length := len(param)
+	return length >= pre.lo && length <= pre.hi
+}
+
+type minConstraintType struct{}
+
+func (minConstraintType) Name() string { return ConstraintMin }
+func (minConstraintType) Analyze(args []string) (any, error) {
+	if len(args) == 0 {
+		return nil, errors.New("min constraint requires an argument")
+	}
+	n, err := strconv.Atoi(args[0])
+	if err != nil {
+		return 0, fmt.Errorf("parse constraint arg: %w", err)
+	}
+	return n, nil
+}
+
+func (minConstraintType) Execute(param string, _ []string, precompiled any) bool {
+	limit, ok := precompiled.(int)
+	if !ok {
+		return false
+	}
+	num, err := strconv.Atoi(param)
+	return err == nil && num >= limit
+}
+
+type maxConstraintType struct{}
+
+func (maxConstraintType) Name() string { return ConstraintMax }
+func (maxConstraintType) Analyze(args []string) (any, error) {
+	if len(args) == 0 {
+		return nil, errors.New("max constraint requires an argument")
+	}
+	n, err := strconv.Atoi(args[0])
+	if err != nil {
+		return 0, fmt.Errorf("parse constraint arg: %w", err)
+	}
+	return n, nil
+}
+
+func (maxConstraintType) Execute(param string, _ []string, precompiled any) bool {
+	limit, ok := precompiled.(int)
+	if !ok {
+		return false
+	}
+	num, err := strconv.Atoi(param)
+	return err == nil && num <= limit
+}
+
+type rangePrecompiled struct {
+	lo int
+	hi int
+}
+
+type rangeConstraintType struct{}
+
+func (rangeConstraintType) Name() string { return ConstraintRange }
+func (rangeConstraintType) Analyze(args []string) (any, error) {
+	if len(args) < 2 {
+		return nil, errors.New("range constraint requires two arguments")
+	}
+	lo, err := strconv.Atoi(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("parse constraint arg: %w", err)
+	}
+	hi, err := strconv.Atoi(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("parse constraint arg: %w", err)
+	}
+	return rangePrecompiled{lo: lo, hi: hi}, nil
+}
+
+func (rangeConstraintType) Execute(param string, _ []string, precompiled any) bool {
+	pre, ok := precompiled.(rangePrecompiled)
+	if !ok {
+		return false
+	}
+	num, err := strconv.Atoi(param)
+	return err == nil && num >= pre.lo && num <= pre.hi
+}
+
+type regexConstraintType struct{}
+
+func (regexConstraintType) Name() string { return ConstraintRegex }
+func (regexConstraintType) Analyze(args []string) (any, error) {
+	if len(args) == 0 {
+		return nil, errors.New("regex constraint requires a pattern argument")
+	}
+	re, err := regexp.Compile(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("parse constraint arg: %w", err)
+	}
+	return re, nil
+}
+
+func (regexConstraintType) Execute(param string, _ []string, precompiled any) bool {
+	re, ok := precompiled.(*regexp.Regexp)
+	if !ok || re == nil {
+		return false
+	}
+	return re.MatchString(param)
+}
+
+// resolveConstraintName handles case-insensitive and alias matching for constraint names.
+func resolveConstraintName(name string) string {
+	switch strings.ToLower(name) {
+	case "minlen":
+		return ConstraintMinLen
+	case "maxlen":
+		return ConstraintMaxLen
+	case "betweenlen":
+		return ConstraintBetweenLen
+	default:
+		return name
+	}
+}

--- a/constraint.go
+++ b/constraint.go
@@ -99,17 +99,17 @@ type customConstraintWrapper struct {
 }
 
 func (*customConstraintWrapper) Analyze(args []string) ([]any, error) {
-	return stringArgsToAny(parseConstraintArgs(args)), nil
+	parsed := parseConstraintArgs(args)
+	return []any{parsed}, nil
 }
 
 func (w *customConstraintWrapper) Execute(param string, data []any) bool {
-	args := make([]string, len(data))
-	for i, d := range data {
-		if s, ok := d.(string); ok {
-			args[i] = s
+	if len(data) > 0 {
+		if args, ok := data[0].([]string); ok {
+			return w.CustomConstraint.Execute(param, args...)
 		}
 	}
-	return w.CustomConstraint.Execute(param, args...)
+	return w.CustomConstraint.Execute(param)
 }
 
 func stringArgsToAny(args []string) []any {
@@ -125,11 +125,8 @@ func parseConstraintArgs(args []string) []string {
 		return args
 	}
 	parsed := splitNonEscaped(args[0], paramConstraintDataSeparator)
-	if len(parsed) == 1 {
-		parsed[0] = RemoveEscapeChar(parsed[0])
-	} else if len(parsed) == 2 {
-		parsed[0] = RemoveEscapeChar(parsed[0])
-		parsed[1] = RemoveEscapeChar(parsed[1])
+	for i := range parsed {
+		parsed[i] = RemoveEscapeChar(parsed[i])
 	}
 	return parsed
 }
@@ -195,19 +192,27 @@ func (c *Constraint) matchConstraint(param string) bool {
 	handler := c.handler
 	data := c.Data
 	if handler == nil {
-		handler = findConstraintHandler(resolveConstraintName(c.Name), nil, nil)
+		handler = findConstraintHandler(c.Name, nil, nil)
+		if handler == nil {
+			handler = findConstraintHandler(resolveConstraintName(c.Name), nil, nil)
+		}
 		if handler == nil {
 			return true
 		}
+		// Cache the resolved handler for future calls.
+		c.handler = handler
 		if analyser, ok := handler.(ConstraintAnalyzer); ok {
-			// Convert raw string data to typed data.
 			rawArgs := make([]string, len(data))
 			for i, d := range data {
-				if s, ok := d.(string); ok {
-					rawArgs[i] = s
+				switch v := d.(type) {
+				case string:
+					rawArgs[i] = v
+				default:
+					rawArgs[i] = fmt.Sprintf("%v", v)
 				}
 			}
 			if typed, err := analyser.Analyze(rawArgs); err == nil {
+				c.Data = typed
 				data = typed
 			}
 		}
@@ -237,7 +242,7 @@ type floatConstraintType struct{}
 
 func (floatConstraintType) Name() string { return ConstraintFloat }
 func (floatConstraintType) Execute(param string, _ []any) bool {
-	_, err := strconv.ParseFloat(param, 64)
+	_, err := strconv.ParseFloat(param, 32)
 	return err == nil
 }
 

--- a/constraint.go
+++ b/constraint.go
@@ -98,9 +98,12 @@ type customConstraintWrapper struct {
 	CustomConstraint
 }
 
-func (*customConstraintWrapper) Analyze(args []string) ([]any, error) {
-	parsed := parseConstraintArgs(args)
-	return []any{parsed}, nil
+func (w *customConstraintWrapper) Analyze(args []string) ([]any, error) {
+	parsedArgs := parseConstraintArgs(args)
+	if analyzer, ok := w.CustomConstraint.(ConstraintAnalyzer); ok {
+		return analyzer.Analyze(parsedArgs)
+	}
+	return []any{parsedArgs}, nil
 }
 
 func (w *customConstraintWrapper) Execute(param string, data []any) bool {
@@ -169,20 +172,25 @@ func findConstraintHandler(name string, regexHandler any, customs []CustomConstr
 
 // newConstraint creates a Constraint with the given handler and data,
 // calling Analyze() if the handler implements ConstraintAnalyzer.
-func newConstraint(handler ConstraintHandler, args []string) *Constraint {
+// rawName is the constraint name as it appeared in the route pattern (e.g. "minlen").
+func newConstraint(handler ConstraintHandler, rawName string, args []string) *Constraint {
+	canonical := handler.Name()
 	c := &Constraint{
-		Name:    handler.Name(),
+		Name:    rawName,
+		ID:      constraintNameToID[canonical],
 		handler: handler,
+		Data:    args,
 	}
 	if analyser, ok := handler.(ConstraintAnalyzer); ok {
 		if typed, err := analyser.Analyze(args); err == nil {
-			c.Data = typed
-		} else {
-			// Store raw strings as fallback for invalid data.
-			c.Data = stringArgsToAny(args)
+			c.typedData = typed
 		}
-	} else {
-		c.Data = stringArgsToAny(args)
+	}
+	// Populate RegexCompiler for backward compat when using default engine.
+	if canonical == ConstraintRegex && len(c.typedData) > 0 {
+		if re, ok := c.typedData[0].(*regexp.Regexp); ok {
+			c.RegexCompiler = re
+		}
 	}
 	return c
 }
@@ -190,7 +198,6 @@ func newConstraint(handler ConstraintHandler, args []string) *Constraint {
 // matchConstraint validates a parameter against this constraint.
 func (c *Constraint) matchConstraint(param string) bool {
 	handler := c.handler
-	data := c.Data
 	if handler == nil {
 		handler = findConstraintHandler(c.Name, nil, nil)
 		if handler == nil {
@@ -199,25 +206,18 @@ func (c *Constraint) matchConstraint(param string) bool {
 		if handler == nil {
 			return true
 		}
-		// Cache the resolved handler for future calls.
 		c.handler = handler
 		if analyser, ok := handler.(ConstraintAnalyzer); ok {
-			rawArgs := make([]string, len(data))
-			for i, d := range data {
-				switch v := d.(type) {
-				case string:
-					rawArgs[i] = v
-				default:
-					rawArgs[i] = fmt.Sprintf("%v", v)
-				}
-			}
-			if typed, err := analyser.Analyze(rawArgs); err == nil {
-				c.Data = typed
-				data = typed
+			if typed, err := analyser.Analyze(c.Data); err == nil {
+				c.typedData = typed
 			}
 		}
+		c.ID = constraintNameToID[handler.Name()]
 	}
-	return handler.Execute(param, data)
+	if len(c.typedData) > 0 {
+		return handler.Execute(param, c.typedData)
+	}
+	return handler.Execute(param, stringArgsToAny(c.Data))
 }
 
 // --- Built-in constraint types ---
@@ -255,7 +255,7 @@ func (alphaConstraintType) Execute(param string, _ []any) bool {
 			return false
 		}
 	}
-	return param != ""
+	return true
 }
 
 type guidConstraintType struct{}

--- a/constraint.go
+++ b/constraint.go
@@ -20,18 +20,17 @@ type ConstraintHandler interface {
 
 	// Execute validates a request parameter value against the constraint.
 	// param is the request parameter value to check.
-	// args are the constraint arguments from the route pattern.
-	// precompiled is data produced by Analyze() at registration time (may be nil).
-	Execute(param string, args []string, precompiled any) bool
+	// data contains the pre-typed constraint data produced by Analyze() at registration time.
+	Execute(param string, data []any) bool
 }
 
 // ConstraintAnalyzer is an optional interface that constraints can implement
-// to preprocess data at route registration time. The returned value is stored
-// and passed to Execute() on every request, avoiding repeated parsing.
+// to preprocess data at route registration time. The returned values are stored
+// in Constraint.Data and passed to Execute() on every request, avoiding repeated parsing.
 type ConstraintAnalyzer interface {
 	// Analyze preprocesses constraint data at route registration time.
-	// Returns an opaque value that will be passed to Execute().
-	Analyze(args []string) (any, error)
+	// Returns pre-typed values that will be stored in Constraint.Data.
+	Analyze(args []string) ([]any, error)
 }
 
 // CustomConstraint is the legacy interface for user-defined constraints.
@@ -46,7 +45,13 @@ type customConstraintWrapper struct {
 	CustomConstraint
 }
 
-func (w *customConstraintWrapper) Execute(param string, args []string, _ any) bool {
+func (w *customConstraintWrapper) Execute(param string, data []any) bool {
+	args := make([]string, len(data))
+	for i, d := range data {
+		if s, ok := d.(string); ok {
+			args[i] = s
+		}
+	}
 	return w.CustomConstraint.Execute(param, args...)
 }
 
@@ -86,37 +91,55 @@ func findConstraintHandler(name string, customs []CustomConstraint) ConstraintHa
 
 // newConstraint creates a Constraint with the given handler and data,
 // calling Analyze() if the handler implements ConstraintAnalyzer.
-func newConstraint(handler ConstraintHandler, data []string) *Constraint {
+func newConstraint(handler ConstraintHandler, args []string) *Constraint {
 	c := &Constraint{
 		Name:    handler.Name(),
-		Data:    data,
 		handler: handler,
 	}
 	if analyser, ok := handler.(ConstraintAnalyzer); ok {
-		pre, err := analyser.Analyze(data)
-		if err == nil {
-			c.precompiled = pre
+		if typed, err := analyser.Analyze(args); err == nil {
+			c.Data = typed
+		} else {
+			// Store raw strings as fallback for invalid data.
+			raw := make([]any, len(args))
+			for i, a := range args {
+				raw[i] = a
+			}
+			c.Data = raw
 		}
+	} else {
+		raw := make([]any, len(args))
+		for i, a := range args {
+			raw[i] = a
+		}
+		c.Data = raw
 	}
 	return c
 }
 
-// matchConstraint checks if a parameter value satisfies the constraint.
+// matchConstraint validates a parameter against this constraint.
 func (c *Constraint) matchConstraint(param string) bool {
 	handler := c.handler
-	precompiled := c.precompiled
+	data := c.Data
 	if handler == nil {
 		handler = findConstraintHandler(resolveConstraintName(c.Name), nil)
 		if handler == nil {
 			return true
 		}
 		if analyser, ok := handler.(ConstraintAnalyzer); ok {
-			if pre, err := analyser.Analyze(c.Data); err == nil {
-				precompiled = pre
+			// Convert raw string data to typed data.
+			rawArgs := make([]string, len(data))
+			for i, d := range data {
+				if s, ok := d.(string); ok {
+					rawArgs[i] = s
+				}
+			}
+			if typed, err := analyser.Analyze(rawArgs); err == nil {
+				data = typed
 			}
 		}
 	}
-	return handler.Execute(param, c.Data, precompiled)
+	return handler.Execute(param, data)
 }
 
 // --- Built-in constraint types ---
@@ -124,7 +147,7 @@ func (c *Constraint) matchConstraint(param string) bool {
 type intConstraintType struct{}
 
 func (intConstraintType) Name() string { return ConstraintInt }
-func (intConstraintType) Execute(param string, _ []string, _ any) bool {
+func (intConstraintType) Execute(param string, _ []any) bool {
 	_, err := strconv.Atoi(param)
 	return err == nil
 }
@@ -132,7 +155,7 @@ func (intConstraintType) Execute(param string, _ []string, _ any) bool {
 type boolConstraintType struct{}
 
 func (boolConstraintType) Name() string { return ConstraintBool }
-func (boolConstraintType) Execute(param string, _ []string, _ any) bool {
+func (boolConstraintType) Execute(param string, _ []any) bool {
 	_, err := strconv.ParseBool(param)
 	return err == nil
 }
@@ -140,27 +163,27 @@ func (boolConstraintType) Execute(param string, _ []string, _ any) bool {
 type floatConstraintType struct{}
 
 func (floatConstraintType) Name() string { return ConstraintFloat }
-func (floatConstraintType) Execute(param string, _ []string, _ any) bool {
-	_, err := strconv.ParseFloat(param, 32)
+func (floatConstraintType) Execute(param string, _ []any) bool {
+	_, err := strconv.ParseFloat(param, 64)
 	return err == nil
 }
 
 type alphaConstraintType struct{}
 
 func (alphaConstraintType) Name() string { return ConstraintAlpha }
-func (alphaConstraintType) Execute(param string, _ []string, _ any) bool {
-	for _, r := range param {
-		if !unicode.IsLetter(r) {
+func (alphaConstraintType) Execute(param string, _ []any) bool {
+	for _, c := range param {
+		if !unicode.IsLetter(c) {
 			return false
 		}
 	}
-	return true
+	return param != ""
 }
 
 type guidConstraintType struct{}
 
 func (guidConstraintType) Name() string { return ConstraintGUID }
-func (guidConstraintType) Execute(param string, _ []string, _ any) bool {
+func (guidConstraintType) Execute(param string, _ []any) bool {
 	_, err := uuid.Parse(param)
 	return err == nil
 }
@@ -168,15 +191,18 @@ func (guidConstraintType) Execute(param string, _ []string, _ any) bool {
 type datetimeConstraintType struct{}
 
 func (datetimeConstraintType) Name() string { return ConstraintDatetime }
-func (datetimeConstraintType) Analyze(args []string) (any, error) {
+func (datetimeConstraintType) Analyze(args []string) ([]any, error) {
 	if len(args) == 0 {
 		return nil, errors.New("datetime constraint requires a layout argument")
 	}
-	return args[0], nil
+	return []any{args[0]}, nil
 }
 
-func (datetimeConstraintType) Execute(param string, _ []string, precompiled any) bool {
-	layout, ok := precompiled.(string)
+func (datetimeConstraintType) Execute(param string, data []any) bool {
+	if len(data) == 0 {
+		return false
+	}
+	layout, ok := data[0].(string)
 	if !ok || layout == "" {
 		return false
 	}
@@ -187,19 +213,22 @@ func (datetimeConstraintType) Execute(param string, _ []string, precompiled any)
 type minLenConstraintType struct{}
 
 func (minLenConstraintType) Name() string { return ConstraintMinLen }
-func (minLenConstraintType) Analyze(args []string) (any, error) {
+func (minLenConstraintType) Analyze(args []string) ([]any, error) {
 	if len(args) == 0 {
 		return nil, errors.New("minLen constraint requires an argument")
 	}
 	n, err := strconv.Atoi(args[0])
 	if err != nil {
-		return 0, fmt.Errorf("parse constraint arg: %w", err)
+		return nil, fmt.Errorf("parse constraint arg: %w", err)
 	}
-	return n, nil
+	return []any{n}, nil
 }
 
-func (minLenConstraintType) Execute(param string, _ []string, precompiled any) bool {
-	limit, ok := precompiled.(int)
+func (minLenConstraintType) Execute(param string, data []any) bool {
+	if len(data) == 0 {
+		return false
+	}
+	limit, ok := data[0].(int)
 	if !ok {
 		return false
 	}
@@ -209,19 +238,22 @@ func (minLenConstraintType) Execute(param string, _ []string, precompiled any) b
 type maxLenConstraintType struct{}
 
 func (maxLenConstraintType) Name() string { return ConstraintMaxLen }
-func (maxLenConstraintType) Analyze(args []string) (any, error) {
+func (maxLenConstraintType) Analyze(args []string) ([]any, error) {
 	if len(args) == 0 {
 		return nil, errors.New("maxLen constraint requires an argument")
 	}
 	n, err := strconv.Atoi(args[0])
 	if err != nil {
-		return 0, fmt.Errorf("parse constraint arg: %w", err)
+		return nil, fmt.Errorf("parse constraint arg: %w", err)
 	}
-	return n, nil
+	return []any{n}, nil
 }
 
-func (maxLenConstraintType) Execute(param string, _ []string, precompiled any) bool {
-	limit, ok := precompiled.(int)
+func (maxLenConstraintType) Execute(param string, data []any) bool {
+	if len(data) == 0 {
+		return false
+	}
+	limit, ok := data[0].(int)
 	if !ok {
 		return false
 	}
@@ -231,34 +263,32 @@ func (maxLenConstraintType) Execute(param string, _ []string, precompiled any) b
 type lenConstraintType struct{}
 
 func (lenConstraintType) Name() string { return ConstraintLen }
-func (lenConstraintType) Analyze(args []string) (any, error) {
+func (lenConstraintType) Analyze(args []string) ([]any, error) {
 	if len(args) == 0 {
 		return nil, errors.New("len constraint requires an argument")
 	}
 	n, err := strconv.Atoi(args[0])
 	if err != nil {
-		return 0, fmt.Errorf("parse constraint arg: %w", err)
+		return nil, fmt.Errorf("parse constraint arg: %w", err)
 	}
-	return n, nil
+	return []any{n}, nil
 }
 
-func (lenConstraintType) Execute(param string, _ []string, precompiled any) bool {
-	limit, ok := precompiled.(int)
+func (lenConstraintType) Execute(param string, data []any) bool {
+	if len(data) == 0 {
+		return false
+	}
+	limit, ok := data[0].(int)
 	if !ok {
 		return false
 	}
 	return len(param) == limit
 }
 
-type betweenLenPrecompiled struct {
-	lo int
-	hi int
-}
-
 type betweenLenConstraintType struct{}
 
 func (betweenLenConstraintType) Name() string { return ConstraintBetweenLen }
-func (betweenLenConstraintType) Analyze(args []string) (any, error) {
+func (betweenLenConstraintType) Analyze(args []string) ([]any, error) {
 	if len(args) < 2 {
 		return nil, errors.New("betweenLen constraint requires two arguments")
 	}
@@ -270,34 +300,44 @@ func (betweenLenConstraintType) Analyze(args []string) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse constraint arg: %w", err)
 	}
-	return betweenLenPrecompiled{lo: lo, hi: hi}, nil
+	return []any{lo, hi}, nil
 }
 
-func (betweenLenConstraintType) Execute(param string, _ []string, precompiled any) bool {
-	pre, ok := precompiled.(betweenLenPrecompiled)
+func (betweenLenConstraintType) Execute(param string, data []any) bool {
+	if len(data) < 2 {
+		return false
+	}
+	lo, ok := data[0].(int)
+	if !ok {
+		return false
+	}
+	hi, ok := data[1].(int)
 	if !ok {
 		return false
 	}
 	length := len(param)
-	return length >= pre.lo && length <= pre.hi
+	return length >= lo && length <= hi
 }
 
 type minConstraintType struct{}
 
 func (minConstraintType) Name() string { return ConstraintMin }
-func (minConstraintType) Analyze(args []string) (any, error) {
+func (minConstraintType) Analyze(args []string) ([]any, error) {
 	if len(args) == 0 {
 		return nil, errors.New("min constraint requires an argument")
 	}
 	n, err := strconv.Atoi(args[0])
 	if err != nil {
-		return 0, fmt.Errorf("parse constraint arg: %w", err)
+		return nil, fmt.Errorf("parse constraint arg: %w", err)
 	}
-	return n, nil
+	return []any{n}, nil
 }
 
-func (minConstraintType) Execute(param string, _ []string, precompiled any) bool {
-	limit, ok := precompiled.(int)
+func (minConstraintType) Execute(param string, data []any) bool {
+	if len(data) == 0 {
+		return false
+	}
+	limit, ok := data[0].(int)
 	if !ok {
 		return false
 	}
@@ -308,19 +348,22 @@ func (minConstraintType) Execute(param string, _ []string, precompiled any) bool
 type maxConstraintType struct{}
 
 func (maxConstraintType) Name() string { return ConstraintMax }
-func (maxConstraintType) Analyze(args []string) (any, error) {
+func (maxConstraintType) Analyze(args []string) ([]any, error) {
 	if len(args) == 0 {
 		return nil, errors.New("max constraint requires an argument")
 	}
 	n, err := strconv.Atoi(args[0])
 	if err != nil {
-		return 0, fmt.Errorf("parse constraint arg: %w", err)
+		return nil, fmt.Errorf("parse constraint arg: %w", err)
 	}
-	return n, nil
+	return []any{n}, nil
 }
 
-func (maxConstraintType) Execute(param string, _ []string, precompiled any) bool {
-	limit, ok := precompiled.(int)
+func (maxConstraintType) Execute(param string, data []any) bool {
+	if len(data) == 0 {
+		return false
+	}
+	limit, ok := data[0].(int)
 	if !ok {
 		return false
 	}
@@ -328,15 +371,10 @@ func (maxConstraintType) Execute(param string, _ []string, precompiled any) bool
 	return err == nil && num <= limit
 }
 
-type rangePrecompiled struct {
-	lo int
-	hi int
-}
-
 type rangeConstraintType struct{}
 
 func (rangeConstraintType) Name() string { return ConstraintRange }
-func (rangeConstraintType) Analyze(args []string) (any, error) {
+func (rangeConstraintType) Analyze(args []string) ([]any, error) {
 	if len(args) < 2 {
 		return nil, errors.New("range constraint requires two arguments")
 	}
@@ -348,22 +386,29 @@ func (rangeConstraintType) Analyze(args []string) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse constraint arg: %w", err)
 	}
-	return rangePrecompiled{lo: lo, hi: hi}, nil
+	return []any{lo, hi}, nil
 }
 
-func (rangeConstraintType) Execute(param string, _ []string, precompiled any) bool {
-	pre, ok := precompiled.(rangePrecompiled)
+func (rangeConstraintType) Execute(param string, data []any) bool {
+	if len(data) < 2 {
+		return false
+	}
+	lo, ok := data[0].(int)
+	if !ok {
+		return false
+	}
+	hi, ok := data[1].(int)
 	if !ok {
 		return false
 	}
 	num, err := strconv.Atoi(param)
-	return err == nil && num >= pre.lo && num <= pre.hi
+	return err == nil && num >= lo && num <= hi
 }
 
 type regexConstraintType struct{}
 
 func (regexConstraintType) Name() string { return ConstraintRegex }
-func (regexConstraintType) Analyze(args []string) (any, error) {
+func (regexConstraintType) Analyze(args []string) ([]any, error) {
 	if len(args) == 0 {
 		return nil, errors.New("regex constraint requires a pattern argument")
 	}
@@ -371,11 +416,14 @@ func (regexConstraintType) Analyze(args []string) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse constraint arg: %w", err)
 	}
-	return re, nil
+	return []any{re}, nil
 }
 
-func (regexConstraintType) Execute(param string, _ []string, precompiled any) bool {
-	re, ok := precompiled.(*regexp.Regexp)
+func (regexConstraintType) Execute(param string, data []any) bool {
+	if len(data) == 0 {
+		return false
+	}
+	re, ok := data[0].(*regexp.Regexp)
 	if !ok || re == nil {
 		return false
 	}

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -14,7 +14,7 @@ func Test_ConstraintMatchConstraint_NilHandler(t *testing.T) {
 		t.Parallel()
 		c := &Constraint{
 			Name: ConstraintMinLen,
-			Data: []string{"3"},
+			Data: []any{3},
 		}
 		require.True(t, c.matchConstraint("hello"))
 		require.False(t, c.matchConstraint("hi"))
@@ -24,7 +24,7 @@ func Test_ConstraintMatchConstraint_NilHandler(t *testing.T) {
 		t.Parallel()
 		c := &Constraint{
 			Name: "unknownConstraint",
-			Data: []string{"5"},
+			Data: []any{"5"},
 		}
 		require.True(t, c.matchConstraint("anything"))
 	})
@@ -33,7 +33,7 @@ func Test_ConstraintMatchConstraint_NilHandler(t *testing.T) {
 		t.Parallel()
 		c := &Constraint{
 			Name: ConstraintDatetime,
-			Data: []string{"2006-01-02"},
+			Data: []any{"2006-01-02"},
 		}
 		require.True(t, c.matchConstraint("2024-01-15"))
 		require.False(t, c.matchConstraint("not-a-date"))
@@ -99,113 +99,113 @@ func Test_ConstraintExecute_IntConstraint(t *testing.T) {
 	t.Parallel()
 
 	handler := intConstraintType{}
-	require.True(t, handler.Execute("42", nil, nil))
-	require.False(t, handler.Execute("abc", nil, nil))
+	require.True(t, handler.Execute("42", nil))
+	require.False(t, handler.Execute("abc", nil))
 }
 
 func Test_ConstraintExecute_BoolConstraint(t *testing.T) {
 	t.Parallel()
 
 	handler := boolConstraintType{}
-	require.True(t, handler.Execute("true", nil, nil))
-	require.True(t, handler.Execute("false", nil, nil))
-	require.True(t, handler.Execute("1", nil, nil))
-	require.True(t, handler.Execute("0", nil, nil))
-	require.False(t, handler.Execute("maybe", nil, nil))
+	require.True(t, handler.Execute("true", nil))
+	require.True(t, handler.Execute("false", nil))
+	require.True(t, handler.Execute("1", nil))
+	require.True(t, handler.Execute("0", nil))
+	require.False(t, handler.Execute("maybe", nil))
 }
 
 func Test_ConstraintExecute_FloatConstraint(t *testing.T) {
 	t.Parallel()
 
 	handler := floatConstraintType{}
-	require.True(t, handler.Execute("3.14", nil, nil))
-	require.False(t, handler.Execute("abc", nil, nil))
+	require.True(t, handler.Execute("3.14", nil))
+	require.False(t, handler.Execute("abc", nil))
 }
 
 func Test_ConstraintExecute_AlphaConstraint(t *testing.T) {
 	t.Parallel()
 
 	handler := alphaConstraintType{}
-	require.True(t, handler.Execute("hello", nil, nil))
-	require.False(t, handler.Execute("hello123", nil, nil))
+	require.True(t, handler.Execute("hello", nil))
+	require.False(t, handler.Execute("hello123", nil))
 }
 
 func Test_ConstraintExecute_GuidConstraint(t *testing.T) {
 	t.Parallel()
 
 	handler := guidConstraintType{}
-	require.True(t, handler.Execute("12345678-1234-1234-1234-123456789abc", nil, nil))
-	require.False(t, handler.Execute("not-a-guid", nil, nil))
+	require.True(t, handler.Execute("12345678-1234-1234-1234-123456789abc", nil))
+	require.False(t, handler.Execute("not-a-guid", nil))
 }
 
-func Test_ConstraintExecute_DatetimeConstraint_NilPrecompiled(t *testing.T) {
+func Test_ConstraintExecute_DatetimeConstraint_NilData(t *testing.T) {
 	t.Parallel()
 
 	handler := datetimeConstraintType{}
-	require.False(t, handler.Execute("2024-01-15", nil, nil))
+	require.False(t, handler.Execute("2024-01-15", nil))
 }
 
 func Test_ConstraintExecute_DatetimeConstraint_EmptyLayout(t *testing.T) {
 	t.Parallel()
 
 	handler := datetimeConstraintType{}
-	require.False(t, handler.Execute("2024-01-15", nil, ""))
+	require.False(t, handler.Execute("2024-01-15", []any{""}))
 }
 
-func Test_ConstraintExecute_MinLenConstraint_NilPrecompiled(t *testing.T) {
+func Test_ConstraintExecute_MinLenConstraint_NilData(t *testing.T) {
 	t.Parallel()
 
 	handler := minLenConstraintType{}
-	require.False(t, handler.Execute("hello", nil, nil))
+	require.False(t, handler.Execute("hello", nil))
 }
 
-func Test_ConstraintExecute_MaxLenConstraint_NilPrecompiled(t *testing.T) {
+func Test_ConstraintExecute_MaxLenConstraint_NilData(t *testing.T) {
 	t.Parallel()
 
 	handler := maxLenConstraintType{}
-	require.False(t, handler.Execute("hello", nil, nil))
+	require.False(t, handler.Execute("hello", nil))
 }
 
-func Test_ConstraintExecute_LenConstraint_NilPrecompiled(t *testing.T) {
+func Test_ConstraintExecute_LenConstraint_NilData(t *testing.T) {
 	t.Parallel()
 
 	handler := lenConstraintType{}
-	require.False(t, handler.Execute("hello", nil, nil))
+	require.False(t, handler.Execute("hello", nil))
 }
 
-func Test_ConstraintExecute_BetweenLenConstraint_NilPrecompiled(t *testing.T) {
+func Test_ConstraintExecute_BetweenLenConstraint_NilData(t *testing.T) {
 	t.Parallel()
 
 	handler := betweenLenConstraintType{}
-	require.False(t, handler.Execute("hello", nil, nil))
+	require.False(t, handler.Execute("hello", nil))
 }
 
-func Test_ConstraintExecute_MinConstraint_NilPrecompiled(t *testing.T) {
+func Test_ConstraintExecute_MinConstraint_NilData(t *testing.T) {
 	t.Parallel()
 
 	handler := minConstraintType{}
-	require.False(t, handler.Execute("10", nil, nil))
+	require.False(t, handler.Execute("10", nil))
 }
 
-func Test_ConstraintExecute_MaxConstraint_NilPrecompiled(t *testing.T) {
+func Test_ConstraintExecute_MaxConstraint_NilData(t *testing.T) {
 	t.Parallel()
 
 	handler := maxConstraintType{}
-	require.False(t, handler.Execute("10", nil, nil))
+	require.False(t, handler.Execute("10", nil))
 }
 
-func Test_ConstraintExecute_RangeConstraint_NilPrecompiled(t *testing.T) {
+func Test_ConstraintExecute_RangeConstraint_NilData(t *testing.T) {
 	t.Parallel()
 
 	handler := rangeConstraintType{}
-	require.False(t, handler.Execute("5", nil, nil))
+	require.False(t, handler.Execute("5", nil))
 }
 
-func Test_ConstraintExecute_RegexConstraint_NilPrecompiled(t *testing.T) {
+func Test_ConstraintExecute_RegexConstraint_NilData(t *testing.T) {
 	t.Parallel()
 
 	handler := regexConstraintType{}
-	require.False(t, handler.Execute("hello", nil, nil))
+	require.False(t, handler.Execute("hello", nil))
 }
 
 func Test_ConstraintExecute_RegexConstraint_Compiled(t *testing.T) {
@@ -213,23 +213,15 @@ func Test_ConstraintExecute_RegexConstraint_Compiled(t *testing.T) {
 
 	re := regexp.MustCompile(`^\d+$`)
 	handler := regexConstraintType{}
-	require.True(t, handler.Execute("123", nil, re))
-	require.False(t, handler.Execute("abc", nil, re))
+	require.True(t, handler.Execute("123", []any{re}))
+	require.False(t, handler.Execute("abc", []any{re}))
 }
 
-func Test_ConstraintMatchConstraint_WithPrecompiled(t *testing.T) {
+func Test_ConstraintMatchConstraint_WithTypedData(t *testing.T) {
 	t.Parallel()
 
 	handler := minLenConstraintType{}
-	pre, err := handler.Analyze([]string{"3"})
-	require.NoError(t, err)
-
-	c := &Constraint{
-		handler:     handler,
-		precompiled: pre,
-		Name:        ConstraintMinLen,
-		Data:        []string{"3"},
-	}
+	c := newConstraint(handler, []string{"3"})
 	require.True(t, c.matchConstraint("hello"))
 	require.False(t, c.matchConstraint("hi"))
 }
@@ -239,18 +231,9 @@ func Test_ConstraintMatchConstraint_NilHandlerWithAnalyzerError(t *testing.T) {
 
 	c := &Constraint{
 		Name: ConstraintMinLen,
-		Data: []string{"notanumber"},
+		Data: []any{"notanumber"},
 	}
 	require.False(t, c.matchConstraint("hello"))
-}
-
-type testCustomConstraintForCoverage struct {
-	allowed string
-}
-
-func (*testCustomConstraintForCoverage) Name() string { return "customTest" }
-func (t *testCustomConstraintForCoverage) Execute(param string, _ ...string) bool {
-	return param == t.allowed
 }
 
 func Test_FindConstraintHandler_CustomPriority(t *testing.T) {
@@ -274,4 +257,13 @@ func Test_FindConstraintHandler_Unknown(t *testing.T) {
 
 	handler := findConstraintHandler("nonexistent", nil)
 	require.Nil(t, handler)
+}
+
+type testCustomConstraintForCoverage struct {
+	allowed string
+}
+
+func (*testCustomConstraintForCoverage) Name() string { return "customTest" }
+func (t *testCustomConstraintForCoverage) Execute(param string, _ ...string) bool {
+	return param == t.allowed
 }

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -14,7 +14,7 @@ func Test_ConstraintMatchConstraint_NilHandler(t *testing.T) {
 		t.Parallel()
 		c := &Constraint{
 			Name: ConstraintMinLen,
-			Data: []any{3},
+			Data: []string{"3"},
 		}
 		require.True(t, c.matchConstraint("hello"))
 		require.False(t, c.matchConstraint("hi"))
@@ -24,7 +24,7 @@ func Test_ConstraintMatchConstraint_NilHandler(t *testing.T) {
 		t.Parallel()
 		c := &Constraint{
 			Name: "unknownConstraint",
-			Data: []any{"5"},
+			Data: []string{"5"},
 		}
 		require.True(t, c.matchConstraint("anything"))
 	})
@@ -33,7 +33,7 @@ func Test_ConstraintMatchConstraint_NilHandler(t *testing.T) {
 		t.Parallel()
 		c := &Constraint{
 			Name: ConstraintDatetime,
-			Data: []any{"2006-01-02"},
+			Data: []string{"2006-01-02"},
 		}
 		require.True(t, c.matchConstraint("2024-01-15"))
 		require.False(t, c.matchConstraint("not-a-date"))
@@ -127,6 +127,7 @@ func Test_ConstraintExecute_AlphaConstraint(t *testing.T) {
 
 	handler := alphaConstraintType{}
 	require.True(t, handler.Execute("hello", nil))
+	require.True(t, handler.Execute("", nil))
 	require.False(t, handler.Execute("hello123", nil))
 }
 
@@ -221,7 +222,7 @@ func Test_ConstraintMatchConstraint_WithTypedData(t *testing.T) {
 	t.Parallel()
 
 	handler := minLenConstraintType{}
-	c := newConstraint(handler, []string{"3"})
+	c := newConstraint(handler, ConstraintMinLen, []string{"3"})
 	require.True(t, c.matchConstraint("hello"))
 	require.False(t, c.matchConstraint("hi"))
 }
@@ -231,7 +232,7 @@ func Test_ConstraintMatchConstraint_NilHandlerWithAnalyzerError(t *testing.T) {
 
 	c := &Constraint{
 		Name: ConstraintMinLen,
-		Data: []any{"notanumber"},
+		Data: []string{"notanumber"},
 	}
 	require.False(t, c.matchConstraint("hello"))
 }
@@ -266,4 +267,36 @@ type testCustomConstraintForCoverage struct {
 func (*testCustomConstraintForCoverage) Name() string { return "customTest" }
 func (t *testCustomConstraintForCoverage) Execute(param string, _ ...string) bool {
 	return param == t.allowed
+}
+
+type testCustomConstraintWithAnalyzer struct {
+	layout string
+}
+
+func (*testCustomConstraintWithAnalyzer) Name() string { return "customDatetime" }
+func (t *testCustomConstraintWithAnalyzer) Execute(param string, args ...string) bool {
+	return param == t.layout
+}
+func (t *testCustomConstraintWithAnalyzer) Analyze(args []string) ([]any, error) {
+	if len(args) > 0 {
+		t.layout = args[0]
+	}
+	return stringArgsToAny(args), nil
+}
+
+func Test_CustomConstraintWrapper_DelegatesAnalyze(t *testing.T) {
+	t.Parallel()
+
+	custom := &testCustomConstraintWithAnalyzer{}
+	handler := findConstraintHandler("customDatetime", nil, []CustomConstraint{custom})
+	require.NotNil(t, handler)
+
+	analyzer, ok := handler.(ConstraintAnalyzer)
+	require.True(t, ok)
+
+	typed, err := analyzer.Analyze([]string{"2006-01-02"})
+	require.NoError(t, err)
+	require.Len(t, typed, 1)
+	require.Equal(t, "2006-01-02", typed[0])
+	require.Equal(t, "2006-01-02", custom.layout)
 }

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -274,9 +274,10 @@ type testCustomConstraintWithAnalyzer struct {
 }
 
 func (*testCustomConstraintWithAnalyzer) Name() string { return "customDatetime" }
-func (t *testCustomConstraintWithAnalyzer) Execute(param string, args ...string) bool {
+func (t *testCustomConstraintWithAnalyzer) Execute(param string, _ ...string) bool {
 	return param == t.layout
 }
+
 func (t *testCustomConstraintWithAnalyzer) Analyze(args []string) ([]any, error) {
 	if len(args) > 0 {
 		t.layout = args[0]

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -1,0 +1,277 @@
+package fiber
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ConstraintMatchConstraint_NilHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resolves handler from Name", func(t *testing.T) {
+		t.Parallel()
+		c := &Constraint{
+			Name: ConstraintMinLen,
+			Data: []string{"3"},
+		}
+		require.True(t, c.matchConstraint("hello"))
+		require.False(t, c.matchConstraint("hi"))
+	})
+
+	t.Run("returns true for unknown constraint name", func(t *testing.T) {
+		t.Parallel()
+		c := &Constraint{
+			Name: "unknownConstraint",
+			Data: []string{"5"},
+		}
+		require.True(t, c.matchConstraint("anything"))
+	})
+
+	t.Run("resolves datetime handler", func(t *testing.T) {
+		t.Parallel()
+		c := &Constraint{
+			Name: ConstraintDatetime,
+			Data: []string{"2006-01-02"},
+		}
+		require.True(t, c.matchConstraint("2024-01-15"))
+		require.False(t, c.matchConstraint("not-a-date"))
+	})
+}
+
+func Test_ConstraintAnalyze_MissingArgs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		handler ConstraintAnalyzer
+		name    string
+	}{
+		{datetimeConstraintType{}, "datetime"},
+		{minLenConstraintType{}, "minLen"},
+		{maxLenConstraintType{}, "maxLen"},
+		{lenConstraintType{}, "len"},
+		{minConstraintType{}, "min"},
+		{maxConstraintType{}, "max"},
+		{regexConstraintType{}, "regex"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := tc.handler.Analyze([]string{})
+			require.Error(t, err)
+		})
+	}
+}
+
+func Test_ConstraintAnalyze_BetweenLen(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing second arg", func(t *testing.T) {
+		t.Parallel()
+		_, err := betweenLenConstraintType{}.Analyze([]string{"1"})
+		require.Error(t, err)
+	})
+}
+
+func Test_ConstraintAnalyze_Range(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing second arg", func(t *testing.T) {
+		t.Parallel()
+		_, err := rangeConstraintType{}.Analyze([]string{"1"})
+		require.Error(t, err)
+	})
+}
+
+func Test_ConstraintAnalyze_Regex(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid pattern", func(t *testing.T) {
+		t.Parallel()
+		_, err := regexConstraintType{}.Analyze([]string{"("})
+		require.Error(t, err)
+	})
+}
+
+func Test_ConstraintExecute_IntConstraint(t *testing.T) {
+	t.Parallel()
+
+	handler := intConstraintType{}
+	require.True(t, handler.Execute("42", nil, nil))
+	require.False(t, handler.Execute("abc", nil, nil))
+}
+
+func Test_ConstraintExecute_BoolConstraint(t *testing.T) {
+	t.Parallel()
+
+	handler := boolConstraintType{}
+	require.True(t, handler.Execute("true", nil, nil))
+	require.True(t, handler.Execute("false", nil, nil))
+	require.True(t, handler.Execute("1", nil, nil))
+	require.True(t, handler.Execute("0", nil, nil))
+	require.False(t, handler.Execute("maybe", nil, nil))
+}
+
+func Test_ConstraintExecute_FloatConstraint(t *testing.T) {
+	t.Parallel()
+
+	handler := floatConstraintType{}
+	require.True(t, handler.Execute("3.14", nil, nil))
+	require.False(t, handler.Execute("abc", nil, nil))
+}
+
+func Test_ConstraintExecute_AlphaConstraint(t *testing.T) {
+	t.Parallel()
+
+	handler := alphaConstraintType{}
+	require.True(t, handler.Execute("hello", nil, nil))
+	require.False(t, handler.Execute("hello123", nil, nil))
+}
+
+func Test_ConstraintExecute_GuidConstraint(t *testing.T) {
+	t.Parallel()
+
+	handler := guidConstraintType{}
+	require.True(t, handler.Execute("12345678-1234-1234-1234-123456789abc", nil, nil))
+	require.False(t, handler.Execute("not-a-guid", nil, nil))
+}
+
+func Test_ConstraintExecute_DatetimeConstraint_NilPrecompiled(t *testing.T) {
+	t.Parallel()
+
+	handler := datetimeConstraintType{}
+	require.False(t, handler.Execute("2024-01-15", nil, nil))
+}
+
+func Test_ConstraintExecute_DatetimeConstraint_EmptyLayout(t *testing.T) {
+	t.Parallel()
+
+	handler := datetimeConstraintType{}
+	require.False(t, handler.Execute("2024-01-15", nil, ""))
+}
+
+func Test_ConstraintExecute_MinLenConstraint_NilPrecompiled(t *testing.T) {
+	t.Parallel()
+
+	handler := minLenConstraintType{}
+	require.False(t, handler.Execute("hello", nil, nil))
+}
+
+func Test_ConstraintExecute_MaxLenConstraint_NilPrecompiled(t *testing.T) {
+	t.Parallel()
+
+	handler := maxLenConstraintType{}
+	require.False(t, handler.Execute("hello", nil, nil))
+}
+
+func Test_ConstraintExecute_LenConstraint_NilPrecompiled(t *testing.T) {
+	t.Parallel()
+
+	handler := lenConstraintType{}
+	require.False(t, handler.Execute("hello", nil, nil))
+}
+
+func Test_ConstraintExecute_BetweenLenConstraint_NilPrecompiled(t *testing.T) {
+	t.Parallel()
+
+	handler := betweenLenConstraintType{}
+	require.False(t, handler.Execute("hello", nil, nil))
+}
+
+func Test_ConstraintExecute_MinConstraint_NilPrecompiled(t *testing.T) {
+	t.Parallel()
+
+	handler := minConstraintType{}
+	require.False(t, handler.Execute("10", nil, nil))
+}
+
+func Test_ConstraintExecute_MaxConstraint_NilPrecompiled(t *testing.T) {
+	t.Parallel()
+
+	handler := maxConstraintType{}
+	require.False(t, handler.Execute("10", nil, nil))
+}
+
+func Test_ConstraintExecute_RangeConstraint_NilPrecompiled(t *testing.T) {
+	t.Parallel()
+
+	handler := rangeConstraintType{}
+	require.False(t, handler.Execute("5", nil, nil))
+}
+
+func Test_ConstraintExecute_RegexConstraint_NilPrecompiled(t *testing.T) {
+	t.Parallel()
+
+	handler := regexConstraintType{}
+	require.False(t, handler.Execute("hello", nil, nil))
+}
+
+func Test_ConstraintExecute_RegexConstraint_Compiled(t *testing.T) {
+	t.Parallel()
+
+	re := regexp.MustCompile(`^\d+$`)
+	handler := regexConstraintType{}
+	require.True(t, handler.Execute("123", nil, re))
+	require.False(t, handler.Execute("abc", nil, re))
+}
+
+func Test_ConstraintMatchConstraint_WithPrecompiled(t *testing.T) {
+	t.Parallel()
+
+	handler := minLenConstraintType{}
+	pre, err := handler.Analyze([]string{"3"})
+	require.NoError(t, err)
+
+	c := &Constraint{
+		handler:     handler,
+		precompiled: pre,
+		Name:        ConstraintMinLen,
+		Data:        []string{"3"},
+	}
+	require.True(t, c.matchConstraint("hello"))
+	require.False(t, c.matchConstraint("hi"))
+}
+
+func Test_ConstraintMatchConstraint_NilHandlerWithAnalyzerError(t *testing.T) {
+	t.Parallel()
+
+	c := &Constraint{
+		Name: ConstraintMinLen,
+		Data: []string{"notanumber"},
+	}
+	require.False(t, c.matchConstraint("hello"))
+}
+
+type testCustomConstraintForCoverage struct {
+	allowed string
+}
+
+func (*testCustomConstraintForCoverage) Name() string { return "customTest" }
+func (t *testCustomConstraintForCoverage) Execute(param string, _ ...string) bool {
+	return param == t.allowed
+}
+
+func Test_FindConstraintHandler_CustomPriority(t *testing.T) {
+	t.Parallel()
+
+	custom := &testCustomConstraintForCoverage{allowed: "x"}
+	handler := findConstraintHandler("customTest", []CustomConstraint{custom})
+	require.NotNil(t, handler)
+}
+
+func Test_FindConstraintHandler_Builtin(t *testing.T) {
+	t.Parallel()
+
+	handler := findConstraintHandler("int", nil)
+	require.NotNil(t, handler)
+	require.Equal(t, "int", handler.Name())
+}
+
+func Test_FindConstraintHandler_Unknown(t *testing.T) {
+	t.Parallel()
+
+	handler := findConstraintHandler("nonexistent", nil)
+	require.Nil(t, handler)
+}

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -240,14 +240,14 @@ func Test_FindConstraintHandler_CustomPriority(t *testing.T) {
 	t.Parallel()
 
 	custom := &testCustomConstraintForCoverage{allowed: "x"}
-	handler := findConstraintHandler("customTest", []CustomConstraint{custom})
+	handler := findConstraintHandler("customTest", nil, []CustomConstraint{custom})
 	require.NotNil(t, handler)
 }
 
 func Test_FindConstraintHandler_Builtin(t *testing.T) {
 	t.Parallel()
 
-	handler := findConstraintHandler("int", nil)
+	handler := findConstraintHandler("int", nil, nil)
 	require.NotNil(t, handler)
 	require.Equal(t, "int", handler.Name())
 }
@@ -255,7 +255,7 @@ func Test_FindConstraintHandler_Builtin(t *testing.T) {
 func Test_FindConstraintHandler_Unknown(t *testing.T) {
 	t.Parallel()
 
-	handler := findConstraintHandler("nonexistent", nil)
+	handler := findConstraintHandler("nonexistent", nil, nil)
 	require.Nil(t, handler)
 }
 

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -458,6 +458,37 @@ func main() {
 }
 ```
 
+#### ConstraintHandler Interface
+
+In addition to the `CustomConstraint` interface, Fiber v3 provides a more powerful `ConstraintHandler` interface that supports precomputation at route registration time. All built-in constraints implement this interface.
+
+```go
+// ConstraintHandler is the interface that all constraints must implement.
+type ConstraintHandler interface {
+    // Name returns the constraint identifier used in route patterns.
+    Name() string
+
+    // Execute validates a request parameter value against the constraint.
+    // data contains the pre-typed constraint data produced by Analyze().
+    Execute(param string, data []any) bool
+}
+```
+
+Optionally, a constraint can implement `ConstraintAnalyzer` to preprocess data at registration time, avoiding repeated parsing on every request:
+
+```go
+// ConstraintAnalyzer is an optional interface for registration-time precomputation.
+type ConstraintAnalyzer interface {
+    // Analyze preprocesses constraint data at route registration time.
+    // Returns pre-typed values that will be stored in Constraint.Data.
+    Analyze(args []string) ([]any, error)
+}
+```
+
+:::note
+Existing `CustomConstraint` implementations continue to work unchanged. They are automatically wrapped to satisfy `ConstraintHandler`. Custom constraints that also implement `ConstraintAnalyzer` will have their `Analyze` method called at registration time.
+:::
+
 ## Middleware
 
 Functions that are designed to make changes to the request or response are called **middleware functions**. [`c.Next()`](../api/ctx.md#next) passes control to the next handler in the matched chain (middleware or route handler); if a handler returns without calling it, the remaining handlers are skipped.

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -610,6 +610,29 @@ testConfig := fiber.TestConfig{
 }
 ```
 
+### Constraint System
+
+The internal constraint system has been unified into a single `ConstraintHandler` interface. Built-in and custom constraints are now treated uniformly through this interface, with an optional `ConstraintAnalyzer` phase for precomputation at route registration time.
+
+```go
+type ConstraintHandler interface {
+    Name() string
+    Execute(param string, data []any) bool
+}
+
+type ConstraintAnalyzer interface {
+    Analyze(args []string) ([]any, error)
+}
+```
+
+Key improvements:
+
+- **Zero per-request parsing**: `strconv.Atoi`, `time.Parse` layouts, and regex compilation happen once at registration via `Analyze()`, not on every request.
+- **Single dispatch**: The previous `TypeConstraint` bitmask switch has been replaced by a single `handler.Execute()` call.
+- **Backward compatible**: Existing `CustomConstraint` implementations continue to work unchanged. The `CustomConstraint` interface, `RegisterCustomConstraint()` API, and `CheckConstraint()` method are all preserved.
+
+The `TypeConstraint` type, `Constraint.ID`, and `Constraint.RegexCompiler` fields are retained but deprecated.
+
 ## 🧠 Context
 
 ### New Features

--- a/path.go
+++ b/path.go
@@ -14,13 +14,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
-	"unicode"
 
 	"github.com/gofiber/utils/v2"
 	utilsbytes "github.com/gofiber/utils/v2/bytes"
 	utilsstrings "github.com/gofiber/utils/v2/strings"
-	"github.com/google/uuid"
 )
 
 type regexMatcher interface {
@@ -98,7 +95,7 @@ var routerParserPool = &sync.Pool{
 
 // routeSegment holds the segment metadata
 type routeSegment struct {
-	regexMatchers map[*Constraint]regexMatcher
+	regexMatchers map[*Constraint]regexMatcher // preserved for custom RegexHandler compat
 	// const information
 	Const       string        // constant part of the route
 	ParamName   string        // name of the parameter for access to it, for wildcards and plus parameters access iterators starting with 1 are added
@@ -132,54 +129,15 @@ const (
 	paramConstraintDataSeparator byte = ','  // separator of data of type constraint for a parameter
 )
 
-// TypeConstraint parameter constraint types
-type TypeConstraint uint16
-
 // Constraint describes the validation rules that apply to a dynamic route
 // segment when matching incoming requests.
+// See constraint.go for the ConstraintHandler and ConstraintAnalyser interfaces.
 type Constraint struct {
-	RegexCompiler     *regexp.Regexp
-	Name              string
-	Data              []string
-	customConstraints []CustomConstraint
-	ID                TypeConstraint
+	handler     ConstraintHandler
+	precompiled any
+	Name        string
+	Data        []string
 }
-
-// CustomConstraint is an interface for custom constraints
-type CustomConstraint interface {
-	// Name returns the name of the constraint.
-	// This name is used in the constraint matching.
-	Name() string
-
-	// Execute executes the constraint.
-	// It returns true if the constraint is matched and right.
-	// param is the parameter value to check.
-	// args are the constraint arguments.
-	Execute(param string, args ...string) bool
-}
-
-const (
-	noConstraint TypeConstraint = 1 << iota
-	intConstraint
-	boolConstraint
-	floatConstraint
-	alphaConstraint
-	datetimeConstraint
-	guidConstraint
-	minLenConstraint
-	maxLenConstraint
-	lenConstraint
-	betweenLenConstraint
-	minConstraint
-	maxConstraint
-	rangeConstraint
-	regexConstraint
-)
-
-const (
-	needOneData = minLenConstraint | maxLenConstraint | lenConstraint | minConstraint | maxConstraint | datetimeConstraint | regexConstraint
-	needTwoData = betweenLenConstraint | rangeConstraint
-)
 
 // list of possible parameter and segment delimiter
 var (
@@ -475,48 +433,46 @@ func (parser *routeParser) analyseParameterPart(pattern string, regexHandler any
 			start := findNextNonEscapedCharPosition(c, paramConstraintDataStart)
 			end := strings.LastIndexByte(c, paramConstraintDataEnd)
 
-			// Assign constraint
+			var constraintName string
+			var data []string
+
 			if start != -1 && end != -1 {
-				constraint := &Constraint{
-					ID:                getParamConstraintType(c[:start]),
-					Name:              c[:start],
-					customConstraints: customConstraints,
-				}
-
-				// remove escapes from data
-				if constraint.ID != regexConstraint {
-					constraint.Data = splitNonEscaped(c[start+1:end], paramConstraintDataSeparator)
-					if len(constraint.Data) == 1 {
-						constraint.Data[0] = RemoveEscapeChar(constraint.Data[0])
-					} else if len(constraint.Data) == 2 { // This is fine, we simply expect two parts
-						constraint.Data[0] = RemoveEscapeChar(constraint.Data[0])
-						constraint.Data[1] = RemoveEscapeChar(constraint.Data[1])
+				constraintName = resolveConstraintName(c[:start])
+				if constraintName == ConstraintRegex {
+					data = []string{c[start+1 : end]}
+				} else {
+					data = splitNonEscaped(c[start+1:end], paramConstraintDataSeparator)
+					if len(data) == 1 {
+						data[0] = RemoveEscapeChar(data[0])
+					} else if len(data) == 2 {
+						data[0] = RemoveEscapeChar(data[0])
+						data[1] = RemoveEscapeChar(data[1])
 					}
 				}
-
-				// Precompile regex if has regex constraint
-				if constraint.ID == regexConstraint {
-					constraint.Data = []string{c[start+1 : end]}
-					compiler := compileRegex(regexHandler, constraint.Data[0])
-					if regexpCompiler, ok := compiler.(*regexp.Regexp); ok {
-						constraint.RegexCompiler = regexpCompiler
-					} else {
-						if regexMatchers == nil {
-							regexMatchers = make(map[*Constraint]regexMatcher)
-						}
-						regexMatchers[constraint] = compiler
-					}
-				}
-
-				constraints = append(constraints, constraint)
 			} else {
-				constraints = append(constraints, &Constraint{
-					ID:                getParamConstraintType(c),
-					Data:              []string{},
-					Name:              c,
-					customConstraints: customConstraints,
-				})
+				constraintName = resolveConstraintName(c)
+				data = []string{}
 			}
+
+			handler := findConstraintHandler(constraintName, customConstraints)
+			if handler == nil {
+				continue
+			}
+
+			constraint := newConstraint(handler, data)
+
+			// Handle custom RegexHandler for regex constraints
+			if handler.Name() == ConstraintRegex && regexHandler != nil && len(data) > 0 {
+				compiler := compileRegex(regexHandler, data[0])
+				if _, ok := compiler.(*regexp.Regexp); !ok {
+					if regexMatchers == nil {
+						regexMatchers = make(map[*Constraint]regexMatcher)
+					}
+					regexMatchers[constraint] = compiler
+				}
+			}
+
+			constraints = append(constraints, constraint)
 		}
 
 		paramName = RemoveEscapeChar(GetTrimmedParam(pattern[0:paramConstraintStartPosition]))
@@ -755,190 +711,15 @@ func RemoveEscapeCharBytes(word []byte) []byte {
 	return word[:dst]
 }
 
-func getParamConstraintType(constraintPart string) TypeConstraint {
-	switch constraintPart {
-	case ConstraintInt:
-		return intConstraint
-	case ConstraintBool:
-		return boolConstraint
-	case ConstraintFloat:
-		return floatConstraint
-	case ConstraintAlpha:
-		return alphaConstraint
-	case ConstraintGUID:
-		return guidConstraint
-	case ConstraintMinLen, ConstraintMinLenLower:
-		return minLenConstraint
-	case ConstraintMaxLen, ConstraintMaxLenLower:
-		return maxLenConstraint
-	case ConstraintLen:
-		return lenConstraint
-	case ConstraintBetweenLen, ConstraintBetweenLenLower:
-		return betweenLenConstraint
-	case ConstraintMin:
-		return minConstraint
-	case ConstraintMax:
-		return maxConstraint
-	case ConstraintRange:
-		return rangeConstraint
-	case ConstraintDatetime:
-		return datetimeConstraint
-	case ConstraintRegex:
-		return regexConstraint
-	default:
-		return noConstraint
-	}
-}
-
-// CheckConstraint validates if a param matches the given constraint
-// Returns true if the param passes the constraint check, false otherwise
+// CheckConstraint validates if a param matches the given constraint.
+// Kept for backward compatibility with external callers.
 func (c *Constraint) CheckConstraint(param string) bool {
-	// First check if there's a custom constraint with the same name
-	// This allows custom constraints to override built-in constraints
-	for _, cc := range c.customConstraints {
-		if cc.Name() == c.Name {
-			return cc.Execute(param, c.Data...)
-		}
-	}
-
-	var (
-		err error
-		num int
-	)
-
-	// Validate constraint has required data
-	if c.ID&needOneData != 0 && len(c.Data) == 0 {
-		return false
-	}
-
-	if c.ID&needTwoData != 0 && len(c.Data) < 2 {
-		return false
-	}
-
-	switch c.ID {
-	case noConstraint:
-		return true
-	case intConstraint:
-		_, err = strconv.Atoi(param)
-	case boolConstraint:
-		_, err = strconv.ParseBool(param)
-	case floatConstraint:
-		_, err = strconv.ParseFloat(param, 32)
-	case alphaConstraint:
-		for _, r := range param {
-			if !unicode.IsLetter(r) {
-				return false
-			}
-		}
-	case guidConstraint:
-		_, err = uuid.Parse(param)
-	case minLenConstraint:
-		data, parseErr := strconv.Atoi(c.Data[0])
-		if parseErr != nil {
-			return false
-		}
-
-		if len(param) < data {
-			return false
-		}
-	case maxLenConstraint:
-		data, parseErr := strconv.Atoi(c.Data[0])
-		if parseErr != nil {
-			return false
-		}
-
-		if len(param) > data {
-			return false
-		}
-	case lenConstraint:
-		data, parseErr := strconv.Atoi(c.Data[0])
-		if parseErr != nil {
-			return false
-		}
-
-		if len(param) != data {
-			return false
-		}
-	case betweenLenConstraint:
-		data, parseErr := strconv.Atoi(c.Data[0])
-		if parseErr != nil {
-			return false
-		}
-
-		data2, parseErr := strconv.Atoi(c.Data[1])
-		if parseErr != nil {
-			return false
-		}
-
-		length := len(param)
-		if length < data || length > data2 {
-			return false
-		}
-	case minConstraint:
-		data, parseErr := strconv.Atoi(c.Data[0])
-		if parseErr != nil {
-			return false
-		}
-
-		num, err = strconv.Atoi(param)
-
-		if err != nil || num < data {
-			return false
-		}
-	case maxConstraint:
-		data, parseErr := strconv.Atoi(c.Data[0])
-		if parseErr != nil {
-			return false
-		}
-
-		num, err = strconv.Atoi(param)
-
-		if err != nil || num > data {
-			return false
-		}
-	case rangeConstraint:
-		data, parseErr := strconv.Atoi(c.Data[0])
-		if parseErr != nil {
-			return false
-		}
-
-		data2, parseErr := strconv.Atoi(c.Data[1])
-		if parseErr != nil {
-			return false
-		}
-
-		num, err = strconv.Atoi(param)
-
-		if err != nil || num < data || num > data2 {
-			return false
-		}
-	case datetimeConstraint:
-		_, err = time.Parse(c.Data[0], param)
-		if err != nil {
-			return false
-		}
-	case regexConstraint:
-		if c.RegexCompiler == nil {
-			return false
-		}
-		if match := c.RegexCompiler.MatchString(param); !match {
-			return false
-		}
-	default:
-		return false
-	}
-
-	return err == nil
+	return c.matchConstraint(param)
 }
 
 func (segment *routeSegment) checkConstraint(constraint *Constraint, param string) bool {
-	if constraint.ID != regexConstraint {
-		return constraint.CheckConstraint(param)
-	}
-
 	if matcher, ok := segment.regexMatchers[constraint]; ok {
 		return matcher.MatchString(param)
 	}
-
-	return constraint.CheckConstraint(param)
+	return constraint.matchConstraint(param)
 }

--- a/path.go
+++ b/path.go
@@ -133,10 +133,9 @@ const (
 // segment when matching incoming requests.
 // See constraint.go for the ConstraintHandler and ConstraintAnalyser interfaces.
 type Constraint struct {
-	handler     ConstraintHandler
-	precompiled any
-	Name        string
-	Data        []string
+	handler ConstraintHandler
+	Name    string
+	Data    []any
 }
 
 // list of possible parameter and segment delimiter
@@ -465,7 +464,9 @@ func (parser *routeParser) analyseParameterPart(pattern string, regexHandler any
 			if handler.Name() == ConstraintRegex && regexHandler != nil && len(data) > 0 {
 				compiler := compileRegex(regexHandler, data[0])
 				if re, ok := compiler.(*regexp.Regexp); ok {
-					constraint.precompiled = re
+					if len(constraint.Data) > 0 {
+						constraint.Data[0] = re
+					}
 				} else {
 					if regexMatchers == nil {
 						regexMatchers = make(map[*Constraint]regexMatcher)

--- a/path.go
+++ b/path.go
@@ -9,6 +9,7 @@ package fiber
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -67,13 +68,76 @@ const (
 	paramConstraintDataSeparator byte = ','  // separator of data of type constraint for a parameter
 )
 
+// TypeConstraint parameter constraint types.
+//
+// Deprecated: Use the ConstraintHandler interface instead. Retained for
+// backward compatibility with external code that reads or compares IDs.
+type TypeConstraint uint16
+
 // Constraint describes the validation rules that apply to a dynamic route
 // segment when matching incoming requests.
 // See constraint.go for the ConstraintHandler and ConstraintAnalyzer interfaces.
 type Constraint struct {
-	handler ConstraintHandler
-	Name    string
-	Data    []any
+	handler   ConstraintHandler
+	typedData []any
+
+	// RegexCompiler is populated when the constraint is a regex and the
+	// default regexp.Compile engine is used.
+	//
+	// Deprecated: Use the ConstraintHandler interface instead. Retained for
+	// backward compatibility with external code that reads this field.
+	RegexCompiler *regexp.Regexp
+
+	// Name is the raw constraint name as it appeared in the route pattern
+	// (e.g. "minlen", not the canonical "minLen").
+	Name string
+
+	// Data holds the raw parsed constraint arguments from the route pattern.
+	Data []string
+
+	// ID identifies the built-in constraint kind.
+	//
+	// Deprecated: Use the ConstraintHandler interface instead. Retained for
+	// backward compatibility with external code that reads or compares IDs.
+	ID TypeConstraint
+}
+
+// Deprecated: Use the ConstraintHandler interface instead.
+const (
+	noConstraint TypeConstraint = 1 << iota
+	intConstraint
+	boolConstraint
+	floatConstraint
+	alphaConstraint
+	datetimeConstraint
+	guidConstraint
+	minLenConstraint
+	maxLenConstraint
+	lenConstraint
+	betweenLenConstraint
+	minConstraint
+	maxConstraint
+	rangeConstraint
+	regexConstraint
+)
+
+// constraintNameToID maps canonical constraint names to their TypeConstraint ID.
+// Deprecated: retained for populating Constraint.ID for backward compatibility.
+var constraintNameToID = map[string]TypeConstraint{
+	ConstraintInt:        intConstraint,
+	ConstraintBool:       boolConstraint,
+	ConstraintFloat:      floatConstraint,
+	ConstraintAlpha:      alphaConstraint,
+	ConstraintDatetime:   datetimeConstraint,
+	ConstraintGUID:       guidConstraint,
+	ConstraintMinLen:     minLenConstraint,
+	ConstraintMaxLen:     maxLenConstraint,
+	ConstraintLen:        lenConstraint,
+	ConstraintBetweenLen: betweenLenConstraint,
+	ConstraintMin:        minConstraint,
+	ConstraintMax:        maxConstraint,
+	ConstraintRange:      rangeConstraint,
+	ConstraintRegex:      regexConstraint,
 }
 
 // list of possible parameter and segment delimiter
@@ -386,7 +450,7 @@ func (parser *routeParser) analyseParameterPart(pattern string, regexHandler any
 				continue
 			}
 
-			constraint := newConstraint(handler, data)
+			constraint := newConstraint(handler, rawName, data)
 			constraints = append(constraints, constraint)
 		}
 

--- a/path.go
+++ b/path.go
@@ -9,8 +9,6 @@ package fiber
 import (
 	"bytes"
 	"fmt"
-	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,65 +17,6 @@ import (
 	utilsbytes "github.com/gofiber/utils/v2/bytes"
 	utilsstrings "github.com/gofiber/utils/v2/strings"
 )
-
-type regexMatcher interface {
-	// MatchString reports whether the string s contains any match of the regex pattern.
-	MatchString(s string) bool
-}
-
-var (
-	regexMatcherType = reflect.TypeFor[regexMatcher]()
-	stringType       = reflect.TypeFor[string]()
-)
-
-func validateRegexHandler(handler any) any {
-	if handler == nil {
-		return regexp.MustCompile
-	}
-
-	handlerValue := reflect.ValueOf(handler)
-	handlerType := handlerValue.Type()
-
-	if handlerType.Kind() != reflect.Func || handlerValue.IsNil() {
-		panic("fiber: Config.RegexHandler must be a non-nil function")
-	}
-	if handlerType.NumIn() != 1 || handlerType.In(0) != stringType || handlerType.NumOut() != 1 {
-		panic("fiber: Config.RegexHandler must have signature func(string) T")
-	}
-	if !handlerType.Out(0).Implements(regexMatcherType) {
-		panic("fiber: Config.RegexHandler return type must support MatchString(string) bool")
-	}
-
-	return handler
-}
-
-func isNilRegexMatcher(matcher regexMatcher) bool {
-	if matcher == nil {
-		return true
-	}
-
-	matcherValue := reflect.ValueOf(matcher)
-	switch matcherValue.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
-		return matcherValue.IsNil()
-	default:
-		return false
-	}
-}
-
-// compileRegex calls the RegexHandler function and returns a regexMatcher.
-func compileRegex(handler any, pattern string) regexMatcher {
-	result := reflect.ValueOf(handler).Call([]reflect.Value{reflect.ValueOf(pattern)})
-	matcher, ok := result[0].Interface().(regexMatcher)
-	if !ok {
-		panic("fiber: Config.RegexHandler return type must support MatchString(string) bool")
-	}
-	if isNilRegexMatcher(matcher) {
-		panic("fiber: Config.RegexHandler must not return nil")
-	}
-
-	return matcher
-}
 
 // routeParser holds the path segments and param names
 type routeParser struct {
@@ -95,7 +34,6 @@ var routerParserPool = &sync.Pool{
 
 // routeSegment holds the segment metadata
 type routeSegment struct {
-	regexMatchers map[*Constraint]regexMatcher // preserved for custom RegexHandler compat
 	// const information
 	Const       string        // constant part of the route
 	ParamName   string        // name of the parameter for access to it, for wildcards and plus parameters access iterators starting with 1 are added
@@ -418,10 +356,7 @@ func (parser *routeParser) analyseParameterPart(pattern string, regexHandler any
 	paramName := RemoveEscapeChar(GetTrimmedParam(processedPart))
 
 	// Check has constraint
-	var (
-		constraints   []*Constraint
-		regexMatchers map[*Constraint]regexMatcher
-	)
+	var constraints []*Constraint
 
 	if hasConstraint := paramConstraintStartPosition != -1 && paramConstraintEndPosition != -1; hasConstraint {
 		constraintString := pattern[paramConstraintStartPosition+1 : paramConstraintEndPosition]
@@ -437,51 +372,24 @@ func (parser *routeParser) analyseParameterPart(pattern string, regexHandler any
 
 			if start != -1 && end != -1 {
 				constraintName = resolveConstraintName(c[:start])
-				if constraintName == ConstraintRegex {
-					data = []string{c[start+1 : end]}
-				} else {
-					data = splitNonEscaped(c[start+1:end], paramConstraintDataSeparator)
-					if len(data) == 1 {
-						data[0] = RemoveEscapeChar(data[0])
-					} else if len(data) == 2 {
-						data[0] = RemoveEscapeChar(data[0])
-						data[1] = RemoveEscapeChar(data[1])
-					}
-				}
+				data = []string{c[start+1 : end]}
 			} else {
 				constraintName = resolveConstraintName(c)
 				data = []string{}
 			}
 
-			handler := findConstraintHandler(constraintName, customConstraints)
+			handler := findConstraintHandler(constraintName, regexHandler, customConstraints)
 			if handler == nil {
 				continue
 			}
 
 			constraint := newConstraint(handler, data)
-
-			// Handle custom RegexHandler for regex constraints
-			if handler.Name() == ConstraintRegex && regexHandler != nil && len(data) > 0 {
-				compiler := compileRegex(regexHandler, data[0])
-				if re, ok := compiler.(*regexp.Regexp); ok {
-					if len(constraint.Data) > 0 {
-						constraint.Data[0] = re
-					}
-				} else {
-					if regexMatchers == nil {
-						regexMatchers = make(map[*Constraint]regexMatcher)
-					}
-					regexMatchers[constraint] = compiler
-				}
-			}
-
 			constraints = append(constraints, constraint)
 		}
 
 		paramName = RemoveEscapeChar(GetTrimmedParam(pattern[0:paramConstraintStartPosition]))
 	}
 
-	// add access iterator to wildcard and plus
 	if isWildCard {
 		parser.wildCardCount++
 		paramName += strconv.Itoa(parser.wildCardCount)
@@ -499,7 +407,6 @@ func (parser *routeParser) analyseParameterPart(pattern string, regexHandler any
 
 	if len(constraints) > 0 {
 		segment.Constraints = constraints
-		segment.regexMatchers = regexMatchers
 	}
 
 	return n, segment
@@ -578,7 +485,7 @@ func (parser *routeParser) getMatch(detectionPath, path string, params *[maxPara
 			if !segment.IsOptional || i != 0 {
 				// check constraint
 				for _, c := range segment.Constraints {
-					if matched := segment.checkConstraint(c, params[paramsIterator]); !matched {
+					if matched := c.matchConstraint(params[paramsIterator]); !matched {
 						return false
 					}
 				}
@@ -718,11 +625,4 @@ func RemoveEscapeCharBytes(word []byte) []byte {
 // Kept for backward compatibility with external callers.
 func (c *Constraint) CheckConstraint(param string) bool {
 	return c.matchConstraint(param)
-}
-
-func (segment *routeSegment) checkConstraint(constraint *Constraint, param string) bool {
-	if matcher, ok := segment.regexMatchers[constraint]; ok {
-		return matcher.MatchString(param)
-	}
-	return constraint.matchConstraint(param)
 }

--- a/path.go
+++ b/path.go
@@ -69,7 +69,7 @@ const (
 
 // Constraint describes the validation rules that apply to a dynamic route
 // segment when matching incoming requests.
-// See constraint.go for the ConstraintHandler and ConstraintAnalyser interfaces.
+// See constraint.go for the ConstraintHandler and ConstraintAnalyzer interfaces.
 type Constraint struct {
 	handler ConstraintHandler
 	Name    string
@@ -367,18 +367,21 @@ func (parser *routeParser) analyseParameterPart(pattern string, regexHandler any
 			start := findNextNonEscapedCharPosition(c, paramConstraintDataStart)
 			end := strings.LastIndexByte(c, paramConstraintDataEnd)
 
-			var constraintName string
+			var rawName string
 			var data []string
 
 			if start != -1 && end != -1 {
-				constraintName = resolveConstraintName(c[:start])
+				rawName = c[:start]
 				data = []string{c[start+1 : end]}
 			} else {
-				constraintName = resolveConstraintName(c)
+				rawName = c
 				data = []string{}
 			}
 
-			handler := findConstraintHandler(constraintName, regexHandler, customConstraints)
+			handler := findConstraintHandler(rawName, regexHandler, customConstraints)
+			if handler == nil {
+				handler = findConstraintHandler(resolveConstraintName(rawName), regexHandler, customConstraints)
+			}
 			if handler == nil {
 				continue
 			}

--- a/path.go
+++ b/path.go
@@ -464,7 +464,9 @@ func (parser *routeParser) analyseParameterPart(pattern string, regexHandler any
 			// Handle custom RegexHandler for regex constraints
 			if handler.Name() == ConstraintRegex && regexHandler != nil && len(data) > 0 {
 				compiler := compileRegex(regexHandler, data[0])
-				if _, ok := compiler.(*regexp.Regexp); !ok {
+				if re, ok := compiler.(*regexp.Regexp); ok {
+					constraint.precompiled = re
+				} else {
 					if regexMatchers == nil {
 						regexMatchers = make(map[*Constraint]regexMatcher)
 					}

--- a/path.go
+++ b/path.go
@@ -122,6 +122,7 @@ const (
 )
 
 // constraintNameToID maps canonical constraint names to their TypeConstraint ID.
+//
 // Deprecated: retained for populating Constraint.ID for backward compatibility.
 var constraintNameToID = map[string]TypeConstraint{
 	ConstraintInt:        intConstraint,

--- a/path_test.go
+++ b/path_test.go
@@ -376,6 +376,40 @@ func Benchmark_Path_matchParams(t *testing.B) {
 }
 
 // go test -race -run Test_RoutePatternMatch
+func Benchmark_ConstraintExecution(b *testing.B) {
+	var ctxParams [maxParams]string
+
+	constraintPatterns := []struct {
+		name    string
+		pattern string
+		url     string
+	}{
+		{"int", "/api/:id<int>", "/api/12345"},
+		{"bool", "/api/:flag<bool>", "/api/true"},
+		{"float", "/api/:val<float>", "/api/3.14"},
+		{"alpha", "/api/:name<alpha>", "/api/hello"},
+		{"guid", "/api/:id<guid>", "/api/12345678-1234-1234-1234-123456789abc"},
+		{"minLen", "/api/:name<minLen(3)>", "/api/hello"},
+		{"maxLen", "/api/:name<maxLen(10)>", "/api/hello"},
+		{"len", "/api/:name<len(5)>", "/api/hello"},
+		{"betweenLen", "/api/:name<betweenLen(2,10)>", "/api/hello"},
+		{"min", "/api/:id<min(5)>", "/api/10"},
+		{"max", "/api/:id<max(100)>", "/api/10"},
+		{"range", "/api/:id<range(1,20)>", "/api/10"},
+		{"datetime", "/api/:date<datetime(2006-01-02)>", "/api/2024-01-15"},
+		{"regex", "/api/:id<regex(^[0-9]+$)>", "/api/12345"},
+	}
+
+	for _, tc := range constraintPatterns {
+		b.Run(tc.name, func(b *testing.B) {
+			parser := parseRoute(tc.pattern, regexp.MustCompile)
+			for b.Loop() {
+				parser.getMatch(tc.url, tc.url, &ctxParams, false)
+			}
+		})
+	}
+}
+
 func Benchmark_RoutePatternMatch(t *testing.B) {
 	benchCaseFn := func(testCollection routeCaseCollection) {
 		for _, c := range testCollection.testCases {

--- a/path_test.go
+++ b/path_test.go
@@ -271,47 +271,47 @@ func Test_ConstraintCheckConstraint_InvalidMetadata(t *testing.T) {
 	}{
 		{
 			name:       "minLen invalid metadata",
-			constraint: *newConstraint(minLenConstraintType{}, []string{"abc"}),
+			constraint: *newConstraint(minLenConstraintType{}, ConstraintMinLen, []string{"abc"}),
 			param:      "abcd",
 		},
 		{
 			name:       "maxLen invalid metadata",
-			constraint: *newConstraint(maxLenConstraintType{}, []string{"abc"}),
+			constraint: *newConstraint(maxLenConstraintType{}, ConstraintMaxLen, []string{"abc"}),
 			param:      "abcd",
 		},
 		{
 			name:       "len invalid metadata",
-			constraint: *newConstraint(lenConstraintType{}, []string{"abc"}),
+			constraint: *newConstraint(lenConstraintType{}, ConstraintLen, []string{"abc"}),
 			param:      "abcd",
 		},
 		{
 			name:       "betweenLen invalid first metadata",
-			constraint: *newConstraint(betweenLenConstraintType{}, []string{"abc", "5"}),
+			constraint: *newConstraint(betweenLenConstraintType{}, ConstraintBetweenLen, []string{"abc", "5"}),
 			param:      "abcd",
 		},
 		{
 			name:       "betweenLen invalid second metadata",
-			constraint: *newConstraint(betweenLenConstraintType{}, []string{"1", "abc"}),
+			constraint: *newConstraint(betweenLenConstraintType{}, ConstraintBetweenLen, []string{"1", "abc"}),
 			param:      "abcd",
 		},
 		{
 			name:       "min invalid metadata",
-			constraint: *newConstraint(minConstraintType{}, []string{"abc"}),
+			constraint: *newConstraint(minConstraintType{}, ConstraintMin, []string{"abc"}),
 			param:      "10",
 		},
 		{
 			name:       "max invalid metadata",
-			constraint: *newConstraint(maxConstraintType{}, []string{"abc"}),
+			constraint: *newConstraint(maxConstraintType{}, ConstraintMax, []string{"abc"}),
 			param:      "10",
 		},
 		{
 			name:       "range invalid first metadata",
-			constraint: *newConstraint(rangeConstraintType{}, []string{"abc", "10"}),
+			constraint: *newConstraint(rangeConstraintType{}, ConstraintRange, []string{"abc", "10"}),
 			param:      "7",
 		},
 		{
 			name:       "range invalid second metadata",
-			constraint: *newConstraint(rangeConstraintType{}, []string{"1", "abc"}),
+			constraint: *newConstraint(rangeConstraintType{}, ConstraintRange, []string{"1", "abc"}),
 			param:      "7",
 		},
 	}
@@ -327,7 +327,7 @@ func Test_ConstraintCheckConstraint_InvalidMetadata(t *testing.T) {
 func Test_ConstraintCheckConstraint_NilRegexMatcher(t *testing.T) {
 	t.Parallel()
 
-	constraint := *newConstraint(regexConstraintType{}, []string{"("})
+	constraint := *newConstraint(regexConstraintType{}, ConstraintRegex, []string{"("})
 
 	require.NotPanics(t, func() {
 		require.False(t, constraint.CheckConstraint("123"))
@@ -626,10 +626,7 @@ func Test_RegexHandler_DefaultCompilerPreservesConstraintField(t *testing.T) {
 	parser := parseRoute("/api/:id<regex(\\d+)>", regexp.MustCompile)
 	require.Len(t, parser.segs, 2)
 	require.Len(t, parser.segs[1].Constraints, 1)
-	require.NotNil(t, parser.segs[1].Constraints[0].Data)
-	require.Len(t, parser.segs[1].Constraints[0].Data, 1)
-	_, ok := parser.segs[1].Constraints[0].Data[0].(*regexp.Regexp)
-	require.True(t, ok)
+	require.NotNil(t, parser.segs[1].Constraints[0].RegexCompiler)
 	require.True(t, parser.segs[1].Constraints[0].matchConstraint("123"))
 	require.False(t, parser.segs[1].Constraints[0].matchConstraint("abc"))
 }
@@ -642,9 +639,6 @@ func Test_RegexHandler_CustomCompilerUsesSegmentMatcher(t *testing.T) {
 	})
 	require.Len(t, parser.segs, 2)
 	require.Len(t, parser.segs[1].Constraints, 1)
-	require.NotNil(t, parser.segs[1].Constraints[0].Data)
-	_, ok := parser.segs[1].Constraints[0].Data[0].(*matchOnlyRegexCompiler)
-	require.True(t, ok)
 	require.True(t, parser.segs[1].Constraints[0].matchConstraint("123"))
 	require.False(t, parser.segs[1].Constraints[0].matchConstraint("abc"))
 }

--- a/path_test.go
+++ b/path_test.go
@@ -271,47 +271,47 @@ func Test_ConstraintCheckConstraint_InvalidMetadata(t *testing.T) {
 	}{
 		{
 			name:       "minLen invalid metadata",
-			constraint: Constraint{ID: minLenConstraint, Data: []string{"abc"}},
+			constraint: *newConstraint(minLenConstraintType{}, []string{"abc"}),
 			param:      "abcd",
 		},
 		{
 			name:       "maxLen invalid metadata",
-			constraint: Constraint{ID: maxLenConstraint, Data: []string{"abc"}},
+			constraint: *newConstraint(maxLenConstraintType{}, []string{"abc"}),
 			param:      "abcd",
 		},
 		{
 			name:       "len invalid metadata",
-			constraint: Constraint{ID: lenConstraint, Data: []string{"abc"}},
+			constraint: *newConstraint(lenConstraintType{}, []string{"abc"}),
 			param:      "abcd",
 		},
 		{
 			name:       "betweenLen invalid first metadata",
-			constraint: Constraint{ID: betweenLenConstraint, Data: []string{"abc", "5"}},
+			constraint: *newConstraint(betweenLenConstraintType{}, []string{"abc", "5"}),
 			param:      "abcd",
 		},
 		{
 			name:       "betweenLen invalid second metadata",
-			constraint: Constraint{ID: betweenLenConstraint, Data: []string{"1", "abc"}},
+			constraint: *newConstraint(betweenLenConstraintType{}, []string{"1", "abc"}),
 			param:      "abcd",
 		},
 		{
 			name:       "min invalid metadata",
-			constraint: Constraint{ID: minConstraint, Data: []string{"abc"}},
+			constraint: *newConstraint(minConstraintType{}, []string{"abc"}),
 			param:      "10",
 		},
 		{
 			name:       "max invalid metadata",
-			constraint: Constraint{ID: maxConstraint, Data: []string{"abc"}},
+			constraint: *newConstraint(maxConstraintType{}, []string{"abc"}),
 			param:      "10",
 		},
 		{
 			name:       "range invalid first metadata",
-			constraint: Constraint{ID: rangeConstraint, Data: []string{"abc", "10"}},
+			constraint: *newConstraint(rangeConstraintType{}, []string{"abc", "10"}),
 			param:      "7",
 		},
 		{
 			name:       "range invalid second metadata",
-			constraint: Constraint{ID: rangeConstraint, Data: []string{"1", "abc"}},
+			constraint: *newConstraint(rangeConstraintType{}, []string{"1", "abc"}),
 			param:      "7",
 		},
 	}
@@ -327,7 +327,7 @@ func Test_ConstraintCheckConstraint_InvalidMetadata(t *testing.T) {
 func Test_ConstraintCheckConstraint_NilRegexMatcher(t *testing.T) {
 	t.Parallel()
 
-	constraint := Constraint{ID: regexConstraint, RegexCompiler: (*regexp.Regexp)(nil)}
+	constraint := *newConstraint(regexConstraintType{}, []string{"("})
 
 	require.NotPanics(t, func() {
 		require.False(t, constraint.CheckConstraint("123"))
@@ -590,7 +590,7 @@ func Test_RegexHandler_DefaultCompilerPreservesConstraintField(t *testing.T) {
 	parser := parseRoute("/api/:id<regex(\\d+)>", regexp.MustCompile)
 	require.Len(t, parser.segs, 2)
 	require.Len(t, parser.segs[1].Constraints, 1)
-	require.NotNil(t, parser.segs[1].Constraints[0].RegexCompiler)
+	require.NotNil(t, parser.segs[1].Constraints[0].precompiled)
 	require.Nil(t, parser.segs[1].regexMatchers)
 }
 
@@ -602,7 +602,7 @@ func Test_RegexHandler_CustomCompilerUsesSegmentMatcher(t *testing.T) {
 	})
 	require.Len(t, parser.segs, 2)
 	require.Len(t, parser.segs[1].Constraints, 1)
-	require.Nil(t, parser.segs[1].Constraints[0].RegexCompiler)
+	require.NotNil(t, parser.segs[1].Constraints[0].precompiled)
 	require.Len(t, parser.segs[1].regexMatchers, 1)
 	require.True(t, parser.segs[1].checkConstraint(parser.segs[1].Constraints[0], "123"))
 	require.False(t, parser.segs[1].checkConstraint(parser.segs[1].Constraints[0], "abc"))

--- a/path_test.go
+++ b/path_test.go
@@ -628,7 +628,8 @@ func Test_RegexHandler_DefaultCompilerPreservesConstraintField(t *testing.T) {
 	require.Len(t, parser.segs[1].Constraints[0].Data, 1)
 	_, ok := parser.segs[1].Constraints[0].Data[0].(*regexp.Regexp)
 	require.True(t, ok)
-	require.Nil(t, parser.segs[1].regexMatchers)
+	require.True(t, parser.segs[1].Constraints[0].matchConstraint("123"))
+	require.False(t, parser.segs[1].Constraints[0].matchConstraint("abc"))
 }
 
 func Test_RegexHandler_CustomCompilerUsesSegmentMatcher(t *testing.T) {
@@ -640,9 +641,10 @@ func Test_RegexHandler_CustomCompilerUsesSegmentMatcher(t *testing.T) {
 	require.Len(t, parser.segs, 2)
 	require.Len(t, parser.segs[1].Constraints, 1)
 	require.NotNil(t, parser.segs[1].Constraints[0].Data)
-	require.Len(t, parser.segs[1].regexMatchers, 1)
-	require.True(t, parser.segs[1].checkConstraint(parser.segs[1].Constraints[0], "123"))
-	require.False(t, parser.segs[1].checkConstraint(parser.segs[1].Constraints[0], "abc"))
+	_, ok := parser.segs[1].Constraints[0].Data[0].(*matchOnlyRegexCompiler)
+	require.True(t, ok)
+	require.True(t, parser.segs[1].Constraints[0].matchConstraint("123"))
+	require.False(t, parser.segs[1].Constraints[0].matchConstraint("abc"))
 }
 
 // Test_RoutePatternMatch_WithRegex verifies RoutePatternMatch works with regex constraints

--- a/path_test.go
+++ b/path_test.go
@@ -378,6 +378,7 @@ func Benchmark_Path_matchParams(t *testing.B) {
 // go test -race -run Test_RoutePatternMatch
 func Benchmark_ConstraintExecution(b *testing.B) {
 	var ctxParams [maxParams]string
+	var match bool
 
 	constraintPatterns := []struct {
 		name    string
@@ -404,10 +405,11 @@ func Benchmark_ConstraintExecution(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			parser := parseRoute(tc.pattern, regexp.MustCompile)
 			for b.Loop() {
-				parser.getMatch(tc.url, tc.url, &ctxParams, false)
+				match = parser.getMatch(tc.url, tc.url, &ctxParams, false)
 			}
 		})
 	}
+	_ = match
 }
 
 func Benchmark_RoutePatternMatch(t *testing.B) {

--- a/path_test.go
+++ b/path_test.go
@@ -624,7 +624,10 @@ func Test_RegexHandler_DefaultCompilerPreservesConstraintField(t *testing.T) {
 	parser := parseRoute("/api/:id<regex(\\d+)>", regexp.MustCompile)
 	require.Len(t, parser.segs, 2)
 	require.Len(t, parser.segs[1].Constraints, 1)
-	require.NotNil(t, parser.segs[1].Constraints[0].precompiled)
+	require.NotNil(t, parser.segs[1].Constraints[0].Data)
+	require.Len(t, parser.segs[1].Constraints[0].Data, 1)
+	_, ok := parser.segs[1].Constraints[0].Data[0].(*regexp.Regexp)
+	require.True(t, ok)
 	require.Nil(t, parser.segs[1].regexMatchers)
 }
 
@@ -636,7 +639,7 @@ func Test_RegexHandler_CustomCompilerUsesSegmentMatcher(t *testing.T) {
 	})
 	require.Len(t, parser.segs, 2)
 	require.Len(t, parser.segs[1].Constraints, 1)
-	require.NotNil(t, parser.segs[1].Constraints[0].precompiled)
+	require.NotNil(t, parser.segs[1].Constraints[0].Data)
 	require.Len(t, parser.segs[1].regexMatchers, 1)
 	require.True(t, parser.segs[1].checkConstraint(parser.segs[1].Constraints[0], "123"))
 	require.False(t, parser.segs[1].checkConstraint(parser.segs[1].Constraints[0], "abc"))


### PR DESCRIPTION
## Summary

Unifies the internal constraint system (TypeConstraint bitmask + switch) and the custom constraint interface (`CustomConstraint`) into a single `ConstraintHandler` interface with an optional analysis phase for precomputation at route registration time.

Closes #4395

## Changes

### New file: `constraint.go`
- `ConstraintHandler` interface: `Name() string` + `Execute(param string, data []any) bool`
- `ConstraintAnalyzer` interface (optional): `Analyze(args []string) ([]any, error)` for precomputation at registration time
- Each built-in constraint is now its own type: `intConstraintType`, `minLenConstraintType`, `regexConstraintType`, etc.
- `customConstraintWrapper` adapts existing `CustomConstraint` implementations automatically and delegates `Analyze()` when the wrapped constraint also implements `ConstraintAnalyzer`
- `findConstraintHandler()` merges custom and built-in constraints; custom constraints take priority, and lookup uses the raw name first so customs can also override alias forms like `minlen`
- `newConstraint()` creates a `Constraint` and calls `Analyze()` when implemented, storing the pre-typed result in the unexported `typedData` field; on analysis errors it falls back to the raw string args at match time
- `matchConstraint()` resolves and caches the handler for manually constructed `Constraint` values (nil handler) and re-runs `Analyze()` directly on the raw `Data` strings
- The regex constraint honors a custom `Config.RegexHandler`; the compiled matcher is stored in `Constraint.typedData` (and mirrored into the deprecated `RegexCompiler` field when the default engine is used)

### Modified: `path.go`
- Removed the `getParamConstraintType()` helper and the ~130-line constraint switch, replaced by a single `handler.Execute()` dispatch
- `analyseParameterPart()` uses `findConstraintHandler()` + `newConstraint()`
- `CheckConstraint()` method kept as a thin wrapper for external callers
- `Constraint` struct gains an unexported `handler` and `typedData []any`; the existing `Name`, `Data`, `ID`, and `RegexCompiler` fields are retained (see Compatibility)

### Tests
- `constraint_test.go` covers handler lookup, analysis, wrapper, and regex handler paths
- `path_test.go` updated to `newConstraint()`; `Benchmark_ConstraintExecution` added covering all built-in constraints

## Performance impact
- Zero per-request parsing: `strconv.Atoi`, `time.Parse` layout, and regex compilation happen once at registration via `Analyze()`
- Single dispatch: replaces the TypeConstraint switch plus custom constraint iteration with one `Execute()` call
- 0 allocations on both branches; geomean roughly on par with `main`

## Compatibility

This rework is fully backward compatible. There are no breaking changes to the exported API.

Preserved:
- `CustomConstraint` interface (auto-wrapped via `customConstraintWrapper`)
- `CheckConstraint()` method for external callers
- `RegisterCustomConstraint()` API
- Route pattern syntax (`:param<constraint(data)>`)
- `Constraint.Data` keeps its `[]string` type (raw parsed args); pre-typed values live in the new unexported `typedData` field
- `Constraint.RegexCompiler` retained (populated for the default regex engine), marked `Deprecated:`
- `Constraint.ID` and the `TypeConstraint` type with its constants retained, marked `Deprecated:`

Deprecated (still functional, scheduled for removal in a future major version):
- `Constraint.ID` / `TypeConstraint`
- `Constraint.RegexCompiler`

Prefer the `ConstraintHandler` interface over reading `ID` or `RegexCompiler` directly.
