### PR TITLE
♻️ refactor: static analysis cleanups

### DIFF
--- a/ctx_interface.go
+++ b/ctx_interface.go
@@ -79,9 +79,7 @@ func (app *App) AcquireCtx(fctx *fasthttp.RequestCtx) CustomCtx {
 
 func (app *App) setHandlerCtxIfNeeded(ctx CustomCtx) {
 	if app.hasCustomCtx || isCustomCtx(ctx) {
-		if setter, ok := ctx.(interface{ setHandlerCtx(CustomCtx) }); ok {
-			setter.setHandlerCtx(ctx)
-		}
+		ctx.setHandlerCtx(ctx)
 	}
 }
 

--- a/middleware/limiter/limiter_sliding.go
+++ b/middleware/limiter/limiter_sliding.go
@@ -186,7 +186,7 @@ func rotateWindow(e *item, ts, expiration uint64) uint64 {
 			e.prevHits = e.currHits
 			e.currHits = 0
 
-			e.exp = ts + expiration - elapsed
+			e.exp = e.exp + expiration
 		}
 	}
 

--- a/middleware/limiter/limiter_sliding.go
+++ b/middleware/limiter/limiter_sliding.go
@@ -185,8 +185,7 @@ func rotateWindow(e *item, ts, expiration uint64) uint64 {
 		} else {
 			e.prevHits = e.currHits
 			e.currHits = 0
-
-			e.exp = e.exp + expiration
+			e.exp += expiration
 		}
 	}
 

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -33,7 +33,7 @@ func New(config ...Config) fiber.Handler {
 
 	// Get timezone location
 	tz, err := time.LoadLocation(cfg.TimeZone)
-	if err != nil || tz == nil {
+	if err != nil {
 		cfg.timeZoneLocation = time.Local
 	} else {
 		cfg.timeZoneLocation = tz


### PR DESCRIPTION
# Description

I'm building a Go static analyzer called [Ghoul](https://fereidani.com/ghoul), and I ran it against the Fiber codebase. It flagged three minor issues all behavior-preserving cleanups which this PR addresses.

Ghoul reports:

```txt
ctx_interface.go:82:20: [redundant-type-assertion] the asserted type is already satisfied by the expression's static type, so the assertion always succeeds (confidence: 8.4/10)
middleware/limiter/limiter_sliding.go:189:28: [canceling-operand] (ts + expiration) - (ts - *expr1) can be simplified to expiration + *expr1 (an operand cancels out) (confidence: 7.8/10)
middleware/logger/logger.go:36:22: [dead-condition] condition is always false; one branch is dead code (confidence: 8.2/10, CWE-570)
```

Each fix is in its own commit. The purpose is to remove redundant/dead code surfaced by static analysis, with no change to runtime behavior:

- **`ctx_interface.go`**: The `CustomCtx` interface already declares `setHandlerCtx`, so the assertion `ctx.(interface{ setHandlerCtx(CustomCtx) })` always succeeds. Removed it; `setHandlerCtx` is now called directly.
- **`middleware/limiter/limiter_sliding.go`**: In `rotateWindow`, `e.exp = ts + expiration - elapsed` (where `elapsed = ts - e.exp`) simplifies to `e.exp + expiration`. Algebraically identical; behavior unchanged. `elapsed` is still used by the `elapsed >= expiration` guard, so there is no unused variable.
- **`middleware/logger/logger.go`**: `time.LoadLocation` never returns a `nil` location together with a `nil` error, so the `|| tz == nil` check was unreachable. Dropped it.

Fixes #

## Changes introduced

- [ ] Benchmarks: Not applicable — these are internal cleanups with no measurable performance impact.
- [ ] Documentation Update: Not applicable.
- [ ] Changelog/What's New: Not applicable — internal refactors with no user-visible behavior change.
- [ ] Migration Guide: Not applicable — no API or behavior changes.
- [ ] API Alignment with Express: Not applicable.
- [ ] API Longevity: Not applicable — no public API is touched.
- [ ] Examples: Not applicable.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [ ] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.