### PR TITLE
Changes CSRF and Session Cookie: Secure and HTTPOnly Default Behaviour to True

### DIFF
--- a/docs/middleware/csrf.md
+++ b/docs/middleware/csrf.md
@@ -57,6 +57,7 @@ app.Use(csrf.New(csrf.Config{
 ## Best Practices & Production Requirements
 
 :::danger Production Requirements
+
 - `CookieSameSite: "Lax"` or `"Strict"`
 - Use `Session` store for better security
 

--- a/docs/middleware/csrf.md
+++ b/docs/middleware/csrf.md
@@ -30,18 +30,25 @@ import (
     "github.com/gofiber/fiber/v3/middleware/csrf"
 )
 
-// Default config (development only)
+// Default config
 app.Use(csrf.New())
+
+// Local HTTP development only
+app.Use(csrf.New(csrf.Config{
+    DisableCookieSecure: true,
+}))
 
 // Production config
 app.Use(csrf.New(csrf.Config{
     CookieName:        "__Host-csrf_",
-    CookieSecure:      true,
-    CookieHTTPOnly:    true,  // false for SPAs
     CookieSameSite:    "Lax",
     CookieSessionOnly: true,
     Extractor:         extractors.FromHeader("X-Csrf-Token"),
     Session:           sessionStore,
+    // Secure cookie defaults are enabled by default. Set DisableCookieSecure to true to disable.
+    // DisableCookieSecure: true,
+    // Cookie HTTP Only is enabled by default. If JavaScript access is intentionally required, set DisableCookieHTTPOnly to true to disable.
+    // DisableCookieHTTPOnly: true,
     // Redaction is enabled by default. Set DisableValueRedaction when you must expose tokens or storage keys in diagnostics.
     // DisableValueRedaction: true,
 }))
@@ -50,8 +57,6 @@ app.Use(csrf.New(csrf.Config{
 ## Best Practices & Production Requirements
 
 :::danger Production Requirements
-
-- `CookieSecure: true` (HTTPS only)
 - `CookieSameSite: "Lax"` or `"Strict"`
 - Use `Session` store for better security
 
@@ -59,7 +64,7 @@ app.Use(csrf.New(csrf.Config{
 
 1. **Always use HTTPS** in production
 2. **Use sessions** for authenticated applications
-3. **Set `CookieSecure: true`** and appropriate SameSite values
+3. **Keep secure cookie defaults enabled** and choose appropriate SameSite values
 4. **Implement XSS protection** alongside CSRF
 5. **Regenerate tokens** after auth changes
 6. **Use `__Host-` cookie prefix** when possible
@@ -75,8 +80,6 @@ To mitigate BREACH attacks, ensure your pages are served over HTTPS, disable HTT
 ```go
 app.Use(csrf.New(csrf.Config{
     CookieName:        "__Host-csrf_",
-    CookieSecure:      true,
-    CookieHTTPOnly:    true,        // Secure - blocks JavaScript
     CookieSameSite:    "Lax",
     CookieSessionOnly: true,
     Extractor:         extractors.FromForm("_csrf"),
@@ -88,18 +91,17 @@ app.Use(csrf.New(csrf.Config{
 
 ```go
 app.Use(csrf.New(csrf.Config{
-    CookieName:        "__Host-csrf_",
-    CookieSecure:      true,
-    CookieHTTPOnly:    false,       // Required for JavaScript access to tokens
-    CookieSameSite:    "Lax",
-    CookieSessionOnly: true,
-    Extractor:         extractors.FromHeader("X-Csrf-Token"),
-    Session:           sessionStore,
+    CookieName:             "__Host-csrf_",
+    DisableCookieHTTPOnly:  true,   // Required for JavaScript access to tokens
+    CookieSameSite:         "Lax",
+    CookieSessionOnly:      true,
+    Extractor:              extractors.FromHeader("X-Csrf-Token"),
+    Session:                sessionStore,
 }))
 ```
 
 :::warning SPA Security Trade-off
-SPAs require `CookieHTTPOnly: false` to access tokens via JavaScript. This slightly increases XSS risk but is necessary for SPA functionality.
+SPAs require `DisableCookieHTTPOnly: true` to access tokens via JavaScript. This slightly increases XSS risk but is necessary for SPA functionality.
 :::
 
 ## Recipes for Common Use Cases
@@ -403,8 +405,10 @@ func (h *csrf.Handler) DeleteToken(c fiber.Ctx) error
 | CookieName        | `string`                           | CSRF cookie name                                                                                                              | `"csrf_"`                    |
 | CookieDomain      | `string`                           | CSRF cookie domain                                                                                                            | `""`                         |
 | CookiePath        | `string`                           | CSRF cookie path                                                                                                              | `""`                         |
-| CookieSecure      | `bool`                             | HTTPS only cookie (**required for production**)                                                                               | `false`                      |
-| CookieHTTPOnly    | `bool`                             | Prevent JavaScript access (**use `false` for SPAs**)                                                                          | `false`                      |
+| CookieSecure      | `bool`                             | HTTPS only cookie                                                                                                             | `true`                       |
+| DisableCookieSecure | `bool`                           | Disable the Secure cookie flag                                                                                                | `false`                      |
+| CookieHTTPOnly    | `bool`                             | Prevent JavaScript access                                                                                                     | `true`                       |
+| DisableCookieHTTPOnly | `bool`                         | Disable the HttpOnly cookie flag (**required for JavaScript token access in SPAs**)                                           | `false`                      |
 | CookieSameSite    | `string`                           | SameSite attribute (**use "Lax" or "Strict"**)                                                                                | `"Lax"`                      |
 | CookieSessionOnly | `bool`                             | Session-only cookie (expires on browser close)                                                                                | `false`                      |
 | IdleTimeout       | `time.Duration`                    | Token expiration time                                                                                                         | `30 * time.Minute`           |

--- a/docs/middleware/session.md
+++ b/docs/middleware/session.md
@@ -68,13 +68,13 @@ app.Use(session.New(session.Config{
     AbsoluteTimeout:   24 * time.Hour,    // Maximum session life
     Extractor:         extractors.FromCookie("__Host-session_id"),
 }))
+```
 
 Notes:
 
 - AbsoluteTimeout must be greater than or equal to IdleTimeout; otherwise, the middleware panics during configuration.
 - CookieSecure and CookieHTTPOnly default to true. Use DisableCookieSecure or DisableCookieHTTPOnly only when you intentionally need to opt out.
 - If CookieSameSite is set to "None", the middleware automatically forces CookieSecure=true when setting the cookie.
-```
 
 ## Usage Patterns
 
@@ -448,7 +448,6 @@ app.Use(session.New(session.Config{
 
     // Cookie Settings
     CookiePath:        "/",
-    CookieDomain:      "example.com",
     CookieSessionOnly: false,   // Persist across browser restarts
 
     // Session ID

--- a/docs/middleware/session.md
+++ b/docs/middleware/session.md
@@ -62,8 +62,7 @@ storage := redis.New(redis.Config{
 
 app.Use(session.New(session.Config{
     Storage:           storage,
-    CookieSecure:      true,              // HTTPS only
-    CookieHTTPOnly:    true,              // Prevent XSS
+
     CookieSameSite:    "Lax",             // CSRF protection
     IdleTimeout:       30 * time.Minute,  // Session timeout
     AbsoluteTimeout:   24 * time.Hour,    // Maximum session life
@@ -73,6 +72,7 @@ app.Use(session.New(session.Config{
 Notes:
 
 - AbsoluteTimeout must be greater than or equal to IdleTimeout; otherwise, the middleware panics during configuration.
+- CookieSecure and CookieHTTPOnly default to true. Use DisableCookieSecure or DisableCookieHTTPOnly only when you intentionally need to opt out.
 - If CookieSameSite is set to "None", the middleware automatically forces CookieSecure=true when setting the cookie.
 ```
 
@@ -439,8 +439,7 @@ app.Use(session.New(session.Config{
     Storage: redisStorage,
 
     // Security
-    CookieSecure:      true,    // HTTPS only (required in production)
-    CookieHTTPOnly:    true,    // No JavaScript access (prevents XSS)
+
     CookieSameSite:    "Lax",   // CSRF protection
 
     // Session Management
@@ -684,8 +683,10 @@ extractors.Chain(extractors ...extractors.Extractor) extractors.Extractor
 | `KeyGenerator`      | `func() string`             | Session ID generator        | `utils.SecureToken`                             |
 | `IdleTimeout`       | `time.Duration`             | Inactivity timeout          | `30 * time.Minute`                         |
 | `AbsoluteTimeout`   | `time.Duration`             | Maximum session duration    | `0` (unlimited)                            |
-| `CookieSecure`      | `bool`                      | HTTPS only                  | `false`                                    |
-| `CookieHTTPOnly`    | `bool`                      | No JavaScript access        | `false`                                    |
+| `CookieSecure`      | `bool`                      | HTTPS only                  | `true`                                     |
+| `DisableCookieSecure` | `bool`                    | Disable the Secure cookie flag | `false`                                 |
+| `CookieHTTPOnly`    | `bool`                      | No JavaScript access        | `true`                                     |
+| `DisableCookieHTTPOnly` | `bool`                  | Disable the HttpOnly cookie flag | `false`                               |
 | `CookieSameSite`    | `string`                    | SameSite attribute          | `"Lax"`                                    |
 | `CookiePath`        | `string`                    | Cookie path                 | `""`                                       |
 | `CookieDomain`      | `string`                    | Cookie domain               | `""`                                       |

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1419,6 +1419,8 @@ The `Expiration` field in the CSRF middleware configuration has been renamed to 
 
 CSRF now redacts tokens and storage keys by default and exposes a `DisableValueRedaction` toggle (default `false`) if you must surface those values in diagnostics.
 
+CSRF cookies now default to `Secure` and `HttpOnly`. Use `DisableCookieSecure` or `DisableCookieHTTPOnly` when you intentionally need to opt out, such as local HTTP development or SPA token access.
+
 The CSRF middleware now validates the [`Sec-Fetch-Site`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site) header for unsafe HTTP methods. When present, requests with invalid `Sec-Fetch-Site` values (not one of "same-origin", "none", "same-site", or "cross-site") are rejected with `ErrFetchSiteInvalid`. Valid or absent headers proceed to standard origin and token validation checks, providing an early gate to catch malformed requests while maintaining compatibility with legitimate cross-site traffic.
 
 ### Idempotency
@@ -1715,6 +1717,8 @@ The session middleware has undergone significant improvements in v3, focusing on
 - **Absolute Timeout**: The `AbsoluteTimeout` field has been added. If you need to set an absolute session timeout, you can use this field to define the duration. The session will expire after the specified duration, regardless of activity.
 
 - **Default KeyGenerator**: Changed from `utils.UUIDv4` to `utils.SecureToken`, producing base64-encoded tokens instead of UUID format.
+
+- **Secure Cookie Defaults**: `CookieSecure` and `CookieHTTPOnly` now default to `true`. Use `DisableCookieSecure` or `DisableCookieHTTPOnly` when you intentionally need to opt out.
 
 For more details on these changes and migration instructions, check the [Session Middleware Migration Guide](./middleware/session.md#migration-guide).
 
@@ -2983,6 +2987,7 @@ app.Use(csrf.New(csrf.Config{
 
 - **KeyLookup Field Removal**: The `KeyLookup` field has been removed from the CSRF middleware configuration. This field was deprecated and is no longer needed as the middleware now uses a more secure approach for token management.
 - **DisableValueRedaction Toggle**: CSRF redacts tokens and storage keys by default; set `DisableValueRedaction` to `true` when diagnostics require the raw values.
+- **Secure Cookie Defaults**: `CookieSecure` and `CookieHTTPOnly` now default to `true`. Use `DisableCookieSecure` or `DisableCookieHTTPOnly` when you intentionally need to opt out.
 
 - **Default KeyGenerator**: Changed from `utils.UUIDv4` to `utils.SecureToken`, producing base64-encoded tokens instead of UUID format.
 
@@ -3181,6 +3186,10 @@ Sessions obtained from a store must be released manually via `sess.Release()`.
 Additionally, replace the deprecated `KeyLookup` option with extractor
 functions such as `session.FromCookie()` or `session.FromHeader()`. Multiple
 extractors can be combined with `session.Chain()`.
+
+Session cookies now default to `Secure` and `HttpOnly`. Use
+`DisableCookieSecure` or `DisableCookieHTTPOnly` when you intentionally need to
+opt out.
 
 ```go
 // Before

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -3000,7 +3000,7 @@ app.Use(csrf.New(csrf.Config{
 
 // After - use Extractor instead
 app.Use(csrf.New(csrf.Config{
-    Extractor: csrf.FromHeader("X-Csrf-Token"),
+    Extractor: extractors.FromHeader("X-Csrf-Token"),
     // other config...
 }))
 ```
@@ -3008,22 +3008,15 @@ app.Use(csrf.New(csrf.Config{
 - **FromCookie Extractor Removal**: The `csrf.FromCookie` extractor has been intentionally removed for security reasons. Using cookie-based extraction defeats the purpose of CSRF protection by making the extracted token always match the cookie value.
 
 ```go
-// Before - This was a security vulnerability
-app.Use(csrf.New(csrf.Config{
-    Extractor: csrf.FromCookie("csrf_token"), // ❌ Insecure!
-}))
-
 // After - Use secure extractors instead
 app.Use(csrf.New(csrf.Config{
-    Extractor: csrf.FromHeader("X-Csrf-Token"), // ✅ Secure
+    Extractor: extractors.FromHeader("X-Csrf-Token"), // ✅ Secure
     // or
-    Extractor: csrf.FromForm("_csrf"),          // ✅ Secure
-    // or
-    Extractor: csrf.FromQuery("csrf_token"),    // ✅ Acceptable
+    Extractor: extractors.FromForm("_csrf"),          // ✅ Secure
 }))
 ```
 
-**Security Note**: The removal of `FromCookie` prevents a common misconfiguration that would completely bypass CSRF protection. The middleware uses the Double Submit Cookie pattern, which requires the token to be submitted through a different channel than the cookie to provide meaningful protection.
+**Security Note**: The removal of `FromCookie` prevents a common misconfiguration that would completely bypass CSRF protection. Query-based extraction is also discouraged because URLs can be logged, cached, and leaked through referrers. The middleware uses the Double Submit Cookie pattern, which requires the token to be submitted through a different channel than the cookie to provide meaningful protection.
 
 #### Idempotency
 

--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -103,13 +103,23 @@ type Config struct {
 
 	// CookieSecure indicates if CSRF cookie is secure.
 	//
-	// Optional. Default: false
+	// Optional. Default: true
 	CookieSecure bool
+
+	// DisableCookieSecure disables the secure flag for the CSRF cookie.
+	//
+	// Optional. Default: false
+	DisableCookieSecure bool
 
 	// CookieHTTPOnly indicates if CSRF cookie is HTTP only.
 	//
-	// Optional. Default: false
+	// Optional. Default: true
 	CookieHTTPOnly bool
+
+	// DisableCookieHTTPOnly disables the HTTP only flag for the CSRF cookie.
+	//
+	// Optional. Default: false
+	DisableCookieHTTPOnly bool
 
 	// CookieSessionOnly decides whether cookie should last for only the browser session.
 	// Ignores Expiration if set to true.
@@ -136,6 +146,8 @@ var ConfigDefault = Config{
 	ErrorHandler:          defaultErrorHandler,
 	Extractor:             extractors.FromHeader(HeaderName),
 	DisableValueRedaction: false,
+	CookieSecure:          true,
+	CookieHTTPOnly:        true,
 }
 
 // defaultErrorHandler is the default error handler that processes errors from fiber.Handler.
@@ -172,6 +184,18 @@ func configDefault(config ...Config) Config {
 	// Check if Extractor is zero value (since it's a struct)
 	if cfg.Extractor.Extract == nil {
 		cfg.Extractor = ConfigDefault.Extractor
+	}
+	if !cfg.CookieSecure {
+		cfg.CookieSecure = ConfigDefault.CookieSecure
+	}
+	if !cfg.CookieHTTPOnly {
+		cfg.CookieHTTPOnly = ConfigDefault.CookieHTTPOnly
+	}
+	if cfg.DisableCookieHTTPOnly {
+		cfg.CookieHTTPOnly = false
+	}
+	if cfg.DisableCookieSecure {
+		cfg.CookieSecure = false
 	}
 	// Validate extractor security configurations
 	validateExtractorSecurity(&cfg)

--- a/middleware/csrf/config_test.go
+++ b/middleware/csrf/config_test.go
@@ -11,6 +11,63 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+func TestConfigDefaultCookieSecurity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		config           Config
+		expectedSecure   bool
+		expectedHTTPOnly bool
+	}{
+		{
+			name:             "empty config uses secure defaults",
+			config:           Config{},
+			expectedSecure:   true,
+			expectedHTTPOnly: true,
+		},
+		{
+			name: "false cookie flags use secure defaults",
+			config: Config{
+				CookieSecure:   false,
+				CookieHTTPOnly: false,
+			},
+			expectedSecure:   true,
+			expectedHTTPOnly: true,
+		},
+		{
+			name: "disable flags opt out of secure defaults",
+			config: Config{
+				DisableCookieSecure:   true,
+				DisableCookieHTTPOnly: true,
+			},
+			expectedSecure:   false,
+			expectedHTTPOnly: false,
+		},
+		{
+			name: "disable flags take precedence over explicit true",
+			config: Config{
+				CookieSecure:          true,
+				CookieHTTPOnly:        true,
+				DisableCookieSecure:   true,
+				DisableCookieHTTPOnly: true,
+			},
+			expectedSecure:   false,
+			expectedHTTPOnly: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := configDefault(tc.config)
+			require.Equal(t, tc.expectedSecure, cfg.CookieSecure)
+			require.Equal(t, tc.expectedHTTPOnly, cfg.CookieHTTPOnly)
+		})
+	}
+}
+
 // Test security validation functions
 func Test_CSRF_ExtractorSecurity_Validation(t *testing.T) {
 	t.Parallel()

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -105,6 +105,71 @@ func (s *failingCSRFStorage) Reset() error {
 
 func (*failingCSRFStorage) Close() error { return nil }
 
+func Test_CSRF_Cookie_Security_Config(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		config         Config
+		expectSecure   bool
+		expectHTTPOnly bool
+	}{
+		{
+			name:           "default config sets secure and HttpOnly",
+			config:         Config{},
+			expectSecure:   true,
+			expectHTTPOnly: true,
+		},
+		{
+			name: "disable flags remove secure and HttpOnly",
+			config: Config{
+				DisableCookieSecure:   true,
+				DisableCookieHTTPOnly: true,
+			},
+			expectSecure:   false,
+			expectHTTPOnly: false,
+		},
+		{
+			name: "CookieSecure false and CookieHTTPOnly false use secure defaults",
+			config: Config{
+				CookieSecure:   false,
+				CookieHTTPOnly: false,
+			},
+			expectSecure:   true,
+			expectHTTPOnly: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := fiber.New()
+			app.Use(New(tc.config))
+			app.Get("/", func(c fiber.Ctx) error {
+				return c.SendStatus(fiber.StatusOK)
+			})
+
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.Header.SetMethod(fiber.MethodGet)
+			app.Handler()(ctx)
+
+			cookie := string(ctx.Response.Header.Peek(fiber.HeaderSetCookie))
+			require.Contains(t, cookie, "SameSite=Lax")
+			if tc.expectSecure {
+				require.Contains(t, cookie, "secure")
+			} else {
+				require.NotContains(t, cookie, "secure")
+			}
+			if tc.expectHTTPOnly {
+				require.Contains(t, cookie, "HttpOnly")
+			} else {
+				require.NotContains(t, cookie, "HttpOnly")
+			}
+		})
+	}
+}
+
 func TestCSRFStorageGetError(t *testing.T) {
 	t.Parallel()
 

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -111,12 +111,14 @@ func Test_CSRF_Cookie_Security_Config(t *testing.T) {
 	tests := []struct {
 		name           string
 		config         Config
+		expectSameSite string
 		expectSecure   bool
 		expectHTTPOnly bool
 	}{
 		{
 			name:           "default config sets secure and HttpOnly",
 			config:         Config{},
+			expectSameSite: "SameSite=Lax",
 			expectSecure:   true,
 			expectHTTPOnly: true,
 		},
@@ -126,6 +128,7 @@ func Test_CSRF_Cookie_Security_Config(t *testing.T) {
 				DisableCookieSecure:   true,
 				DisableCookieHTTPOnly: true,
 			},
+			expectSameSite: "SameSite=Lax",
 			expectSecure:   false,
 			expectHTTPOnly: false,
 		},
@@ -135,6 +138,17 @@ func Test_CSRF_Cookie_Security_Config(t *testing.T) {
 				CookieSecure:   false,
 				CookieHTTPOnly: false,
 			},
+			expectSameSite: "SameSite=Lax",
+			expectSecure:   true,
+			expectHTTPOnly: true,
+		},
+		{
+			name: "SameSite None forces secure with disabled secure",
+			config: Config{
+				CookieSameSite:      "None",
+				DisableCookieSecure: true,
+			},
+			expectSameSite: "SameSite=None",
 			expectSecure:   true,
 			expectHTTPOnly: true,
 		},
@@ -155,7 +169,7 @@ func Test_CSRF_Cookie_Security_Config(t *testing.T) {
 			app.Handler()(ctx)
 
 			cookie := string(ctx.Response.Header.Peek(fiber.HeaderSetCookie))
-			require.Contains(t, cookie, "SameSite=Lax")
+			require.Contains(t, cookie, tc.expectSameSite)
 			if tc.expectSecure {
 				require.Contains(t, cookie, "secure")
 			} else {

--- a/middleware/session/config.go
+++ b/middleware/session/config.go
@@ -72,13 +72,23 @@ type Config struct {
 
 	// CookieSecure specifies if the session cookie should be secure.
 	//
-	// Optional. Default: false
+	// Optional. Default: true
 	CookieSecure bool
+
+	// DisableCookieSecure disables the secure flag for the session cookie.
+	//
+	// Optional. Default: false
+	DisableCookieSecure bool
 
 	// CookieHTTPOnly specifies if the session cookie should be HTTP-only.
 	//
-	// Optional. Default: false
+	// Optional. Default: true
 	CookieHTTPOnly bool
+
+	// DisableCookieHTTPOnly disables the HTTP only flag for the session cookie.
+	//
+	// Optional. Default: false
+	DisableCookieHTTPOnly bool
 
 	// CookieSessionOnly determines if the cookie should expire when the browser session ends.
 	//
@@ -95,6 +105,8 @@ var ConfigDefault = Config{
 	KeyGenerator:   utils.SecureToken,
 	Extractor:      extractors.FromCookie("session_id"),
 	CookieSameSite: "Lax",
+	CookieSecure:   true,
+	CookieHTTPOnly: true,
 }
 
 // DefaultErrorHandler logs the error and sends a 500 status code.
@@ -158,6 +170,22 @@ func configDefault(config ...Config) Config {
 
 	if cfg.CookieSameSite == "" {
 		cfg.CookieSameSite = ConfigDefault.CookieSameSite
+	}
+
+	if !cfg.CookieSecure {
+		cfg.CookieSecure = ConfigDefault.CookieSecure
+	}
+
+	if !cfg.CookieHTTPOnly {
+		cfg.CookieHTTPOnly = ConfigDefault.CookieHTTPOnly
+	}
+
+	if cfg.DisableCookieSecure {
+		cfg.CookieSecure = false
+	}
+
+	if cfg.DisableCookieHTTPOnly {
+		cfg.CookieHTTPOnly = false
 	}
 
 	return cfg

--- a/middleware/session/config_test.go
+++ b/middleware/session/config_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestConfigDefault(t *testing.T) {
+	t.Parallel()
+
 	// Test default config
 	cfg := configDefault()
 	require.Equal(t, 30*time.Minute, cfg.IdleTimeout)
@@ -18,9 +20,13 @@ func TestConfigDefault(t *testing.T) {
 	require.NotNil(t, cfg.Extractor)
 	require.Equal(t, "session_id", cfg.Extractor.Key)
 	require.Equal(t, "Lax", cfg.CookieSameSite)
+	require.True(t, cfg.CookieSecure)
+	require.True(t, cfg.CookieHTTPOnly)
 }
 
 func TestConfigDefaultWithCustomConfig(t *testing.T) {
+	t.Parallel()
+
 	// Test custom config
 	customConfig := Config{
 		IdleTimeout:  48 * time.Hour,
@@ -34,7 +40,66 @@ func TestConfigDefaultWithCustomConfig(t *testing.T) {
 	require.Equal(t, "X-Custom-Session", cfg.Extractor.Key)
 }
 
+func TestConfigDefaultCookieSecurity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		config           Config
+		expectedSecure   bool
+		expectedHTTPOnly bool
+	}{
+		{
+			name:             "empty config uses secure defaults",
+			config:           Config{},
+			expectedSecure:   true,
+			expectedHTTPOnly: true,
+		},
+		{
+			name: "false cookie flags use secure defaults",
+			config: Config{
+				CookieSecure:   false,
+				CookieHTTPOnly: false,
+			},
+			expectedSecure:   true,
+			expectedHTTPOnly: true,
+		},
+		{
+			name: "disable flags opt out of secure defaults",
+			config: Config{
+				DisableCookieSecure:   true,
+				DisableCookieHTTPOnly: true,
+			},
+			expectedSecure:   false,
+			expectedHTTPOnly: false,
+		},
+		{
+			name: "disable flags take precedence over explicit true",
+			config: Config{
+				CookieSecure:          true,
+				CookieHTTPOnly:        true,
+				DisableCookieSecure:   true,
+				DisableCookieHTTPOnly: true,
+			},
+			expectedSecure:   false,
+			expectedHTTPOnly: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := configDefault(tc.config)
+			require.Equal(t, tc.expectedSecure, cfg.CookieSecure)
+			require.Equal(t, tc.expectedHTTPOnly, cfg.CookieHTTPOnly)
+		})
+	}
+}
+
 func TestDefaultErrorHandler(t *testing.T) {
+	t.Parallel()
+
 	// Create a new Fiber app
 	app := fiber.New()
 
@@ -47,6 +112,8 @@ func TestDefaultErrorHandler(t *testing.T) {
 }
 
 func TestAbsoluteTimeoutValidation(t *testing.T) {
+	t.Parallel()
+
 	require.PanicsWithValue(t, "[session] AbsoluteTimeout must be greater than or equal to IdleTimeout", func() {
 		configDefault(Config{
 			IdleTimeout:     30 * time.Minute,

--- a/middleware/session/middleware.go
+++ b/middleware/session/middleware.go
@@ -86,6 +86,8 @@ func NewWithStore(config ...Config) (fiber.Handler, *Store) {
 
 	if cfg.Store == nil {
 		cfg.Store = NewStore(cfg)
+	} else {
+		applyStoreCookieOptOuts(&cfg)
 	}
 
 	handler := func(c fiber.Ctx) error {
@@ -116,6 +118,17 @@ func NewWithStore(config ...Config) (fiber.Handler, *Store) {
 	}
 
 	return handler, cfg.Store
+}
+
+func applyStoreCookieOptOuts(cfg *Config) {
+	if cfg.DisableCookieSecure {
+		cfg.Store.DisableCookieSecure = true
+		cfg.Store.CookieSecure = false
+	}
+	if cfg.DisableCookieHTTPOnly {
+		cfg.Store.DisableCookieHTTPOnly = true
+		cfg.Store.CookieHTTPOnly = false
+	}
 }
 
 var registerLogContextTagsOnce sync.Once

--- a/middleware/session/middleware_test.go
+++ b/middleware/session/middleware_test.go
@@ -444,6 +444,33 @@ func Test_Session_NewWithStore(t *testing.T) {
 	require.Equal(t, "value="+token, string(ctx.Response.Body()))
 }
 
+func Test_Session_NewWithSuppliedStoreHonorsCookieOptOuts(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore()
+	app := fiber.New()
+
+	app.Use(New(Config{
+		Store:                 store,
+		DisableCookieSecure:   true,
+		DisableCookieHTTPOnly: true,
+	}))
+	app.Get("/", func(c fiber.Ctx) error {
+		sess := FromContext(c)
+		sess.Set("key", "value")
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	cookie := resp.Header.Get(fiber.HeaderSetCookie)
+	require.Contains(t, cookie, "SameSite=Lax")
+	require.NotContains(t, cookie, "secure")
+	require.NotContains(t, cookie, "HttpOnly")
+}
+
 func Test_Session_FromSession(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"errors"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -945,7 +944,7 @@ func Test_Session_Cookie(t *testing.T) {
 	// cookie should be set on Save ( even if empty data )
 	cookie := ctx.Response().Header.PeekCookie("session_id")
 	require.NotNil(t, cookie)
-	require.Regexp(t, `^session_id=[A-Za-z0-9\-_]{43}; max-age=\d+; path=/; SameSite=Lax$`, string(cookie))
+	require.Regexp(t, `^session_id=[A-Za-z0-9_-]{43}; max-age=\d+; path=/; HttpOnly; secure; SameSite=Lax$`, string(cookie))
 }
 
 // go test -run Test_Session_Cookie_SameSite
@@ -956,60 +955,40 @@ func Test_Session_Cookie_SameSite(t *testing.T) {
 		expectedInHeader string
 		name             string
 		sameSite         string
-		initialSecure    bool
 	}{
 		{
-			name:             "Lax should not force secure",
+			name:             "Lax",
 			sameSite:         "Lax",
-			initialSecure:    false,
 			expectedInHeader: "SameSite=Lax",
 		},
 		{
-			name:             "Lax with secure should stay secure",
-			sameSite:         "Lax",
-			initialSecure:    true,
-			expectedInHeader: "SameSite=Lax; secure",
-		},
-		{
-			name:             "Strict should not force secure",
+			name:             "Strict",
 			sameSite:         "Strict",
-			initialSecure:    false,
 			expectedInHeader: "SameSite=Strict",
 		},
 		{
-			name:             "Strict with secure should stay secure",
-			sameSite:         "Strict",
-			initialSecure:    true,
-			expectedInHeader: "SameSite=Strict; secure",
-		},
-		{
-			name:             "None should force secure",
+			name:             "None",
 			sameSite:         "None",
-			initialSecure:    false,
-			expectedInHeader: "SameSite=None; secure",
+			expectedInHeader: "SameSite=None",
 		},
 		{
-			name:             "None with secure should stay secure",
-			sameSite:         "None",
-			initialSecure:    true,
-			expectedInHeader: "SameSite=None; secure",
-		},
-		{
-			name:             "Case-insensitive none should force secure",
+			name:             "case-insensitive none",
 			sameSite:         "none",
-			initialSecure:    false,
-			expectedInHeader: "SameSite=None; secure",
+			expectedInHeader: "SameSite=None",
 		},
 		{
-			name:             "Case-insensitive strict should not force secure",
+			name:             "case-insensitive strict",
 			sameSite:         "strict",
-			initialSecure:    false,
 			expectedInHeader: "SameSite=Strict",
 		},
 		{
-			name:             "Default should be Lax",
+			name:             "invalid falls back to Lax",
 			sameSite:         "invalid",
-			initialSecure:    false,
+			expectedInHeader: "SameSite=Lax",
+		},
+		{
+			name:             "empty uses default Lax",
+			sameSite:         "",
 			expectedInHeader: "SameSite=Lax",
 		},
 	}
@@ -1017,39 +996,109 @@ func Test_Session_Cookie_SameSite(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			// session store
 			store := NewStore(Config{
 				CookieSameSite: tc.sameSite,
-				CookieSecure:   tc.initialSecure,
 			})
 
-			// fiber instance
 			app := fiber.New()
-
-			// fiber context
 			ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
 			defer app.ReleaseCtx(ctx)
 
-			// get session
 			sess, err := store.Get(ctx)
 			require.NoError(t, err)
 			defer sess.Release()
 
-			// save session to trigger cookie setting
 			err = sess.Save()
 			require.NoError(t, err)
 
-			// check cookie
 			cookie := string(ctx.Response().Header.PeekCookie("session_id"))
-			// The order of attributes in the cookie string is not guaranteed.
-			// Instead of checking for a single substring, we check for the presence of each part.
-			parts := strings.SplitSeq(tc.expectedInHeader, "; ")
-			for part := range parts {
-				require.Contains(t, cookie, part)
-			}
+			require.Contains(t, cookie, tc.expectedInHeader)
+		})
+	}
+}
 
-			// Also check that secure is NOT present when it shouldn't be
-			if !tc.initialSecure && tc.sameSite != "None" && tc.sameSite != "none" {
+// go test -run Test_Session_Cookie_Secure_Config
+func Test_Session_Cookie_Secure_Config(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		expectedInHeader string
+		name             string
+		config           Config
+		expectSecure     bool
+	}{
+		{
+			name:             "default config sets secure",
+			config:           Config{},
+			expectSecure:     true,
+			expectedInHeader: "SameSite=Lax",
+		},
+		{
+			name: "explicit secure stays secure",
+			config: Config{
+				CookieSecure: true,
+			},
+			expectSecure:     true,
+			expectedInHeader: "SameSite=Lax",
+		},
+		{
+			name: "CookieSecure false uses default secure",
+			config: Config{
+				CookieSecure: false,
+			},
+			expectSecure:     true,
+			expectedInHeader: "SameSite=Lax",
+		},
+		{
+			name: "DisableCookieSecure disables secure with Lax",
+			config: Config{
+				CookieSameSite:      "Lax",
+				DisableCookieSecure: true,
+			},
+			expectSecure:     false,
+			expectedInHeader: "SameSite=Lax",
+		},
+		{
+			name: "DisableCookieSecure disables secure with Strict",
+			config: Config{
+				CookieSameSite:      "Strict",
+				DisableCookieSecure: true,
+			},
+			expectSecure:     false,
+			expectedInHeader: "SameSite=Strict",
+		},
+		{
+			name: "SameSite None forces secure despite DisableCookieSecure",
+			config: Config{
+				CookieSameSite:      "None",
+				DisableCookieSecure: true,
+			},
+			expectSecure:     true,
+			expectedInHeader: "SameSite=None",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := NewStore(tc.config)
+
+			app := fiber.New()
+			ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+			defer app.ReleaseCtx(ctx)
+
+			sess, err := store.Get(ctx)
+			require.NoError(t, err)
+			defer sess.Release()
+
+			err = sess.Save()
+			require.NoError(t, err)
+
+			cookie := string(ctx.Response().Header.PeekCookie("session_id"))
+			require.Contains(t, cookie, tc.expectedInHeader)
+			if tc.expectSecure {
+				require.Contains(t, cookie, "secure")
+			} else {
 				require.NotContains(t, cookie, "secure")
 			}
 		})

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -1026,11 +1026,13 @@ func Test_Session_Cookie_Secure_Config(t *testing.T) {
 		name             string
 		config           Config
 		expectSecure     bool
+		expectHTTPOnly   bool
 	}{
 		{
 			name:             "default config sets secure",
 			config:           Config{},
 			expectSecure:     true,
+			expectHTTPOnly:   true,
 			expectedInHeader: "SameSite=Lax",
 		},
 		{
@@ -1039,6 +1041,7 @@ func Test_Session_Cookie_Secure_Config(t *testing.T) {
 				CookieSecure: true,
 			},
 			expectSecure:     true,
+			expectHTTPOnly:   true,
 			expectedInHeader: "SameSite=Lax",
 		},
 		{
@@ -1047,6 +1050,7 @@ func Test_Session_Cookie_Secure_Config(t *testing.T) {
 				CookieSecure: false,
 			},
 			expectSecure:     true,
+			expectHTTPOnly:   true,
 			expectedInHeader: "SameSite=Lax",
 		},
 		{
@@ -1056,6 +1060,7 @@ func Test_Session_Cookie_Secure_Config(t *testing.T) {
 				DisableCookieSecure: true,
 			},
 			expectSecure:     false,
+			expectHTTPOnly:   true,
 			expectedInHeader: "SameSite=Lax",
 		},
 		{
@@ -1065,7 +1070,17 @@ func Test_Session_Cookie_Secure_Config(t *testing.T) {
 				DisableCookieSecure: true,
 			},
 			expectSecure:     false,
+			expectHTTPOnly:   true,
 			expectedInHeader: "SameSite=Strict",
+		},
+		{
+			name: "DisableCookieHTTPOnly disables HttpOnly",
+			config: Config{
+				DisableCookieHTTPOnly: true,
+			},
+			expectSecure:     true,
+			expectHTTPOnly:   false,
+			expectedInHeader: "SameSite=Lax",
 		},
 		{
 			name: "SameSite None forces secure despite DisableCookieSecure",
@@ -1074,6 +1089,7 @@ func Test_Session_Cookie_Secure_Config(t *testing.T) {
 				DisableCookieSecure: true,
 			},
 			expectSecure:     true,
+			expectHTTPOnly:   true,
 			expectedInHeader: "SameSite=None",
 		},
 	}
@@ -1100,6 +1116,11 @@ func Test_Session_Cookie_Secure_Config(t *testing.T) {
 				require.Contains(t, cookie, "secure")
 			} else {
 				require.NotContains(t, cookie, "secure")
+			}
+			if tc.expectHTTPOnly {
+				require.Contains(t, cookie, "HttpOnly")
+			} else {
+				require.NotContains(t, cookie, "HttpOnly")
 			}
 		})
 	}


### PR DESCRIPTION
# Description

This PR makes session and CSRF cookies secure by default. Both middleware configurations now default `CookieSecure` and `CookieHTTPOnly` to `true`, improving the default security posture for applications that use Fiber sessions or CSRF protection without explicit cookie settings.

Because Go `bool` fields cannot distinguish an omitted value from an explicit `false`, this PR also adds explicit opt-out flags: `DisableCookieSecure` and `DisableCookieHTTPOnly`. These flags give users a clear migration path for local development or deployments that intentionally need non-secure or non-HttpOnly cookies while preserving secure defaults for new and existing default configurations.

Fixes #4344 

## Changes introduced

- [ ] Benchmarks: Not run. The changes are configuration defaulting and cookie attribute propagation; no performance-sensitive hot path or allocation-heavy logic was introduced.
- [x] Documentation Update: Updated the session and CSRF middleware docs to show that `CookieSecure` and `CookieHTTPOnly` now default to `true`, and that `DisableCookieSecure` / `DisableCookieHTTPOnly` are the explicit opt-out flags.
- [x] Changelog/What's New: Added release notes explaining that session and CSRF cookies now default to `Secure` and `HttpOnly`, with explicit opt-out flags.
- [x] Migration Guide: If an application relied on insecure session or CSRF cookies, set `DisableCookieSecure: true`. If it relied on JavaScript-readable cookies, set `DisableCookieHTTPOnly: true`. Existing `CookieSecure: true` and `CookieHTTPOnly: true` configurations continue to work.
- [ ] API Alignment with Express: Not applicable. This change adjusts Fiber middleware cookie security defaults and opt-out configuration rather than adding an Express-aligned API.
- [x] API Longevity: Existing `CookieSecure` and `CookieHTTPOnly` fields are preserved for compatibility. New disable flags avoid changing the public bool fields to pointers or enums, preventing compile-time breakage while allowing explicit opt-out behavior.
- [x] Examples: Updated middleware documentation examples to show `DisableCookieSecure` for local HTTP development and `DisableCookieHTTPOnly` for SPA token access.

Additional test coverage was added for:

- session config secure and HttpOnly defaults
- session cookie Secure behavior, including `SameSite=None` forcing Secure
- CSRF config secure and HttpOnly defaults
- CSRF emitted `Set-Cookie` attributes

## Type of change

- [x] Enhancement (improvement to existing features and functionality)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist


- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.