### PR TITLE
🐛 bug: prevent session store error disclosure

### DIFF
--- a/middleware/session/middleware.go
+++ b/middleware/session/middleware.go
@@ -5,7 +5,6 @@ package session
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/gofiber/fiber/v3"
@@ -98,7 +97,8 @@ func NewWithStore(config ...Config) (fiber.Handler, *Store) {
 		m := acquireMiddleware()
 		if err := m.initialize(c, &cfg); err != nil {
 			releaseMiddleware(m)
-			return fmt.Errorf("session: failed to get session: %w", err)
+			handleSessionError(c, cfg.ErrorHandler, err)
+			return nil
 		}
 
 		stackErr := c.Next()
@@ -119,6 +119,14 @@ func NewWithStore(config ...Config) (fiber.Handler, *Store) {
 }
 
 var registerLogContextTagsOnce sync.Once
+
+func handleSessionError(c fiber.Ctx, handler func(fiber.Ctx, error), err error) {
+	if handler != nil {
+		handler(c, err)
+		return
+	}
+	DefaultErrorHandler(c, err)
+}
 
 func registerLogContextTags() {
 	logger.RegisterContextTag("session-id", func(ctx any) string {

--- a/middleware/session/middleware_test.go
+++ b/middleware/session/middleware_test.go
@@ -667,7 +667,9 @@ type failingStorage struct {
 }
 
 func (s *failingStorage) GetWithContext(context.Context, string) ([]byte, error) { return nil, s.err }
-func (s *failingStorage) Get(string) ([]byte, error)                             { return nil, s.err }
+
+func (s *failingStorage) Get(string) ([]byte, error) { return nil, s.err }
+
 func (s *failingStorage) SetWithContext(context.Context, string, []byte, time.Duration) error {
 	return s.err
 }
@@ -699,4 +701,35 @@ func Test_Session_Middleware_StoreError(t *testing.T) {
 	ctx.Request.Header.SetCookie("session_id", "some-session-id")
 	require.NotPanics(t, func() { h(ctx) })
 	require.Equal(t, fiber.StatusInternalServerError, ctx.Response.StatusCode())
+	require.Equal(t, "Internal Server Error", string(ctx.Response.Body()))
+	require.NotContains(t, string(ctx.Response.Body()), storage.err.Error())
+}
+
+func Test_Session_Middleware_StoreError_CustomErrorHandler(t *testing.T) {
+	t.Parallel()
+
+	storageErr := errors.New("redis dial tcp redis.internal.corp:6379: connect: connection refused")
+	storage := &failingStorage{err: storageErr}
+	app := fiber.New()
+	var handledErr error
+	app.Use(New(Config{
+		Storage: storage,
+		ErrorHandler: func(c fiber.Ctx, err error) {
+			handledErr = err
+			require.NoError(t, c.Status(fiber.StatusInternalServerError).SendString("session unavailable"))
+		},
+	}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fiber.MethodGet)
+	ctx.Request.Header.SetCookie("session_id", "some-session-id")
+	app.Handler()(ctx)
+
+	require.ErrorIs(t, handledErr, storageErr)
+	require.Equal(t, fiber.StatusInternalServerError, ctx.Response.StatusCode())
+	require.Equal(t, "session unavailable", string(ctx.Response.Body()))
 }


### PR DESCRIPTION
### Motivation

- Prevent storage-layer errors from being returned to Fiber's global ErrorHandler and leaked to clients when session initialization fails.
- Preserve the previous non-panic behavior for failing stores while ensuring default responses are generic and backend details remain server-side only.

### Description

- Stop returning the wrapped storage error from the middleware initialization path and route failures through a new helper `handleSessionError` that invokes the session `ErrorHandler` if set or `DefaultErrorHandler` otherwise.
- Ensure the middleware returns `nil` after the error handler runs so the app-level ErrorHandler is not given the raw storage error.
- Add tests: `Test_Session_Middleware_StoreError` verifies default behavior returns a generic "Internal Server Error" body and does not contain storage error text, and `Test_Session_Middleware_StoreError_CustomErrorHandler` verifies a custom `ErrorHandler` receives the original storage error and can control the response body.
- Minor cleanup: removed an unused `fmt` import in the modified file.

### Testing

- `go test ./middleware/session -run 'Test_Session_Middleware_StoreError' -count=1 -v` — passed (both default and custom error-handler cases).
- `make test` — full test suite passed (`DONE 3542 tests, 1 skipped`).
- `make audit` — partially failed because `govulncheck` reported known vulnerabilities in the configured Go 1.25.1 standard library toolchain (external to these changes); other audit steps (`go mod verify`, `go vet`) completed.
- `make generate`, `make betteralign`, `make format`, and `make lint` — all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a4e3a93688333ada345c6d39f6cfc)