### PR TITLE
perf(csrf,redirect): share scheme/host matching and skip url.Parse on the hot path

### DIFF
--- a/internal/schemehost/schemehost.go
+++ b/internal/schemehost/schemehost.go
@@ -1,0 +1,125 @@
+// Package schemehost compares the scheme and host of two URLs for same-origin
+// checks. It is shared by the CSRF middleware (Origin/Referer validation) and
+// the core redirect logic (open-redirect prevention).
+package schemehost
+
+import (
+	"net/url"
+	"strings"
+
+	utilsstrings "github.com/gofiber/utils/v2/strings"
+)
+
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+)
+
+// Match reports whether (schemeA, hostA) and (schemeB, hostB) denote the same
+// origin. Scheme comparison is case-insensitive and default ports (http:80,
+// https:443) are normalized so "example.com" and "example.com:443" match.
+func Match(schemeA, hostA, schemeB, hostB string) bool {
+	normalizedSchemeA := utilsstrings.ToLower(schemeA)
+	normalizedSchemeB := utilsstrings.ToLower(schemeB)
+
+	normalizedHostA := normalizeSchemeHost(normalizedSchemeA, hostA)
+	normalizedHostB := normalizeSchemeHost(normalizedSchemeB, hostB)
+
+	return normalizedSchemeA == normalizedSchemeB && normalizedHostA == normalizedHostB
+}
+
+func normalizeSchemeHost(scheme, host string) string {
+	host = utilsstrings.ToLower(host)
+
+	var defaultPort string
+	switch scheme {
+	case schemeHTTP:
+		defaultPort = "80"
+	case schemeHTTPS:
+		defaultPort = "443"
+	default:
+		return host
+	}
+
+	// Fast path for a clean "host" or "host:port" value (the common case),
+	// avoiding the url.Parse allocation. Anything unusual (userinfo, path,
+	// percent-encoding, bracketed IPv6, control chars, empty/invalid port, ...)
+	// falls back to the url.Parse path, which preserves the exact legacy behavior.
+	if hasPort, clean := classifyHostPort(host); clean {
+		if hasPort {
+			return host
+		}
+		return host + ":" + defaultPort
+	}
+
+	return normalizeSchemeHostViaParse(scheme, host, defaultPort)
+}
+
+// classifyHostPort reports whether host is a plain "<reg-name-or-IPv4>" or
+// "<reg-name-or-IPv4>:<port>" value (clean) and, if so, whether it carries an
+// explicit numeric port. The accepted character set is deliberately narrow
+// (lowercase ASCII letters, digits, '.', '-', and a single ':'); anything else,
+// including bracketed IPv6 literals, returns clean=false and is handled by the
+// url.Parse fallback so behavior stays identical to the legacy implementation.
+func classifyHostPort(host string) (hasPort, clean bool) { //nolint:nonamedreturns // names document the two booleans
+	colon := -1
+	for i := 0; i < len(host); i++ {
+		c := host[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '.', c == '-':
+			// safe reg-name / IPv4 character
+		case c == ':':
+			if colon >= 0 {
+				return false, false // more than one colon -> not a clean host:port
+			}
+			colon = i
+		default:
+			return false, false // brackets, control chars, anything else
+		}
+	}
+
+	if colon < 0 {
+		return false, host != "" // no port; empty host falls back to url.Parse
+	}
+	if !allDigits(host[colon+1:]) {
+		return false, false // "host:" or "host:abc" -> let url.Parse decide
+	}
+	return true, true
+}
+
+// allDigits reports whether s is non-empty and all ASCII digits.
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// normalizeSchemeHostViaParse is the url.Parse-based fallback. host is already
+// lowercased and scheme is known to be http or https.
+func normalizeSchemeHostViaParse(scheme, host, defaultPort string) string {
+	parsedHost, err := url.Parse(scheme + "://" + host)
+	if err != nil {
+		return host
+	}
+
+	if port := parsedHost.Port(); port != "" {
+		return host
+	}
+
+	hostname := parsedHost.Hostname()
+	if hostname == "" {
+		return host
+	}
+
+	if strings.IndexByte(hostname, ':') >= 0 && !strings.HasPrefix(hostname, "[") {
+		hostname = "[" + hostname + "]"
+	}
+
+	return hostname + ":" + defaultPort
+}

