### PR TITLE
test(middleware): raise coverage above 90% for timeout, logger, idempotency, limiter, cache

### DIFF
--- a/middleware/cache/coverage_test.go
+++ b/middleware/cache/coverage_test.go
@@ -1,0 +1,506 @@
+package cache
+
+import (
+	"bytes"
+	"container/heap"
+	"context"
+	"errors"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tinylib/msgp/msgp"
+	"github.com/valyala/fasthttp"
+)
+
+var errCacheWriteBudget = errors.New("write budget exhausted")
+
+// alwaysErrWriter fails on every write.
+type alwaysErrWriter struct{}
+
+func (alwaysErrWriter) Write([]byte) (int, error) { return 0, errCacheWriteBudget }
+
+// encodeMsgErrorSweep drives the per-write error branches of an EncodeMsg
+// implementation. The msgp writer enforces an 18-byte minimum buffer, so a
+// single failing writer only surfaces an error at fixed flush boundaries.
+// Sweeping the buffer size moves the first flush through the encode sequence,
+// exercising a different write's error branch on each iteration.
+func encodeMsgErrorSweep(t *testing.T, marshaledLen int, encode func(*msgp.Writer) error) {
+	t.Helper()
+
+	sawErr := false
+	for sz := 18; sz <= marshaledLen+18; sz++ {
+		w := msgp.NewWriterSize(alwaysErrWriter{}, sz)
+		err := encode(w)
+		if err == nil {
+			err = w.Flush()
+		}
+		if err != nil {
+			sawErr = true
+		}
+	}
+	require.True(t, sawErr)
+}
+
+func populatedItem() item {
+	return item{
+		headers: []cachedHeader{
+			{key: []byte("X-A"), value: []byte("1")},
+			{key: []byte("X-B"), value: []byte("two")},
+		},
+		body:            []byte("response body"),
+		ctype:           []byte("text/plain"),
+		cencoding:       []byte("gzip"),
+		cacheControl:    []byte("max-age=60"),
+		expires:         []byte("Wed, 21 Oct 2026 07:28:00 GMT"),
+		etag:            []byte(`"abc123"`),
+		date:            1,
+		status:          200,
+		age:             2,
+		exp:             3,
+		ttl:             4,
+		forceRevalidate: true,
+		revalidate:      true,
+		shareable:       true,
+		private:         true,
+		heapidx:         5,
+	}
+}
+
+func Test_item_MarshalUnmarshal_Populated(t *testing.T) {
+	t.Parallel()
+
+	v := populatedItem()
+	bts, err := v.MarshalMsg(nil)
+	require.NoError(t, err)
+
+	var out item
+	left, err := out.UnmarshalMsg(bts)
+	require.NoError(t, err)
+	require.Empty(t, left)
+	require.Equal(t, v, out)
+}
+
+func Test_item_EncodeDecode_Populated(t *testing.T) {
+	t.Parallel()
+
+	v := populatedItem()
+	var buf bytes.Buffer
+	w := msgp.NewWriter(&buf)
+	require.NoError(t, v.EncodeMsg(w))
+	require.NoError(t, w.Flush())
+
+	var out item
+	require.NoError(t, out.DecodeMsg(msgp.NewReader(&buf)))
+	require.Equal(t, v, out)
+}
+
+func Test_item_Decode_Truncated(t *testing.T) {
+	t.Parallel()
+
+	v := populatedItem()
+	full, err := v.MarshalMsg(nil)
+	require.NoError(t, err)
+
+	for i := 0; i < len(full); i++ {
+		prefix := full[:i]
+
+		var out item
+		_, uerr := out.UnmarshalMsg(prefix)
+		require.Error(t, uerr, "UnmarshalMsg should fail on prefix len %d", i)
+
+		var dec item
+		require.Error(t, dec.DecodeMsg(msgp.NewReader(bytes.NewReader(prefix))))
+	}
+}
+
+func Test_item_EncodeMsg_WriterErrors(t *testing.T) {
+	t.Parallel()
+
+	v := populatedItem()
+	full, err := v.MarshalMsg(nil)
+	require.NoError(t, err)
+
+	encodeMsgErrorSweep(t, len(full), v.EncodeMsg)
+}
+
+func Test_item_Decode_UnknownField(t *testing.T) {
+	t.Parallel()
+
+	var raw []byte
+	raw = msgp.AppendMapHeader(raw, 2)
+	raw = msgp.AppendString(raw, "unknownField")
+	raw = msgp.AppendString(raw, "ignored")
+	raw = msgp.AppendString(raw, "status")
+	raw = msgp.AppendInt(raw, 204)
+
+	var out item
+	_, err := out.UnmarshalMsg(raw)
+	require.NoError(t, err)
+	require.Equal(t, 204, out.status)
+
+	var dec item
+	require.NoError(t, dec.DecodeMsg(msgp.NewReader(bytes.NewReader(raw))))
+	require.Equal(t, 204, dec.status)
+}
+
+func Test_item_Decode_LimitExceeded(t *testing.T) {
+	t.Parallel()
+
+	// headers array exceeds the configured limit of 1024.
+	var raw []byte
+	raw = msgp.AppendMapHeader(raw, 1)
+	raw = msgp.AppendString(raw, "headers")
+	raw = msgp.AppendArrayHeader(raw, 1025)
+
+	var out item
+	_, err := out.UnmarshalMsg(raw)
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+
+	var dec item
+	require.ErrorIs(t, dec.DecodeMsg(msgp.NewReader(bytes.NewReader(raw))), msgp.ErrLimitExceeded)
+}
+
+func Test_cachedHeader_Roundtrip_Populated(t *testing.T) {
+	t.Parallel()
+
+	v := cachedHeader{key: []byte("Content-Type"), value: []byte("text/html")}
+	bts, err := v.MarshalMsg(nil)
+	require.NoError(t, err)
+
+	var out cachedHeader
+	_, err = out.UnmarshalMsg(bts)
+	require.NoError(t, err)
+	require.Equal(t, v, out)
+
+	for i := 0; i < len(bts); i++ {
+		var trunc cachedHeader
+		_, terr := trunc.UnmarshalMsg(bts[:i])
+		require.Error(t, terr)
+
+		var dec cachedHeader
+		require.Error(t, dec.DecodeMsg(msgp.NewReader(bytes.NewReader(bts[:i]))))
+	}
+}
+
+func Test_cachedHeader_EncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	v := cachedHeader{key: []byte("Content-Type"), value: []byte("text/html")}
+
+	var buf bytes.Buffer
+	w := msgp.NewWriter(&buf)
+	require.NoError(t, v.EncodeMsg(w))
+	require.NoError(t, w.Flush())
+
+	var out cachedHeader
+	require.NoError(t, out.DecodeMsg(msgp.NewReader(&buf)))
+	require.Equal(t, v, out)
+
+	full, err := v.MarshalMsg(nil)
+	require.NoError(t, err)
+	encodeMsgErrorSweep(t, len(full), v.EncodeMsg)
+}
+
+func Test_cachedHeader_Decode_UnknownAndLimits(t *testing.T) {
+	t.Parallel()
+
+	// Unknown field is skipped.
+	var raw []byte
+	raw = msgp.AppendMapHeader(raw, 2)
+	raw = msgp.AppendString(raw, "zz")
+	raw = msgp.AppendString(raw, "ignored")
+	raw = msgp.AppendString(raw, "key")
+	raw = msgp.AppendBytes(raw, []byte("X-Test"))
+
+	var out cachedHeader
+	_, err := out.UnmarshalMsg(raw)
+	require.NoError(t, err)
+	require.Equal(t, []byte("X-Test"), out.key)
+
+	var dec cachedHeader
+	require.NoError(t, dec.DecodeMsg(msgp.NewReader(bytes.NewReader(raw))))
+	require.Equal(t, []byte("X-Test"), dec.key)
+
+	// key over the 512-byte limit.
+	var bigKey []byte
+	bigKey = msgp.AppendMapHeader(bigKey, 1)
+	bigKey = msgp.AppendString(bigKey, "key")
+	bigKey = msgp.AppendBytes(bigKey, make([]byte, 513))
+	var k cachedHeader
+	_, err = k.UnmarshalMsg(bigKey)
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+
+	// value over the 16384-byte limit.
+	var bigVal []byte
+	bigVal = msgp.AppendMapHeader(bigVal, 1)
+	bigVal = msgp.AppendString(bigVal, "value")
+	bigVal = msgp.AppendBytes(bigVal, make([]byte, 16385))
+	var vv cachedHeader
+	_, err = vv.UnmarshalMsg(bigVal)
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+}
+
+// Test_item_Decode_FieldLimits covers the per-field ErrLimitExceeded branches
+// of the item byte fields.
+func Test_item_Decode_FieldLimits(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		field string
+		size  int
+	}{
+		{"ctype", 257},
+		{"cencoding", 129},
+		{"cacheControl", 2049},
+		{"expires", 129},
+		{"etag", 257},
+	}
+	for _, tc := range cases {
+		var raw []byte
+		raw = msgp.AppendMapHeader(raw, 1)
+		raw = msgp.AppendString(raw, tc.field)
+		raw = msgp.AppendBytes(raw, make([]byte, tc.size))
+
+		var out item
+		_, err := out.UnmarshalMsg(raw)
+		require.ErrorIs(t, err, msgp.ErrLimitExceeded, "field %s", tc.field)
+
+		var dec item
+		require.ErrorIs(t, dec.DecodeMsg(msgp.NewReader(bytes.NewReader(raw))), msgp.ErrLimitExceeded, "field %s", tc.field)
+	}
+}
+
+func Test_indexedHeap_PushAndOps(t *testing.T) {
+	t.Parallel()
+
+	h := &indexedHeap{}
+
+	// put inserts entries and returns tracking indices.
+	idxA := h.put("a", 30, 1)
+	idxB := h.put("b", 10, 2)
+	idxC := h.put("c", 20, 3)
+	require.Equal(t, 3, h.Len())
+
+	// The lowest expiration must come out first.
+	key, _ := h.removeFirst()
+	require.Equal(t, "b", key)
+
+	// Remove an arbitrary tracked entry.
+	key, _ = h.remove(idxC)
+	require.Equal(t, "c", key)
+	_ = idxA
+	_ = idxB
+
+	// Directly exercise the heap.Interface Push method (not used by put()).
+	h2 := &indexedHeap{indices: []int{0}}
+	heap.Push(h2, heapEntry{key: "z", exp: 5, idx: 0})
+	require.Equal(t, 1, h2.Len())
+	require.Equal(t, "z", h2.entries[0].key)
+}
+
+func Test_parseUintDirective(t *testing.T) {
+	t.Parallel()
+
+	v, ok := parseUintDirective([]byte("60"))
+	require.True(t, ok)
+	require.Equal(t, uint64(60), v)
+
+	_, ok = parseUintDirective(nil)
+	require.False(t, ok)
+
+	_, ok = parseUintDirective([]byte("not-a-number"))
+	require.False(t, ok)
+
+	// Invalid max-age values are ignored when parsing full directives.
+	parsed := parseResponseCacheControl([]byte("max-age=abc, s-maxage=xyz"))
+	require.False(t, parsed.maxAgeSet)
+	require.False(t, parsed.sMaxAgeSet)
+}
+
+func Test_allowsSharedCacheDirectives(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, allowsSharedCacheDirectives(responseCacheControl{hasPrivate: true}))
+	require.True(t, allowsSharedCacheDirectives(responseCacheControl{hasPublic: true}))
+	require.True(t, allowsSharedCacheDirectives(responseCacheControl{sMaxAgeSet: true}))
+	require.True(t, allowsSharedCacheDirectives(responseCacheControl{mustRevalidate: true}))
+	require.True(t, allowsSharedCacheDirectives(responseCacheControl{proxyRevalidate: true}))
+	require.False(t, allowsSharedCacheDirectives(responseCacheControl{}))
+}
+
+func Test_secondsConversions_Overflow(t *testing.T) {
+	t.Parallel()
+
+	// secondsToTime clamps values beyond math.MaxInt64.
+	require.Equal(t, time.Unix(math.MaxInt64, 0).UTC(), secondsToTime(math.MaxUint64))
+	require.Equal(t, time.Unix(5, 0).UTC(), secondsToTime(5))
+
+	// secondsToDuration clamps on overflow.
+	require.Equal(t, time.Duration(math.MaxInt64), secondsToDuration(math.MaxUint64))
+	require.Equal(t, 5*time.Second, secondsToDuration(5))
+}
+
+func Test_makeHashAuthFunc(t *testing.T) {
+	t.Parallel()
+
+	pool := &sync.Pool{}
+	fn := makeHashAuthFunc(pool)
+	got := fn([]byte("Bearer token"))
+	require.Len(t, got, hexLen)
+	// Stable for the same input, and uses the pool on the second call.
+	require.Equal(t, got, fn([]byte("Bearer token")))
+}
+
+func Test_manager_get_StorageErrors(t *testing.T) {
+	t.Parallel()
+
+	// Storage GetWithContext returns an error.
+	storage := newFailingCacheStorage()
+	storage.errs["get|k"] = errors.New("boom")
+	m := newManager(storage, true)
+	_, err := m.get(context.Background(), "k")
+	require.ErrorContains(t, err, redactedKey)
+
+	// Stored bytes fail to unmarshal.
+	storage2 := newFailingCacheStorage()
+	storage2.data["k"] = []byte{0xff, 0xff, 0xff}
+	m2 := newManager(storage2, false)
+	_, err = m2.get(context.Background(), "k")
+	require.ErrorContains(t, err, "unmarshal")
+
+	// Cache miss.
+	m3 := newManager(newFailingCacheStorage(), false)
+	_, err = m3.get(context.Background(), "missing")
+	require.ErrorIs(t, err, errCacheMiss)
+
+	// Memory-backed unexpected type.
+	m4 := newManager(nil, false)
+	m4.memory.Set("k", "not-an-item", time.Minute)
+	_, err = m4.get(context.Background(), "k")
+	require.ErrorContains(t, err, "unexpected entry type")
+}
+
+func Test_manager_getRaw_Paths(t *testing.T) {
+	t.Parallel()
+
+	// Storage error.
+	storage := newFailingCacheStorage()
+	storage.errs["get|k"] = errors.New("boom")
+	m := newManager(storage, false)
+	_, err := m.getRaw(context.Background(), "k")
+	require.ErrorContains(t, err, "boom")
+
+	// Storage hit.
+	storage2 := newFailingCacheStorage()
+	storage2.data["k"] = []byte("raw-value")
+	m2 := newManager(storage2, false)
+	raw, err := m2.getRaw(context.Background(), "k")
+	require.NoError(t, err)
+	require.Equal(t, []byte("raw-value"), raw)
+
+	// Memory hit.
+	m3 := newManager(nil, false)
+	require.NoError(t, m3.setRaw(context.Background(), "k", []byte("mem"), time.Minute))
+	raw, err = m3.getRaw(context.Background(), "k")
+	require.NoError(t, err)
+	require.Equal(t, []byte("mem"), raw)
+
+	// Memory unexpected raw type.
+	m4 := newManager(nil, false)
+	m4.memory.Set("k", 12345, time.Minute)
+	_, err = m4.getRaw(context.Background(), "k")
+	require.ErrorContains(t, err, "unexpected raw entry type")
+
+	// Miss.
+	m5 := newManager(newFailingCacheStorage(), false)
+	_, err = m5.getRaw(context.Background(), "missing")
+	require.ErrorIs(t, err, errCacheMiss)
+}
+
+func Test_manager_set_StorageError(t *testing.T) {
+	t.Parallel()
+
+	storage := newFailingCacheStorage()
+	storage.errs["set|k"] = errors.New("boom")
+	m := newManager(storage, false)
+
+	it := m.acquire()
+	it.status = 200
+	err := m.set(context.Background(), "k", it, time.Minute)
+	require.ErrorContains(t, err, "boom")
+
+	// setRaw storage error.
+	require.ErrorContains(t, m.setRaw(context.Background(), "k", []byte("v"), time.Minute), "boom")
+}
+
+func Test_manager_get_StorageRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	storage := newFailingCacheStorage()
+	m := newManager(storage, false)
+
+	it := m.acquire()
+	it.status = 201
+	it.body = []byte("hello")
+	require.NoError(t, m.set(context.Background(), "k", it, time.Minute))
+
+	got, err := m.get(context.Background(), "k")
+	require.NoError(t, err)
+	require.Equal(t, 201, got.status)
+	require.Equal(t, []byte("hello"), got.body)
+}
+
+func Test_varyManifest_StoreLoad(t *testing.T) {
+	t.Parallel()
+
+	m := newManager(newFailingCacheStorage(), false)
+	ctx := context.Background()
+
+	// Empty names is a no-op store.
+	require.NoError(t, storeVaryManifest(ctx, m, "mk", nil, time.Minute))
+
+	// Missing manifest -> no names, no error.
+	names, ok, err := loadVaryManifest(ctx, m, "mk")
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, names)
+
+	// Store and load a real manifest.
+	require.NoError(t, storeVaryManifest(ctx, m, "mk", []string{"accept", "accept-encoding"}, time.Minute))
+	names, ok, err = loadVaryManifest(ctx, m, "mk")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"accept", "accept-encoding"}, names)
+
+	// A wildcard manifest is treated as uncacheable.
+	require.NoError(t, m.setRaw(ctx, "star", []byte("*"), time.Minute))
+	names, ok, err = loadVaryManifest(ctx, m, "star")
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, names)
+
+	// Storage error propagates.
+	storage := newFailingCacheStorage()
+	storage.errs["get|mk"] = errors.New("boom")
+	mErr := newManager(storage, false)
+	_, _, err = loadVaryManifest(ctx, mErr, "mk")
+	require.ErrorContains(t, err, "boom")
+}
+
+func Test_makeBuildVaryKeyFunc(t *testing.T) {
+	t.Parallel()
+
+	fn := makeBuildVaryKeyFunc(&sync.Pool{})
+
+	var hdr fasthttp.RequestHeader
+	hdr.Set("Accept", "application/json")
+	hdr.Set("Accept-Encoding", "gzip")
+
+	key := fn([]string{"accept", "accept-encoding"}, &hdr)
+	require.Contains(t, key, "|vary|")
+	// Deterministic for the same inputs (also exercises the pooled buffer path).
+	require.Equal(t, key, fn([]string{"accept", "accept-encoding"}, &hdr))
+}

