### PR TITLE
🐛 bug: reject empty CORS wildcard labels

### DIFF
--- a/middleware/cors/utils.go
+++ b/middleware/cors/utils.go
@@ -95,7 +95,7 @@ func (s subdomain) match(o string) bool {
 	// Extract the subdomain part (without the trailing dot) and ensure it
 	// doesn't contain empty labels.
 	sub := o[len(s.prefix) : suffixStartIndex-1]
-	if sub == "" || strings.HasPrefix(sub, ".") || strings.Contains(sub, "..") {
+	if sub == "" || strings.HasPrefix(sub, ".") || strings.HasSuffix(sub, ".") || strings.Contains(sub, "..") {
 		return false
 	}
 

--- a/middleware/cors/utils_test.go
+++ b/middleware/cors/utils_test.go
@@ -130,6 +130,8 @@ func Benchmark_CORS_SubdomainMatch(b *testing.B) {
 }
 
 func Test_CORS_SubdomainMatch(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		sub      subdomain
@@ -203,10 +205,18 @@ func Test_CORS_SubdomainMatch(t *testing.T) {
 			origin:   "https://..example.com",
 			expected: false,
 		},
+		{
+			name:     "no match with empty label before suffix",
+			sub:      subdomain{prefix: "https://", suffix: "example.com"},
+			origin:   "https://foo..example.com",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := tt.sub.match(tt.origin)
 			assert.Equal(t, tt.expected, got, "subdomain.match()")
 		})


### PR DESCRIPTION
### Motivation
- Prevent malformed origins such as `https://foo..example.com` from matching wildcard `AllowOrigins` entries and being reflected with credentialed CORS headers by hardening the wildcard subdomain validation.

### Description
- Add a `strings.HasSuffix(sub, ".")` check in `subdomain.match` to reject wildcard portions that end with a dot.
- Add a regression unit test for `https://foo..example.com` and enable `t.Parallel()` for the table test and each subtest to follow repository testing guidance.

### Testing
- Ran `go test ./middleware/cors -run Test_CORS_SubdomainMatch` which passed.
- Ran the full suite with `make test` which passed (3643 tests, 1 skipped).
- Ran `make generate`, `make betteralign`, `make format`, and `make lint` which succeeded, and ran `make audit` which failed due to `govulncheck` reporting Go standard library vulnerabilities in the configured `go1.25.1` toolchain.