### PR TITLE
⚡ perf(binder): cache decoder type metadata across requests

### DIFF
--- a/binder/binder_test.go
+++ b/binder/binder_test.go
@@ -143,6 +143,21 @@ func Test_SetParserDecoder_CustomConverter(t *testing.T) {
 	require.Equal(t, myInt(5), d.V)
 }
 
+// Test_SetParserDecoder_AliasTagIgnored: ParserConfig.SetAliasTag must not
+// override the per-source binding tag (one global tag breaks multi-source binding).
+func Test_SetParserDecoder_AliasTagIgnored(t *testing.T) {
+	SetParserDecoder(ParserConfig{SetAliasTag: "ignored", IgnoreUnknownKeys: true, ZeroEmpty: true})
+	defer SetParserDecoder(ParserConfig{IgnoreUnknownKeys: true, ZeroEmpty: true})
+
+	type data struct {
+		Greeting string `query:"v"`
+	}
+	d := new(data)
+	err := parse("query", d, map[string][]string{"v": {"hello"}})
+	require.NoError(t, err)
+	require.Equal(t, "hello", d.Greeting)
+}
+
 func Test_formatBindData_typeMismatch(t *testing.T) {
 	t.Parallel()
 	out := struct{}{}

--- a/binder/mapping.go
+++ b/binder/mapping.go
@@ -56,17 +56,18 @@ func SetParserDecoder(parserConfig ParserConfig) {
 
 	for _, tag := range tags {
 		decoderPoolMap[tag] = &sync.Pool{New: func() any {
-			return decoderBuilder(parserConfig)
+			return decoderBuilder(tag, parserConfig)
 		}}
 	}
 }
 
-func decoderBuilder(parserConfig ParserConfig) any {
+func decoderBuilder(aliasTag string, parserConfig ParserConfig) any {
 	decoder := schema.NewDecoder()
 	decoder.IgnoreUnknownKeys(parserConfig.IgnoreUnknownKeys)
-	if parserConfig.SetAliasTag != "" {
-		decoder.SetAliasTag(parserConfig.SetAliasTag)
-	}
+	// Bake the per-source tag once (pools are keyed per tag); doing it per
+	// request reset the decoder's type cache. ParserConfig.SetAliasTag is not
+	// honored here: one global tag is incompatible with per-source binding.
+	decoder.SetAliasTag(aliasTag)
 	for _, v := range parserConfig.ParserType {
 		decoder.RegisterConverter(reflect.ValueOf(v.CustomType).Interface(), v.Converter)
 	}
@@ -80,7 +81,7 @@ func init() {
 
 	for _, tag := range tags {
 		decoderPoolMap[tag] = &sync.Pool{New: func() any {
-			return decoderBuilder(ParserConfig{
+			return decoderBuilder(tag, ParserConfig{
 				IgnoreUnknownKeys: true,
 				ZeroEmpty:         true,
 			})
@@ -113,9 +114,8 @@ func parseToStruct(aliasTag string, out any, data map[string][]string, files ...
 	schemaDecoder := pool.Get().(*schema.Decoder) //nolint:errcheck,forcetypeassert // not needed
 	defer pool.Put(schemaDecoder)
 
-	// Set alias tag
-	schemaDecoder.SetAliasTag(aliasTag)
-
+	// Alias tag is baked in at build time (see decoderBuilder); setting it here
+	// would reset the decoder's type cache on every request.
 	if err := schemaDecoder.Decode(out, data, files...); err != nil {
 		return fmt.Errorf("%w", err)
 	}

--- a/binder/mapping_test.go
+++ b/binder/mapping_test.go
@@ -415,7 +415,7 @@ func Test_decoderBuilder(t *testing.T) {
 		IgnoreUnknownKeys: false,
 		ZeroEmpty:         false,
 	}
-	decAny := decoderBuilder(parserConfig)
+	decAny := decoderBuilder(bindingForm, parserConfig)
 	dec, ok := decAny.(*schema.Decoder)
 	require.True(t, ok)
 	var out struct {


### PR DESCRIPTION
# Description

`parseToStruct` called `schema.Decoder.SetAliasTag` on every request.
`SetAliasTag` unconditionally calls the schema cache's `reset()`, wiping the
decoder's reflection-derived type metadata (`structInfo`) and parsed-path cache.
So on every `Bind`, the cache `gofiber/schema` maintains was thrown away and
rebuilt from reflection.

Each binding source has its own decoder pool keyed by tag (`decoderPoolMap[tag]`),
so the alias tag is constant for a pooled decoder. This bakes the per-source tag
into the decoder once at build time and removes the per-request `SetAliasTag`
call, keeping the type cache warm across requests.

`ParserConfig.SetAliasTag` is intentionally not used to override the per-source
tag: a single global alias tag is incompatible with Fiber's per-source binding
(query/header/cookie/form/uri each need their own tag), and the previous
per-request reset already used the per-source tag at runtime. Binding behavior is
unchanged; `Test_SetParserDecoder_AliasTagIgnored` guards this.

## Changes introduced

- [x] Benchmarks below. Binding is ~50% faster and allocates ~54-68% less.

benchstat (count=10, default benchtime, Apple M2 Pro), all p=0.000:

```
                 sec/op             allocs/op    B/op
Bind_Query      2.483µ -> 1.282µ   52 -> 24     2373 -> 521         -48%
Bind_Header     2.409µ -> 1.201µ   53 -> 22     2317 -> 457         -50%
Bind_All       10.950µ -> 5.041µ  187 -> 59     9.78Ki -> 1.985Ki   -54%
```

geomean: -50.9% time, -79.4% bytes, -60.8% allocs.

## Type of change

- [x] Performance improvement (non-breaking change which improves efficiency)

## Checklist

- [x] Self-review done; the non-obvious cache behavior is commented.
- [x] Added a regression test (`Test_SetParserDecoder_AliasTagIgnored`); existing binder + root bind tests pass.
- [x] Aimed for minimal allocations; provided benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
