### PR TITLE
🐛 bug: guard typed-nil errors

### DIFF
--- a/app.go
+++ b/app.go
@@ -30,6 +30,7 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/gofiber/fiber/v3/binder"
+	"github.com/gofiber/fiber/v3/internal/nilerror"
 	"github.com/gofiber/fiber/v3/log"
 )
 
@@ -618,6 +619,10 @@ var httpReadResponse = http.ReadResponse
 
 // DefaultErrorHandler that process return errors from handlers
 func DefaultErrorHandler(c Ctx, err error) error {
+	if nilerror.IsNil(err) {
+		err = nil
+	}
+
 	code := StatusInternalServerError
 	var e *Error
 	matched := errors.As(err, &e)

--- a/app_test.go
+++ b/app_test.go
@@ -37,6 +37,14 @@ import (
 	"github.com/valyala/fasthttp/fasthttputil"
 )
 
+type typedNilHandlerError struct {
+	message string
+}
+
+func (e *typedNilHandlerError) Error() string {
+	return e.message
+}
+
 type fileView struct {
 	path    string
 	content string
@@ -638,6 +646,21 @@ func Test_DefaultErrorHandler_TypedNilFiberError(t *testing.T) {
 	t.Cleanup(func() { app.ReleaseCtx(c) })
 
 	var err *Error
+	require.NotPanics(t, func() {
+		require.NoError(t, DefaultErrorHandler(c, err))
+	})
+	require.Equal(t, StatusInternalServerError, c.fasthttp.Response.StatusCode())
+	require.Equal(t, utils.StatusMessage(StatusInternalServerError), string(c.fasthttp.Response.Body()))
+}
+
+func Test_DefaultErrorHandler_TypedNilCustomError(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	var err *typedNilHandlerError
 	require.NotPanics(t, func() {
 		require.NoError(t, DefaultErrorHandler(c, err))
 	})

--- a/bind.go
+++ b/bind.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/gofiber/fiber/v3/binder"
+	"github.com/gofiber/fiber/v3/internal/nilerror"
 	"github.com/gofiber/schema"
 	"github.com/gofiber/utils/v2"
 	utilsbytes "github.com/gofiber/utils/v2/bytes"
@@ -158,7 +159,7 @@ func (b *Bind) SkipValidation(skip bool) *Bind {
 
 // Check WithAutoHandling/WithoutAutoHandling errors and return it by usage.
 func (b *Bind) returnErr(err error) error {
-	if err == nil {
+	if nilerror.IsNil(err) {
 		return nil
 	}
 

--- a/bind_test.go
+++ b/bind_test.go
@@ -25,6 +25,14 @@ import (
 
 const helloWorld = "hello world"
 
+type typedNilBindError struct {
+	message string
+}
+
+func (e *typedNilBindError) Error() string {
+	return e.message
+}
+
 // go test -run Test_returnErr -v
 func Test_returnErr(t *testing.T) {
 	app := New()
@@ -43,6 +51,19 @@ func Test_returnErr_TypedNilFiberError(t *testing.T) {
 
 	var err *Error
 	require.NoError(t, c.Bind().WithAutoHandling().returnErr(err))
+}
+
+func Test_returnErr_TypedNilCustomError(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	var err *typedNilBindError
+	require.NotPanics(t, func() {
+		require.NoError(t, c.Bind().WithAutoHandling().returnErr(err))
+	})
 }
 
 func Test_returnBindErr_TypedNilFiberError(t *testing.T) {

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -160,14 +160,14 @@ type Ctx interface {
 	// Abandon marks this context as abandoned. An abandoned context will not be
 	// returned to the pool when ReleaseCtx is called.
 	//
-	// This is used by the timeout middleware to return immediately while the
-	// handler goroutine continues using the context safely.
+	// This is used by the timeout and SSE middlewares to return immediately while a
+	// goroutine continues using the context safely.
 	//
 	// Only call ForceRelease after Abandon if you can guarantee no other goroutine
 	// (including Fiber's requestHandler and ErrorHandler) will touch the context.
-	// The timeout middleware intentionally does NOT call ForceRelease to avoid
-	// races, which means timed-out requests leak their contexts until a safe
-	// reclamation strategy exists.
+	// Callers that cannot make that guarantee themselves can instead call
+	// ScheduleReclaim, which arranges a race-free ForceRelease once the handler has
+	// finished and the request handler has released the context.
 	Abandon()
 	// IsAbandoned returns true if Abandon() was called on this context.
 	IsAbandoned() bool
@@ -176,6 +176,27 @@ type Ctx interface {
 	// ErrorHandler) have completely finished using this context. Calling it while
 	// any goroutine is still running causes races.
 	ForceRelease()
+	// ScheduleReclaim arms automatic reclamation of an abandoned context, returning
+	// it to the pool once it is safe to do so.
+	//
+	// handlerDone must be closed once the goroutine that still uses this context
+	// (for the timeout middleware, the handler goroutine) has completely finished.
+	// cancel, if non-nil, is the CancelFunc of the context installed for that
+	// goroutine and is invoked as soon as it finishes.
+	//
+	// ForceRelease is performed only after BOTH handlerDone is closed AND the request
+	// handler has released the context (signaled from ReleaseCtx/releaseDefaultCtx),
+	// which makes the reclamation race-free. If handlerDone never closes — a handler
+	// that never returns — the context is intentionally never reclaimed, because the
+	// handler still owns it.
+	//
+	// This method calls Abandon internally, so callers do not need to call Abandon
+	// separately. Calling Abandon before ScheduleReclaim is still safe (idempotent).
+	ScheduleReclaim(handlerDone <-chan struct{}, cancel context.CancelFunc)
+	// signalReleased records that the request handler is done touching an abandoned,
+	// reclaim-armed context (event b). It is a no-op when reclamation was not armed
+	// and is safe to call multiple times.
+	signalReleased()
 	renderExtensions(bind any)
 	// Bind You can bind body, cookie, headers etc. into the map, map slice, struct easily by using Binding method.
 	// It gives custom binding support, detailed binding options and more.

--- a/internal/nilerror/nilerror.go
+++ b/internal/nilerror/nilerror.go
@@ -12,7 +12,7 @@ func IsNil(err error) bool {
 
 	v := reflect.ValueOf(err)
 	switch v.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice:
 		return v.IsNil()
 	default:
 		return false

--- a/internal/nilerror/nilerror.go
+++ b/internal/nilerror/nilerror.go
@@ -1,0 +1,20 @@
+package nilerror
+
+import (
+	"reflect"
+)
+
+// IsNil reports whether err is nil or contains a typed-nil value.
+func IsNil(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	v := reflect.ValueOf(err)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}

--- a/middleware/limiter/limiter.go
+++ b/middleware/limiter/limiter.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/internal/nilerror"
 )
 
 const (
@@ -30,6 +31,10 @@ func New(config ...Config) fiber.Handler {
 
 // getEffectiveStatusCode returns the actual status code, considering both the error and response status
 func getEffectiveStatusCode(c fiber.Ctx, err error) int {
+	if nilerror.IsNil(err) {
+		return c.Response().StatusCode()
+	}
+
 	// If there's an error and it's a *fiber.Error, use its status code
 	var fiberErr *fiber.Error
 	if errors.As(err, &fiberErr) && fiberErr != nil {

--- a/middleware/limiter/limiter_test.go
+++ b/middleware/limiter/limiter_test.go
@@ -26,6 +26,14 @@ type failingLimiterStorage struct {
 
 const testLimiterClientKey = "client-key"
 
+type typedNilLimiterError struct {
+	message string
+}
+
+func (e *typedNilLimiterError) Error() string {
+	return e.message
+}
+
 func newFailingLimiterStorage() *failingLimiterStorage {
 	return &failingLimiterStorage{
 		data: make(map[string][]byte),
@@ -206,6 +214,21 @@ func TestGetEffectiveStatusCodeTypedNilFiberError(t *testing.T) {
 	c.Response().SetStatusCode(fiber.StatusAccepted)
 
 	var err *fiber.Error
+	require.NotPanics(t, func() {
+		require.Equal(t, fiber.StatusAccepted, getEffectiveStatusCode(c, err))
+	})
+}
+
+func TestGetEffectiveStatusCodeTypedNilCustomError(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	c.Response().SetStatusCode(fiber.StatusAccepted)
+
+	var err *typedNilLimiterError
 	require.NotPanics(t, func() {
 		require.Equal(t, fiber.StatusAccepted, getEffectiveStatusCode(c, err))
 	})


### PR DESCRIPTION
### Motivation
- A recent change removed a generic typed-nil guard which allowed non-nil error interfaces that wrap nil pointers to reach `errors.As`, `err.Error()` or `Unwrap()` and trigger panics in error handling paths. 
- This is a availability regression where application-provided typed-nil errors (e.g. `var e *MyErr; return e`) can crash request goroutines when `DefaultErrorHandler`, binder handling, or limiter code inspect the error. 
- The change restores a small, centralized safety check so handlers treat typed-nil values as nil and avoid invoking methods that may dereference a nil receiver.

### Description
- Add `internal/nilerror.IsNil(error) bool`, a reflection-based helper that reports whether an `error` is nil or contains a typed-nil value. 
- Normalize typed-nil errors to `nil` in `DefaultErrorHandler` (`app.go`) before calling `errors.As` or `err.Error()`. 
- Use `internal/nilerror.IsNil` in binder error handling (`Bind.returnErr` in `bind.go`) so typed-nil binder/validator errors are treated as nil and not passed to `err.Error()`. 
- Short-circuit limiter status-code extraction (`middleware/limiter/limiter.go`) when the passed `err` is typed-nil so `errors.As` is not invoked on a typed-nil custom error. 
- Add regression tests that exercise typed-nil custom errors in the default handler, binder return path, and limiter status-code path, and refresh generated `Ctx` interface (`ctx_interface_gen.go`) via `make generate`.

### Testing
- `make audit` — FAILED because `govulncheck` discovered standard-library issues with the local Go toolchain (`go1.25.1`); these are unrelated to the code changes and require newer Go patch releases to silence (govulncheck exited with non-zero and listed multiple standard-library advisories). 
- `make generate` — succeeded and refreshed generated artifacts (reflected in `ctx_interface_gen.go`). 
- `make betteralign` — succeeded. 
- `make format` — succeeded. 
- `make lint` — succeeded (`0 issues`). 
- `make test` — succeeded; full test run completed with `DONE 3481 tests, 2 skipped`. 
- Targeted `go test` for the newly added typed-nil regression checks passed (the added tests for handler, binder, and limiter did not panic and passed assertions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2388d957788333b89ebc660e20a653)