### PR TITLE
📒 doc: fix keyauth extractor examples

### DIFF
--- a/docs/middleware/keyauth.md
+++ b/docs/middleware/keyauth.md
@@ -181,7 +181,6 @@ import (
     "crypto/sha256"
     "crypto/subtle"
     "github.com/gofiber/fiber/v3"
-    "github.com/gofiber/fiber/v3/extractors"
     "github.com/gofiber/fiber/v3/middleware/keyauth"
 )
 

--- a/docs/middleware/keyauth.md
+++ b/docs/middleware/keyauth.md
@@ -28,6 +28,7 @@ import (
     "crypto/sha256"
     "crypto/subtle"
     "github.com/gofiber/fiber/v3"
+    "github.com/gofiber/fiber/v3/extractors"
     "github.com/gofiber/fiber/v3/middleware/keyauth"
 )
 
@@ -50,7 +51,7 @@ func main() {
 
     // Register middleware before the routes that need it
     app.Use(keyauth.New(keyauth.Config{
-        Extractor:  keyauth.FromCookie("access_token"),
+        Extractor:  extractors.FromCookie("access_token"),
         Validator:  validateAPIKey,
     }))
 
@@ -91,6 +92,7 @@ import (
     "crypto/sha256"
     "crypto/subtle"
     "github.com/gofiber/fiber/v3"
+    "github.com/gofiber/fiber/v3/extractors"
     "github.com/gofiber/fiber/v3/middleware/keyauth"
     "regexp"
     "strings"
@@ -132,7 +134,7 @@ func main() {
 
     app.Use(keyauth.New(keyauth.Config{
         Next:      authFilter,
-        Extractor: keyauth.FromCookie("access_token"),
+        Extractor: extractors.FromCookie("access_token"),
         Validator: validateAPIKey,
     }))
 
@@ -179,6 +181,7 @@ import (
     "crypto/sha256"
     "crypto/subtle"
     "github.com/gofiber/fiber/v3"
+    "github.com/gofiber/fiber/v3/extractors"
     "github.com/gofiber/fiber/v3/middleware/keyauth"
 )
 


### PR DESCRIPTION
## Description

The KeyAuth middleware docs (`docs/middleware/keyauth.md`) have three runnable `package main` examples, and all three fail to compile as written:

1. **Basic example** and **Authenticate only certain endpoints** call `keyauth.FromCookie("access_token")` — but `FromCookie` does not exist in the `keyauth` package. `go vet` reports `undefined: keyauth.FromCookie`.
2. **Apply middleware in the handler** is fine, but the **Typical Usage** snippet and the rest of the page correctly use `extractors.FromCookie(...)` from the shared `github.com/gofiber/fiber/v3/extractors` package — and the first two examples never import that package.

In Fiber v3 the extractor helpers live in the shared `extractors` package (the `keyauth` package itself imports it and defaults to `extractors.FromAuthHeader`). The page's own Config table already says to use `extractors.FromCookie(...)` from "the shared extractors package", so the early examples were just internally inconsistent.

## Fix

- Add the missing `"github.com/gofiber/fiber/v3/extractors"` import to the example import blocks.
- Replace `keyauth.FromCookie(...)` with `extractors.FromCookie(...)` in the two affected examples.

After the change all three examples compile (`go vet` passes; the originals failed). Docs-only.
