### PR TITLE
♻️ Refactor: replace appendLowerBytes with utilsbytes.UnsafeToLower

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/gofiber/utils/v2"
+	utilsbytes "github.com/gofiber/utils/v2/bytes"
 	"github.com/valyala/bytebufferpool"
 	"github.com/valyala/fasthttp"
 )
@@ -656,10 +657,9 @@ func (c *DefaultCtx) configDependentPaths() {
 	// another path is specified which is for routing recognition only
 	// use the path that was changed by the previous configuration flags
 	// If CaseSensitive is disabled, we lowercase the original path
+	c.detectionPath = append(c.detectionPath[:0], c.path...)
 	if !c.app.config.CaseSensitive {
-		c.detectionPath = appendLowerBytes(c.detectionPath, c.path)
-	} else {
-		c.detectionPath = append(c.detectionPath[:0], c.path...)
+		utilsbytes.UnsafeToLower(c.detectionPath)
 	}
 	// If StrictRouting is disabled, we strip all trailing slashes
 	if !c.app.config.StrictRouting && len(c.detectionPath) > 1 && c.detectionPath[len(c.detectionPath)-1] == '/' {

--- a/path.go
+++ b/path.go
@@ -164,22 +164,6 @@ var (
 	}
 )
 
-func appendLowerBytes(dst, src []byte) []byte {
-	dst = dst[:0]
-	if cap(dst) < len(src) {
-		dst = make([]byte, len(src))
-	} else {
-		dst = dst[:len(src)]
-	}
-	for i, c := range src {
-		if 'A' <= c && c <= 'Z' {
-			c += 'a' - 'A'
-		}
-		dst[i] = c
-	}
-	return dst
-}
-
 // RoutePatternMatch reports whether path matches the provided Fiber route pattern.
 //
 // Patterns use the same syntax as routes registered on an App, including


### PR DESCRIPTION
# Description

The appendLowerBytes function in Fiber can be replaced with utilsbytes.UnsafeToLower to improve maintainability 

## Type of change

- [x] Performance improvement (non-breaking change which improves efficiency)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

Before you submit your pull request, please make sure you meet these requirements:

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [ ] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [ ] Provided benchmarks for the new code to analyze and improve upon.

## Commit formatting

Please use emojis in commit messages for an easy way to identify the purpose or intention of a commit. Check out the emoji cheatsheet here: [CONTRIBUTING.md](https://github.com/gofiber/fiber/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
