### PR TITLE
test(cors): add unit tests for isOriginSerializedOrNull

### DIFF
--- a/middleware/cors/utils_test.go
+++ b/middleware/cors/utils_test.go
@@ -54,6 +54,64 @@ func Test_NormalizeOrigin(t *testing.T) {
 	}
 }
 
+func Test_isOriginSerializedOrNull(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		origin             string
+		expectedSerialized bool
+		expectedNull       bool
+	}{
+		{
+			name:               "literal null origin",
+			origin:             "null",
+			expectedSerialized: false,
+			expectedNull:       true,
+		},
+		{
+			name:               "valid http origin",
+			origin:             "https://example.com",
+			expectedSerialized: true,
+			expectedNull:       false,
+		},
+		{
+			name:               "valid origin with port",
+			origin:             "http://example.com:8080",
+			expectedSerialized: true,
+			expectedNull:       false,
+		},
+		{
+			name:               "invalid origin",
+			origin:             "not-an-origin",
+			expectedSerialized: false,
+			expectedNull:       false,
+		},
+		{
+			name:               "empty string",
+			origin:             "",
+			expectedSerialized: false,
+			expectedNull:       false,
+		},
+		{
+			name:               "origin with path is invalid",
+			origin:             "https://example.com/path",
+			expectedSerialized: false,
+			expectedNull:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			isSerialized, isNull := isOriginSerializedOrNull(tt.origin)
+			assert.Equal(t, tt.expectedSerialized, isSerialized, "isSerialized mismatch for origin %q", tt.origin)
+			assert.Equal(t, tt.expectedNull, isNull, "isNull mismatch for origin %q", tt.origin)
+		})
+	}
+}
+
 // go test -v -run=^$ -bench=Benchmark_CORS_SubdomainMatch -benchmem -count=4
 func Benchmark_CORS_SubdomainMatch(b *testing.B) {
 	s := subdomain{


### PR DESCRIPTION
The `isOriginSerializedOrNull` function in `middleware/cors/cors.go` had no direct unit tests, despite being part of the CORS security logic that handles the null origin (used by sandboxed iframes and redirected requests).
This PR adds table-driven tests covering all meaningful input categories:

- The literal "null" origin (RFC 6454 opaque origin)
- A valid serialized origin (https://example.com)
- A valid origin with port (http://example.com:8080)
- An invalid/malformed origin string
- An empty string
- An origin with a path (which is invalid per CORS spec)