### PR TITLE
🐛 bug: validate wildcard CORS origins before matching

### DIFF
--- a/middleware/cors/utils.go
+++ b/middleware/cors/utils.go
@@ -72,6 +72,11 @@ type subdomain struct {
 }
 
 func (s subdomain) match(o string) bool {
+	isValid, normalizedOrigin := normalizeOrigin(o)
+	if !isValid || normalizedOrigin != o {
+		return false
+	}
+
 	// Not a subdomain if not long enough for a dot separator.
 	if len(o) < len(s.prefix)+len(s.suffix)+1 {
 		return false

--- a/middleware/cors/utils_test.go
+++ b/middleware/cors/utils_test.go
@@ -209,8 +209,9 @@ func Test_CORS_SubdomainMatch(t *testing.T) {
 			name:     "no match with malformed origin port before suffix",
 			sub:      subdomain{prefix: "https://", suffix: "example.com"},
 			origin:   "https://evil.com:any.example.com",
-      expected: false,
-    },
+			expected: false,
+		},
+		{
 			name:     "no match with empty label before suffix",
 			sub:      subdomain{prefix: "https://", suffix: "example.com"},
 			origin:   "https://foo..example.com",

--- a/middleware/cors/utils_test.go
+++ b/middleware/cors/utils_test.go
@@ -203,6 +203,12 @@ func Test_CORS_SubdomainMatch(t *testing.T) {
 			origin:   "https://..example.com",
 			expected: false,
 		},
+		{
+			name:     "no match with malformed origin port before suffix",
+			sub:      subdomain{prefix: "https://", suffix: "example.com"},
+			origin:   "https://evil.com:any.example.com",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Motivation
- Prevent wildcard CORS rules like `https://*.example.com` from matching malformed Origin headers such as `https://evil.com:any.example.com` that are not valid serialized origins, which could be reflected in `Access-Control-Allow-Origin` when `AllowCredentials` is enabled.

### Description
- Ensure candidate request Origins are valid serialized origins by calling `normalizeOrigin` and requiring the normalized form to equal the raw Origin before applying the existing prefix/suffix subdomain matching in `subdomain.match` (changed in `middleware/cors/utils.go`).
- Add a regression test asserting the malformed Origin `https://evil.com:any.example.com` does not match `https://*.example.com` (added to `middleware/cors/utils_test.go`).

### Testing
- Ran `go test ./middleware/cors -run Test_CORS_SubdomainMatch -count=1`, which passed (`ok github.com/gofiber/fiber/v3/middleware/cors 0.019s`).
- Ran the repository checks: `make generate`, `make betteralign`, `make format`, `make lint`, and `make test` all completed successfully; `make test` ran the full suite (`DONE 3643 tests, 1 skipped`).
- `make audit` reported failures from `govulncheck` targeting the installed Go standard library (25 vulnerabilities reported for the toolchain), causing `make audit` to fail; this is an environment/toolchain vulnerability report and not a regression in the patch itself.