### PR TITLE
feat: add HTTP QUERY method support (RFC 10008)

### DIFF
--- a/app.go
+++ b/app.go
@@ -599,6 +599,7 @@ const (
 	methodOptions
 	methodTrace
 	methodPatch
+	methodQuery
 )
 
 // HTTP methods enabled by default
@@ -612,6 +613,7 @@ var DefaultMethods = []string{
 	methodOptions: MethodOptions,
 	methodTrace:   MethodTrace,
 	methodPatch:   MethodPatch,
+	methodQuery:   MethodQuery,
 }
 
 // httpReadResponse - Used for test mocking http.ReadResponse
@@ -1065,6 +1067,12 @@ func (app *App) Trace(path string, handler any, handlers ...any) Router {
 // modifications to a resource.
 func (app *App) Patch(path string, handler any, handlers ...any) Router {
 	return app.Add([]string{MethodPatch}, path, handler, handlers...)
+}
+
+// Query registers a route for QUERY methods that performs a safe, idempotent
+// query with a request body.
+func (app *App) Query(path string, handler any, handlers ...any) Router {
+	return app.Add([]string{MethodQuery}, path, handler, handlers...)
 }
 
 // Add allows you to specify multiple HTTP methods to register a route.

--- a/app_test.go
+++ b/app_test.go
@@ -1770,6 +1770,9 @@ func Test_App_Group(t *testing.T) {
 	grp.Trace("/TRACE", dummyHandler)
 	testStatus200(t, app, "/test/TRACE", MethodTrace)
 
+	grp.Query("/QUERY", dummyHandler)
+	testStatus200(t, app, "/test/QUERY", MethodQuery)
+
 	grp.All("/ALL", dummyHandler)
 	testStatus200(t, app, "/test/ALL", MethodPost)
 
@@ -1807,7 +1810,8 @@ func Test_App_RouteChain(t *testing.T) {
 		Connect(dummyHandler).
 		Options(dummyHandler).
 		Trace(dummyHandler).
-		Patch(dummyHandler)
+		Patch(dummyHandler).
+		Query(dummyHandler)
 
 	testStatus200(t, app, "/test", MethodGet)
 	testStatus200(t, app, "/test", MethodHead)
@@ -1818,6 +1822,7 @@ func Test_App_RouteChain(t *testing.T) {
 	testStatus200(t, app, "/test", MethodOptions)
 	testStatus200(t, app, "/test", MethodTrace)
 	testStatus200(t, app, "/test", MethodPatch)
+	testStatus200(t, app, "/test", MethodQuery)
 
 	register.RouteChain("/v1").Get(dummyHandler).Post(dummyHandler)
 
@@ -2606,6 +2611,7 @@ func Test_App_Stack(t *testing.T) {
 	app.Get("/path1", testEmptyHandler)
 	app.Get("/path2", testEmptyHandler)
 	app.Post("/path3", testEmptyHandler)
+	app.Query("/path4", testEmptyHandler)
 
 	app.startupProcess()
 
@@ -2621,6 +2627,7 @@ func Test_App_Stack(t *testing.T) {
 	require.Len(t, stack[app.methodInt(MethodConnect)], 1)
 	require.Len(t, stack[app.methodInt(MethodOptions)], 1)
 	require.Len(t, stack[app.methodInt(MethodTrace)], 1)
+	require.Len(t, stack[app.methodInt(MethodQuery)], 2)
 }
 
 // go test -run Test_App_HandlersCount

--- a/app_test.go
+++ b/app_test.go
@@ -1298,6 +1298,9 @@ func Test_App_Methods(t *testing.T) {
 	app.Trace("/:john?/:doe?", dummyHandler)
 	testStatus200(t, app, "/john/doe", MethodTrace)
 
+	app.Query("/:john?/:doe?", dummyHandler)
+	testStatus200(t, app, "/john/doe", MethodQuery)
+
 	app.Get("/:john?/:doe?", dummyHandler)
 	testStatus200(t, app, "/john/doe", MethodGet)
 

--- a/client/request.go
+++ b/client/request.go
@@ -664,6 +664,11 @@ func (r *Request) Patch(url string) (*Response, error) {
 	return r.SetURL(url).SetMethod(fiber.MethodPatch).Send()
 }
 
+// Query sends a QUERY request to the given URL.
+func (r *Request) Query(url string) (*Response, error) {
+	return r.SetURL(url).SetMethod(fiber.MethodQuery).Send()
+}
+
 // Custom sends a request with a custom HTTP method to the given URL.
 func (r *Request) Custom(url, method string) (*Response, error) {
 	return r.SetURL(url).SetMethod(method).Send()

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -1067,6 +1067,34 @@ func Test_Request_Patch(t *testing.T) {
 	}
 }
 
+func Test_Request_Query(t *testing.T) {
+	t.Parallel()
+
+	app, ln, start := createHelperServer(t)
+
+	app.Query("/", func(c fiber.Ctx) error {
+		return c.Send(c.Body())
+	})
+
+	go start()
+	time.Sleep(100 * time.Millisecond)
+
+	client := New().SetDial(ln)
+
+	for range 5 {
+		resp, err := AcquireRequest().
+			SetClient(client).
+			SetRawBody([]byte("query body")).
+			Query("http://example.com")
+
+		require.NoError(t, err)
+		require.Equal(t, fiber.StatusOK, resp.StatusCode())
+		require.Equal(t, "query body", resp.String())
+
+		resp.Close()
+	}
+}
+
 func Test_Request_Header_With_Server(t *testing.T) {
 	t.Parallel()
 	handler := func(c fiber.Ctx) error {

--- a/constants.go
+++ b/constants.go
@@ -11,6 +11,7 @@ const (
 	MethodConnect = "CONNECT" // RFC 7231, 4.3.6
 	MethodOptions = "OPTIONS" // RFC 7231, 4.3.7
 	MethodTrace   = "TRACE"   // RFC 7231, 4.3.8
+	MethodQuery   = "QUERY"   // RFC 10008
 	methodUse     = "USE"
 )
 

--- a/docs/api/constants.md
+++ b/docs/api/constants.md
@@ -18,6 +18,7 @@ const (
     MethodConnect = "CONNECT" // RFC 7231, 4.3.6
     MethodOptions = "OPTIONS" // RFC 7231, 4.3.7
     MethodTrace   = "TRACE"   // RFC 7231, 4.3.8
+    MethodQuery   = "QUERY"   // RFC 10008
     methodUse     = "USE"
 )
 ```

--- a/docs/client/request.md
+++ b/docs/client/request.md
@@ -101,6 +101,14 @@ func (r *Request) Head(url string) (*Response, error)
 func (r *Request) Options(url string) (*Response, error)
 ```
 
+### Query
+
+**Query** sends a QUERY request. It sets the URL and method to QUERY, then sends the request.
+
+```go title="Signature"
+func (r *Request) Query(url string) (*Response, error)
+```
+
 ### Custom
 
 **Custom** sends a request using a custom HTTP method. For example, you can use this to send a TRACE or CONNECT request.

--- a/docs/middleware/cache.md
+++ b/docs/middleware/cache.md
@@ -118,7 +118,7 @@ By default, cache keys include:
 
 This prevents common collisions from path-only keys (for example, `/?id=1` vs `/?id=2`) while keeping fragmentation bounded.
 
-The middleware **does not include request body/form values in the default cache key**.
+The middleware **does not include request body/form values in the default cache key**, with one exception: as required by [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html), `QUERY` requests incorporate the request body into the key. Small bodies are used verbatim; larger bodies are hashed (SHA-256) to keep the key bounded.
 
 Cache lookup/storage is applied only for `GET` and `HEAD` requests by default. Other HTTP methods bypass the cache middleware. You can change this via the `Methods` config field.
 

--- a/docs/partials/routing/handler.md
+++ b/docs/partials/routing/handler.md
@@ -16,6 +16,7 @@ func (app *App) Connect(path string, handler any, handlers ...any) Router
 func (app *App) Options(path string, handler any, handlers ...any) Router
 func (app *App) Trace(path string, handler any, handlers ...any) Router
 func (app *App) Patch(path string, handler any, handlers ...any) Router
+func (app *App) Query(path string, handler any, handlers ...any) Router
 
 // Add registers the same handlers on multiple methods at once.
 // The handlers run in order, starting with `handler` and then the variadic `handlers`.

--- a/domain.go
+++ b/domain.go
@@ -527,6 +527,12 @@ func (d *domainRouter) Patch(path string, handler any, handlers ...any) Router {
 	return d.Add([]string{MethodPatch}, path, handler, handlers...)
 }
 
+// Query registers a route for QUERY methods.
+// The handler only executes when the request hostname matches the domain pattern.
+func (d *domainRouter) Query(path string, handler any, handlers ...any) Router {
+	return d.Add([]string{MethodQuery}, path, handler, handlers...)
+}
+
 // Add allows you to specify multiple HTTP methods to register a route.
 // The handler only executes when the request hostname matches the domain pattern.
 func (d *domainRouter) Add(methods []string, path string, handler any, handlers ...any) Router {
@@ -672,6 +678,10 @@ func (r *domainRegistering) Trace(handler any, handlers ...any) Register {
 
 func (r *domainRegistering) Patch(handler any, handlers ...any) Register {
 	return r.Add([]string{MethodPatch}, handler, handlers...)
+}
+
+func (r *domainRegistering) Query(handler any, handlers ...any) Register {
+	return r.Add([]string{MethodQuery}, handler, handlers...)
 }
 
 func (r *domainRegistering) Add(methods []string, handler any, handlers ...any) Register {

--- a/domain_test.go
+++ b/domain_test.go
@@ -255,6 +255,7 @@ func Test_Domain_HTTPMethods(t *testing.T) {
 		{method: MethodPut, reg: func(r Router, p string, h any, hs ...any) Router { return r.Put(p, h, hs...) }},
 		{method: MethodDelete, reg: func(r Router, p string, h any, hs ...any) Router { return r.Delete(p, h, hs...) }},
 		{method: MethodPatch, reg: func(r Router, p string, h any, hs ...any) Router { return r.Patch(p, h, hs...) }},
+		{method: MethodQuery, reg: func(r Router, p string, h any, hs ...any) Router { return r.Query(p, h, hs...) }},
 		{method: MethodOptions, reg: func(r Router, p string, h any, hs ...any) Router { return r.Options(p, h, hs...) }},
 		{method: MethodConnect, reg: func(r Router, p string, h any, hs ...any) Router { return r.Connect(p, h, hs...) }},
 		{method: MethodTrace, reg: func(r Router, p string, h any, hs ...any) Router { return r.Trace(p, h, hs...) }},
@@ -1058,8 +1059,11 @@ func Test_Domain_RouteChainAllMethods(t *testing.T) {
 	rc.Patch(func(c Ctx) error {
 		return c.SendString("patch")
 	})
+	rc.Query(func(c Ctx) error {
+		return c.SendString("query")
+	})
 
-	for _, method := range []string{MethodPut, MethodDelete, MethodPatch, MethodOptions} {
+	for _, method := range []string{MethodPut, MethodDelete, MethodPatch, MethodOptions, MethodQuery} {
 		req := httptest.NewRequest(method, "/test", http.NoBody)
 		req.Host = "api.example.com"
 		resp, err := app.Test(req)

--- a/group.go
+++ b/group.go
@@ -162,6 +162,12 @@ func (grp *Group) Patch(path string, handler any, handlers ...any) Router {
 	return grp.Add([]string{MethodPatch}, path, handler, handlers...)
 }
 
+// Query registers a route for QUERY methods that performs a safe, idempotent
+// query with a request body.
+func (grp *Group) Query(path string, handler any, handlers ...any) Router {
+	return grp.Add([]string{MethodQuery}, path, handler, handlers...)
+}
+
 // Add allows you to specify multiple HTTP methods to register a route.
 // The provided handlers are executed in order, starting with `handler` and then the variadic `handlers`.
 func (grp *Group) Add(methods []string, path string, handler any, handlers ...any) Router {

--- a/helpers.go
+++ b/helpers.go
@@ -935,6 +935,8 @@ func (app *App) methodInt(s string) int {
 			return methodTrace
 		case MethodPatch:
 			return methodPatch
+		case MethodQuery:
+			return methodQuery
 		default:
 			return -1
 		}
@@ -954,7 +956,8 @@ func IsMethodSafe(m string) bool {
 	case MethodGet,
 		MethodHead,
 		MethodOptions,
-		MethodTrace:
+		MethodTrace,
+		MethodQuery:
 		return true
 	default:
 		return false

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1291,9 +1291,12 @@ func defaultKeyGenerator(c fiber.Ctx, cfg *Config) string {
 	}
 
 	if c.Method() == fiber.MethodQuery {
-		bodyDigest := sha256.Sum256(c.Request().Body())
+		// RFC 10008 requires the cache key to incorporate the request content.
+		// boundKeySegment keeps small bodies raw (no hashing on the hot path) and
+		// only hashes bodies larger than maxKeyDimensionSegmentLength, which bounds
+		// the key length for the in-memory map and external Storage backends.
 		buf = append(buf, '|', 'b', '=')
-		buf = hex.AppendEncode(buf, bodyDigest[:])
+		buf = append(buf, boundKeySegment(utils.UnsafeString(c.Request().Body()))...)
 	}
 
 	result := string(buf)

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1290,6 +1290,12 @@ func defaultKeyGenerator(c fiber.Ctx, cfg *Config) string {
 		buf = append(buf, canonicalCookieSubset(c, cfg.KeyCookies)...)
 	}
 
+	if c.Method() == fiber.MethodQuery {
+		bodyDigest := sha256.Sum256(c.Request().Body())
+		buf = append(buf, '|', 'b', '=')
+		buf = hex.AppendEncode(buf, bodyDigest[:])
+	}
+
 	result := string(buf)
 
 	// Reset buffer and return to pool, but discard if it grew too large

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -1110,6 +1110,114 @@ func Test_Cache_CustomMethods(t *testing.T) {
 	})
 }
 
+func Test_Cache_QueryMethod(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same body hits cache", func(t *testing.T) {
+		t.Parallel()
+		app := fiber.New()
+		app.Use(New(Config{
+			Methods: []string{fiber.MethodQuery},
+		}))
+
+		var count atomic.Int32
+		app.Query("/", func(c fiber.Ctx) error {
+			current := count.Add(1)
+			return c.SendString(strconv.Itoa(int(current)))
+		})
+
+		body := []byte(`{"filter":"active"}`)
+
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodQuery, "/", bytes.NewReader(body)))
+		require.NoError(t, err)
+		require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, "1", string(respBody))
+
+		resp, err = app.Test(httptest.NewRequest(fiber.MethodQuery, "/", bytes.NewReader(body)))
+		require.NoError(t, err)
+		require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+		respBody, err = io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, "1", string(respBody))
+	})
+
+	t.Run("different body produces different cache key", func(t *testing.T) {
+		t.Parallel()
+		app := fiber.New()
+		app.Use(New(Config{
+			Methods: []string{fiber.MethodQuery},
+		}))
+
+		var count atomic.Int32
+		app.Query("/", func(c fiber.Ctx) error {
+			current := count.Add(1)
+			return c.SendString(strconv.Itoa(int(current)))
+		})
+
+		bodyA := []byte(`{"filter":"active"}`)
+		bodyB := []byte(`{"filter":"archived"}`)
+
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodQuery, "/", bytes.NewReader(bodyA)))
+		require.NoError(t, err)
+		require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+
+		resp, err = app.Test(httptest.NewRequest(fiber.MethodQuery, "/", bytes.NewReader(bodyB)))
+		require.NoError(t, err)
+		require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+		require.Equal(t, int32(2), count.Load())
+
+		resp, err = app.Test(httptest.NewRequest(fiber.MethodQuery, "/", bytes.NewReader(bodyA)))
+		require.NoError(t, err)
+		require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+	})
+
+	t.Run("empty body is cacheable", func(t *testing.T) {
+		t.Parallel()
+		app := fiber.New()
+		app.Use(New(Config{
+			Methods: []string{fiber.MethodQuery},
+		}))
+
+		var count atomic.Int32
+		app.Query("/", func(c fiber.Ctx) error {
+			current := count.Add(1)
+			return c.SendString(strconv.Itoa(int(current)))
+		})
+
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodQuery, "/", http.NoBody))
+		require.NoError(t, err)
+		require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+
+		resp, err = app.Test(httptest.NewRequest(fiber.MethodQuery, "/", http.NoBody))
+		require.NoError(t, err)
+		require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+		require.Equal(t, int32(1), count.Load())
+	})
+
+	t.Run("not cached when QUERY not in Methods", func(t *testing.T) {
+		t.Parallel()
+		app := fiber.New()
+		app.Use(New()) // default Methods: GET, HEAD
+
+		var count atomic.Int32
+		app.Query("/", func(c fiber.Ctx) error {
+			current := count.Add(1)
+			return c.SendString(strconv.Itoa(int(current)))
+		})
+
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodQuery, "/", bytes.NewReader([]byte(`{}`))))
+		require.NoError(t, err)
+		require.Equal(t, cacheUnreachable, resp.Header.Get("X-Cache"))
+
+		resp, err = app.Test(httptest.NewRequest(fiber.MethodQuery, "/", bytes.NewReader([]byte(`{}`))))
+		require.NoError(t, err)
+		require.Equal(t, cacheUnreachable, resp.Header.Get("X-Cache"))
+		require.Equal(t, int32(2), count.Load())
+	})
+}
+
 func Test_Cache_DefaultKeyDimensions(t *testing.T) {
 	t.Parallel()
 
@@ -3770,6 +3878,32 @@ func Benchmark_Cache_AdditionalHeaders(b *testing.B) {
 
 	require.Equal(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
 	require.Equal(b, []byte("foobar"), fctx.Response.Header.Peek("X-Foobar"))
+}
+
+func Benchmark_Cache_QueryMethod(b *testing.B) {
+	app := fiber.New()
+	app.Use(New(Config{
+		Methods: []string{fiber.MethodQuery},
+	}))
+
+	app.Query("/demo", func(c fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	h := app.Handler()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.SetMethod(fiber.MethodQuery)
+	fctx.Request.SetRequestURI("/demo")
+	fctx.Request.SetBody([]byte(`{"filter":"active","page":1}`))
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		h(fctx)
+	}
+
+	require.Equal(b, fiber.StatusOK, fctx.Response.Header.StatusCode())
 }
 
 func Benchmark_Cache_MaxSize(b *testing.B) {

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -1216,6 +1216,42 @@ func Test_Cache_QueryMethod(t *testing.T) {
 		require.Equal(t, cacheUnreachable, resp.Header.Get("X-Cache"))
 		require.Equal(t, int32(2), count.Load())
 	})
+
+	t.Run("large bodies past the hashing threshold stay distinct", func(t *testing.T) {
+		t.Parallel()
+		app := fiber.New()
+		app.Use(New(Config{
+			Methods: []string{fiber.MethodQuery},
+		}))
+
+		var count atomic.Int32
+		app.Query("/", func(c fiber.Ctx) error {
+			current := count.Add(1)
+			return c.SendString(strconv.Itoa(int(current)))
+		})
+
+		// Both bodies exceed maxKeyDimensionSegmentLength (192) and share the same
+		// 192-byte prefix, so they only differ on the hashed tail. Distinct keys
+		// prove the body is still fully incorporated, not truncated.
+		prefix := strings.Repeat("a", maxKeyDimensionSegmentLength)
+		bodyA := []byte(prefix + "-active")
+		bodyB := []byte(prefix + "-archived")
+
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodQuery, "/", bytes.NewReader(bodyA)))
+		require.NoError(t, err)
+		require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+
+		resp, err = app.Test(httptest.NewRequest(fiber.MethodQuery, "/", bytes.NewReader(bodyB)))
+		require.NoError(t, err)
+		require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+		require.Equal(t, int32(2), count.Load())
+
+		// Re-sending bodyA hits its own cached entry.
+		resp, err = app.Test(httptest.NewRequest(fiber.MethodQuery, "/", bytes.NewReader(bodyA)))
+		require.NoError(t, err)
+		require.Equal(t, cacheHit, resp.Header.Get("X-Cache"))
+		require.Equal(t, int32(2), count.Load())
+	})
 }
 
 func Test_Cache_DefaultKeyDimensions(t *testing.T) {

--- a/middleware/cors/config.go
+++ b/middleware/cors/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	// AllowMethods defines a list methods allowed when accessing the resource.
 	// This is used in response to a preflight request.
 	//
-	// Optional. Default value []string{"GET", "POST", "HEAD", "PUT", "DELETE", "PATCH"}
+	// Optional. Default value []string{"GET", "POST", "HEAD", "PUT", "DELETE", "PATCH", "QUERY"}
 	AllowMethods []string
 
 	// AllowHeaders defines a list of request headers that can be used when
@@ -98,6 +98,7 @@ var ConfigDefault = Config{
 		fiber.MethodPut,
 		fiber.MethodDelete,
 		fiber.MethodPatch,
+		fiber.MethodQuery,
 	},
 	AllowHeaders:        []string{},
 	AllowCredentials:    false,

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -612,6 +612,7 @@ func Test_CORS_Headers_BasedOnRequestType(t *testing.T) {
 		fiber.MethodDelete,
 		fiber.MethodPatch,
 		fiber.MethodHead,
+		fiber.MethodQuery,
 	}
 
 	// Get handler pointer

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -140,7 +140,7 @@ func testDefaultOrEmptyConfig(t *testing.T, app *fiber.App) {
 	ctx.Request.Header.Set(fiber.HeaderOrigin, "http://localhost")
 	h(ctx)
 
-	require.Equal(t, "GET, POST, HEAD, PUT, DELETE, PATCH", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowMethods)))
+	require.Equal(t, "GET, POST, HEAD, PUT, DELETE, PATCH, QUERY", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowMethods)))
 	require.Empty(t, string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowHeaders)))
 	require.Empty(t, string(ctx.Response.Header.Peek(fiber.HeaderAccessControlMaxAge)))
 }
