### PR TITLE
⚡ perf(app): avoid per-request heap allocation in DefaultErrorHandler

### DIFF
--- a/app.go
+++ b/app.go
@@ -624,8 +624,7 @@ func DefaultErrorHandler(c Ctx, err error) error {
 	}
 
 	code := StatusInternalServerError
-	var e *Error
-	matched := errors.As(err, &e)
+	e, matched := asFiberError(err)
 	if matched && e != nil {
 		code = e.Code
 	}
@@ -635,6 +634,22 @@ func DefaultErrorHandler(c Ctx, err error) error {
 	}
 	c.Set(HeaderContentType, MIMETextPlainCharsetUTF8)
 	return c.Status(code).SendString(message)
+}
+
+// asFiberError reports whether err is or wraps a *Error and returns it. A direct
+// *Error is matched alloc-free by a type assertion; wrapped or joined errors
+// fall back to errors.As.
+func asFiberError(err error) (*Error, bool) {
+	if err == nil {
+		return nil, false
+	}
+	if e, ok := err.(*Error); ok { //nolint:errorlint // intentional fast path; wrapped/joined errors fall through to errors.As below
+		return e, true
+	}
+	// Declared here so errors.As's &target escapes only on this slow path.
+	var target *Error
+	matched := errors.As(err, &target)
+	return target, matched
 }
 
 // New creates a new Fiber named instance.


### PR DESCRIPTION
# Description

`DefaultErrorHandler` extracted the `*fiber.Error` via `errors.As(err, &e)`.
Because `errors.As` takes its target as `any`, passing `&e` boxes the pointer
into an interface and the compiler moves `e` to the heap. This was the only
per-request heap allocation on every error response (404, 405, 500 and any
handler-returned error), confirmed via `go build -gcflags='-m'`
(`moved to heap: e`) and the `Benchmark_Router_NotFound` / `Benchmark_Router_Chain`
alloc profiles.

The new `asFiberError` helper fast-paths a direct `*Error` with a plain type
assertion (exactly what the router returns for `ErrNotFound` /
`ErrMethodNotAllowed` / `ErrInternalServerError`) and only falls back to
`errors.As` for wrapped or joined errors. The escaping `&target` lives only in
the slow-path branch, so the common error path is allocation-free. Behaviour is
identical to `errors.As` for the `*Error` type.

## Changes introduced

- [x] Benchmarks: the error path drops from 1 alloc / 8 B to 0 and gets 16-31%
  faster; the success path is unchanged.

benchstat (count=10, default benchtime, Apple M2 Pro), all deltas p=0.000 except
the success-path control:

```
                                   sec/op             allocs/op   B/op
Router_NotFound                   258.9n -> 202.2n    1 -> 0      8 -> 0   -21.90%
Router_Chain                      159.8n -> 110.1n    1 -> 0      8 -> 0   -31.05%
App_MethodNotAllowed              291.6n -> 244.3n    1 -> 0      8 -> 0   -16.22%
App_MethodNotAllowed_Parallel      41.44n ->  28.38n  1 -> 0      8 -> 0   -31.52%
Router_Handler (success, control)  78.10n ->  76.10n  0 -> 0      0 -> 0   -2.56%
```

Behaviour preserved for wrapped errors (`fmt.Errorf("%w", ...)`), `errors.Join`
and typed-nil `*Error`, covered by existing `Test_DefaultErrorHandler_*`,
`Test_MultiError`, `Test_App_UseMountedErrorHandler*` and
`TestErrorHandler_PicksRightOne`.

## Type of change

- [x] Performance improvement (non-breaking change which improves efficiency)

## Checklist

- [x] Conducted a self-review of the code and commented the non-obvious escape trick.
- [x] Ensured new and existing unit tests pass locally.
- [x] Aimed for optimal performance with minimal allocations.
- [x] Provided benchmarks for the changed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
