### PR TITLE
test(session): cover deadline/error paths and delegate Middleware lifecycle methods

### DIFF
--- a/middleware/session/middleware.go
+++ b/middleware/session/middleware.go
@@ -323,12 +323,7 @@ func (m *Middleware) Keys() []any {
 //
 //	err := m.Destroy()
 func (m *Middleware) Destroy() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	err := m.Session.Destroy()
-	m.isDestroyed = true
-	return err
+	return m.DestroyWithContext(m.resolveContext())
 }
 
 // DestroyWithContext destroys the session using the provided context for cancellation and timeout control.
@@ -384,10 +379,7 @@ func (m *Middleware) ID() string {
 //
 //	err := m.Reset()
 func (m *Middleware) Reset() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	return m.Session.Reset()
+	return m.ResetWithContext(m.resolveContext())
 }
 
 // ResetWithContext resets the session using the provided context for cancellation and timeout control.
@@ -420,10 +412,7 @@ func (m *Middleware) ResetWithContext(ctx context.Context) error {
 //
 //	err := m.Regenerate()
 func (m *Middleware) Regenerate() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	return m.Session.Regenerate()
+	return m.RegenerateWithContext(m.resolveContext())
 }
 
 // RegenerateWithContext generates a new session ID while preserving session data,

--- a/middleware/session/middleware_test.go
+++ b/middleware/session/middleware_test.go
@@ -849,6 +849,38 @@ func Test_Middleware_RegenerateWithContext(t *testing.T) {
 	_ = store
 }
 
+// go test -run Test_Middleware_WithContext_ErrorPropagation
+func Test_Middleware_WithContext_ErrorPropagation(t *testing.T) {
+	t.Parallel()
+
+	canceledCtx := func() context.Context {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	}
+
+	t.Run("DestroyWithContext propagates canceled context and marks destroyed", func(t *testing.T) {
+		t.Parallel()
+		m := &Middleware{Session: newSessionWithStorage(t, &contextStorage{})}
+		require.ErrorIs(t, m.DestroyWithContext(canceledCtx()), context.Canceled)
+		require.True(t, m.isDestroyed)
+	})
+
+	t.Run("ResetWithContext propagates storage error", func(t *testing.T) {
+		t.Parallel()
+		storageErr := errors.New("storage unavailable")
+		m := &Middleware{Session: newSessionWithStorage(t, &failingStorage{err: storageErr})}
+		require.ErrorIs(t, m.ResetWithContext(t.Context()), storageErr)
+	})
+
+	t.Run("RegenerateWithContext propagates storage error", func(t *testing.T) {
+		t.Parallel()
+		storageErr := errors.New("storage unavailable")
+		m := &Middleware{Session: newSessionWithStorage(t, &failingStorage{err: storageErr})}
+		require.ErrorIs(t, m.RegenerateWithContext(t.Context()), storageErr)
+	})
+}
+
 func Test_Middleware_ResolveContext(t *testing.T) {
 	t.Parallel()
 

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -1772,6 +1772,7 @@ func Test_Session_RegenerateWithContext(t *testing.T) {
 		require.NoError(t, err)
 
 		originalID := freshSession.ID()
+		freshSession.Set("name", "fenny")
 
 		err = freshSession.Save()
 		require.NoError(t, err)
@@ -1791,6 +1792,8 @@ func Test_Session_RegenerateWithContext(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, originalID, sess.ID())
 		require.True(t, sess.Fresh())
+		// Regenerate must preserve session data (unlike Reset, which clears it).
+		require.Equal(t, "fenny", sess.Get("name"))
 	})
 }
 
@@ -1865,24 +1868,19 @@ func Test_Session_SaveWithContext(t *testing.T) {
 		require.NoError(t, sess.SaveWithContext(t.Context()))
 	})
 
