### PR TITLE
chore: remove dead code flagged by ghoul static analyzer

### DIFF
--- a/middleware/cors/utils.go
+++ b/middleware/cors/utils.go
@@ -7,32 +7,6 @@ import (
 	utilsstrings "github.com/gofiber/utils/v2/strings"
 )
 
-// matchScheme compares the scheme of the domain and pattern
-func matchScheme(domain, pattern string) bool {
-	dScheme, _, dFound := strings.Cut(domain, ":")
-	pScheme, _, pFound := strings.Cut(pattern, ":")
-	return dFound && pFound && dScheme == pScheme
-}
-
-// normalizeDomain removes the scheme and port from the input domain
-func normalizeDomain(input string) string {
-	// Remove scheme
-	if after, found := strings.CutPrefix(input, "https://"); found {
-		input = after
-	} else if after, found := strings.CutPrefix(input, "http://"); found {
-		input = after
-	}
-
-	// Find and remove port, if present
-	if input != "" && input[0] != '[' {
-		if before, _, found := strings.Cut(input, ":"); found {
-			input = before
-		}
-	}
-
-	return input
-}
-
 // normalizeOrigin checks if the provided origin is in a correct format
 // and normalizes it by removing any path or trailing slash.
 // It returns a boolean indicating whether the origin is valid

--- a/middleware/cors/utils_test.go
+++ b/middleware/cors/utils_test.go
@@ -54,65 +54,6 @@ func Test_NormalizeOrigin(t *testing.T) {
 	}
 }
 
