### PR TITLE
test(cache,limiter): inject clock to make time-dependent tests deterministic

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -142,8 +142,6 @@ func New(config ...Config) fiber.Handler {
 		}
 	}
 
-	utils.StartTimeStampUpdater()
-
 	// Cache settings
 	mux := &sync.RWMutex{}
 	// Create manager to simplify storage operations ( see manager.go )
@@ -210,7 +208,7 @@ func New(config ...Config) fiber.Handler {
 
 		entry.heapidx = candidate.heapIdx
 
-		remainingTTL := max(time.Until(secondsToTime(entry.exp)), 0)
+		remainingTTL := max(secondsToTime(entry.exp).Sub(cfg.now()), 0)
 
 		if err := manager.set(ctx, candidate.key, entry, remainingTTL); err != nil {
 			return fmt.Errorf("cache: failed to restore heap index for key %q: %w", maskKey(candidate.key), err)
@@ -296,7 +294,7 @@ func New(config ...Config) fiber.Handler {
 		// Lock entry before reading the current timestamp so freshness decisions
 		// are based on the time the protected cache entry is evaluated.
 		mux.Lock()
-		ts := safeUnixSeconds(time.Now())
+		ts := safeUnixSeconds(cfg.now())
 		locked := true
 		unlock := func() {
 			if locked {
@@ -730,7 +728,7 @@ func New(config ...Config) fiber.Handler {
 		}
 		e.age = ageVal
 		e.shareable = isSharedCacheAllowed
-		now := time.Now().UTC()
+		now := cfg.now().UTC()
 		nowUnix := safeUnixSeconds(now)
 		dateHeader := c.Response().Header.Peek(fiber.HeaderDate)
 		parsedDate, _ := parseHTTPDate(dateHeader)
@@ -775,7 +773,7 @@ func New(config ...Config) fiber.Handler {
 					expiration = time.Nanosecond
 					expiresParseError = true
 				} else {
-					expiration = time.Until(expiresAt)
+					expiration = expiresAt.Sub(cfg.now())
 				}
 				expirationSource = expirationSourceExpires
 			}
@@ -798,7 +796,7 @@ func New(config ...Config) fiber.Handler {
 			return nil
 		}
 
-		ts = safeUnixSeconds(time.Now())
+		ts = safeUnixSeconds(cfg.now())
 		responseTS := max(ts, nowUnix)
 
 		maxAgeSeconds := uint64(time.Duration(math.MaxInt64) / time.Second)
@@ -1149,34 +1147,6 @@ func parseRequestCacheControl(cc []byte) requestCacheDirectives {
 
 func parseRequestCacheControlString(cc string) requestCacheDirectives {
 	return parseRequestCacheControl(utils.UnsafeBytes(cc))
-}
-
-func needsExactTimestamp(e *item, directives requestCacheDirectives, ts uint64) bool {
-	if e == nil {
-		return false
-	}
-
-	if directives.maxAgeSet || directives.minFreshSet {
-		return true
-	}
-
-	if e.exp != 0 {
-		// utils.Timestamp() is refreshed on a 1s ticker, so it can lag the real
-		// wall clock by almost one second. Re-read precisely once the cached
-		// second is within 1s of expiring.
-		if ts+1 >= e.exp {
-			return true
-		}
-	}
-
-	return timestampPredatesStoredSecond(e, ts)
-}
-
-func timestampPredatesStoredSecond(e *item, ts uint64) bool {
-	// When the coarse timestamp falls behind the second used to compute this
-	// entry's exp value, resident age math can underflow. Re-read precisely
-	// until the shared timestamp has caught up to the stored second.
-	return e.ttl != 0 && ts < e.exp && e.ttl < e.exp-ts
 }
 
 func cachedResponseAge(e *item, now uint64) uint64 {

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -29,6 +29,31 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+// testClock is a manually advanced clock that makes time-dependent freshness
+// tests deterministic: instead of sleeping past a TTL boundary (which is racy
+// under -race -count -shuffle), tests advance the clock explicitly. It is safe
+// for the concurrent reads performed by the cache handler.
+type testClock struct {
+	now time.Time
+	mu  sync.Mutex
+}
+
+func newTestClock(start time.Time) *testClock {
+	return &testClock{now: start}
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testClock) Add(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
 type failingCacheStorage struct {
 	data map[string][]byte
 	errs map[string]error
@@ -2161,8 +2186,12 @@ func Test_CacheInvalidExpiresStoredAsStale(t *testing.T) {
 func Test_CacheSMaxAgeOverridesMaxAgeWhenShorter(t *testing.T) {
 	t.Parallel()
 
+	// Drive freshness from a manually advanced clock so the immediate cache hit
+	// can never straddle a whole-second boundary (the previous time.Sleep based
+	// version flaked under -race -count -shuffle).
+	clock := newTestClock(time.Now().Truncate(time.Second))
 	app := fiber.New()
-	app.Use(New())
+	app.Use(New(Config{clock: clock.Now}))
 
 	var count int
 	app.Get("/", func(c fiber.Ctx) error {
@@ -2182,7 +2211,9 @@ func Test_CacheSMaxAgeOverridesMaxAgeWhenShorter(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "1", string(body))
 
-	time.Sleep(1700 * time.Millisecond)
+	// Advance past the 1s s-maxage window; max-age=10 is longer, so the shorter
+	// s-maxage must win and the entry must be treated as stale.
+	clock.Add(1100 * time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
 	require.NoError(t, err)
@@ -4373,43 +4404,6 @@ func Test_Cache_HelperFunctions(t *testing.T) {
 		require.Equal(t, uint64(1234567890), result)
 	})
 
-	t.Run("needsExactTimestamp nil entry", func(t *testing.T) {
-		t.Parallel()
-		require.False(t, needsExactTimestamp(nil, requestCacheDirectives{}, 100))
-	})
-
-	t.Run("needsExactTimestamp request directives", func(t *testing.T) {
-		t.Parallel()
-		e := &item{exp: 200}
-		require.True(t, needsExactTimestamp(e, requestCacheDirectives{maxAgeSet: true}, 100))
-		require.True(t, needsExactTimestamp(e, requestCacheDirectives{minFreshSet: true}, 100))
-	})
-
-	t.Run("needsExactTimestamp expiration boundary", func(t *testing.T) {
-		t.Parallel()
-		e := &item{exp: 100}
-		require.True(t, needsExactTimestamp(e, requestCacheDirectives{}, 99))
-		require.False(t, needsExactTimestamp(e, requestCacheDirectives{}, 98))
-	})
-
-	t.Run("needsExactTimestamp predates stored second", func(t *testing.T) {
-		t.Parallel()
-		e := &item{exp: 110, ttl: 10}
-		require.True(t, needsExactTimestamp(e, requestCacheDirectives{}, 99))
-	})
-
-	t.Run("timestampPredatesStoredSecond zero ttl", func(t *testing.T) {
-		t.Parallel()
-		require.False(t, timestampPredatesStoredSecond(&item{exp: 110}, 99))
-	})
-
-	t.Run("timestampPredatesStoredSecond lagging coarse timestamp", func(t *testing.T) {
-		t.Parallel()
-		e := &item{exp: 110, ttl: 10}
-		require.True(t, timestampPredatesStoredSecond(e, 99))
-		require.False(t, timestampPredatesStoredSecond(e, 100))
-	})
-
 	t.Run("remainingFreshness nil", func(t *testing.T) {
 		t.Parallel()
 		result := remainingFreshness(nil, 100)
@@ -5507,7 +5501,7 @@ func Test_hasDirective(t *testing.T) {
 
 // Test_CacheInvalidator_RaceWithExactTimestamp exercises the path where one
 // request triggers CacheInvalidator (writing e.exp under mux.Lock) while
-// concurrent requests evaluate needsExactTimestamp(e, ...). The fields must be
+// concurrent requests evaluate freshness (reading e.exp). The fields must be
 // read under the lock; -race will flag a regression. The test also asserts
 // the invalidator path actually drives fresh handler executions, so a
 // regression that silently disabled invalidation would also fail.

--- a/middleware/cache/config.go
+++ b/middleware/cache/config.go
@@ -45,6 +45,11 @@ type Config struct {
 	// Default: nil
 	ExpirationGenerator func(fiber.Ctx, *Config) time.Duration
 
+	// clock overrides the time source used for freshness decisions. It is
+	// unexported so it never becomes part of the public API and exists solely to
+	// make time-dependent tests deterministic. When nil, time.Now is used.
+	clock func() time.Time
+
 	// CacheHeader header on response header, indicate cache status, with the following possible return value
 	//
 	// hit, miss, unreachable
@@ -183,6 +188,16 @@ func configDefault(config ...Config) Config {
 		}
 	}
 	return cfg
+}
+
+// now returns the current time used for freshness decisions. Production uses
+// time.Now; tests can inject a deterministic clock via the unexported clock
+// field.
+func (cfg *Config) now() time.Time {
+	if cfg.clock != nil {
+		return cfg.clock()
+	}
+	return time.Now()
 }
 
 func normalizeHeaderDimensions(values, defaults []string) []string {

--- a/middleware/limiter/config.go
+++ b/middleware/limiter/config.go
@@ -158,7 +158,13 @@ func configDefault(config ...Config) Config {
 // deterministic clock via the unexported clock field.
 func (cfg *Config) currentSecond() uint64 {
 	if cfg.clock != nil {
-		return uint64(cfg.clock().Unix())
+		// Guard against pre-epoch (negative) timestamps so the int64 -> uint64
+		// conversion never wraps to a huge value and corrupts window math.
+		sec := cfg.clock().Unix()
+		if sec < 0 {
+			return 0
+		}
+		return uint64(sec)
 	}
 	return uint64(utils.Timestamp())
 }

--- a/middleware/limiter/config.go
+++ b/middleware/limiter/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/utils/v2"
 )
 
 const defaultLimiterMax = 5
@@ -35,6 +36,12 @@ type Config struct {
 	//
 	// Default: A function that returns the static `Expiration` value from the config.
 	ExpirationFunc func(c fiber.Ctx) time.Duration
+
+	// clock overrides the timestamp source used for window accounting. It is
+	// unexported so it never becomes part of the public API and exists solely to
+	// make time-dependent tests deterministic. When nil, the cached
+	// utils.Timestamp() is used on the hot path.
+	clock func() time.Time
 
 	// KeyGenerator allows you to generate custom keys, by default c.IP() is used
 	//
@@ -143,4 +150,15 @@ func configDefault(config ...Config) Config {
 		}
 	}
 	return cfg
+}
+
+// currentSecond returns the current Unix time in whole seconds used for window
+// accounting. Production reads the cached utils.Timestamp() (refreshed by a 1s
+// ticker) to keep the hot path allocation- and syscall-free; tests can inject a
+// deterministic clock via the unexported clock field.
+func (cfg *Config) currentSecond() uint64 {
+	if cfg.clock != nil {
+		return uint64(cfg.clock().Unix())
+	}
+	return uint64(utils.Timestamp())
 }

--- a/middleware/limiter/limiter_fixed.go
+++ b/middleware/limiter/limiter_fixed.go
@@ -61,7 +61,7 @@ func (FixedWindow) New(cfg *Config) fiber.Handler {
 		}
 
 		// Get timestamp
-		ts := uint64(utils.Timestamp())
+		ts := cfg.currentSecond()
 
 		// Set expiration if entry does not exist
 		if e.exp == 0 {

--- a/middleware/limiter/limiter_sliding.go
+++ b/middleware/limiter/limiter_sliding.go
@@ -63,7 +63,7 @@ func (SlidingWindow) New(cfg *Config) fiber.Handler {
 		}
 
 		// Get timestamp
-		ts := uint64(utils.Timestamp())
+		ts := cfg.currentSecond()
 
 		// Rotate window
 		resetInSec := rotateWindow(e, ts, expiration)
@@ -133,7 +133,7 @@ func (SlidingWindow) New(cfg *Config) fiber.Handler {
 			}
 			e = entry
 
-			ts = uint64(utils.Timestamp())
+			ts = cfg.currentSecond()
 			resetInSec = rotateWindow(e, ts, expiration)
 			weight = float64(resetInSec) / float64(expiration)
 

--- a/middleware/limiter/limiter_test.go
+++ b/middleware/limiter/limiter_test.go
@@ -19,6 +19,31 @@ import (
 	"github.com/gofiber/fiber/v3/internal/storage/memory"
 )
 
+// testClock is a manually advanced clock that makes window-expiry tests
+// deterministic: instead of sleeping past a window boundary (racy under
+// -race -count -shuffle), tests advance the clock explicitly. It is safe for
+// the concurrent reads performed by the limiter handler.
+type testClock struct {
+	now time.Time
+	mu  sync.Mutex
+}
+
+func newTestClock(start time.Time) *testClock {
+	return &testClock{now: start}
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testClock) Add(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
 type failingLimiterStorage struct {
 	data map[string][]byte
 	errs map[string]error
@@ -692,12 +717,14 @@ func Test_Limiter_With_Max_Func(t *testing.T) {
 // go test -run Test_Limiter_Fixed_ExpirationFuncOverridesStaticExpiration -race -v
 func Test_Limiter_Fixed_ExpirationFuncOverridesStaticExpiration(t *testing.T) {
 	t.Parallel()
+	clock := newTestClock(time.Now().Truncate(time.Second))
 	app := fiber.New()
 
 	app.Use(New(Config{
 		Max:               2,
 		Expiration:        10 * time.Second,
 		ExpirationFunc:    func(_ fiber.Ctx) time.Duration { return 2 * time.Second },
+		clock:             clock.Now,
 		LimiterMiddleware: FixedWindow{},
 	}))
 
@@ -717,7 +744,8 @@ func Test_Limiter_Fixed_ExpirationFuncOverridesStaticExpiration(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusTooManyRequests, resp.StatusCode)
 
-	time.Sleep(3 * time.Second)
+	// Advance past the 2s ExpirationFunc window so the fixed window resets.
+	clock.Add(3 * time.Second)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
 	require.NoError(t, err)
@@ -1130,11 +1158,13 @@ func Test_Limiter_Sliding_Window_RecalculatesAfterHandlerDelay(t *testing.T) {
 
 func Test_Limiter_Sliding_Window_ExpiresStalePrevHits(t *testing.T) {
 	t.Parallel()
+	clock := newTestClock(time.Now().Truncate(time.Second))
 	app := fiber.New()
 
 	app.Use(New(Config{
 		Max:               1,
 		Expiration:        time.Second,
+		clock:             clock.Now,
 		LimiterMiddleware: SlidingWindow{},
 	}))
 
@@ -1146,7 +1176,8 @@ func Test_Limiter_Sliding_Window_ExpiresStalePrevHits(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusOK, resp.StatusCode)
 
-	time.Sleep(2500 * time.Millisecond)
+	// Advance two full windows so the previous-window hits age out completely.
+	clock.Add(2500 * time.Millisecond)
 
 	resp, err = app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
 	require.NoError(t, err)

--- a/middleware/limiter/limiter_test.go
+++ b/middleware/limiter/limiter_test.go
@@ -1789,3 +1789,16 @@ func Test_Sliding_Window(t *testing.T) {
 		singleRequest(true)
 	}
 }
+
+// Test_Config_currentSecond_NegativeClock verifies that an injected pre-epoch
+// (negative Unix) timestamp is clamped to 0 instead of wrapping to a huge
+// uint64, while a non-negative timestamp is converted unchanged.
+func Test_Config_currentSecond_NegativeClock(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{clock: func() time.Time { return time.Unix(-100, 0) }}
+	require.Equal(t, uint64(0), cfg.currentSecond())
+
+	cfg.clock = func() time.Time { return time.Unix(42, 0) }
+	require.Equal(t, uint64(42), cfg.currentSecond())
+}


### PR DESCRIPTION
## Problem

The `repeated` CI job runs the suite with `-race -count=15 -shuffle=on` to surface flakes. Time-dependent tests in `middleware/cache` and `middleware/limiter` fail intermittently because they assert freshness / rate-limit window behavior against the wall clock at **whole-second granularity**.

Example: `Test_CacheSMaxAgeOverridesMaxAgeWhenShorter` caches with `s-maxage=1` and asserts a `hit` on the immediately following request. The cache evaluates freshness as `ts >= e.exp` with `ts := safeUnixSeconds(time.Now())`. If the store and the hit request straddle a Unix-second boundary, the 1s entry is already "expired" and the hit becomes a `miss`, which is exactly what the failing run showed (`expected: "hit", actual: "miss"`).

## Approach

Make the time source injectable through an **unexported, per-instance `clock` field** on each `Config`:

- Unexported, so it never becomes part of the public API.
- Per-instance, so it is safe under `t.Parallel()` (a global `var now = time.Now` would race).
- Same-package tests set it via `Config{clock: ...}` and advance a manual fake clock instead of `time.Sleep`, which is both deterministic and much faster.

### cache
- Reads `time.Now()` under the lock via `cfg.now()`, keeping the existing freshness-after-lock behavior.
- Removes the orphaned `needsExactTimestamp` / `timestampPredatesStoredSecond` helpers and their unit tests. They lost their only production caller when the coarse-clock hot path was removed; only the tests still referenced them.
- `Test_CacheSMaxAgeOverridesMaxAgeWhenShorter` now advances the fake clock.

### limiter
- **Keeps the cached `utils.Timestamp()` hot-path read in production** via `cfg.currentSecond()`. The injected clock is used only when set (tests), so the per-request hot path is unchanged for users.
- Two window-expiry tests now advance the fake clock.

## Verification

| Check | Result |
| --- | --- |
| `cache` `-race -count=15 -shuffle=on` (CI settings) | pass (~62s) |
| `limiter` sub-second window tests `-race -count=40 -shuffle=on` | pass |
| `limiter` full package `-race -shuffle=on` | pass |
| converted tests `-race -count=40-50 -shuffle=on` | pass |
| `go build ./...`, `go vet`, `gofmt -l` | clean |
| public API | no exported `Clock` field added |

## Notes
- `idempotency` is intentionally out of scope: it reads no wall-clock time itself (expiry is delegated to the storage GC), so an injectable clock would have nothing to act on.
- Several limiter tests still use `time.Sleep(3s)` with generous margins; they are slow but not flaky, and can be migrated to the clock in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