--- a/internal/schemehost/schemehost_test.go
+++ b/internal/schemehost/schemehost_test.go
@@ -1,0 +1,164 @@
+package schemehost
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	utilsstrings "github.com/gofiber/utils/v2/strings"
+	"github.com/stretchr/testify/assert"
+)
+
+// refNormalizeSchemeHost is the original url.Parse-based implementation, kept as
+// a behavioral reference. The fast-path normalizeSchemeHost must produce
+// identical output for every input.
+func refNormalizeSchemeHost(scheme, host string) string {
+	host = utilsstrings.ToLower(host)
+
+	defaultPort := ""
+	switch scheme {
+	case schemeHTTP:
+		defaultPort = "80"
+	case schemeHTTPS:
+		defaultPort = "443"
+	default:
+		return host
+	}
+
+	parsedHost, err := url.Parse(scheme + "://" + host)
+	if err != nil {
+		return host
+	}
+
+	if port := parsedHost.Port(); port != "" {
+		return host
+	}
+
+	hostname := parsedHost.Hostname()
+	if hostname == "" {
+		return host
+	}
+
+	if strings.IndexByte(hostname, ':') >= 0 && !strings.HasPrefix(hostname, "[") {
+		hostname = "[" + hostname + "]"
+	}
+
+	return hostname + ":" + defaultPort
+}
+
+var corpus = []string{
+	"example.com", "example.com:8080", "example.com:443", "example.com:80",
+	"[::1]", "[::1]:8080", "[::1]:443", "::1", "a:b:c",
+	"EXAMPLE.COM", "Example.Com:8080",
+	"example.com:", "example.com:abc", ":8080", ":", "",
+	"[::1", "::1]", "[]", "[]:80", "[]:", "[::1]:", "[::1]:abc",
+	"192.168.0.1", "192.168.0.1:80", "[2001:db8::1]", "[2001:db8::1]:8443",
+	"exa_mple.com", "host name", "exam ple.com",
+	"xn--caf-dma.com", "example.com.", "example.com..",
+	"user@example.com", "user:pass@example.com", "example.com/path",
+	"example.com?q=1", "example.com#frag", "example%2ecom",
+	"localhost", "localhost:3000", "127.0.0.1:0",
+	"[fe80::1%eth0]", "[fe80::1%25eth0]:8080",
+	"example.com:99999", "example.com:0", "host:00080",
+	"\\example.com", "example.com\\", "[::1]extra", "[::1]x:80", "\x01",
+}
+
+// Test_normalizeSchemeHost_matchesReference verifies the fast path produces the
+// exact same result as the url.Parse reference across a broad, adversarial corpus.
+func Test_normalizeSchemeHost_matchesReference(t *testing.T) {
+	t.Parallel()
+	for _, scheme := range []string{"http", "https", "ftp", "HTTP", "HTTPS", ""} {
+		for _, host := range corpus {
+			got := normalizeSchemeHost(scheme, host)
+			want := refNormalizeSchemeHost(scheme, host)
+			assert.Equal(t, want, got, "normalizeSchemeHost(%q, %q)", scheme, host)
+		}
+	}
+}
+
+func Test_normalizeSchemeHost(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name, scheme, host, expectedHost string
+	}{
+		{"http default port added", "http", "example.com", "example.com:80"},
+		{"https default port added", "https", "example.com", "example.com:443"},
+		{"http custom port preserved", "http", "example.com:8080", "example.com:8080"},
+		{"https ipv6 default port added", "https", "[::1]", "[::1]:443"},
+		{"unknown scheme preserved", "ftp", "example.com", "example.com"},
+		{"https ipv6 custom port preserved", "https", "[::1]:8080", "[::1]:8080"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expectedHost, normalizeSchemeHost(tc.scheme, tc.host))
+		})
+	}
+}
+
+func Test_Match(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		schemeA, hostA, schemeB, hostB string
+		want                           bool
+	}{
+		{"https", "example.com", "https", "example.com", true},
+		{"https", "example.com", "https", "example.com:443", true},
+		{"http", "example.com", "http", "example.com:80", true},
+		{"https", "example.com:443", "https", "example.com:443", true},
+		{"HTTPS", "Example.com", "https", "example.com", true},
+		{"https", "example.com", "http", "example.com", false},
+		{"https", "example.com", "https", "evil.com", false},
+		{"https", "example.com:8080", "https", "example.com", false},
+		{"https", "[::1]", "https", "[::1]:443", true},
+		{"https", "[::1]:8080", "https", "[::1]", false},
+	}
+	for _, tc := range tests {
+		got := Match(tc.schemeA, tc.hostA, tc.schemeB, tc.hostB)
+		assert.Equal(t, tc.want, got, "Match(%q,%q,%q,%q)", tc.schemeA, tc.hostA, tc.schemeB, tc.hostB)
+	}
+}
+
+func Benchmark_normalizeSchemeHost(b *testing.B) {
+	cases := []struct{ name, scheme, host string }{
+		{"noport", "https", "example.com"},
+		{"port", "https", "example.com:8080"},
+		{"ipv4", "https", "192.168.0.1"},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			var s string
+			for b.Loop() {
+				s = normalizeSchemeHost(tc.scheme, tc.host)
+			}
+			_ = s
+		})
+	}
+}
+
+func Benchmark_Match(b *testing.B) {
+	b.ReportAllocs()
+	var ok bool
+	for b.Loop() {
+		ok = Match("https", "example.com", "https", "example.com")
+	}
+	_ = ok
+}
+
+// FuzzNormalizeSchemeHost asserts the fast path stays byte-for-byte equivalent
+// to the url.Parse reference for arbitrary host strings.
+func FuzzNormalizeSchemeHost(f *testing.F) {
+	for _, host := range corpus {
+		f.Add(host)
+	}
+	f.Fuzz(func(t *testing.T, host string) {
+		for _, scheme := range []string{"http", "https", "ftp", ""} {
+			got := normalizeSchemeHost(scheme, host)
+			want := refNormalizeSchemeHost(scheme, host)
+			if got != want {
+				t.Fatalf("normalizeSchemeHost(%q, %q) = %q, want %q", scheme, host, got, want)
+			}
+		}
+	})
+}

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/extractors"
 	"github.com/gofiber/fiber/v3/internal/redact"
