### PR TITLE
chore: Test handling of empty and malformed entries in ctx.IP()

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -3621,6 +3621,75 @@ func Test_Ctx_IP_ProxyHeader_InvalidIPs(t *testing.T) {
 	require.False(t, c.isTrustedProxyIP("invalid"))
 }
 
+// go test -run Test_Ctx_IP_ProxyHeader_MalformedEntries
+func Test_Ctx_IP_ProxyHeader_MalformedEntries(t *testing.T) {
+	t.Parallel()
+	t.Run("no_trusted_proxy", func(t *testing.T) {
+		t.Parallel()
+		app := New(Config{
+			ProxyHeader:        HeaderXForwardedFor,
+			EnableIPValidation: true,
+		})
+		fastCtx := &fasthttp.RequestCtx{}
+		fastCtx.SetRemoteAddr(testNetAddr{network: "tcp", address: "0.0.0.0"})
+		c := app.AcquireCtx(fastCtx)
+
+		// Leading comma and space: ", 203.0.113.195, 70.41.3.18"
+		c.Request().Header.Set(HeaderXForwardedFor, ", 203.0.113.195, 70.41.3.18")
+		require.Equal(t, "203.0.113.195", c.IP(), "should skip leading empty entry")
+
+		// Empty entry in the middle: "203.0.113.195, , 70.41.3.18"
+		c.Request().Header.Set(HeaderXForwardedFor, "203.0.113.195, , 70.41.3.18")
+		require.Equal(t, "203.0.113.195", c.IP(), "should skip middle empty entry")
+
+		// Trailing comma: "203.0.113.195, 70.41.3.18, "
+		c.Request().Header.Set(HeaderXForwardedFor, "203.0.113.195, 70.41.3.18, ")
+		require.Equal(t, "203.0.113.195", c.IP(), "should skip trailing empty entry")
+
+		// Whitespace-only entry: "203.0.113.195,   , 70.41.3.18"
+		c.Request().Header.Set(HeaderXForwardedFor, "203.0.113.195,   , 70.41.3.18")
+		require.Equal(t, "203.0.113.195", c.IP(), "should skip whitespace-only entry")
+
+		// Multiple consecutive commas: ",,,203.0.113.195,,,"
+		c.Request().Header.Set(HeaderXForwardedFor, ",,,203.0.113.195,,,")
+		require.Equal(t, "203.0.113.195", c.IP(), "should skip consecutive commas")
+
+		// All entries empty/invalid falls back to RemoteIP
+		c.Request().Header.Set(HeaderXForwardedFor, ", , , ")
+		require.Equal(t, "0.0.0.0", c.IP(), "all empty should fall back to RemoteIP")
+	})
+
+	t.Run("with_trusted_proxy", func(t *testing.T) {
+		t.Parallel()
+		app := New(Config{
+			ProxyHeader:        HeaderXForwardedFor,
+			EnableIPValidation: true,
+			TrustProxyConfig: TrustProxyConfig{
+				Proxies: []string{"10.0.0.1"},
+			},
+		})
+		fastCtx := &fasthttp.RequestCtx{}
+		fastCtx.SetRemoteAddr(testNetAddr{network: "tcp", address: "10.0.0.1"})
+		c := app.AcquireCtx(fastCtx)
+
+		// Leading comma with trusted proxy chain
+		c.Request().Header.Set(HeaderXForwardedFor, ", 203.0.113.195, 10.0.0.1")
+		require.Equal(t, "203.0.113.195", c.IP(), "trusted proxy: should skip leading empty entry and return first non-trusted")
+
+		// Empty entry between trusted and non-trusted
+		c.Request().Header.Set(HeaderXForwardedFor, "10.0.0.1, , 203.0.113.195")
+		require.Equal(t, "203.0.113.195", c.IP(), "trusted proxy: should skip empty entry between IPs")
+
+		// All trusted proxies with empty entries
+		c.Request().Header.Set(HeaderXForwardedFor, ", 10.0.0.1, ")
+		require.Equal(t, "10.0.0.1", c.IP(), "trusted proxy: when all are trusted, return the last valid one")
+
+		// All entries empty with trusted proxy config falls back to RemoteIP
+		c.Request().Header.Set(HeaderXForwardedFor, ", , , ")
+		require.Equal(t, "10.0.0.1", c.IP(), "trusted proxy: all empty falls back to RemoteIP")
+	})
+}
+
 func Test_Ctx_IP_TrustedProxyIPv6Range(t *testing.T) {
 	t.Parallel()
 	app := New(Config{

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -3636,27 +3636,27 @@ func Test_Ctx_IP_ProxyHeader_MalformedEntries(t *testing.T) {
 
 		// Leading comma and space: ", 203.0.113.195, 70.41.3.18"
 		c.Request().Header.Set(HeaderXForwardedFor, ", 203.0.113.195, 70.41.3.18")
-		require.Equal(t, "203.0.113.195", c.IP(), "should skip leading empty entry")
+		require.Equal(t, "203.0.113.195", c.extractIPFromHeader(HeaderXForwardedFor), "should skip leading empty entry")
 
 		// Empty entry in the middle: "203.0.113.195, , 70.41.3.18"
 		c.Request().Header.Set(HeaderXForwardedFor, "203.0.113.195, , 70.41.3.18")
-		require.Equal(t, "203.0.113.195", c.IP(), "should skip middle empty entry")
+		require.Equal(t, "203.0.113.195", c.extractIPFromHeader(HeaderXForwardedFor), "should skip middle empty entry")
 
 		// Trailing comma: "203.0.113.195, 70.41.3.18, "
 		c.Request().Header.Set(HeaderXForwardedFor, "203.0.113.195, 70.41.3.18, ")
-		require.Equal(t, "203.0.113.195", c.IP(), "should skip trailing empty entry")
+		require.Equal(t, "203.0.113.195", c.extractIPFromHeader(HeaderXForwardedFor), "should skip trailing empty entry")
 
 		// Whitespace-only entry: "203.0.113.195,   , 70.41.3.18"
 		c.Request().Header.Set(HeaderXForwardedFor, "203.0.113.195,   , 70.41.3.18")
-		require.Equal(t, "203.0.113.195", c.IP(), "should skip whitespace-only entry")
+		require.Equal(t, "203.0.113.195", c.extractIPFromHeader(HeaderXForwardedFor), "should skip whitespace-only entry")
 
 		// Multiple consecutive commas: ",,,203.0.113.195,,,"
 		c.Request().Header.Set(HeaderXForwardedFor, ",,,203.0.113.195,,,")
-		require.Equal(t, "203.0.113.195", c.IP(), "should skip consecutive commas")
+		require.Equal(t, "203.0.113.195", c.extractIPFromHeader(HeaderXForwardedFor), "should skip consecutive commas")
 
 		// All entries empty/invalid falls back to RemoteIP
 		c.Request().Header.Set(HeaderXForwardedFor, ", , , ")
-		require.Equal(t, "0.0.0.0", c.IP(), "all empty should fall back to RemoteIP")
+		require.Equal(t, "0.0.0.0", c.extractIPFromHeader(HeaderXForwardedFor), "all empty should fall back to RemoteIP")
 	})
 
 	t.Run("with_trusted_proxy", func(t *testing.T) {
@@ -3664,6 +3664,7 @@ func Test_Ctx_IP_ProxyHeader_MalformedEntries(t *testing.T) {
 		app := New(Config{
 			ProxyHeader:        HeaderXForwardedFor,
 			EnableIPValidation: true,
+			TrustProxy:         true,
 			TrustProxyConfig: TrustProxyConfig{
 				Proxies: []string{"10.0.0.1"},
 			},


### PR DESCRIPTION
## Description

When parsing the X-Forwarded-For header, Ctx.IP() does not gracefully handle empty or whitespace-only entries.

## Changes
- Added comprehensive tests in Test_Ctx_IP_ProxyHeader_MalformedEntries
- Tests cover: leading/trailing commas, whitespace-only entries, all-empty fallback, trusted proxy scenarios

Closes davontepowlowsk1i/gofiber-fiber#1