### PR TITLE
🐛 bug: harden extractor chain recursion and add chain introspection

### DIFF
--- a/docs/guide/extractors.md
+++ b/docs/guide/extractors.md
@@ -32,6 +32,7 @@ Extractors are utilities that middleware uses to get values from different parts
 - `FromQuery(param string)`: Extract from URL query parameters
 - `FromCustom(key string, fn func(fiber.Ctx) (string, error))`: Define custom extraction logic with metadata
 - `Chain(extractors ...Extractor)`: Chain multiple extractors with fallback logic
+- `Extractor.Contains(pred func(Extractor) bool)`: Check whether an extractor/chain contains a matching extractor
 
 ### Extractor Structure
 
@@ -60,8 +61,24 @@ The `Chain` function creates extractors that try multiple sources in order:
 - Returns the first successful extraction (non-empty value with no error)
 - If all extractors fail, returns the last error encountered or `ErrNotFound`
 - **Robust error handling**: Skips extractors with `nil` Extract functions
+- **Cycle prevention**: Detects recursive chain re-entry and returns `ErrChainCycle`
 - Preserves the source and key from the first extractor for metadata
 - Stores a defensive copy of all chained extractors for introspection via the `Chain` field
+
+### Chain Introspection
+
+Use `Contains` to inspect an extractor tree with a predicate:
+
+```go
+chain := extractors.Chain(
+    extractors.FromHeader("X-CSRF-Token"),
+    extractors.FromCookie("CSRF"),
+)
+
+hasCSRFCookie := chain.Contains(func(e extractors.Extractor) bool {
+    return e.Source == extractors.SourceCookie && e.Key == "CSRF"
+})
+```
 
 ## Why Middleware Uses Extractors
 