+	"github.com/gofiber/fiber/v3/internal/schemehost"
 	"github.com/gofiber/fiber/v3/middleware/logger"
 )
 
@@ -368,7 +369,7 @@ func originMatchesHost(c fiber.Ctx, trustedOrigins []string, trustedSubOrigins [
 		return ErrOriginInvalid
 	}
 
-	if schemeAndHostMatch(originURL.Scheme, originURL.Host, c.Scheme(), c.Host()) {
+	if schemehost.Match(originURL.Scheme, originURL.Host, c.Scheme(), c.Host()) {
 		return nil
 	}
 
@@ -399,7 +400,7 @@ func refererMatchesHost(c fiber.Ctx, trustedOrigins []string, trustedSubOrigins 
 		return ErrRefererInvalid
 	}
 
-	if schemeAndHostMatch(refererURL.Scheme, refererURL.Host, c.Scheme(), c.Host()) {
+	if schemehost.Match(refererURL.Scheme, refererURL.Host, c.Scheme(), c.Host()) {
 		return nil
 	}
 

--- a/middleware/csrf/helpers.go
+++ b/middleware/csrf/helpers.go
@@ -22,50 +22,6 @@ func compareStrings(a, b string) bool {
 	return subtle.ConstantTimeCompare(utils.UnsafeBytes(a), utils.UnsafeBytes(b)) == 1
 }
 
-func schemeAndHostMatch(schemeA, hostA, schemeB, hostB string) bool {
-	normalizedSchemeA := utilsstrings.ToLower(schemeA)
-	normalizedSchemeB := utilsstrings.ToLower(schemeB)
-
-	normalizedHostA := normalizeSchemeHost(normalizedSchemeA, hostA)
-	normalizedHostB := normalizeSchemeHost(normalizedSchemeB, hostB)
-
-	return normalizedSchemeA == normalizedSchemeB && normalizedHostA == normalizedHostB
-}
-
-func normalizeSchemeHost(scheme, host string) string {
-	host = utilsstrings.ToLower(host)
-
-	defaultPort := ""
-	switch scheme {
-	case schemeHTTP:
-		defaultPort = "80"
-	case schemeHTTPS:
-		defaultPort = "443"
-	default:
-		return host
-	}
-
-	parsedHost, err := url.Parse(scheme + "://" + host)
-	if err != nil {
-		return host
-	}
-
-	if port := parsedHost.Port(); port != "" {
-		return host
-	}
-
-	hostname := parsedHost.Hostname()
-	if hostname == "" {
-		return host
-	}
-
-	if strings.IndexByte(hostname, ':') >= 0 && !strings.HasPrefix(hostname, "[") {
-		hostname = "[" + hostname + "]"
-	}
-
-	return hostname + ":" + defaultPort
-}
-
 // normalizeOrigin checks if the provided origin is in a correct format
 // and normalizes it by removing any path or trailing slash.
 // It returns a boolean indicating whether the origin is valid

--- a/middleware/csrf/helpers_test.go
+++ b/middleware/csrf/helpers_test.go
@@ -55,61 +55,6 @@ func Test_normalizeOrigin(t *testing.T) {
 	}
 }
 
-func Test_normalizeSchemeHost(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name         string
-		scheme       string
-		host         string
-		expectedHost string
-	}{
-		{
-			name:         "http default port added",
-			scheme:       "http",
-			host:         "example.com",
-			expectedHost: "example.com:80",
-		},
-		{
-			name:         "https default port added",
-			scheme:       "https",
-			host:         "example.com",
-			expectedHost: "example.com:443",
-		},
-		{
-			name:         "http custom port preserved",
-			scheme:       "http",
-			host:         "example.com:8080",
-			expectedHost: "example.com:8080",
-		},
-		{
-			name:         "https ipv6 default port added",
-			scheme:       "https",
-			host:         "[::1]",
-			expectedHost: "[::1]:443",
-		},
-		{
-			name:         "unknown scheme preserved",
-			scheme:       "ftp",
-			host:         "example.com",
-			expectedHost: "example.com",
-		},
-		{
-			name:         "https ipv6 custom port preserved",
-			scheme:       "https",
-			host:         "[::1]:8080",
-			expectedHost: "[::1]:8080",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.expectedHost, normalizeSchemeHost(tc.scheme, tc.host))
-		})
-	}
-}
-
 // go test -run -v TestSubdomainMatch
 func TestSubdomainMatch(t *testing.T) {
 	t.Parallel()

--- a/redirect.go
+++ b/redirect.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/gofiber/utils/v2"
 	utilsbytes "github.com/gofiber/utils/v2/bytes"
-	utilsstrings "github.com/gofiber/utils/v2/strings"
 	"github.com/valyala/bytebufferpool"
 	"github.com/valyala/fasthttp"
 
 	"github.com/gofiber/fiber/v3/binder"
+	"github.com/gofiber/fiber/v3/internal/schemehost"
 )
 
 // Pool for redirection
