### PR TITLE
🐛 bug: separate cache authorization key segment

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -229,7 +229,7 @@ func New(config ...Config) fiber.Handler {
 		manifestKey := baseKey + "|vary"
 		if hasAuthorization {
 			authHash := hashAuthorization(c.Request().Header.Peek(fiber.HeaderAuthorization))
-			baseKey += "_auth_" + authHash
+			baseKey += "|auth=" + authHash
 			manifestKey = baseKey + "|vary"
 		}
 		key := baseKey

--- a/middleware/cache/cache_security_test.go
+++ b/middleware/cache/cache_security_test.go
@@ -689,3 +689,44 @@ func Test_Cache_Security_QueryBody_RawHashDomain(t *testing.T) {
 	require.Equal(t, cacheHit, doQuery(bodyA), "identical body must hit cache")
 	require.Equal(t, int32(2), count.Load())
 }
+
+func Test_Cache_Security_QueryBody_CannotInjectAuthorizationSuffix(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Expiration: 1 * time.Hour,
+		Methods:    []string{fiber.MethodQuery},
+	}))
+
+	var count atomic.Int32
+	app.Query("/", func(c fiber.Ctx) error {
+		count.Add(1)
+		c.Set(fiber.HeaderCacheControl, "public, max-age=60")
+		return c.SendString("handler auth=" + c.Get(fiber.HeaderAuthorization))
+	})
+
+	const authHeader = "Bearer victim-token"
+	const baseBody = "B"
+	authSum := sha256.Sum256([]byte(authHeader))
+	authHash := hex.EncodeToString(authSum[:])
+	craftedBody := baseBody + "|auth=" + authHash
+
+	authReq := httptest.NewRequest(fiber.MethodQuery, "/", strings.NewReader(baseBody))
+	authReq.Header.Set(fiber.HeaderAuthorization, authHeader)
+	authResp, err := app.Test(authReq)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, authResp.StatusCode)
+	require.Equal(t, cacheMiss, authResp.Header.Get("X-Cache"))
+
+	unauthReq := httptest.NewRequest(fiber.MethodQuery, "/", strings.NewReader(craftedBody))
+	unauthResp, err := app.Test(unauthReq)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, unauthResp.StatusCode)
+	require.Equal(t, cacheMiss, unauthResp.Header.Get("X-Cache"))
+
+	body, err := io.ReadAll(unauthResp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "handler auth=", string(body))
+	require.Equal(t, int32(2), count.Load())
+}


### PR DESCRIPTION
### Motivation
- A small-body fast path in the default QUERY key generator appended escaped body bytes verbatim, which allowed attacker-controlled body bytes to mimic the cache middleware's later Authorization suffix and cause Authorization/no-Authorization cache key collisions.

### Description
- Replace the unescaped `_auth_` suffix with a delimiter-separated `|auth=` key segment in `middleware/cache/cache.go` so the key generator's escaping preserves domain separation for the authorization partition.
- Add `Test_Cache_Security_QueryBody_CannotInjectAuthorizationSuffix` in `middleware/cache/cache_security_test.go` that exercises an authenticated QUERY request and a crafted unauthenticated QUERY body to assert they do not share a cached entry.

### Testing
- Ran `go list -m -mod=readonly all` which completed and printed `go list ok`.
- Ran `go test ./middleware/cache -run 'Test_Cache_Security_QueryBody_(CannotInjectAuthorizationSuffix|RawHashDomain)' -count=1` which passed with `ok github.com/gofiber/fiber/v3/middleware/cache 0.023s`.
- Ran `make audit` which failed because `govulncheck` flagged 25 Go standard-library vulnerabilities under the pinned Go toolchain (Go 1.25.1), causing `make audit` to exit non-zero.
- Ran `make generate`, `make betteralign`, `make format`, `make lint`, and `make test`; `make generate`/`make betteralign`/`make format` completed, `make lint` reported `0 issues.`, and `make test` ran the full suite with `DONE 3783 tests, 1 skipped` (all run tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f4662e108833380aca005d269bd46)