--- a/extractors/README.md
+++ b/extractors/README.md
@@ -36,6 +36,7 @@ type Extractor struct {
 - `FromQuery(param string)`: Extract from URL query parameters
 - `FromCustom(key string, fn func(fiber.Ctx) (string, error))`: Define custom extraction logic with metadata
 - `Chain(extractors ...Extractor)`: Chain multiple extractors with fallback
+- `Extractor.Contains(pred func(Extractor) bool)`: Check this extractor/chain against a predicate
 
 ### Source Inspection
 
@@ -67,8 +68,24 @@ The `Chain` function implements fallback logic:
 - Returns first successful extraction (non-empty value, no error)
 - If all extractors fail, returns the last error encountered or `ErrNotFound`
 - **Skips extractors with `nil` Extract functions** (graceful error handling)
+- Detects recursive chain re-entry and returns `ErrChainCycle`
 - Preserves metadata from first extractor for introspection
 - Stores defensive copy for runtime inspection via the `Chain` field
+
+### Chain Introspection
+
+Use `Contains` to inspect an extractor tree with a predicate.
+
+```go
+chain := Chain(
+    FromHeader("X-CSRF-Token"),
+    FromCookie("CSRF"),
+)
+
+hasCSRFCookie := chain.Contains(func(e Extractor) bool {
+    return e.Source == SourceCookie && e.Key == "CSRF"
+})
+```
 
 ## Security Considerations
 

--- a/extractors/extractors.go
+++ b/extractors/extractors.go
@@ -63,6 +63,9 @@ const (
 // ErrNotFound is returned when the requested value is missing or empty.
 var ErrNotFound = errors.New("value not found")
 
+// ErrChainCycle is returned when a chain extractor recursively invokes itself.
+var ErrChainCycle = errors.New("cyclic extractor chain")
+
 // Extractor defines a value extraction method with metadata.
 type Extractor struct {
 	Extract    func(fiber.Ctx) (string, error)
@@ -70,6 +73,38 @@ type Extractor struct {
 	AuthScheme string      // The auth scheme used, e.g., "Bearer"
 	Chain      []Extractor // For chained extractors, stores all extractors in the chain
 	Source     Source      // The type of source being extracted from
+}
+
+// Contains reports whether this extractor, or any extractor in its chain, matches pred.
+//
+// If pred is nil, Contains returns false.
+func (e Extractor) Contains(pred func(Extractor) bool) bool {
+	if pred == nil {
+		return false
+	}
+
+	stack := make([]*Extractor, 0, len(e.Chain)+1)
+	stack = append(stack, &e)
+
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		curr := stack[last]
+		stack = stack[:last]
+
+		if pred(*curr) {
+			return true
+		}
+
+		for i := range curr.Chain {
+			stack = append(stack, &curr.Chain[i])
+		}
+	}
+
+	return false
+}
+
+type chainGuardKey struct {
+	id *byte
 }
 
 // FromAuthHeader extracts a value from the Authorization header with an optional prefix.
@@ -474,9 +509,17 @@ func Chain(extractors ...Extractor) Extractor {
 	// Use the source and key from the first extractor as the primary
 	primarySource := extractors[0].Source
 	primaryKey := extractors[0].Key
+	guardKey := chainGuardKey{id: new(byte)}
 
 	return Extractor{
 		Extract: func(c fiber.Ctx) (string, error) {
+			if active, ok := c.Locals(guardKey).(bool); ok && active {
+				return "", ErrChainCycle
+			}
+
+			c.Locals(guardKey, true)
+			defer c.Locals(guardKey, false)
+
 			var lastErr error // last error encountered (including ErrNotFound)
 
 			for _, extractor := range extractors {

--- a/extractors/extractors_test.go
+++ b/extractors/extractors_test.go
@@ -23,7 +23,7 @@ func Test_Extractors_Missing(t *testing.T) {
 		require.ErrorIs(t, err, ErrNotFound)
 		return nil
 	})
-	_, err := app.Test(newRequest(fiber.MethodGet, "/test"))
+	_, err := app.Test(newRequest("/test"))
 	require.NoError(t, err)
 
 	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
@@ -55,9 +55,9 @@ func Test_Extractors_Missing(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound)
 }
 
-// newRequest creates a new *http.Request for Fiber's app.Test
-func newRequest(method, target string) *http.Request {
-	req, err := http.NewRequestWithContext(context.Background(), method, target, http.NoBody)
+// newRequest creates a new GET *http.Request for Fiber's app.Test.
+func newRequest(target string) *http.Request {
+	req, err := http.NewRequestWithContext(context.Background(), fiber.MethodGet, target, http.NoBody)
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +78,7 @@ func Test_Extractors(t *testing.T) {
 			require.Equal(t, "token_from_param", token)
 			return nil
 		})
-		_, err := app.Test(newRequest(fiber.MethodGet, "/test/token_from_param"))
+		_, err := app.Test(newRequest("/test/token_from_param"))
 		require.NoError(t, err)
 	})
 
@@ -280,6 +280,48 @@ func Test_Extractor_Chain_Introspection(t *testing.T) {
 	require.Equal(t, "token", chainExtractor.Chain[1].Key)
 	require.Equal(t, SourceCookie, chainExtractor.Chain[2].Source)
 	require.Equal(t, "auth", chainExtractor.Chain[2].Key)
+}
+
+func Test_Extractor_Contains(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_predicate", func(t *testing.T) {
+		t.Parallel()
+
+		extractor := FromHeader("X-Token")
+		require.False(t, extractor.Contains(nil))
+	})
+
+	t.Run("single_extractor_match", func(t *testing.T) {
+		t.Parallel()
+
+		extractor := FromCookie("CSRF")
+		require.True(t, extractor.Contains(func(e Extractor) bool {
+			return e.Source == SourceCookie && e.Key == "CSRF"
+		}))
+	})
+
+	t.Run("nested_chain_match", func(t *testing.T) {
+		t.Parallel()
+
+		inner := Chain(FromHeader("X-Token"), FromCookie("CSRF"))
+		outer := Chain(FromQuery("token"), inner)
+
+		require.True(t, outer.Contains(func(e Extractor) bool {
+			return e.Source == SourceCookie && e.Key == "CSRF"
+		}))
+	})
+
+	t.Run("nested_chain_no_match", func(t *testing.T) {
+		t.Parallel()
+
+		inner := Chain(FromHeader("X-Token"), FromCookie("session"))
+		outer := Chain(FromQuery("token"), inner)
+
+		require.False(t, outer.Contains(func(e Extractor) bool {
+			return e.Source == SourceCookie && e.Key == "CSRF"
+		}))
+	})
 }
 
 // go test -run Test_Extractor_FromCustom
@@ -813,6 +855,92 @@ func Test_Extractor_Chain_MixedScenarios(t *testing.T) {
 	})
 }
 
