### PR TITLE
forward store errors in session initialize to ErrorHandler instead of panicking

### DIFF
--- a/middleware/session/middleware.go
+++ b/middleware/session/middleware.go
@@ -95,7 +95,15 @@ func NewWithStore(config ...Config) (fiber.Handler, *Store) {
 
 		// Acquire session middleware
 		m := acquireMiddleware()
-		m.initialize(c, &cfg)
+		if err := m.initialize(c, &cfg); err != nil {
+			releaseMiddleware(m)
+			if cfg.ErrorHandler != nil {
+				cfg.ErrorHandler(c, err)
+			} else {
+				DefaultErrorHandler(c, err)
+			}
+			return nil
+		}
 
 		stackErr := c.Next()
 
@@ -142,13 +150,13 @@ func clearMiddlewareContext(c fiber.Ctx) {
 }
 
 // initialize sets up middleware for the request.
-func (m *Middleware) initialize(c fiber.Ctx, cfg *Config) {
+func (m *Middleware) initialize(c fiber.Ctx, cfg *Config) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	session, err := cfg.Store.getSession(c)
 	if err != nil {
-		panic(err) // handle or log this error appropriately in production
+		return err
 	}
 
 	m.config = *cfg
@@ -156,6 +164,7 @@ func (m *Middleware) initialize(c fiber.Ctx, cfg *Config) {
 	m.ctx = c
 
 	storeMiddlewareContext(c, session, m)
+	return nil
 }
 
 // saveSession handles session saving and error management after the response.

--- a/middleware/session/middleware_test.go
+++ b/middleware/session/middleware_test.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -657,4 +659,91 @@ func Test_Session_Middleware_Store(t *testing.T) {
 	ctx.Request.Header.SetMethod(fiber.MethodGet)
 	h(ctx)
 	require.Equal(t, fiber.StatusOK, ctx.Response.StatusCode())
+}
+
+// failingStorage is a fiber.Storage implementation whose Get always returns an error.
+type failingStorage struct{}
+
+var errStoreUnavailable = errors.New("store unavailable")
+
+func (*failingStorage) GetWithContext(_ context.Context, _ string) ([]byte, error) {
+	return nil, errStoreUnavailable
+}
+
+func (*failingStorage) Get(_ string) ([]byte, error) {
+	return nil, errStoreUnavailable
+}
+
+func (*failingStorage) SetWithContext(_ context.Context, _ string, _ []byte, _ time.Duration) error {
+	return errStoreUnavailable
+}
+
+func (*failingStorage) Set(_ string, _ []byte, _ time.Duration) error {
+	return errStoreUnavailable
+}
+
+func (*failingStorage) DeleteWithContext(_ context.Context, _ string) error {
+	return nil
+}
+
+func (*failingStorage) Delete(_ string) error {
+	return nil
+}
+
+func (*failingStorage) ResetWithContext(_ context.Context) error {
+	return nil
+}
+
+func (*failingStorage) Reset() error {
+	return nil
+}
+
+func (*failingStorage) Close() error {
+	return nil
+}
+
+// Test_Session_Middleware_StoreError verifies that a store error during session
+// initialization is forwarded to the ErrorHandler instead of panicking the server.
+func Test_Session_Middleware_StoreError(t *testing.T) {
+	t.Parallel()
+
+	var (
+		handlerReached bool
+		mu             sync.Mutex
+	)
+
+	// Custom ErrorHandler that records the call.
+	var capturedErr error
+	app := fiber.New()
+	app.Use(New(Config{
+		Storage: &failingStorage{},
+		ErrorHandler: func(_ fiber.Ctx, err error) {
+			mu.Lock()
+			capturedErr = err
+			mu.Unlock()
+		},
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		mu.Lock()
+		handlerReached = true
+		mu.Unlock()
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	h := app.Handler()
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fiber.MethodGet)
+	// Send a cookie so getSession tries Storage.GetWithContext and hits the error.
+	ctx.Request.Header.SetCookie("session_id", "some-existing-id")
+	h(ctx)
+
+	mu.Lock()
+	reached := handlerReached
+	err := capturedErr
+	mu.Unlock()
+
+	require.False(t, reached, "route handler must not be called when store fails")
+	require.ErrorIs(t, err, errStoreUnavailable, "ErrorHandler must receive the store error")
 }


### PR DESCRIPTION
fixes #4348.

**problem:** `initialize()` calls `panic(err)` when the backing store returns an error during session lookup. a redis timeout, network blip, or misconfigured store crashes the entire server process rather than being handled gracefully.

**fix:** `initialize()` now returns the error. the handler in `NewWithStore` catches it, releases the middleware back to the pool, and routes the error through `cfg.ErrorHandler` (or `DefaultErrorHandler` if none is configured) — the same path that `saveSession()` already uses for save-time errors.

regression test: `Test_Session_Middleware_StoreError` — sends a request with a session cookie to an app backed by a storage that always returns an error. verifies the route handler is never reached and the `ErrorHandler` receives the store error.