-// go test -run -v Test_MatchScheme
-func Test_MatchScheme(t *testing.T) {
-	testCases := []struct {
-		domain   string
-		pattern  string
-		expected bool
-	}{
-		{domain: "http://example.com", pattern: "http://example.com", expected: true},           // Exact match should work.
-		{domain: "https://example.com", pattern: "http://example.com", expected: false},         // Scheme mismatch should matter.
-		{domain: "http://example.com", pattern: "https://example.com", expected: false},         // Scheme mismatch should matter.
-		{domain: "http://example.com", pattern: "http://example.org", expected: true},           // Different domains should not matter.
-		{domain: "http://example.com", pattern: "http://example.com:8080", expected: true},      // Port should not matter.
-		{domain: "http://example.com:8080", pattern: "http://example.com", expected: true},      // Port should not matter.
-		{domain: "http://example.com:8080", pattern: "http://example.com:8081", expected: true}, // Different ports should not matter.
-		{domain: "http://localhost", pattern: "http://localhost", expected: true},               // Localhost should match.
-		{domain: "http://127.0.0.1", pattern: "http://127.0.0.1", expected: true},               // IPv4 address should match.
-		{domain: "http://[::1]", pattern: "http://[::1]", expected: true},                       // IPv6 address should match.
-	}
-
-	for _, tc := range testCases {
-		result := matchScheme(tc.domain, tc.pattern)
-
-		if result != tc.expected {
-			t.Errorf("Expected matchScheme('%s', '%s') to be %v, but got %v", tc.domain, tc.pattern, tc.expected, result)
-		}
-	}
-}
-
-// go test -run -v Test_NormalizeDomain
-func Test_NormalizeDomain(t *testing.T) {
-	testCases := []struct {
-		input          string
-		expectedOutput string
-	}{
-		{input: "http://example.com", expectedOutput: "example.com"},                     // Simple case with http scheme.
-		{input: "https://example.com", expectedOutput: "example.com"},                    // Simple case with https scheme.
-		{input: "http://example.com:3000", expectedOutput: "example.com"},                // Case with port.
-		{input: "https://example.com:3000", expectedOutput: "example.com"},               // Case with port and https scheme.
-		{input: "http://example.com/path", expectedOutput: "example.com/path"},           // Case with path.
-		{input: "http://example.com?query=123", expectedOutput: "example.com?query=123"}, // Case with query.
-		{input: "http://example.com#fragment", expectedOutput: "example.com#fragment"},   // Case with fragment.
-		{input: "example.com", expectedOutput: "example.com"},                            // Case without scheme.
-		{input: "example.com:8080", expectedOutput: "example.com"},                       // Case without scheme but with port.
-		{input: "sub.example.com", expectedOutput: "sub.example.com"},                    // Case with subdomain.
-		{input: "sub.sub.example.com", expectedOutput: "sub.sub.example.com"},            // Case with nested subdomain.
-		{input: "http://localhost", expectedOutput: "localhost"},                         // Case with localhost.
-		{input: "http://127.0.0.1", expectedOutput: "127.0.0.1"},                         // Case with IPv4 address.
-		{input: "http://[::1]", expectedOutput: "[::1]"},                                 // Case with IPv6 address.
-	}
-
-	for _, tc := range testCases {
-		output := normalizeDomain(tc.input)
-
-		if output != tc.expectedOutput {
-			t.Errorf("Expected normalized domain '%s' for input '%s', but got: '%s'", tc.expectedOutput, tc.input, output)
-		}
-	}
-}
-
 // go test -v -run=^$ -bench=Benchmark_CORS_SubdomainMatch -benchmem -count=4
 func Benchmark_CORS_SubdomainMatch(b *testing.B) {
 	s := subdomain{

--- a/middleware/sse/event.go
+++ b/middleware/sse/event.go
@@ -120,16 +120,6 @@ func jsonMarshalOrDefault(jsonMarshal []utils.JSONMarshal) utils.JSONMarshal {
 	return json.Marshal
 }
 
-func writeData(w *bufio.Writer, data string) error {
-	data = normalizeNewlines(data)
-	for line := range strings.SplitSeq(data, "\n") {
-		if _, err := fmt.Fprintf(w, "data: %s\n", line); err != nil {
-			return fmt.Errorf("sse: write data: %w", err)
-		}
-	}
-	return nil
-}
-
 func appendField(w *bytes.Buffer, field, value string) {
 	w.WriteString(field) //nolint:errcheck // bytes.Buffer writes never fail.
 	w.WriteString(": ")  //nolint:errcheck // bytes.Buffer writes never fail.

--- a/middleware/sse/sse_test.go
+++ b/middleware/sse/sse_test.go
@@ -228,15 +228,6 @@ func Test_SSE_CommentReturnsWriterError(t *testing.T) {
 	require.ErrorIs(t, writeComment(w, ""), writeErr)
 }
 
-func Test_SSE_WriteDataReturnsWriterError(t *testing.T) {
-	t.Parallel()
-
-	writeErr := errors.New("write failed")
-	w := bufio.NewWriterSize(errWriter{err: writeErr}, 1)
-
-	require.ErrorIs(t, writeData(w, "hello"), writeErr)
-}
-
 func Test_SSE_NewWritesHeadersAndEvents(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Hi 👋

I ran [ghoul](https://fereidani.com/ghoul) against Fiber again, and this round it surfaced a set of dead-code and duplicate-code findings. This PR removes the ones that are clearly safe; the rest I've left untouched with notes, since they felt like judgment calls I didn't want to make for you.

Here are the reports:

```txt
app.go:1613:2: [duplicate-case-body] this case body is identical to an earlier case; likely a copy-paste error (confidence: 8.0/10)
middleware/cache/cache.go:1105:6: [dead-code] function parseMaxAge is never referenced; it is dead code (confidence: 7.4/10, CWE-563)
middleware/cache/cache.go:1148:6: [dead-code] function parseRequestCacheControlString is never referenced; it is dead code (confidence: 7.4/10, CWE-563)
middleware/cache/cache.go:1582:6: [dead-code] function allowsSharedCache is never referenced; it is dead code (confidence: 7.4/10, CWE-563)
middleware/cors/utils.go:11:6: [dead-code] function matchScheme is never referenced; it is dead code (confidence: 7.4/10, CWE-563)
middleware/cors/utils.go:18:6: [dead-code] function normalizeDomain is never referenced; it is dead code (confidence: 7.4/10, CWE-563)
middleware/session/data.go:46:6: [dead-code] function releaseData is never referenced; it is dead code (confidence: 7.4/10, CWE-563)
middleware/sse/event.go:123:6: [dead-code] function writeData is never referenced; it is dead code (confidence: 7.4/10, CWE-563)
```

## What I changed

Each fix is in its own commit.

**`middleware/cors` removed `matchScheme` and `normalizeDomain`**
These are the older origin-handling helpers, fully superseded by `normalizeOrigin` and `subdomain.match`. Their only remaining callers were their own unit tests, which I removed alongside them.

**`middleware/sse` removed `writeData`**
`writeData` is an exact duplicate of `appendData` (same newline normalization and per-line `data:` writing), just writing to a `*bufio.Writer` instead of a buffer. Production builds frames via `writeEvent` → `appendData`, so `writeData` was unused. Removed it together with its dedicated error test.

## What I left for you to look at

A few findings looked intentional or risky to change blind, so I've left them as-is for your review rather than guess:

- **`app.go:1613` duplicate-case-body.** The `default` branch and the `err == nil` case both produce `StatusBadRequest`, and several network-error cases both map to `ErrBadGateway`. These read as intentional distinct conditions that legitimately share an outcome rather than copy-paste mistakes, so merging them could lose the semantic distinction. Worth a glance if you agree.

- **`middleware/cache` `parseMaxAge`, `parseRequestCacheControlString`, `allowsSharedCache`.** These are only referenced from tests (production uses the byte-oriented parsers directly). They could be dropped by having the tests call the byte versions, but that's mostly a style call, so I left the decision to you.

- **`middleware/session` `releaseData`.** This pool-release helper isn't called anywhere in production only ~19 times across the test suite while its counterpart `acquireData` is used in production. It may be intentionally test-only, or it may hint at a release path that should be wired up; either way I didn't want to assume, so I'm flagging it for you.
