### PR TITLE
🐛 bug: isolate default timeout responses

### DIFF
--- a/middleware/timeout/timeout.go
+++ b/middleware/timeout/timeout.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"runtime/debug"
 
-	"github.com/valyala/fasthttp"
-
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/log"
 )
@@ -112,10 +110,9 @@ func handleTimeout(
 		// Build the default timeout response separately from the RequestCtx response.
 		// The timed-out handler can keep running and may have already buffered
 		// application data there, so reusing it could disclose partial output.
-		var timeoutResp fasthttp.Response
-		timeoutResp.SetStatusCode(fiber.StatusRequestTimeout)
-		timeoutResp.SetBodyString(fiber.ErrRequestTimeout.Message)
-		ctx.RequestCtx().TimeoutErrorWithResponse(&timeoutResp)
+		// TimeoutErrorWithCode constructs a fresh fasthttp.Response internally, so
+		// the active RequestCtx response is never read.
+		ctx.RequestCtx().TimeoutErrorWithCode(fiber.ErrRequestTimeout.Message, fiber.StatusRequestTimeout)
 	} else {
 		// Prepare the timeout response before marking the RequestCtx as timed out so
 		// custom OnTimeout handlers can shape the response body.

--- a/middleware/timeout/timeout.go
+++ b/middleware/timeout/timeout.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"runtime/debug"
 
+	"github.com/valyala/fasthttp"
+
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/log"
 )
@@ -105,23 +107,32 @@ func handleTimeout(
 	handlerDone <-chan struct{},
 	cfg Config,
 ) error {
-	// Prepare the timeout response before marking the RequestCtx as timed out so
-	// custom OnTimeout handlers can shape the response body.
-	timeoutErr := invokeOnTimeout(ctx, cfg)
+	var timeoutErr error
+	if cfg.OnTimeout == nil {
+		// Build the default timeout response separately from the RequestCtx response.
+		// The timed-out handler can keep running and may have already buffered
+		// application data there, so reusing it could disclose partial output.
+		var timeoutResp fasthttp.Response
+		timeoutResp.SetStatusCode(fiber.StatusRequestTimeout)
+		timeoutResp.SetBodyString(fiber.ErrRequestTimeout.Message)
+		ctx.RequestCtx().TimeoutErrorWithResponse(&timeoutResp)
+	} else {
+		// Prepare the timeout response before marking the RequestCtx as timed out so
+		// custom OnTimeout handlers can shape the response body.
+		timeoutErr = invokeOnTimeout(ctx, cfg)
 
-	// If no OnTimeout handler is configured or the response is still the default
-	// 200/empty, ensure a sensible timeout response is captured for fasthttp to send.
-	if cfg.OnTimeout == nil || (ctx.Response().StatusCode() == fiber.StatusOK && len(ctx.Response().Body()) == 0) {
-		ctx.Response().SetStatusCode(fiber.StatusRequestTimeout)
-		if len(ctx.Response().Body()) == 0 {
+		// If the response is still the default 200/empty, ensure a sensible timeout
+		// response is captured for fasthttp to send.
+		if ctx.Response().StatusCode() == fiber.StatusOK && len(ctx.Response().Body()) == 0 {
+			ctx.Response().SetStatusCode(fiber.StatusRequestTimeout)
 			ctx.Response().SetBodyString(fiber.ErrRequestTimeout.Message)
 		}
-	}
 
-	// Tell fasthttp to not recycle the RequestCtx - it will acquire a new one
-	// for the response and send the captured payload (either default or from
-	// OnTimeout). All ctx mutations after this call are ignored by fasthttp.
-	ctx.RequestCtx().TimeoutErrorWithResponse(&ctx.RequestCtx().Response)
+		// Tell fasthttp to not recycle the RequestCtx - it will acquire a new one
+		// for the response and send the captured payload from OnTimeout. All ctx
+		// mutations after this call are ignored by fasthttp.
+		ctx.RequestCtx().TimeoutErrorWithResponse(&ctx.RequestCtx().Response)
+	}
 
 	// Schedule race-free reclamation of the abandoned context. The context is
 	// returned to the pool only after BOTH the handler goroutine finishes AND

--- a/middleware/timeout/timeout_test.go
+++ b/middleware/timeout/timeout_test.go
@@ -152,6 +152,29 @@ func TestTimeout_HandlerReturnsEarlyOnCancel(t *testing.T) {
 	require.Less(t, elapsed, 100*time.Millisecond)
 }
 
+// TestTimeout_DefaultResponseClearsBufferedBody verifies that the default timeout
+// response does not disclose data buffered by a handler that timed out before
+// completing successfully.
+func TestTimeout_DefaultResponseClearsBufferedBody(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Get("/partial", New(func(c fiber.Ctx) error {
+		require.NoError(t, c.SendString("LEAKED-PARTIAL-SECRET"))
+		<-c.Context().Done()
+		return c.Context().Err()
+	}, Config{Timeout: 20 * time.Millisecond}))
+
+	req := httptest.NewRequest(fiber.MethodGet, "/partial", http.NoBody)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusRequestTimeout, resp.StatusCode)
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	require.Equal(t, fiber.ErrRequestTimeout.Message, string(body))
+}
+
 // TestTimeout_CustomError tests that returning a user-defined error is also treated as a timeout.
 func TestTimeout_CustomError(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
### Motivation
- Prevent disclosure of partially buffered handler output when a request times out by avoiding reusing the active `RequestCtx` response for the default timeout path.
- Preserve the Abandon/ScheduleReclaim reclamation fix while ensuring the app's default error handling does not race with abandoned handler goroutines.

### Description
- Build a fresh `fasthttp.Response` for the default timeout path and call `RequestCtx().TimeoutErrorWithResponse(&timeoutResp)` so buffered application data in the active `RequestCtx` is never reused for the 408 response. (`middleware/timeout/timeout.go`)
- Keep the existing `OnTimeout` behavior: when `OnTimeout` is configured, allow it to shape `ctx.Response()` and then capture that response via `TimeoutErrorWithResponse(&ctx.RequestCtx().Response)`. (`middleware/timeout/timeout.go`)
- Return the appropriate error from `handleTimeout` (nil for the default path and `invokeOnTimeout` result when `OnTimeout` runs) and preserve the race-free reclamation via `ScheduleReclaim` for `*fiber.DefaultCtx`. (`middleware/timeout/timeout.go`)
- Add a regression test `TestTimeout_DefaultResponseClearsBufferedBody` that pre-buffers a string in the handler and verifies the client receives the canonical `Request Timeout` body on the default timeout path. (`middleware/timeout/timeout_test.go`)

### Testing
- Ran `make audit`; `go mod verify` and `go vet` ran but `govulncheck` surfaced standard-library issues in the configured Go toolchain (reported vulnerabilities in Go 1.25.x), so `make audit` exited non-zero (informational for the toolchain, not caused by the change).
- Ran `make generate` and `make betteralign`; both completed successfully.
- Ran `make format` and `make lint`; both succeeded with no new lint issues.
- Ran the full test suite via `make test`; all tests passed successfully (`go test` completed). The middleware timeout package was also run with race detection: `go test ./middleware/timeout -race` passed and the new regression test `TestTimeout_DefaultResponseClearsBufferedBody` verifies the fix.