### PR TITLE
🐛 fix: pprof trailing-slash redirect and proxy balancer empty-server panic

### DIFF
--- a/middleware/pprof/pprof.go
+++ b/middleware/pprof/pprof.go
@@ -73,7 +73,7 @@ func New(config ...Config) fiber.Handler {
 		default:
 			// pprof index only works with trailing slash
 			if strings.HasSuffix(path, "/") {
-				path = utils.TrimRight(path, '/')
+				path = prefix + utils.TrimRight(path, '/')
 			} else {
 				path = prefix + "/"
 			}

--- a/middleware/pprof/pprof_test.go
+++ b/middleware/pprof/pprof_test.go
@@ -173,6 +173,28 @@ func Test_Pprof_Other_WithPrefix(t *testing.T) {
 	require.Equal(t, fiber.StatusSeeOther, resp.StatusCode)
 }
 
+func Test_Pprof_TrailingSlash_RedirectsWithinPrefix(t *testing.T) {
+	app := fiber.New()
+
+	app.Use(New())
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/debug/pprof/heap/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusSeeOther, resp.StatusCode)
+	require.Equal(t, "/debug/pprof/heap", resp.Header.Get(fiber.HeaderLocation))
+}
+
+func Test_Pprof_TrailingSlash_RedirectsWithinPrefix_WithPrefix(t *testing.T) {
+	app := fiber.New()
+
+	app.Use(New(Config{Prefix: "/federated-fiber"}))
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/federated-fiber/debug/pprof/heap/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusSeeOther, resp.StatusCode)
+	require.Equal(t, "/federated-fiber/debug/pprof/heap", resp.Header.Get(fiber.HeaderLocation))
+}
+
 // go test -run Test_Pprof_Next
 func Test_Pprof_Next(t *testing.T) {
 	app := fiber.New()

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -274,6 +274,9 @@ func (r *roundrobin) get() string {
 // BalancerForward Forward performs the given http request with round robin algorithm to server and fills the given http response.
 // This method will return a fiber.Handler
 func BalancerForward(servers []string, clients ...*fasthttp.Client) fiber.Handler {
+	if len(servers) == 0 {
+		panic("Servers cannot be empty")
+	}
 	r := &roundrobin{
 		current: 0,
 		pool:    servers,

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -1035,7 +1035,7 @@ func Test_Proxy_Balancer_Forward_Local(t *testing.T) {
 func Test_Proxy_Balancer_Forward_Empty_Servers(t *testing.T) {
 	t.Parallel()
 
-	require.Panics(t, func() {
+	require.PanicsWithValue(t, "Servers cannot be empty", func() {
 		BalancerForward([]string{})
 	})
 }

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -1031,6 +1031,15 @@ func Test_Proxy_Balancer_Forward_Local(t *testing.T) {
 	require.Equal(t, "forwarded", string(b))
 }
 
+// go test -run Test_Proxy_Balancer_Forward_Empty_Servers
+func Test_Proxy_Balancer_Forward_Empty_Servers(t *testing.T) {
+	t.Parallel()
+
+	require.Panics(t, func() {
+		BalancerForward([]string{})
+	})
+}
+
 func Test_Proxy_Balancer_Forward_OverwritesXRealIP(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- pprof: the default-case redirect dropped the route prefix because the path had already been stripped with strings.CutPrefix, so requests like /debug/pprof/heap/ were redirected to /heap outside the pprof namespace. Prepend the prefix so the redirect stays within /debug/pprof.
- proxy: BalancerForward with an empty server list panicked with an integer divide by zero on the first request. Fail fast at setup with the same panic message used by Config validation.