### PR TITLE
🐛 bug: preserve legacy custom constraint arguments

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -101,7 +101,9 @@ type customConstraintWrapper struct {
 func (w *customConstraintWrapper) Analyze(args []string) ([]any, error) {
 	parsedArgs := parseConstraintArgs(args)
 	if analyzer, ok := w.CustomConstraint.(ConstraintAnalyzer); ok {
-		return analyzer.Analyze(parsedArgs)
+		if _, err := analyzer.Analyze(parsedArgs); err != nil {
+			return nil, err
+		}
 	}
 	return []any{parsedArgs}, nil
 }

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -297,7 +297,29 @@ func Test_CustomConstraintWrapper_DelegatesAnalyze(t *testing.T) {
 
 	typed, err := analyzer.Analyze([]string{"2006-01-02"})
 	require.NoError(t, err)
-	require.Len(t, typed, 1)
-	require.Equal(t, "2006-01-02", typed[0])
+	require.Equal(t, []any{[]string{"2006-01-02"}}, typed)
 	require.Equal(t, "2006-01-02", custom.layout)
+}
+
+type testCustomConstraintWithTypedAnalyzer struct{}
+
+func (*testCustomConstraintWithTypedAnalyzer) Name() string { return "customRole" }
+func (*testCustomConstraintWithTypedAnalyzer) Execute(param string, args ...string) bool {
+	return len(args) == 1 && args[0] == "admin" && param == "admin"
+}
+
+func (*testCustomConstraintWithTypedAnalyzer) Analyze(args []string) ([]any, error) {
+	return stringArgsToAny(args), nil
+}
+
+func Test_CustomConstraintWrapper_ExecuteKeepsLegacyArgsWithAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	custom := &testCustomConstraintWithTypedAnalyzer{}
+	handler := findConstraintHandler("customRole", nil, []CustomConstraint{custom})
+	require.NotNil(t, handler)
+
+	c := newConstraint(handler, "customRole", []string{"admin"})
+	require.True(t, c.matchConstraint("admin"))
+	require.False(t, c.matchConstraint("guest"))
 }


### PR DESCRIPTION
### Motivation
- Fix a route-matching regression where custom constraints that also implement `ConstraintAnalyzer` could have their configured route arguments dropped at request time, enabling an opt‑in constraint bypass.
- Restore backward-compatible behavior so legacy `CustomConstraint.Execute(param, args ...string)` continues to receive the parsed `[]string` arguments while still running analyzer validation/side effects.

### Description
- Change `customConstraintWrapper.Analyze` to invoke the underlying `ConstraintAnalyzer` for validation/side effects but ignore its typed return values and always return `[]any{parsedArgs}` so legacy argument shape is preserved.
- Preserve request-time behavior by ensuring `newConstraint` and `Constraint.matchConstraint` continue to use the wrapper-provided legacy `[]string` payload when calling `Execute`.
- Add/adjust tests in `constraint_test.go` to assert the wrapper returns the legacy `[]string` shape and to cover the regression with `Test_CustomConstraintWrapper_ExecuteKeepsLegacyArgsWithAnalyzer`.
- No public API changes; behavior is restored to be backward-compatible with legacy custom constraints.

### Testing
- Ran `go test ./...` and `make test`, which completed successfully (all tests passed; summary: `DONE 3583 tests, 1 skipped`).
- Ran `make generate`, `make betteralign`, `make format`, and `make lint`, which succeeded (`make lint` reported `0 issues`).
- Ran `make audit`, which exercises `govulncheck` and failed in this environment due to known standard-library vulnerabilities reported against the toolchain `go1.25.1` (25 stdlib issues); this is an environment/toolchain issue and not caused by these code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e31b122b883339a80aa3c4c918c5a)