+// go test -run Test_Extractor_Chain_Cycle_Prevention
+func Test_Extractor_Chain_Cycle_Prevention(t *testing.T) {
+	t.Parallel()
+
+	t.Run("direct_cycle_returns_err_chain_cycle", func(t *testing.T) {
+		t.Parallel()
+
+		app := fiber.New()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(ctx) })
+
+		var chainExtractor Extractor
+		chainExtractor = Chain(FromCustom("cycle", func(c fiber.Ctx) (string, error) {
+			return chainExtractor.Extract(c)
+		}))
+
+		token, err := chainExtractor.Extract(ctx)
+		require.Empty(t, token)
+		require.ErrorIs(t, err, ErrChainCycle)
+	})
+
+	t.Run("indirect_cycle_returns_err_chain_cycle", func(t *testing.T) {
+		t.Parallel()
+
+		app := fiber.New()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(ctx) })
+
+		var chainA, chainB Extractor
+		chainA = Chain(FromCustom("to-b", func(c fiber.Ctx) (string, error) {
+			return chainB.Extract(c)
+		}))
+		chainB = Chain(FromCustom("to-a", func(c fiber.Ctx) (string, error) {
+			return chainA.Extract(c)
+		}))
+
+		token, err := chainA.Extract(ctx)
+		require.Empty(t, token)
+		require.ErrorIs(t, err, ErrChainCycle)
+	})
+
+	t.Run("nested_non_cyclic_chain_still_works", func(t *testing.T) {
+		t.Parallel()
+
+		app := fiber.New()
+		ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(ctx) })
+		ctx.Request().Header.Set("X-Token", "token_from_header")
+
+		inner := Chain(FromHeader("X-Token"), FromQuery("token"))
+		outer := Chain(inner, FromCookie("token"))
+
+		token, err := outer.Extract(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "token_from_header", token)
+	})
+}
+
+func Test_Extractor_Chain_ReusedAcrossMiddleware(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	shared := Chain(FromHeader("X-Token"), FromQuery("token"))
+
+	app.Use(func(c fiber.Ctx) error {
+		token, err := shared.Extract(c)
+		require.NoError(t, err)
+		require.Equal(t, "token_from_header", token)
+		return c.Next()
+	})
+
+	app.Get("/test", func(c fiber.Ctx) error {
+		token, err := shared.Extract(c)
+		require.NoError(t, err)
+		require.Equal(t, "token_from_header", token)
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+
+	req := newRequest("/test")
+	req.Header.Set("X-Token", "token_from_header")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusNoContent, resp.StatusCode)
+}
+
 // go test -run Test_Extractor_SourceTypes
 func Test_Extractor_SourceTypes(t *testing.T) {
 	t.Parallel()
@@ -894,7 +1022,7 @@ func Test_Extractor_URL_Encoded(t *testing.T) {
 			require.Equal(t, "token/with/slashes", token)
 			return nil
 		})
-		_, err := app.Test(newRequest(fiber.MethodGet, "/test/token%2Fwith%2Fslashes"))
+		_, err := app.Test(newRequest("/test/token%2Fwith%2Fslashes"))
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
## Summary
This PR improves extractor chain robustness and discoverability by:

1. Preventing recursive chain re-entry loops at runtime.
2. Adding generic chain introspection via a predicate-based helper.
3. Expanding tests for cycle handling, nested chain traversal, and shared-chain middleware reuse.
4. Updating package and guide docs to describe the new behavior and usage.

## Why
While working through chain behavior, there were two gaps:

1. Recursive chain invocation could recurse indefinitely without a guard.
2. Middleware authors had no built-in way to inspect chain composition (for example, to verify expected source/key usage in a composed chain).

This PR addresses both.

## Changes
1. Added `ErrChainCycle` and per-chain request-local cycle guard in `Chain` execution.
2. Added `Extractor.Contains(pred func(Extractor) bool)` for chain introspection.
3. Switched `Contains` traversal to an iterative stack walk for lower overhead and no recursion depth risk.
4. Added tests covering:
1. Direct and indirect recursive chain cycles.
2. Nested non-cyclic chain behavior.
3. Reuse of the same shared chain across middleware in a single request.
4. Predicate-based introspection behavior.
5. Updated docs in:
1. `extractors/README.md`
2. `docs/guide/extractors.md`

## Validation
1. `make audit`
2. `make generate`
3. `make betteralign`
4. `make format`
5. `make lint`
6. `go test ./extractors`
7. `make markdown`

## Related Discussion
This PR also explicitly addresses my feedback from:
https://github.com/gofiber/fiber/pull/4439