@@ -642,7 +642,7 @@ func Test_CORS_Headers_BasedOnRequestType(t *testing.T) {
 			handler(ctx)
 			require.Equal(t, 204, ctx.Response.StatusCode(), "Status code should be 204")
 			require.Equal(t, "*", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)), "Access-Control-Allow-Origin header should be set")
-			require.Equal(t, "GET, POST, HEAD, PUT, DELETE, PATCH", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowMethods)), "Access-Control-Allow-Methods header should be set (preflight request)")
+			require.Equal(t, "GET, POST, HEAD, PUT, DELETE, PATCH, QUERY", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowMethods)), "Access-Control-Allow-Methods header should be set (preflight request)")
 			require.Empty(t, string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowHeaders)), "Access-Control-Allow-Headers header should be set (preflight request)")
 		}
 	})
@@ -676,7 +676,7 @@ func Test_CORS_Headers_BasedOnRequestType(t *testing.T) {
 			handler(ctx)
 			require.Equal(t, 204, ctx.Response.StatusCode(), "Status code should be 204")
 			require.Equal(t, "*", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)), "Access-Control-Allow-Origin header should be set")
-			require.Equal(t, "GET, POST, HEAD, PUT, DELETE, PATCH", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowMethods)), "Access-Control-Allow-Methods header should be set (preflight request)")
+			require.Equal(t, "GET, POST, HEAD, PUT, DELETE, PATCH, QUERY", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowMethods)), "Access-Control-Allow-Methods header should be set (preflight request)")
 			require.Equal(t, "X-Custom-Header", string(ctx.Response.Header.Peek(fiber.HeaderAccessControlAllowHeaders)), "Access-Control-Allow-Headers header should be set (preflight request)")
 		}
 	})

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -121,7 +121,7 @@ func New(config ...Config) fiber.Handler {
 
 		// Action depends on the HTTP method
 		switch c.Method() {
-		case fiber.MethodGet, fiber.MethodHead, fiber.MethodOptions, fiber.MethodTrace:
+		case fiber.MethodGet, fiber.MethodHead, fiber.MethodOptions, fiber.MethodTrace, fiber.MethodQuery:
 			cookieToken := c.Cookies(cfg.CookieName)
 
 			if cookieToken != "" {

--- a/middleware/logger/utils.go
+++ b/middleware/logger/utils.go
@@ -13,7 +13,7 @@ func methodColor(method string, colors *fiber.Colors) string {
 		return ""
 	}
 	switch method {
-	case fiber.MethodGet:
+	case fiber.MethodGet, fiber.MethodQuery:
 		return colors.Cyan
 	case fiber.MethodPost:
 		return colors.Green
@@ -27,8 +27,6 @@ func methodColor(method string, colors *fiber.Colors) string {
 		return colors.Magenta
 	case fiber.MethodOptions:
 		return colors.Blue
-	case fiber.MethodQuery:
-		return colors.Cyan
 	default:
 		return colors.Reset
 	}

--- a/middleware/logger/utils.go
+++ b/middleware/logger/utils.go
@@ -27,6 +27,8 @@ func methodColor(method string, colors *fiber.Colors) string {
 		return colors.Magenta
 	case fiber.MethodOptions:
 		return colors.Blue
+	case fiber.MethodQuery:
+		return colors.Cyan
 	default:
 		return colors.Reset
 	}

--- a/register.go
+++ b/register.go
@@ -16,6 +16,7 @@ type Register interface {
 	Options(handler any, handlers ...any) Register
 	Trace(handler any, handlers ...any) Register
 	Patch(handler any, handlers ...any) Register
+	Query(handler any, handlers ...any) Register
 
 	Add(methods []string, handler any, handlers ...any) Register
 
@@ -104,6 +105,12 @@ func (r *Registering) Trace(handler any, handlers ...any) Register {
 // modifications to a resource.
 func (r *Registering) Patch(handler any, handlers ...any) Register {
 	return r.Add([]string{MethodPatch}, handler, handlers...)
+}
+
+// Query registers a route for QUERY methods that performs a safe, idempotent
+// query with a request body.
+func (r *Registering) Query(handler any, handlers ...any) Register {
+	return r.Add([]string{MethodQuery}, handler, handlers...)
 }
 
 // Add allows you to specify multiple HTTP methods to register a route.

--- a/router.go
+++ b/router.go
@@ -28,6 +28,7 @@ type Router interface {
 	Options(path string, handler any, handlers ...any) Router
 	Trace(path string, handler any, handlers ...any) Router
 	Patch(path string, handler any, handlers ...any) Router
+	Query(path string, handler any, handlers ...any) Router
 
 	Add(methods []string, path string, handler any, handlers ...any) Router
 	All(path string, handler any, handlers ...any) Router


### PR DESCRIPTION
Register QUERY as a first-class HTTP method alongside the existing nine.
QUERY is safe and idempotent, allowing request bodies for complex queries
without the URL-length constraints of GET.

- Add MethodQuery constant and methodQuery iota
- Add Query() to Router, Register interfaces and all implementations
  (App, Group, Registering, domainRouter, domainRegistering)
- Add Query() client shorthand on Request
- Mark QUERY as safe in IsMethodSafe (idempotent follows from safe)
- Include QUERY in CSRF safe-method branch (no token required)
- Include QUERY in CORS default AllowMethods
- Add QUERY color to logger middleware
- Update constants documentation