### PR TITLE
chore: remove test-only dead code and add manual deadcode workflow

### DIFF
--- a/.github/workflows/deadcode.yml
+++ b/.github/workflows/deadcode.yml
@@ -1,0 +1,47 @@
+name: Dead Code (manual)
+
+# Manually-triggered, report-only scan for dead code that the standard `unused`
+# linter cannot catch: unexported symbols referenced only from test files.
+# staticcheck (like golangci-lint's `unused`) counts test references as usage,
+# so this job strips *_test.go and re-runs staticcheck, surfacing test-only
+# symbols as unused (U1000). It never modifies the repo and never posts; the
+# findings are written to the run summary. It does not fail the run, because
+# some flagged symbols may be intentionally test-only (review each by hand).
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deadcode:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: stable
+
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+
+      - name: Detect test-only dead code (report only)
+        run: |
+          work="$(mktemp -d)"
+          rsync -a --exclude='.git' ./ "$work/"
+          find "$work" -name '*_test.go' -delete
+          cd "$work"
+          {
+            echo "## Dead code report (test-only / unused)"
+            echo
+            echo "Unexported symbols unused once test files are removed."
+            echo "Some may be intentional test-only helpers; review each by hand."
+            echo
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          staticcheck -checks=U1000 ./... 2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/client/core.go
+++ b/client/core.go
@@ -7,10 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"slices"
-	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/valyala/fasthttp"
@@ -32,19 +29,6 @@ type ResponseHook func(*Client, *Response, *Request) error
 
 // RetryConfig is an alias for the `retry.Config` type from the `addon/retry` package.
 type RetryConfig = retry.Config
-
-// addMissingPort appends the appropriate port number to the given address if it doesn't have one.
-// If isTLS is true, it uses port 443; otherwise, it uses port 80.
-func addMissingPort(addr string, isTLS bool) string { //revive:disable-line:flag-parameter
-	if strings.IndexByte(addr, ':') != -1 {
-		return addr
-	}
-	port := 80
-	if isTLS {
-		port = 443
-	}
-	return net.JoinHostPort(addr, strconv.Itoa(port))
-}
 
 // core stores middleware and plugin definitions and defines the request execution process.
 type core struct {

--- a/client/core_test.go
+++ b/client/core_test.go
@@ -18,49 +18,6 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
-func Test_AddMissing_Port(t *testing.T) {
-	t.Parallel()
-
-	type args struct {
-		addr  string
-		isTLS bool
-	}
-	tests := []struct {
-		name string
-		want string
-		args args
-	}{
-		{
-			name: "do anything",
-			args: args{
-				addr: "example.com:1234",
-			},
-			want: "example.com:1234",
-		},
-		{
-			name: "add 80 port",
-			args: args{
-				addr: "example.com",
-			},
-			want: "example.com:80",
-		},
-		{
-			name: "add 443 port",
-			args: args{
-				addr:  "example.com",
-				isTLS: true,
-			},
-			want: "example.com:443",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, tt.want, addMissingPort(tt.args.addr, tt.args.isTLS))
-		})
-	}
-}
-
 func Test_Exec_Func(t *testing.T) {
 	t.Parallel()
 	ln := fasthttputil.NewInmemoryListener()

--- a/helpers.go
+++ b/helpers.go
@@ -219,20 +219,6 @@ func (*App) isASCII(s string) bool {
 	return true
 }
 
-// uniqueRouteStack drop all not unique routes from the slice
-func uniqueRouteStack(stack []*Route) []*Route {
-	m := make(map[*Route]struct{}, len(stack))
-	unique := make([]*Route, 0, len(stack))
-	for _, v := range stack {
-		if _, ok := m[v]; !ok {
-			m[v] = struct{}{}
-			unique = append(unique, v)
-		}
-	}
-
-	return unique
-}
-
 // defaultString returns the value or a default value if it is set
 func defaultString(value string, defaultValue []string) string {
 	if value == "" && len(defaultValue) > 0 {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -630,35 +630,6 @@ func Benchmark_Utils_SortAcceptedTypes_Unsorted(b *testing.B) {
 	}, acceptedTypes)
 }
 
-func Test_Utils_UniqueRouteStack(t *testing.T) {
-	t.Parallel()
-	route1 := &Route{}
-	route2 := &Route{}
-	route3 := &Route{}
-	require.Equal(
-		t,
-		[]*Route{
-			route1,
-			route2,
-			route3,
-		},
-		uniqueRouteStack([]*Route{
-			route1,
-			route1,
-			route1,
-			route2,
-			route2,
-			route2,
-			route3,
-			route3,
-			route3,
-			route1,
-			route2,
-			route3,
-		}),
-	)
-}
-
 func Test_Utils_getGroupPath(t *testing.T) {
 	t.Parallel()
 	res := getGroupPath("/v1", "/")

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1101,15 +1101,6 @@ func parseResponseCacheControl(cc []byte) responseCacheControl {
 	return parsed
 }
 
-// parseMaxAge extracts the max-age directive from a Cache-Control header.
-func parseMaxAge(cc string) (time.Duration, bool) {
-	parsed := parseResponseCacheControl(utils.UnsafeBytes(cc))
-	if !parsed.maxAgeSet {
-		return 0, false
-	}
-	return secondsToDuration(parsed.maxAge), true
-}
-
 func parseRequestCacheControl(cc []byte) requestCacheDirectives {
 	directives := requestCacheDirectives{}
 	parseCacheControlDirectives(cc, func(key, value []byte) {
@@ -1143,10 +1134,6 @@ func parseRequestCacheControl(cc []byte) requestCacheDirectives {
 		}
 	})
 	return directives
-}
-
-func parseRequestCacheControlString(cc string) requestCacheDirectives {
-	return parseRequestCacheControl(utils.UnsafeBytes(cc))
 }
 
 func cachedResponseAge(e *item, now uint64) uint64 {
@@ -1586,10 +1573,6 @@ func allowsSharedCacheDirectives(cc responseCacheControl) bool {
 	// authenticated requests §3.6 requires an explicit shared-cache directive. Therefore,
 	// an Expires header alone MUST NOT allow sharing when Authorization is present.
 	return false
-}
-
-func allowsSharedCache(cc string) bool {
-	return allowsSharedCacheDirectives(parseResponseCacheControl(utils.UnsafeBytes(cc)))
 }
 
 func makeHashAuthFunc(hexBufPool *sync.Pool) func([]byte) string {

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -2448,7 +2448,7 @@ func Test_CacheMaxStaleServesStaleResponse(t *testing.T) {
 	req.Header.Set(fiber.HeaderCacheControl, "max-stale=5")
 	resp, err = app.Test(req)
 	require.NoError(t, err)
-	require.Equalf(t, cacheHit, resp.Header.Get("X-Cache"), "dirs=%+v Age=%s count=%d", parseRequestCacheControlString("max-stale=5"), resp.Header.Get(fiber.HeaderAge), count)
+	require.Equalf(t, cacheHit, resp.Header.Get("X-Cache"), "dirs=%+v Age=%s count=%d", parseRequestCacheControl([]byte("max-stale=5")), resp.Header.Get(fiber.HeaderAge), count)
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "1", string(body))
@@ -3003,7 +3003,7 @@ func Test_CacheMinFreshForcesRevalidation(t *testing.T) {
 	req.Header.Set(fiber.HeaderCacheControl, "min-fresh=10")
 	resp, err = app.Test(req)
 	require.NoError(t, err)
-	require.Equalf(t, cacheMiss, resp.Header.Get("X-Cache"), "dirs=%+v Age=%s count=%d", parseRequestCacheControlString("min-fresh=10"), resp.Header.Get(fiber.HeaderAge), count)
+	require.Equalf(t, cacheMiss, resp.Header.Get("X-Cache"), "dirs=%+v Age=%s count=%d", parseRequestCacheControl([]byte("min-fresh=10")), resp.Header.Get(fiber.HeaderAge), count)
 	body, err = io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "2", string(body))
@@ -3453,72 +3453,6 @@ func Test_CacheMaxAgeDirective(t *testing.T) {
 	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
 	require.NoError(t, err)
 	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
-}
-
-func Test_ParseMaxAge(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		header string
-		expect time.Duration
-		ok     bool
-	}{
-		{"max-age=60", 60 * time.Second, true},
-		{"public, max-age=86400", 86400 * time.Second, true},
-		{"no-store", 0, false},
-		{"max-age=invalid", 0, false},
-		{"public, s-maxage=100, max-age=50", 50 * time.Second, true},
-		{"MAX-AGE=20", 20 * time.Second, true},
-		{"public , max-age=0", 0, true},
-		{"public , max-age", 0, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.header, func(t *testing.T) {
-			t.Parallel()
-			d, ok := parseMaxAge(tt.header)
-			if tt.ok != ok {
-				t.Fatalf("expected ok=%v got %v", tt.ok, ok)
-			}
-			if ok && d != tt.expect {
-				t.Fatalf("expected %v got %v", tt.expect, d)
-			}
-		})
-	}
-}
-
-func Test_AllowsSharedCache(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		directives string
-		expect     bool
-	}{
-		{"public", true},
-		{"private", false},
-		{"s-maxage=60", true},
-		{"public, max-age=60", true},
-		{"public, must-revalidate", true},
-		{"max-age=60", false},
-		{"no-cache", false},
-		{"no-cache, s-maxage=60", true},
-		{"", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.directives, func(t *testing.T) {
-			t.Parallel()
-
-			got := allowsSharedCache(tt.directives)
-			require.Equal(t, tt.expect, got, "directives: %q", tt.directives)
-		})
-	}
-
-	t.Run("private overrules public", func(t *testing.T) {
-		t.Parallel()
-
-		got := allowsSharedCache(strings.ToUpper("private, public"))
-		require.False(t, got)
-	})
 }
 
 func TestCacheSkipsAuthorizationByDefault(t *testing.T) {

--- a/router.go
+++ b/router.go
@@ -69,9 +69,8 @@ type Route struct {
 }
 
 var (
-	defaultGreedyParameterKeys        = []string{"*", "+"}
-	preferredWildcardGreedyParameters = []string{"*", "+"}
-	preferredPlusGreedyParameters     = []string{"+", "*"}
+	defaultGreedyParameterKeys    = []string{"*", "+"}
+	preferredPlusGreedyParameters = []string{"+", "*"}
 )
 
 // URL generates a URL from the route path and parameters.

--- a/router_test.go
+++ b/router_test.go
@@ -2476,7 +2476,7 @@ func Test_Route_URL(t *testing.T) {
 	t.Run("preferred greedy parameters default fallback", func(t *testing.T) {
 		t.Parallel()
 		require.Equal(t, preferredPlusGreedyParameters, preferredGreedyParameters("+1"))
-		require.Equal(t, preferredWildcardGreedyParameters, preferredGreedyParameters("*1"))
+		require.Equal(t, []string{"*", "+"}, preferredGreedyParameters("*1"))
 		require.Equal(t, defaultGreedyParameterKeys, preferredGreedyParameters(""))
 		require.Equal(t, defaultGreedyParameterKeys, preferredGreedyParameters("name"))
 	})


### PR DESCRIPTION
## Description

Removes unexported symbols that are referenced **only by tests** (production never calls them). These slip past golangci-lint's `unused`, because staticcheck counts test references as usage. Also adds a manual, read-only workflow to surface this class of dead code on demand.

## Removed (pure dead code)

| Symbol | Location | Why it is safe |
| --- | --- | --- |
| `addMissingPort` | `client/core.go` | not wired anywhere in production |
| `uniqueRouteStack` | `helpers.go` | no caller |
| `parseMaxAge` | `middleware/cache/cache.go` | prod parses max-age via `parseResponseCacheControl` (bytes) |
| `parseRequestCacheControlString` | `middleware/cache/cache.go` | thin string wrapper; prod uses `parseRequestCacheControl` (bytes) |
| `allowsSharedCache` | `middleware/cache/cache.go` | prod uses `allowsSharedCacheDirectives` directly |
| `preferredWildcardGreedyParameters` | `router.go` | duplicate of `defaultGreedyParameterKeys`; test now asserts the literal |

Their dedicated tests are removed; two cache debug-message call sites switch to the byte-oriented parser. `go build ./...`, `go vet`, and the full test suite (43 packages) pass; `gofmt` clean.

## New workflow: `.github/workflows/deadcode.yml`

- Trigger: `workflow_dispatch` only (manual).
- `permissions: contents: read` (read-only token).
- Report-only: strips `*_test.go`, runs `staticcheck -checks=U1000`, and writes findings to the run summary. It does not modify the repo, does not post, and does not fail the run (some flagged symbols may be intentional test-only helpers).

This catches exactly what the standard `unused` linter cannot: code reachable only from tests.

## Intentionally NOT removed (flagged as possible missing wiring, not dead code)

These look unused but may indicate a latent gap rather than dead code, so they are left for a separate decision:

- `matchEtagStrong` (`helpers.go`) - strong ETag comparison per RFC 9110 is not implemented in production (the etag middleware only does weak comparison).
- `releaseData` (`middleware/session/data.go`) - `acquireData()` is used in production but the data object is never returned to the pool; possible pool/GC leak.
- `getCookiesByHost` (`client/cookiejar.go`) - test-only inspection helper, entangled in the cookie-jar test; removing it would require rewriting that test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