-	t.Run("save with context when in middleware handler", func(t *testing.T) {
+	t.Run("save with context is a no-op when in middleware handler", func(t *testing.T) {
 		t.Parallel()
-		store := NewStore()
-		app := fiber.New()
-		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
-		defer app.ReleaseCtx(ctx)
+		// Back the session with a storage that errors on any write: a real save
+		// would surface that error, so a nil return proves no write happened.
+		sess := newSessionWithStorage(t, &failingStorage{err: errors.New("Set must not be called")})
+		sess.Set("name", "fenny")
 
-		sess, err := store.Get(ctx)
-		require.NoError(t, err)
-		defer sess.Release()
-
-		// Simulate middleware context
+		// Simulate the session being in use by the middleware handler.
 		m := &Middleware{Session: sess}
-		ctx.Locals(middlewareContextKey, m)
+		sess.ctx.Locals(middlewareContextKey, m)
 
-		// SaveWithContext should be a no-op when session is in use by middleware
-		err = sess.SaveWithContext(t.Context())
-		require.NoError(t, err)
+		// SaveWithContext must be a no-op when the session is in use by middleware.
+		require.NoError(t, sess.SaveWithContext(t.Context()))
 	})
 }
 
@@ -2009,6 +2007,51 @@ func Test_Session_WithContext_CanceledContext(t *testing.T) {
 		sess := newSessionWithStorage(t, &contextStorage{})
 		sess.Set("name", "fenny")
 		require.ErrorIs(t, sess.SaveWithContext(canceledCtx()), context.Canceled)
+	})
+}
+
+// go test -run Test_Session_WithContext_DeadlineContext
+func Test_Session_WithContext_DeadlineContext(t *testing.T) {
+	t.Parallel()
+
+	// contextStorage honors a deadline by returning ctx.Err(). An already-expired
+	// deadline yields context.DeadlineExceeded, the primary motivation for the
+	// *WithContext variants (bounding slow or unresponsive backends).
+	expiredCtx := func() context.Context {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+		t.Cleanup(cancel)
+		return ctx
+	}
+
+	t.Run("DestroyWithContext honors expired deadline", func(t *testing.T) {
+		t.Parallel()
+		sess := newSessionWithStorage(t, &contextStorage{})
+		sess.Set("name", "fenny")
+		require.ErrorIs(t, sess.DestroyWithContext(expiredCtx()), context.DeadlineExceeded)
+		// A timed-out delete must not wipe the in-memory session.
+		require.Equal(t, "fenny", sess.Get("name"))
+	})
+
+	t.Run("RegenerateWithContext honors expired deadline", func(t *testing.T) {
+		t.Parallel()
+		sess := newSessionWithStorage(t, &contextStorage{})
+		require.ErrorIs(t, sess.RegenerateWithContext(expiredCtx()), context.DeadlineExceeded)
+	})
+
+	t.Run("ResetWithContext honors expired deadline", func(t *testing.T) {
+		t.Parallel()
+		sess := newSessionWithStorage(t, &contextStorage{})
+		sess.Set("name", "fenny")
+		require.ErrorIs(t, sess.ResetWithContext(expiredCtx()), context.DeadlineExceeded)
+		// A timed-out delete must not wipe the in-memory session.
+		require.Equal(t, "fenny", sess.Get("name"))
+	})
+
+	t.Run("SaveWithContext honors expired deadline", func(t *testing.T) {
+		t.Parallel()
+		sess := newSessionWithStorage(t, &contextStorage{})
+		sess.Set("name", "fenny")
+		require.ErrorIs(t, sess.SaveWithContext(expiredCtx()), context.DeadlineExceeded)
 	})
 }
 


### PR DESCRIPTION
## Follow-up to #4393

PR #4393 added the `*WithContext` session variants. The review findings turned out to be **missing coverage / minor cleanup, not bugs** (behavior verified correct locally). This PR closes those gaps.

### Code
- `Middleware.Destroy/Reset/Regenerate` now delegate to their `*WithContext` variants instead of duplicating the lock + `isDestroyed` handling. This matches the `Session` methods and makes the documented "the non-context variants delegate to these" statement true for `Middleware` too. No behavior change (covered by existing middleware tests).

### Tests
- **`Test_Session_WithContext_DeadlineContext`**: an expired `context.WithDeadline` yields `context.DeadlineExceeded` across Destroy/Regenerate/Reset/Save; a timed-out delete keeps in-memory data intact. (Previously only an already-cancelled context was covered; the deadline case is the primary motivation for the variants.)
- **`Test_Middleware_WithContext_ErrorPropagation`**: the middleware wrappers propagate cancelled/storage errors and set `isDestroyed` (previously only the happy path was tested).
- Strengthened "save no-op in middleware handler": backed by a failing storage, the `nil` return positively proves the write is skipped.
- `Test_Session_RegenerateWithContext` now asserts data is **preserved** across regenerate (the subtest was named "preserves data" but never set/checked any).

### Validation
- `go test ./middleware/session/... -race -shuffle=on` passes; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)