### PR TITLE
docs: replace interface{} with any (Go 1.18+)

### DIFF
--- a/client/response.go
+++ b/client/response.go
@@ -110,7 +110,7 @@ func (r *Response) String() string {
 	return utils.TrimSpace(string(r.Body()))
 }
 
-// JSON unmarshal the response body into the given interface{} using JSON.
+// JSON unmarshal the response body into the given any using JSON.
 func (r *Response) JSON(v any) error {
 	if r.client == nil {
 		return ErrClientNil
@@ -119,7 +119,7 @@ func (r *Response) JSON(v any) error {
 	return r.client.jsonUnmarshal(r.Body(), v)
 }
 
-// CBOR unmarshal the response body into the given interface{} using CBOR.
+// CBOR unmarshal the response body into the given any using CBOR.
 func (r *Response) CBOR(v any) error {
 	if r.client == nil {
 		return ErrClientNil
@@ -128,7 +128,7 @@ func (r *Response) CBOR(v any) error {
 	return r.client.cborUnmarshal(r.Body(), v)
 }
 
-// XML unmarshal the response body into the given interface{} using XML.
+// XML unmarshal the response body into the given any using XML.
 func (r *Response) XML(v any) error {
 	if r.client == nil {
 		return ErrClientNil

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -53,7 +53,7 @@ type Views interface {
 
     // Outputs a template to the provided buffer using the provided template,
     // template name, and bound data
-    Render(io.Writer, string, interface{}, ...string) error
+    Render(io.Writer, string, any, ...string) error
 }
 ```
 
@@ -117,7 +117,7 @@ Fiber supports adding custom functions to templates.
 Adds a global function to all templates.
 
 ```go title="Signature"
-func (e *Engine) AddFunc(name string, fn interface{}) IEngineCore
+func (e *Engine) AddFunc(name string, fn any) IEngineCore
 ```
 
 <Tabs>
@@ -163,7 +163,7 @@ app.Get("/", func (c fiber.Ctx) error {
 Adds a Map of functions (keyed by name) to all templates.
 
 ```go title="Signature"
-func (e *Engine) AddFuncMap(m map[string]interface{}) IEngineCore
+func (e *Engine) AddFuncMap(m map[string]any) IEngineCore
 ```
 
 <Tabs>
@@ -172,7 +172,7 @@ func (e *Engine) AddFuncMap(m map[string]interface{}) IEngineCore
 ```go
 // Add `ToUpper` to engine
 engine := html.New("./views", ".html")
-engine.AddFuncMap(map[string]interface{}{
+engine.AddFuncMap(map[string]any{
     "ToUpper": func(s string) string {
         return strings.ToUpper(s)
     },

--- a/docs/middleware/session.md
+++ b/docs/middleware/session.md
@@ -471,7 +471,7 @@ Session data supports basic Go types by default:
 - `uint`, `uint8`, `uint16`, `uint32`, `uint64`
 - `bool`, `float32`, `float64`
 - `[]byte`, `complex64`, `complex128`
-- `interface{}`
+- `any`
 
 For custom types (structs, maps, slices), you must register them for encoding/decoding:
 
@@ -645,7 +645,7 @@ store.Reset(ctx context.Context) error
 store.Delete(ctx context.Context, sessionID string) error
 
 // Type registration
-store.RegisterType(interface{})
+store.RegisterType(any)
 ```
 
 ### Session Methods (Store Pattern)

--- a/docs/middleware/session.md
+++ b/docs/middleware/session.md
@@ -645,7 +645,7 @@ store.Reset(ctx context.Context) error
 store.Delete(ctx context.Context, sessionID string) error
 
 // Type registration
-store.RegisterType(any)
+store.RegisterType(User{})
 ```
 
 ### Session Methods (Store Pattern)

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -708,7 +708,7 @@ The `TypeConstraint` type, `Constraint.ID`, and `Constraint.RegexCompiler` field
 ### Changed Methods
 
 - **Bind**: Now used for binding instead of view binding. Use `c.ViewBind()` for view binding.
-- **Format**: Parameter changed from `body interface{}` to `handlers ...ResFmt`.
+- **Format**: Parameter changed from `body any` to `handlers ...ResFmt`.
 - **Redirect**: Use `c.Redirect().To()` instead.
 - **SendFile**: Now supports different configurations using a config parameter.
 - **Attachment and Download**: Non-ASCII filenames now use `filename*` as


### PR DESCRIPTION
Replace `interface{}` with `any` across 4 files for Go 1.18+ compatibility.