### PR TITLE
chore: add MIMETextEventStream constant

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -21,6 +21,7 @@ const (
 	MIMETextPlain             = "text/plain"
 	MIMETextJavaScript        = "text/javascript"
 	MIMETextCSS               = "text/css"
+	MIMETextEventStream       = "text/event-stream"
 	MIMEApplicationXML        = "application/xml"
 	MIMEApplicationJSON       = "application/json"
 	MIMEApplicationJavaScript = "application/javascript"

--- a/docs/api/constants.md
+++ b/docs/api/constants.md
@@ -31,6 +31,7 @@ const (
     MIMETextPlain                        = "text/plain"
     MIMETextJavaScript                   = "text/javascript"
     MIMETextCSS                          = "text/css"
+    MIMETextEventStream                  = "text/event-stream"
     MIMEApplicationXML                   = "application/xml"
     MIMEApplicationJSON                  = "application/json"
     MIMEApplicationCBOR                  = "application/cbor"

--- a/middleware/sse/constants.go
+++ b/middleware/sse/constants.go
@@ -1,5 +1,0 @@
-package sse
-
-import "github.com/gofiber/fiber/v3"
-
-const mimeTextEventStream = fiber.MIMETextEventStream

--- a/middleware/sse/constants.go
+++ b/middleware/sse/constants.go
@@ -1,3 +1,5 @@
 package sse
 
-const mimeTextEventStream = "text/event-stream"
+import "github.com/gofiber/fiber/v3"
+
+const mimeTextEventStream = fiber.MIMETextEventStream

--- a/middleware/sse/sse.go
+++ b/middleware/sse/sse.go
@@ -28,7 +28,7 @@ func New(config ...Config) fiber.Handler {
 	}
 
 	return func(c fiber.Ctx) error {
-		c.Set(fiber.HeaderContentType, mimeTextEventStream)
+		c.Set(fiber.HeaderContentType, fiber.MIMETextEventStream)
 		c.Set(fiber.HeaderCacheControl, "no-cache")
 		c.Set(fiber.HeaderConnection, "keep-alive")
 		c.Set("X-Accel-Buffering", "no")

--- a/middleware/sse/sse_test.go
+++ b/middleware/sse/sse_test.go
@@ -257,7 +257,7 @@ func Test_SSE_NewWritesHeadersAndEvents(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "last-1", capturedLastEventID)
 	require.Equal(t, fiber.StatusOK, resp.StatusCode)
-	require.Equal(t, mimeTextEventStream, resp.Header.Get(fiber.HeaderContentType))
+	require.Equal(t, fiber.MIMETextEventStream, resp.Header.Get(fiber.HeaderContentType))
 	require.Equal(t, "no-cache", resp.Header.Get(fiber.HeaderCacheControl))
 	require.Equal(t, "keep-alive", resp.Header.Get(fiber.HeaderConnection))
 	require.Equal(t, "no", resp.Header.Get("X-Accel-Buffering"))

--- a/req.go
+++ b/req.go
@@ -334,7 +334,7 @@ func (c *DefaultCtx) AcceptsXML() bool {
 
 // AcceptsEventStream reports whether the Accept header allows text/event-stream.
 func (c *DefaultCtx) AcceptsEventStream() bool {
-	return c.Accepts("text/event-stream") != ""
+	return c.Accepts(MIMETextEventStream) != ""
 }
 
 // Cookies are used for getting a cookie value by key.


### PR DESCRIPTION
Every commonly-used MIME type in Fiber is exposed as a public MIME* constant in constants.go, except text/event-stream. As a result:
 - Ctx.AcceptsEventStream() hardcoded the raw string "text/event-stream".
- The SSE middleware defined its own private mimeTextEventStream constant for the exact same value.

This PR adds the public fiber.MIMETextEventStream constant and makes both call sites use it, giving a single source of truth and consistency with the rest of the MIME* family.