@@ -383,7 +383,7 @@ func (r *Redirect) Back(fallback ...string) error {
 	if location != "" {
 		if !strings.HasPrefix(location, "/") || strings.HasPrefix(location, "//") {
 			parsed, err := url.Parse(location)
-			if err != nil || (parsed.Scheme != "" && parsed.Host == "") || (parsed.Host != "" && !schemeAndHostMatch(parsed.Scheme, parsed.Host, r.c.Scheme(), r.c.Host())) {
+			if err != nil || (parsed.Scheme != "" && parsed.Host == "") || (parsed.Host != "" && !schemehost.Match(parsed.Scheme, parsed.Host, r.c.Scheme(), r.c.Host())) {
 				location = "" // Reject invalid or cross-origin referrers
 			}
 		}
@@ -401,50 +401,6 @@ func (r *Redirect) Back(fallback ...string) error {
 	}
 
 	return r.To(location)
-}
-
-func schemeAndHostMatch(schemeA, hostA, schemeB, hostB string) bool {
-	normalizedSchemeA := utilsstrings.ToLower(schemeA)
-	normalizedSchemeB := utilsstrings.ToLower(schemeB)
-
-	normalizedHostA := normalizeRedirectSchemeHost(normalizedSchemeA, hostA)
-	normalizedHostB := normalizeRedirectSchemeHost(normalizedSchemeB, hostB)
-
-	return normalizedSchemeA == normalizedSchemeB && normalizedHostA == normalizedHostB
-}
-
-func normalizeRedirectSchemeHost(scheme, host string) string {
-	host = utilsstrings.ToLower(host)
-
-	defaultPort := ""
-	switch scheme {
-	case schemeHTTP:
-		defaultPort = "80"
-	case schemeHTTPS:
-		defaultPort = "443"
-	default:
-		return host
-	}
-
-	parsedHost, err := url.Parse(scheme + "://" + host)
-	if err != nil {
-		return host
-	}
-
-	if port := parsedHost.Port(); port != "" {
-		return host
-	}
-
-	hostname := parsedHost.Hostname()
-	if hostname == "" {
-		return host
-	}
-
-	if strings.IndexByte(hostname, ':') >= 0 && !strings.HasPrefix(hostname, "[") {
-		hostname = "[" + hostname + "]"
-	}
-
-	return hostname + ":" + defaultPort
 }
 
 // parseAndClearFlashMessages is a method to get flash messages before they are getting removed


### PR DESCRIPTION
## Summary

`schemeAndHostMatch` + `normalizeSchemeHost` were duplicated verbatim in two
security-relevant spots:

- the CSRF middleware (Origin/Referer validation), and
- the core redirect logic (`Redirect.Back`'s open-redirect prevention).

Each called `url.Parse` twice per request only to split host and port. This PR
extracts the shared logic into a new `internal/schemehost` package and adds a
fast path that handles clean `<host>` / `<host>:<port>` values directly,
avoiding the `url.Parse` allocation. Anything unusual (userinfo, path,
percent-encoding, bracketed IPv6, control characters, empty/invalid port) falls
back to the **unchanged** `url.Parse` path.

The security-critical top-level `url.Parse(origin)` / `url.Parse(referer)`
(input validation -> `ErrOriginInvalid`) is untouched.

## Equivalence / safety

- **Differential test** (`Test_normalizeSchemeHost_matchesReference`): the fast
  path is compared against a copy of the previous `url.Parse`-based
  implementation across a broad, adversarial corpus.
- **Fuzz target** (`FuzzNormalizeSchemeHost`): 6M+ executions, zero divergence.
- Explicit contract table (`Test_normalizeSchemeHost`) and `Test_Match` cover
  the documented behavior. Full CSRF suite and root redirect tests pass.

## Benchmarks

benchstat, count=6, Apple M2 Pro:

| Benchmark | allocs/op | B/op | ns/op |
|---|---|---|---|
| `schemehost.Match` | 6 -> 2 (-67%) | 368 -> 32 | -78% |
| `normalizeSchemeHost/noport` | 3 -> 1 (-67%) | 184 -> 16 | -80% |
| `normalizeSchemeHost/port` | 2 -> 0 (-100%) | 168 -> 0 | -88% |

The optimization now benefits both the CSRF unsafe-request path and
`Redirect.Back`.

## Notes

`normalizeOrigin` / `subdomain` are also duplicated (between CSRF and CORS) but
have **diverged** in their validation rules, so they are intentionally left in
place; unifying them is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
