### PR TITLE
🐛 bug: fix data race on lazy appListKeys generation in Render

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -831,9 +831,7 @@ func (c *DefaultCtx) renderExtensions(bind any) {
 		}
 	}
 
-	if len(c.app.mountFields.appListKeys) == 0 {
-		c.app.generateAppListKeys()
-	}
+	c.app.mountFields.appListKeysOnce.Do(c.app.generateAppListKeys)
 }
 
 // Bind You can bind body, cookie, headers etc. into the map, map slice, struct easily by using Binding method.

--- a/mount.go
+++ b/mount.go
@@ -20,6 +20,8 @@ type mountFields struct {
 	mountPath string
 	// Ordered keys of apps (sorted by key length for Render)
 	appListKeys []string
+	// guards one-time generation of appListKeys
+	appListKeysOnce sync.Once
 	// check added routes of sub-apps
 	subAppsRoutesAdded sync.Once
 	// check mounted sub-apps
@@ -115,7 +117,7 @@ func (app *App) mountStartupProcess() {
 		// add routes of sub-apps
 		app.mountFields.subAppsProcessed.Do(func() {
 			app.appendSubAppLists(app.mountFields.appList)
-			app.generateAppListKeys()
+			app.mountFields.appListKeysOnce.Do(app.generateAppListKeys)
 		})
 		// adds the routes of the sub-apps to the current application.
 		app.mountFields.subAppsRoutesAdded.Do(func() {


### PR DESCRIPTION
## Summary

`Test_Ctx_RenderWithLocals` intermittently fails the race detector in CI (see [failed run](https://github.com/gofiber/fiber/actions/runs/27768572306)). The test runs two parallel subtests (`EmptyBind`, `NilBind`) that share a single `*App` and call `Render` concurrently.

`renderExtensions` (`ctx.go`) lazily generated `app.mountFields.appListKeys` behind a non-atomic guard:

```go
if len(c.app.mountFields.appListKeys) == 0 {
    c.app.generateAppListKeys()
}
```

The `len` check and the `append` inside `generateAppListKeys` (`mount.go`) are not atomic, so two concurrent `Render` calls both observe `len == 0` and both write to the shared slice while the other reads it (the `len` read, and the `slices.Backward` iteration over the slice during `Render`). The race detector reports:

- **Write** at `mount.go:130` in `generateAppListKeys` (the `append`)
- **Read** at `ctx.go:834` / during `Render` in `res.go`

## Fix

Introduce a dedicated `sync.Once` (`appListKeysOnce`) in `mountFields` and route both callers of `generateAppListKeys` through it:

- the lazy path in `renderExtensions` (`ctx.go`)
- the startup path in `mountStartupProcess` (`mount.go`), kept inside the existing `subAppsProcessed.Do` block, after `appendSubAppLists`

The keys are now generated exactly once with proper happens-before ordering; concurrent renders block until generation finishes and then read a slice that is never mutated again. Sharing a single `Once` between both callers also removes a latent double-append that the old code allowed if the lazy path ever ran before `mountStartupProcess`.

This preserves existing behavior: `appListKeys` was already generated only once in practice (the old `len == 0` guard never re-fired, the slice is never reset, and `appList` does not grow after startup). Route rebuilds via `RebuildTree()` are unaffected, since they only rebuild the route prefix trees and never touch `appListKeys`.

## Verification

- `go test -race -run 'Test_Ctx_RenderWithLocals$' -count=200 .` passes clean. The original code trips the detector on the first iteration.
- The full root package and all middleware packages pass with `-race`.
- `go vet ./...` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)