### PR TITLE
perf(cache): append canonical key segments into the pooled buffer

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1277,17 +1277,17 @@ func defaultKeyGenerator(c fiber.Ctx, cfg *Config) string {
 
 	if !cfg.DisableQueryKeys {
 		buf = append(buf, '|', 'q', '=')
-		buf = append(buf, canonicalQueryString(c.Request().URI())...)
+		buf = appendCanonicalQueryString(buf, c.Request().URI())
 	}
 
 	if len(cfg.KeyHeaders) > 0 {
 		buf = append(buf, '|', 'h', '=')
-		buf = append(buf, canonicalHeaderSubset(&c.Request().Header, cfg.KeyHeaders)...)
+		buf = appendCanonicalHeaderSubset(buf, &c.Request().Header, cfg.KeyHeaders)
 	}
 
 	if len(cfg.KeyCookies) > 0 {
 		buf = append(buf, '|', 'c', '=')
-		buf = append(buf, canonicalCookieSubset(c, cfg.KeyCookies)...)
+		buf = appendCanonicalCookieSubset(buf, c, cfg.KeyCookies)
 	}
 
 	result := string(buf)
@@ -1302,23 +1302,28 @@ func defaultKeyGenerator(c fiber.Ctx, cfg *Config) string {
 	return result
 }
 
-func canonicalQueryString(uri *fasthttp.URI) string {
+// appendCanonicalQueryString appends the canonicalized query segment to dst.
+// It avoids copying the raw query and the intermediate result string the caller
+// would otherwise have to re-append.
+func appendCanonicalQueryString(dst []byte, uri *fasthttp.URI) []byte {
 	raw := uri.QueryString()
 	if len(raw) == 0 {
-		return ""
+		return dst
 	}
 
-	query := utils.CopyString(utils.UnsafeString(raw))
+	// Safe: the segment is consumed synchronously (appended/hashed) before the
+	// request buffer can be mutated, so no stable copy is required.
+	query := utils.UnsafeString(raw)
 
 	// Pre-scan query string to detect excessive parameters before expensive parsing.
 	// This prevents DoS via url.ParseQuery allocating large maps/slices.
 	if len(query) > maxQueryBufferSize {
-		return boundKeySegment(escapeKeyDelimiters(query))
+		return appendBoundKeySegment(dst, escapeKeyDelimiters(query))
 	}
 
 	// Fast path: single key=value pair needs no parsing or sorting
 	if strings.IndexByte(query, '&') < 0 {
-		return boundKeySegment(escapeKeyDelimiters(query))
+		return appendBoundKeySegment(dst, escapeKeyDelimiters(query))
 	}
 
 	// Quick count of potential parameters (ampersands + 1)
@@ -1328,14 +1333,14 @@ func canonicalQueryString(uri *fasthttp.URI) string {
 			paramCount++
 			if paramCount > maxQueryParams {
 				// Too many parameters detected, hash without parsing
-				return boundKeySegment(escapeKeyDelimiters(query))
+				return appendBoundKeySegment(dst, escapeKeyDelimiters(query))
 			}
 		}
 	}
 
 	parsed, err := url.ParseQuery(query)
 	if err != nil {
-		return boundKeySegment(escapeKeyDelimiters(query))
+		return appendBoundKeySegment(dst, escapeKeyDelimiters(query))
 	}
 
 	// Double-check actual parameter count after parsing
@@ -1343,7 +1348,7 @@ func canonicalQueryString(uri *fasthttp.URI) string {
 	for _, values := range parsed {
 		actualCount += len(values)
 		if actualCount > maxQueryParams {
-			return boundKeySegment(escapeKeyDelimiters(query))
+			return appendBoundKeySegment(dst, escapeKeyDelimiters(query))
 		}
 	}
 
@@ -1380,7 +1385,7 @@ func canonicalQueryString(uri *fasthttp.URI) string {
 					*bufPtr = buf
 					keyBufferPool.Put(bufPtr)
 				}
-				return boundKeySegment(escapeKeyDelimiters(query))
+				return appendBoundKeySegment(dst, escapeKeyDelimiters(query))
 			}
 
 			buf = append(buf, escapedKey...)
@@ -1389,7 +1394,7 @@ func canonicalQueryString(uri *fasthttp.URI) string {
 		}
 	}
 
-	result := boundKeySegment(string(buf))
+	dst = appendBoundKeySegment(dst, utils.UnsafeString(buf))
 
 	// Return buffer to pool if not oversized
 	if cap(buf) <= defaultKeyBufferCap*4 {
@@ -1397,51 +1402,41 @@ func canonicalQueryString(uri *fasthttp.URI) string {
 		keyBufferPool.Put(bufPtr)
 	}
 
-	return result
+	return dst
 }
 
-func canonicalHeaderSubset(header *fasthttp.RequestHeader, names []string) string {
-	if len(names) == 0 {
-		return ""
-	}
-
-	buf := make([]byte, 0, len(names)*16)
+func appendCanonicalHeaderSubset(dst []byte, header *fasthttp.RequestHeader, names []string) []byte {
 	for idx, name := range names {
 		if idx > 0 {
-			buf = append(buf, '|')
+			dst = append(dst, '|')
 		}
 		// Escape name (though names are normalized and trusted)
-		buf = append(buf, escapeKeyDelimiters(name)...)
-		buf = append(buf, ':')
+		dst = append(dst, escapeKeyDelimiters(name)...)
+		dst = append(dst, ':')
 		headerValue := header.Peek(name)
 		// Escape value to prevent delimiter injection
 		escapedValue := escapeKeyDelimiters(utils.UnsafeString(headerValue))
-		buf = append(buf, boundKeySegment(escapedValue)...)
+		dst = appendBoundKeySegment(dst, escapedValue)
 	}
 
-	return string(buf)
+	return dst
 }
 
-func canonicalCookieSubset(c fiber.Ctx, names []string) string {
-	if len(names) == 0 {
-		return ""
-	}
-
-	buf := make([]byte, 0, len(names)*16)
+func appendCanonicalCookieSubset(dst []byte, c fiber.Ctx, names []string) []byte {
 	for idx, name := range names {
 		if idx > 0 {
-			buf = append(buf, '|')
+			dst = append(dst, '|')
 		}
 		// Escape name (though names are normalized and trusted)
-		buf = append(buf, escapeKeyDelimiters(name)...)
-		buf = append(buf, ':')
+		dst = append(dst, escapeKeyDelimiters(name)...)
+		dst = append(dst, ':')
 		cookieValue := c.Cookies(name)
 		// Escape value to prevent delimiter injection
 		escapedValue := escapeKeyDelimiters(cookieValue)
-		buf = append(buf, boundKeySegment(escapedValue)...)
+		dst = appendBoundKeySegment(dst, escapedValue)
 	}
 
-	return string(buf)
+	return dst
 }
 
 // escapeKeyDelimiters escapes pipe, colon, and backslash characters used as delimiters in cache keys
@@ -1465,6 +1460,17 @@ func boundKeySegment(segment string) string {
 	}
 	hash := sha256.Sum256(utils.UnsafeBytes(segment))
 	return "sha256:" + hex.EncodeToString(hash[:])
+}
+
+// appendBoundKeySegment appends segment to dst, hashing it first when it exceeds
+// the per-dimension length bound (same policy as boundKeySegment).
+func appendBoundKeySegment(dst []byte, segment string) []byte {
+	if len(segment) <= maxKeyDimensionSegmentLength {
+		return append(dst, segment...)
+	}
+	hash := sha256.Sum256(utils.UnsafeBytes(segment))
+	dst = append(dst, "sha256:"...)
+	return hex.AppendEncode(dst, hash[:])
 }
 
 func parseVary(vary string) ([]string, bool) {

--- a/middleware/cache/keygen_test.go
+++ b/middleware/cache/keygen_test.go
@@ -1,0 +1,89 @@
+package cache
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+type keygenCase struct {
+	headers  map[string]string
+	name     string
+	uri      string
+	cookie   string
+	want     string
+	keyCooks []string
+	noQuery  bool
+}
+
+func keygenCorpus() []keygenCase {
+	return []keygenCase{
+		{name: "noquery", uri: "/demo", want: "/|q=|h=Accept:|Accept-Encoding:|Accept-Language:"},
+		{name: "single", uri: "/demo?foo=bar", want: "/|q=foo=bar|h=Accept:|Accept-Encoding:|Accept-Language:"},
+		{name: "multi_dup", uri: "/demo?b=2&a=1&a=3", want: "/|q=a=1&a=3&b=2|h=Accept:|Accept-Encoding:|Accept-Language:"},
+		{name: "path_delims", uri: "/a|b:c\\d?x=1", want: "/|q=x=1|h=Accept:|Accept-Encoding:|Accept-Language:"},
+		{name: "query_escape", uri: "/p?k=a b&z=%2F&k=z", want: "/|q=k=a+b&k=z&z=%2F|h=Accept:|Accept-Encoding:|Accept-Language:"},
+		{name: "with_headers", uri: "/p?foo=bar", headers: map[string]string{"Accept": "text/html", "Accept-Encoding": "gzip"}, want: "/|q=foo=bar|h=Accept:text/html|Accept-Encoding:gzip|Accept-Language:"},
+		{name: "with_cookie", uri: "/p?foo=bar", cookie: "sid=abc123", keyCooks: []string{"sid"}, want: "/|q=foo=bar|h=Accept:|Accept-Encoding:|Accept-Language:|c=sid:abc123"},
+		{name: "long_query", uri: "/p?q=" + strings.Repeat("x", 300), want: "/|q=sha256:4d86f7dbfc8b3bfe229da7e27f4ac8f6cf8114e24e5cb6b5af1d09cb4cc3d982|h=Accept:|Accept-Encoding:|Accept-Language:"},
+		{name: "long_path", uri: "/" + strings.Repeat("p", 300) + "?a=1", want: "/|q=a=1|h=Accept:|Accept-Encoding:|Accept-Language:"},
+		{name: "disable_query", uri: "/p?foo=bar", noQuery: true, want: "/|h=Accept:|Accept-Encoding:|Accept-Language:"},
+		{name: "header_val_delims", uri: "/p", headers: map[string]string{"Accept": "a|b:c"}, want: "/|q=|h=Accept:a\\pb\\cc|Accept-Encoding:|Accept-Language:"},
+		{name: "empty_query", uri: "/p?", want: "/|q=|h=Accept:|Accept-Encoding:|Accept-Language:"},
+		{name: "many_params", uri: "/p?" + strings.Repeat("k=v&", 200) + "z=1", want: "/|q=sha256:f8f7166c8aec35092b4c6f66a895ec9f302746c6310aa0dbfde45cbd30aa1829|h=Accept:|Accept-Encoding:|Accept-Language:"},
+	}
+}
+
+func buildKeygenCtx(tc *keygenCase) (fiber.Ctx, *Config) {
+	app := fiber.New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	c.Request().SetRequestURI(tc.uri)
+	c.Request().Header.SetMethod(fiber.MethodGet)
+	for k, v := range tc.headers {
+		c.Request().Header.Set(k, v)
+	}
+	if tc.cookie != "" {
+		c.Request().Header.Set("Cookie", tc.cookie)
+	}
+	cfg := ConfigDefault
+	cfg.DisableQueryKeys = tc.noQuery
+	if tc.keyCooks != nil {
+		cfg.KeyCookies = tc.keyCooks
+	}
+	return c, &cfg
+}
+
+func Benchmark_defaultKeyGenerator(b *testing.B) {
+	cases := []struct{ name, uri string }{
+		{"noquery", "/demo"},
+		{"singleparam", "/demo?foo=bar"},
+		{"multiparam", "/demo?foo=bar&baz=qux&alpha=1"},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			c, cfg := buildKeygenCtx(&keygenCase{uri: tc.uri})
+			b.ReportAllocs()
+			var s string
+			for b.Loop() {
+				s = defaultKeyGenerator(c, cfg)
+			}
+			_ = s
+		})
+	}
+}
+
+// Test_defaultKeyGenerator_stableKeys pins the exact cache-key output so the
+// allocation refactor of the canonical* helpers stays byte-for-byte identical.
+func Test_defaultKeyGenerator_stableKeys(t *testing.T) {
+	t.Parallel()
+	for _, tc := range keygenCorpus() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c, cfg := buildKeygenCtx(&tc)
+			require.Equal(t, tc.want, defaultKeyGenerator(c, cfg))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`defaultKeyGenerator`'s canonical query/header/cookie helpers each allocated
their own `[]byte` buffer and returned a `string`, which the caller then
re-appended (copied) into the pooled key buffer - wasted intermediate
allocations on the cache-key hot path.

This converts them to append directly into the caller's buffer
(`appendCanonicalQueryString` / `appendCanonicalHeaderSubset` /
`appendCanonicalCookieSubset`) and adds `appendBoundKeySegment` so the
length-bounding hash path appends in place too (via `hex.AppendEncode`). The raw
query string no longer needs a defensive copy (it is consumed synchronously),
so `utils.CopyString` becomes `utils.UnsafeString`.

With the default config (`KeyHeaders` = Accept/Accept-Encoding/Accept-Language),
the common path now needs a single allocation: the final key string.

## Correctness

Key output is **byte-for-byte identical**, pinned by a new test
(`Test_defaultKeyGenerator_stableKeys`, 13 cases) covering query sorting, URL
escaping, SHA256 length-bounding (DoS guard), header delimiter escaping,
cookies and `DisableQueryKeys`. The full cache suite, including
`cache_security_test.go`, passes.

The SHA256 length-bounding is unchanged in behavior (and only runs for
oversized segments); it is a key-size guard, not a hot-path cost.

## Benchmarks

benchstat, count=6, Apple M2 Pro:

| Benchmark | allocs/op | B/op | ns/op |
|---|---|---|---|
| `defaultKeyGenerator/noquery` (default config) | 3 -> 1 (-67%) | 144 -> 48 | -17% |
| `defaultKeyGenerator/singleparam` | 4 -> 1 (-75%) | 168 -> 64 | -20% |
| `defaultKeyGenerator/multiparam` | 9 -> 5 (-44%) | 320 -> 176 | -10% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