--- a/middleware/cache/coverage_test.go
+++ b/middleware/cache/coverage_test.go
@@ -104,7 +104,7 @@ func Test_item_Decode_Truncated(t *testing.T) {
 	full, err := v.MarshalMsg(nil)
 	require.NoError(t, err)
 
-	for i := 0; i < len(full); i++ {
+	for i := range len(full) {
 		prefix := full[:i]
 
 		var out item
@@ -175,7 +175,7 @@ func Test_cachedHeader_Roundtrip_Populated(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, v, out)
 
-	for i := 0; i < len(bts); i++ {
+	for i := range len(bts) {
 		var trunc cachedHeader
 		_, terr := trunc.UnmarshalMsg(bts[:i])
 		require.Error(t, terr)

--- a/middleware/cache/coverage_test.go
+++ b/middleware/cache/coverage_test.go
@@ -30,18 +30,17 @@ func (alwaysErrWriter) Write([]byte) (int, error) { return 0, errCacheWriteBudge
 func encodeMsgErrorSweep(t *testing.T, marshaledLen int, encode func(*msgp.Writer) error) {
 	t.Helper()
 
-	sawErr := false
+	// An always-failing writer must surface an error for every buffer size,
+	// either on the first mid-encode flush or on the final Flush, so assert per
+	// iteration rather than once overall.
 	for sz := 18; sz <= marshaledLen+18; sz++ {
 		w := msgp.NewWriterSize(alwaysErrWriter{}, sz)
 		err := encode(w)
 		if err == nil {
 			err = w.Flush()
 		}
-		if err != nil {
-			sawErr = true
-		}
+		require.Error(t, err, "expected writer failure for buffer size %d", sz)
 	}
-	require.True(t, sawErr)
 }
 
 func populatedItem() item {
@@ -232,6 +231,8 @@ func Test_cachedHeader_Decode_UnknownAndLimits(t *testing.T) {
 	var k cachedHeader
 	_, err = k.UnmarshalMsg(bigKey)
 	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+	var kDec cachedHeader
+	require.ErrorIs(t, kDec.DecodeMsg(msgp.NewReader(bytes.NewReader(bigKey))), msgp.ErrLimitExceeded)
 
 	// value over the 16384-byte limit.
 	var bigVal []byte
@@ -241,6 +242,8 @@ func Test_cachedHeader_Decode_UnknownAndLimits(t *testing.T) {
 	var vv cachedHeader
 	_, err = vv.UnmarshalMsg(bigVal)
 	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+	var vvDec cachedHeader
+	require.ErrorIs(t, vvDec.DecodeMsg(msgp.NewReader(bytes.NewReader(bigVal))), msgp.ErrLimitExceeded)
 }
 
 // Test_item_Decode_FieldLimits covers the per-field ErrLimitExceeded branches

--- a/middleware/idempotency/idempotency_test.go
+++ b/middleware/idempotency/idempotency_test.go
@@ -54,8 +54,15 @@ func Test_Idempotency(t *testing.T) {
 		return nil
 	})
 
-	// Needs to be at least a second as the memory storage doesn't support shorter durations.
-	const lifetime = 2 * time.Second
+	// The memory storage expires entries on a coarse 1-second clock
+	// (exp = uint32(ttl.Seconds()) + Timestamp()), so a freshly stored entry has
+	// up to a full second less real headroom than its nominal lifetime. Keep the
+	// lifetime comfortably above that 1-second granularity so the back-to-back
+	// "store then replay" assertions below don't flake when a slow CI runner
+	// pauses between two consecutive requests. It must also stay small enough
+	// that the /slow handler's 3*lifetime sleep finishes within the 15s request
+	// timeout used in doReq.
+	const lifetime = 3 * time.Second
 
 	app.Use(New(Config{
 		Lifetime: lifetime,

--- a/middleware/idempotency/response_coverage_test.go
+++ b/middleware/idempotency/response_coverage_test.go
@@ -1,0 +1,196 @@
+package idempotency
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tinylib/msgp/msgp"
+)
+
+// errBudgetWriter is an io.Writer that accepts up to n bytes total and then
+// fails. It is used to drive the error-handling branches of EncodeMsg by
+// failing the underlying writer at every possible offset.
+type errBudgetWriter struct {
+	n int
+}
+
+var errWriteBudget = errors.New("write budget exhausted")
+
+func (w *errBudgetWriter) Write(p []byte) (int, error) {
+	if w.n <= 0 {
+		return 0, errWriteBudget
+	}
+	if len(p) > w.n {
+		k := w.n
+		w.n = 0
+		return k, errWriteBudget
+	}
+	w.n -= len(p)
+	return len(p), nil
+}
+
+func populatedResponse() response {
+	return response{
+		Headers: map[string][]string{
+			"Content-Type": {"application/json"},
+			"X-Multi":      {"a", "b", "c"},
+		},
+		Body:       []byte("hello world"),
+		StatusCode: 200,
+	}
+}
+
+// Test_response_MarshalUnmarshal_Populated exercises the headers-map, body and
+// status-code paths of MarshalMsg/UnmarshalMsg with non-empty data, including
+// the clear()/reuse branch when unmarshaling into an already-populated value.
+func Test_response_MarshalUnmarshal_Populated(t *testing.T) {
+	t.Parallel()
+
+	v := populatedResponse()
+	bts, err := v.MarshalMsg(nil)
+	require.NoError(t, err)
+
+	// Unmarshal into a value that already has a populated Headers map and Body
+	// to exercise the clear()/capacity-reuse branches.
+	out := response{
+		Headers: map[string][]string{"stale": {"value"}},
+		Body:    make([]byte, 0, 64),
+	}
+	left, err := out.UnmarshalMsg(bts)
+	require.NoError(t, err)
+	require.Empty(t, left)
+	require.Equal(t, v.Headers, out.Headers)
+	require.Equal(t, v.Body, out.Body)
+	require.Equal(t, v.StatusCode, out.StatusCode)
+}
+
+// Test_response_EncodeDecode_Populated exercises the streaming EncodeMsg /
+// DecodeMsg paths with non-empty data.
+func Test_response_EncodeDecode_Populated(t *testing.T) {
+	t.Parallel()
+
+	v := populatedResponse()
+
+	var buf bytes.Buffer
+	w := msgp.NewWriter(&buf)
+	require.NoError(t, v.EncodeMsg(w))
+	require.NoError(t, w.Flush())
+
+	// Decode into a value with a pre-existing Headers map to hit the clear() branch.
+	out := response{Headers: map[string][]string{"stale": {"x"}}}
+	r := msgp.NewReader(&buf)
+	require.NoError(t, out.DecodeMsg(r))
+
+	require.Equal(t, v.Headers, out.Headers)
+	require.Equal(t, v.Body, out.Body)
+	require.Equal(t, v.StatusCode, out.StatusCode)
+}
+
+// Test_response_UnmarshalMsg_UnknownField verifies the default/skip branch of
+// both UnmarshalMsg and DecodeMsg when an unrecognized map key is present.
+func Test_response_UnmarshalMsg_UnknownField(t *testing.T) {
+	t.Parallel()
+
+	// Build a map with one known field ("sc") and one unknown field ("zz").
+	var raw []byte
+	raw = msgp.AppendMapHeader(raw, 2)
+	raw = msgp.AppendString(raw, "zz")
+	raw = msgp.AppendString(raw, "ignored")
+	raw = msgp.AppendString(raw, "sc")
+	raw = msgp.AppendInt(raw, 418)
+
+	var out response
+	left, err := out.UnmarshalMsg(raw)
+	require.NoError(t, err)
+	require.Empty(t, left)
+	require.Equal(t, 418, out.StatusCode)
+
+	// Same for the streaming decoder.
+	var dec response
+	r := msgp.NewReader(bytes.NewReader(raw))
+	require.NoError(t, dec.DecodeMsg(r))
+	require.Equal(t, 418, dec.StatusCode)
+}
+
+// Test_response_Decode_Truncated feeds every truncated prefix of a valid
+// encoding to UnmarshalMsg and DecodeMsg, exercising the error-return branch of
+// each individual read in the generated code.
+func Test_response_Decode_Truncated(t *testing.T) {
+	t.Parallel()
+
+	v0 := populatedResponse()
+	full, err := v0.MarshalMsg(nil)
+	require.NoError(t, err)
+
+	for i := 0; i < len(full); i++ {
+		prefix := full[:i]
+
+		var out response
+		_, uerr := out.UnmarshalMsg(prefix)
+		require.Error(t, uerr, "UnmarshalMsg should fail on prefix len %d", i)
+
+		var dec response
+		r := msgp.NewReader(bytes.NewReader(prefix))
+		require.Error(t, dec.DecodeMsg(r), "DecodeMsg should fail on prefix len %d", i)
+	}
+}
+
+// Test_response_Decode_LimitExceeded covers the ErrLimitExceeded branches for
+// both the outer headers map and the per-header value array.
+func Test_response_Decode_LimitExceeded(t *testing.T) {
+	t.Parallel()
+
+	// Outer headers map header exceeds the 1024 limit.
+	var bigMap []byte
+	bigMap = msgp.AppendMapHeader(bigMap, 1)
+	bigMap = msgp.AppendString(bigMap, "hs")
+	bigMap = msgp.AppendMapHeader(bigMap, 1025)
+
+	var out response
+	_, err := out.UnmarshalMsg(bigMap)
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+
+	var dec response
+	require.ErrorIs(t, dec.DecodeMsg(msgp.NewReader(bytes.NewReader(bigMap))), msgp.ErrLimitExceeded)
+
+	// Per-header value array header exceeds the 1024 limit.
+	var bigArr []byte
+	bigArr = msgp.AppendMapHeader(bigArr, 1)
+	bigArr = msgp.AppendString(bigArr, "hs")
+	bigArr = msgp.AppendMapHeader(bigArr, 1)
+	bigArr = msgp.AppendString(bigArr, "key")
+	bigArr = msgp.AppendArrayHeader(bigArr, 1025)
+
+	var out2 response
+	_, err = out2.UnmarshalMsg(bigArr)
+	require.ErrorIs(t, err, msgp.ErrLimitExceeded)
+
+	var dec2 response
+	require.ErrorIs(t, dec2.DecodeMsg(msgp.NewReader(bytes.NewReader(bigArr))), msgp.ErrLimitExceeded)
+}
+
+// Test_response_EncodeMsg_WriterErrors drives the error-return branches of
+// EncodeMsg by failing the underlying writer at every byte offset.
+func Test_response_EncodeMsg_WriterErrors(t *testing.T) {
+	t.Parallel()
+
+	v0 := populatedResponse()
+	full, err := v0.MarshalMsg(nil)
+	require.NoError(t, err)
+
+	sawErr := false
+	for budget := 0; budget < len(full); budget++ {
+		v := populatedResponse()
+		w := msgp.NewWriterSize(&errBudgetWriter{n: budget}, 8)
+		encErr := v.EncodeMsg(w)
+		if encErr == nil {
+			encErr = w.Flush()
+		}
+		if encErr != nil {
+			sawErr = true
+		}
+	}
+	require.True(t, sawErr, "expected at least one writer error across budgets")
+}

--- a/middleware/idempotency/response_coverage_test.go
+++ b/middleware/idempotency/response_coverage_test.go
@@ -124,7 +124,7 @@ func Test_response_Decode_Truncated(t *testing.T) {
 	full, err := v0.MarshalMsg(nil)
 	require.NoError(t, err)
 
-	for i := 0; i < len(full); i++ {
+	for i := range len(full) {
 		prefix := full[:i]
 
 		var out response
@@ -181,7 +181,7 @@ func Test_response_EncodeMsg_WriterErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	sawErr := false
-	for budget := 0; budget < len(full); budget++ {
+	for budget := range len(full) {
 		v := populatedResponse()
 		w := msgp.NewWriterSize(&errBudgetWriter{n: budget}, 8)
 		encErr := v.EncodeMsg(w)

--- a/middleware/idempotency/response_coverage_test.go
+++ b/middleware/idempotency/response_coverage_test.go
@@ -180,7 +180,9 @@ func Test_response_EncodeMsg_WriterErrors(t *testing.T) {
 	full, err := v0.MarshalMsg(nil)
 	require.NoError(t, err)
 
-	sawErr := false
+	// A writer that accepts fewer than the full encoding's bytes must always
+	// surface an error (either mid-encode or on Flush), so assert per budget
+	// rather than once overall.
 	for budget := range len(full) {
 		v := populatedResponse()
 		w := msgp.NewWriterSize(&errBudgetWriter{n: budget}, 8)
@@ -188,9 +190,6 @@ func Test_response_EncodeMsg_WriterErrors(t *testing.T) {
 		if encErr == nil {
 			encErr = w.Flush()
 		}
-		if encErr != nil {
-			sawErr = true
-		}
+		require.Error(t, encErr, "expected writer failure for budget %d", budget)
 	}
-	require.True(t, sawErr, "expected at least one writer error across budgets")
 }

--- a/middleware/limiter/coverage_test.go
+++ b/middleware/limiter/coverage_test.go
@@ -172,7 +172,7 @@ func Test_item_Decode_Truncated(t *testing.T) {
 	full, err := item{currHits: 3, prevHits: 5, exp: 99}.MarshalMsg(nil)
 	require.NoError(t, err)
 
-	for i := 0; i < len(full); i++ {
+	for i := range len(full) {
 		prefix := full[:i]
 
 		var out item
@@ -215,7 +215,7 @@ func Test_item_EncodeMsg_WriterErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	sawErr := false
-	for budget := 0; budget < len(full); budget++ {
+	for budget := range len(full) {
 		w := msgp.NewWriterSize(&limiterErrWriter{n: budget}, 8)
 		encErr := item{currHits: 3, prevHits: 5, exp: 99}.EncodeMsg(w)
 		if encErr == nil {

--- a/middleware/limiter/coverage_test.go
+++ b/middleware/limiter/coverage_test.go
@@ -1,0 +1,229 @@
+package limiter
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+	"github.com/tinylib/msgp/msgp"
+	"github.com/valyala/fasthttp"
+)
+
+// limiterErrWriter is an io.Writer that accepts up to n bytes total and then
+// fails, used to exercise the error-handling branches of EncodeMsg.
+type limiterErrWriter struct {
+	n int
+}
+
+var errLimiterWriteBudget = errors.New("write budget exhausted")
+
+func (w *limiterErrWriter) Write(p []byte) (int, error) {
+	if w.n <= 0 {
+		return 0, errLimiterWriteBudget
+	}
+	if len(p) > w.n {
+		k := w.n
+		w.n = 0
+		return k, errLimiterWriteBudget
+	}
+	w.n -= len(p)
+	return len(p), nil
+}
+
+func Test_secondsToDuration(t *testing.T) {
+	t.Parallel()
+
+	d, ok := secondsToDuration(5)
+	require.True(t, ok)
+	require.Equal(t, 5*time.Second, d)
+
+	// Overflow: seconds larger than math.MaxInt64 / time.Second.
+	const maxSeconds = uint64(math.MaxInt64 / int64(time.Second))
+	d, ok = secondsToDuration(maxSeconds + 1)
+	require.False(t, ok)
+	require.Equal(t, time.Duration(math.MaxInt64), d)
+}
+
+func Test_ttlDuration(t *testing.T) {
+	t.Parallel()
+
+	// Normal case.
+	require.Equal(t, 3*time.Second, ttlDuration(1, 2))
+
+	const maxSeconds = uint64(math.MaxInt64 / int64(time.Second))
+
+	// resetInSec overflows.
+	require.Equal(t, time.Duration(math.MaxInt64), ttlDuration(maxSeconds+1, 1))
+
+	// expiration overflows.
+	require.Equal(t, time.Duration(math.MaxInt64), ttlDuration(1, maxSeconds+1))
+
+	// reset + expiration overflows even though each fits individually.
+	require.Equal(t, time.Duration(math.MaxInt64), ttlDuration(maxSeconds, maxSeconds))
+}
+
+func Test_bucketForOriginalHit(t *testing.T) {
+	t.Parallel()
+
+	e := &item{currHits: 3, prevHits: 7}
+
+	// ts before the recorded window expiry -> current bucket.
+	require.Equal(t, &e.currHits, bucketForOriginalHit(e, 100, 50, 60))
+
+	// ts within one expiration after the window expiry -> previous bucket.
+	require.Equal(t, &e.prevHits, bucketForOriginalHit(e, 100, 130, 60))
+
+	// ts more than one expiration past the window expiry -> nil.
+	require.Nil(t, bucketForOriginalHit(e, 100, 200, 60))
+}
+
+func Test_rotateWindow(t *testing.T) {
+	t.Parallel()
+
+	// Fresh entry sets expiration.
+	e := &item{}
+	require.Equal(t, uint64(10), rotateWindow(e, 100, 10))
+	require.Equal(t, uint64(110), e.exp)
+
+	// Entry expired within one window -> previous hits carry over.
+	e = &item{currHits: 4, exp: 100}
+	rotateWindow(e, 105, 10)
+	require.Equal(t, 4, e.prevHits)
+	require.Equal(t, 0, e.currHits)
+	require.Equal(t, uint64(110), e.exp)
+
+	// Entry expired beyond a full window -> everything resets.
+	e = &item{currHits: 4, prevHits: 9, exp: 100}
+	rotateWindow(e, 200, 10)
+	require.Equal(t, 0, e.prevHits)
+	require.Equal(t, 0, e.currHits)
+	require.Equal(t, uint64(210), e.exp)
+}
+
+func Test_getEffectiveStatusCode_FiberError(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	c.Response().SetStatusCode(fiber.StatusOK)
+
+	// A real *fiber.Error returns its code.
+	require.Equal(t, fiber.StatusTeapot, getEffectiveStatusCode(c, fiber.NewError(fiber.StatusTeapot, "teapot")))
+
+	// A generic error falls back to the response status code.
+	c.Response().SetStatusCode(fiber.StatusBadGateway)
+	require.Equal(t, fiber.StatusBadGateway, getEffectiveStatusCode(c, errors.New("generic")))
+}
+
+func Test_manager_get_UnmarshalError(t *testing.T) {
+	t.Parallel()
+
+	storage := newFailingLimiterStorage()
+	storage.data["k"] = []byte{0xff, 0xff, 0xff} // not a valid msgp item
+
+	m := newManager(storage, true)
+	_, err := m.get(context.Background(), "k")
+	require.Error(t, err)
+	require.ErrorContains(t, err, redactedKey)
+}
+
+func Test_manager_get_RoundTripWithStorage(t *testing.T) {
+	t.Parallel()
+
+	storage := newFailingLimiterStorage()
+	m := newManager(storage, false)
+
+	it := m.acquire()
+	it.currHits = 2
+	it.prevHits = 1
+	it.exp = 42
+	require.NoError(t, m.set(context.Background(), "k", it, time.Second))
+
+	got, err := m.get(context.Background(), "k")
+	require.NoError(t, err)
+	require.Equal(t, 2, got.currHits)
+	require.Equal(t, 1, got.prevHits)
+	require.Equal(t, uint64(42), got.exp)
+}
+
+func Test_manager_get_MemoryUnexpectedType(t *testing.T) {
+	t.Parallel()
+
+	m := newManager(nil, false) // memory-backed
+	m.memory.Set("k", "not-an-item", time.Minute)
+
+	_, err := m.get(context.Background(), "k")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unexpected entry type")
+}
+
+// Test_item_Decode_Truncated exercises the per-read error branches of the
+// generated item decoders by feeding every truncated prefix.
+func Test_item_Decode_Truncated(t *testing.T) {
+	t.Parallel()
+
+	full, err := item{currHits: 3, prevHits: 5, exp: 99}.MarshalMsg(nil)
+	require.NoError(t, err)
+
+	for i := 0; i < len(full); i++ {
+		prefix := full[:i]
+
+		var out item
+		_, uerr := out.UnmarshalMsg(prefix)
+		require.Error(t, uerr, "UnmarshalMsg should fail on prefix len %d", i)
+
+		var dec item
+		require.Error(t, dec.DecodeMsg(msgp.NewReader(bytes.NewReader(prefix))))
+	}
+}
+
+// Test_item_Decode_UnknownField covers the default/skip branch of the item
+// decoders.
+func Test_item_Decode_UnknownField(t *testing.T) {
+	t.Parallel()
+
+	var raw []byte
+	raw = msgp.AppendMapHeader(raw, 2)
+	raw = msgp.AppendString(raw, "zz")
+	raw = msgp.AppendString(raw, "ignored")
+	raw = msgp.AppendString(raw, "exp")
+	raw = msgp.AppendUint64(raw, 7)
+
+	var out item
+	_, err := out.UnmarshalMsg(raw)
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), out.exp)
+
+	var dec item
+	require.NoError(t, dec.DecodeMsg(msgp.NewReader(bytes.NewReader(raw))))
+	require.Equal(t, uint64(7), dec.exp)
+}
+
+// Test_item_EncodeMsg_WriterErrors drives the error branches of EncodeMsg by
+// failing the underlying writer at every byte offset.
+func Test_item_EncodeMsg_WriterErrors(t *testing.T) {
+	t.Parallel()
+
+	full, err := item{currHits: 3, prevHits: 5, exp: 99}.MarshalMsg(nil)
+	require.NoError(t, err)
+
+	sawErr := false
+	for budget := 0; budget < len(full); budget++ {
+		w := msgp.NewWriterSize(&limiterErrWriter{n: budget}, 8)
+		encErr := item{currHits: 3, prevHits: 5, exp: 99}.EncodeMsg(w)
+		if encErr == nil {
+			encErr = w.Flush()
+		}
+		if encErr != nil {
+			sawErr = true
+		}
+	}
+	require.True(t, sawErr)
+}

--- a/middleware/limiter/coverage_test.go
+++ b/middleware/limiter/coverage_test.go
@@ -214,16 +214,14 @@ func Test_item_EncodeMsg_WriterErrors(t *testing.T) {
 	full, err := item{currHits: 3, prevHits: 5, exp: 99}.MarshalMsg(nil)
 	require.NoError(t, err)
 
-	sawErr := false
+	// A writer that accepts fewer than the full encoding's bytes must always
+	// surface an error (either mid-encode or on Flush), so assert per budget.
 	for budget := range len(full) {
 		w := msgp.NewWriterSize(&limiterErrWriter{n: budget}, 8)
 		encErr := item{currHits: 3, prevHits: 5, exp: 99}.EncodeMsg(w)
 		if encErr == nil {
 			encErr = w.Flush()
 		}
-		if encErr != nil {
-			sawErr = true
-		}
+		require.Error(t, encErr, "expected writer failure for budget %d", budget)
 	}
-	require.True(t, sawErr)
 }

--- a/middleware/logger/coverage_test.go
+++ b/middleware/logger/coverage_test.go
@@ -1,0 +1,199 @@
+package logger
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	fiberlog "github.com/gofiber/fiber/v3/log"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_methodColor_AllMethods exercises every branch of methodColor, including
+// the nil-colors short circuit and the default case.
+func Test_methodColor_AllMethods(t *testing.T) {
+	t.Parallel()
+
+	colors := &fiber.DefaultColors
+
+	require.Empty(t, methodColor(fiber.MethodGet, nil))
+
+	cases := map[string]string{
+		fiber.MethodGet:     colors.Cyan,
+		fiber.MethodQuery:   colors.Cyan,
+		fiber.MethodPost:    colors.Green,
+		fiber.MethodPut:     colors.Yellow,
+		fiber.MethodDelete:  colors.Red,
+		fiber.MethodPatch:   colors.White,
+		fiber.MethodHead:    colors.Magenta,
+		fiber.MethodOptions: colors.Blue,
+		"UNKNOWN":           colors.Reset,
+	}
+	for method, want := range cases {
+		require.Equal(t, want, methodColor(method, colors), "method %q", method)
+	}
+}
+
+// Test_statusColor_AllRanges exercises every branch of statusColor, including
+// the nil-colors short circuit and each status range.
+func Test_statusColor_AllRanges(t *testing.T) {
+	t.Parallel()
+
+	colors := &fiber.DefaultColors
+
+	require.Empty(t, statusColor(fiber.StatusOK, nil))
+
+	require.Equal(t, colors.Green, statusColor(fiber.StatusOK, colors))
+	require.Equal(t, colors.Blue, statusColor(fiber.StatusMovedPermanently, colors))
+	require.Equal(t, colors.Yellow, statusColor(fiber.StatusBadRequest, colors))
+	require.Equal(t, colors.Red, statusColor(fiber.StatusInternalServerError, colors))
+}
+
+// Test_customLoggerWriter_InvalidLevel verifies the default branch of Write
+// returns (0, nil) for a level outside the supported set.
+func Test_customLoggerWriter_InvalidLevel(t *testing.T) {
+	t.Parallel()
+
+	logger := fiberlog.DefaultLogger[*log.Logger]()
+	logger.SetOutput(bytes.NewBuffer(nil))
+
+	cl := &customLoggerWriter[*log.Logger]{
+		loggerInstance: logger,
+		level:          fiberlog.LevelFatal,
+	}
+
+	n, err := cl.Write([]byte("ignored"))
+	require.NoError(t, err)
+	require.Zero(t, n)
+}
+
+// Test_loadTimestamp_Empty verifies loadTimestamp returns an empty string when
+// the atomic value has never been stored.
+func Test_loadTimestamp_Empty(t *testing.T) {
+	t.Parallel()
+
+	var v atomic.Value
+	require.Empty(t, loadTimestamp(&v))
+}
+
+// Test_UnknownTagError_WithHint covers the Hint branch of Error().
+func Test_UnknownTagError_WithHint(t *testing.T) {
+	t.Parallel()
+
+	err := &UnknownTagError{Tag: "method", Hint: "did you mean ${method}?"}
+	require.Contains(t, err.Error(), "did you mean ${method}?")
+	require.Contains(t, err.Error(), `"method"`)
+}
+
+// Test_RegisterContextTag verifies that a context tag registered through the
+// public helper renders in a logger format and panics on invalid input.
+func Test_RegisterContextTag(t *testing.T) {
+	t.Parallel()
+
+	const tagName = "cov-ctx-tag"
+	RegisterContextTag(tagName, func(_ any) string {
+		return "rendered-value"
+	})
+
+	buf := bytes.NewBuffer(nil)
+	app := fiber.New()
+	app.Use(New(Config{
+		Format: "${" + tagName + "}\n",
+		Stream: buf,
+	}))
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Contains(t, buf.String(), "rendered-value")
+
+	require.Panics(t, func() {
+		RegisterContextTag("", func(_ any) string { return "" })
+	})
+	require.Panics(t, func() {
+		RegisterContextTag("name", nil)
+	})
+}
+
+// Test_RegisterContextTag_EmptyValue ensures the empty-return path of the
+// registered renderer writes nothing.
+func Test_RegisterContextTag_EmptyValue(t *testing.T) {
+	t.Parallel()
+
+	const tagName = "cov-ctx-empty"
+	RegisterContextTag(tagName, func(_ any) string {
+		return ""
+	})
+
+	buf := bytes.NewBuffer(nil)
+	app := fiber.New()
+	app.Use(New(Config{
+		Format: "[${" + tagName + "}]\n",
+		Stream: buf,
+	}))
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Contains(t, buf.String(), "[]")
+}
+
+// Test_Logger_PreRegisteredMiddlewareTag exercises emptyLogTag: a format that
+// references a built-in middleware tag (api-key) compiles and renders nothing
+// when the producing middleware has not registered a value.
+func Test_Logger_PreRegisteredMiddlewareTag(t *testing.T) {
+	t.Parallel()
+
+	buf := bytes.NewBuffer(nil)
+	app := fiber.New()
+	app.Use(New(Config{
+		Format: "[${" + fiberlog.TagAPIKey + "}]\n",
+		Stream: buf,
+	}))
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Contains(t, buf.String(), "[]")
+}
+
+// Test_Logger_New_TimeDoneUpdater verifies the New path that starts a dedicated
+// timestamp updater when TimeDone is configured (covers startTimestampUpdater).
+func Test_Logger_New_TimeDoneUpdater(t *testing.T) {
+	t.Parallel()
+
+	done := make(chan struct{})
+	defer close(done)
+
+	buf := bytes.NewBuffer(nil)
+	app := fiber.New()
+	app.Use(New(Config{
+		Format:       "${time}\n",
+		TimeFormat:   time.RFC3339Nano,
+		TimeInterval: 5 * time.Millisecond,
+		TimeDone:     done,
+		Stream:       buf,
+	}))
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, buf.String())
+}

--- a/middleware/logger/coverage_test.go
+++ b/middleware/logger/coverage_test.go
@@ -1,3 +1,4 @@
+//nolint:depguard // Because we test logging :D
 package logger
 
 import (

--- a/middleware/logger/coverage_test.go
+++ b/middleware/logger/coverage_test.go
@@ -1,11 +1,10 @@
-//nolint:depguard // Because we test logging :D
 package logger
 
 import (
 	"bytes"
-	"log"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -56,16 +55,14 @@ func Test_statusColor_AllRanges(t *testing.T) {
 }
 
 // Test_customLoggerWriter_InvalidLevel verifies the default branch of Write
-// returns (0, nil) for a level outside the supported set.
+// returns (0, nil) for a level outside the supported set. An unsupported level
+// routes to the default case before loggerInstance is ever touched, so a nil
+// instance is safe and we avoid mutating any shared/global logger state.
 func Test_customLoggerWriter_InvalidLevel(t *testing.T) {
 	t.Parallel()
 
-	logger := fiberlog.DefaultLogger[*log.Logger]()
-	logger.SetOutput(bytes.NewBuffer(nil))
-
-	cl := &customLoggerWriter[*log.Logger]{
-		loggerInstance: logger,
-		level:          fiberlog.LevelFatal,
+	cl := &customLoggerWriter[any]{
+		level: fiberlog.LevelFatal,
 	}
 
 	n, err := cl.Write([]byte("ignored"))
@@ -196,5 +193,12 @@ func Test_Logger_New_TimeDoneUpdater(t *testing.T) {
 	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusOK, resp.StatusCode)
-	require.NotEmpty(t, buf.String())
+
+	// The format always emits a trailing newline, so a non-empty buffer alone
+	// would pass even if ${time} rendered empty. Trim it and assert the rendered
+	// timestamp is present and well-formed, proving the updater path ran.
+	rendered := strings.TrimRight(buf.String(), "\n")
+	require.NotEmpty(t, rendered)
+	_, parseErr := time.Parse(time.RFC3339Nano, rendered)
+	require.NoError(t, parseErr)
 }

--- a/middleware/timeout/timeout_test.go
+++ b/middleware/timeout/timeout_test.go
@@ -278,6 +278,90 @@ func TestTimeout_CustomHandler(t *testing.T) {
 	require.JSONEq(t, `{"error":"timeout"}`, string(body))
 }
 
+// TestTimeout_OnTimeoutWritesResponse exercises the timeout path (tCtx.Done())
+// while a custom OnTimeout handler shapes the response body. The handler blocks
+// past the deadline so the middleware takes the timeout branch rather than the
+// handler-returned branch.
+func TestTimeout_OnTimeoutWritesResponse(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	var called atomic.Int32
+	app.Get("/on-timeout-body", New(func(c fiber.Ctx) error {
+		// Wait until the deadline fires, then linger so the middleware has
+		// already selected the timeout case before we return.
+		<-c.Context().Done()
+		time.Sleep(40 * time.Millisecond)
+		return nil
+	}, Config{
+		Timeout: 20 * time.Millisecond,
+		OnTimeout: func(c fiber.Ctx) error {
+			called.Add(1)
+			return c.Status(fiber.StatusServiceUnavailable).SendString("custom timeout body")
+		},
+	}))
+
+	req := httptest.NewRequest(fiber.MethodGet, "/on-timeout-body", http.NoBody)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusServiceUnavailable, resp.StatusCode)
+	require.Equal(t, int32(1), called.Load())
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	require.Equal(t, "custom timeout body", string(body))
+}
+
+// TestTimeout_OnTimeoutEmptyResponse exercises the timeout path with an
+// OnTimeout handler that leaves the response untouched (still default 200/empty),
+// so the middleware falls back to writing the default 408 timeout response.
+func TestTimeout_OnTimeoutEmptyResponse(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	var called atomic.Int32
+	app.Get("/on-timeout-empty", New(func(c fiber.Ctx) error {
+		<-c.Context().Done()
+		time.Sleep(40 * time.Millisecond)
+		return nil
+	}, Config{
+		Timeout: 20 * time.Millisecond,
+		OnTimeout: func(_ fiber.Ctx) error {
+			called.Add(1)
+			// Intentionally do not write any response.
+			return nil
+		},
+	}))
+
+	req := httptest.NewRequest(fiber.MethodGet, "/on-timeout-empty", http.NoBody)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusRequestTimeout, resp.StatusCode)
+	require.Equal(t, int32(1), called.Load())
+
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	require.Equal(t, fiber.ErrRequestTimeout.Message, string(body))
+}
+
+// TestTimeout_DeadlineErrorDefaultResponse verifies that when the handler returns
+// a timeout error and no OnTimeout is configured, invokeOnTimeout falls back to
+// fiber.ErrRequestTimeout. The handler returns immediately so the result is
+// processed via the handler-returned branch deterministically.
+func TestTimeout_DeadlineErrorDefaultResponse(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+
+	app.Get("/deadline-default", New(func(_ fiber.Ctx) error {
+		return context.DeadlineExceeded
+	}, Config{Timeout: time.Second}))
+
+	req := httptest.NewRequest(fiber.MethodGet, "/deadline-default", http.NoBody)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusRequestTimeout, resp.StatusCode)
+}
+
 // TestTimeout_PanicInHandler verifies that panics in the handler return 500.
 func TestTimeout_PanicInHandler(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Add targeted tests to bring five middleware packages that were below 90%
statement coverage up over the threshold:

- timeout   87.3% -> 91.5%: cover the OnTimeout timeout path (both the
  custom-response and default-fallback branches) and the default
  invokeOnTimeout return.
- logger     85.7% -> 94.5%: unit tests for methodColor/statusColor,
  the customLoggerWriter default branch, loadTimestamp, RegisterContextTag,
  the pre-registered middleware-tag stub, and the New TimeDone updater path.
- idempotency 69.9% -> 95.1%: populated round-trips plus truncation,
  limit-exceeded, unknown-field and writer-error sweeps for the generated
  response msgp codecs.
- limiter    80.4% -> 91.1%: unit tests for sliding-window helpers
  (rotateWindow, bucketForOriginalHit, ttlDuration, secondsToDuration),
  getEffectiveStatusCode, manager error paths, and item msgp codecs.
- cache      74.0% -> 91.6%: tests for the indexed heap Push, cache-control
  parsing, seconds conversions, hash/vary helpers, manager error paths,
  vary manifest store/load, and comprehensive item/cachedHeader msgp codec
  coverage (round-trip, truncation, per-field limits, writer-error sweep).

All changes are test-only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HYJmcJM9qp4pcQbHa64D92