### PR TITLE
🐛 bug: fix client config locking races

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -144,6 +144,9 @@ func (c *Client) R() *Request {
 
 // RequestHook returns the user-defined request hooks.
 func (c *Client) RequestHook() []RequestHook {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.userRequestHooks
 }
 
@@ -158,6 +161,9 @@ func (c *Client) AddRequestHook(h ...RequestHook) *Client {
 
 // ResponseHook returns the user-defined response hooks.
 func (c *Client) ResponseHook() []ResponseHook {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.userResponseHooks
 }
 
@@ -172,66 +178,102 @@ func (c *Client) AddResponseHook(h ...ResponseHook) *Client {
 
 // JSONMarshal returns the JSON marshal function used by the client.
 func (c *Client) JSONMarshal() utils.JSONMarshal {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.jsonMarshal
 }
 
 // SetJSONMarshal sets the JSON marshal function to use.
 func (c *Client) SetJSONMarshal(f utils.JSONMarshal) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.jsonMarshal = f
 	return c
 }
 
 // JSONUnmarshal returns the JSON unmarshal function used by the client.
 func (c *Client) JSONUnmarshal() utils.JSONUnmarshal {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.jsonUnmarshal
 }
 
 // SetJSONUnmarshal sets the JSON unmarshal function to use.
 func (c *Client) SetJSONUnmarshal(f utils.JSONUnmarshal) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.jsonUnmarshal = f
 	return c
 }
 
 // XMLMarshal returns the XML marshal function used by the client.
 func (c *Client) XMLMarshal() utils.XMLMarshal {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.xmlMarshal
 }
 
 // SetXMLMarshal sets the XML marshal function to use.
 func (c *Client) SetXMLMarshal(f utils.XMLMarshal) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.xmlMarshal = f
 	return c
 }
 
 // XMLUnmarshal returns the XML unmarshal function used by the client.
 func (c *Client) XMLUnmarshal() utils.XMLUnmarshal {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.xmlUnmarshal
 }
 
 // SetXMLUnmarshal sets the XML unmarshal function to use.
 func (c *Client) SetXMLUnmarshal(f utils.XMLUnmarshal) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.xmlUnmarshal = f
 	return c
 }
 
 // CBORMarshal returns the CBOR marshal function used by the client.
 func (c *Client) CBORMarshal() utils.CBORMarshal {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.cborMarshal
 }
 
 // SetCBORMarshal sets the CBOR marshal function to use.
 func (c *Client) SetCBORMarshal(f utils.CBORMarshal) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.cborMarshal = f
 	return c
 }
 
 // CBORUnmarshal returns the CBOR unmarshal function used by the client.
 func (c *Client) CBORUnmarshal() utils.CBORUnmarshal {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.cborUnmarshal
 }
 
 // SetCBORUnmarshal sets the CBOR unmarshal function to use.
 func (c *Client) SetCBORUnmarshal(f utils.CBORUnmarshal) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.cborUnmarshal = f
 	return c
 }
@@ -331,6 +373,9 @@ func (c *Client) SetProxyURL(proxyURL string) error {
 
 // RetryConfig returns the current retry configuration.
 func (c *Client) RetryConfig() *RetryConfig {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.retryConfig
 }
 
@@ -345,34 +390,52 @@ func (c *Client) SetRetryConfig(config *RetryConfig) *Client {
 
 // BaseURL returns the client's base URL.
 func (c *Client) BaseURL() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.baseURL
 }
 
 // SetBaseURL sets the base URL prefix for all requests made by the client.
 func (c *Client) SetBaseURL(url string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.baseURL = url
 	return c
 }
 
 // Header returns all header values associated with the provided key.
 func (c *Client) Header(key string) []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.header.PeekMultiple(key)
 }
 
 // AddHeader adds a single header field and its value to the client. These headers apply to all requests.
 func (c *Client) AddHeader(key, val string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.header.Add(key, val)
 	return c
 }
 
 // SetHeader sets a single header field and its value in the client.
 func (c *Client) SetHeader(key, val string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.header.Set(key, val)
 	return c
 }
 
 // AddHeaders adds multiple header fields and their values to the client.
 func (c *Client) AddHeaders(h map[string][]string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.header.AddHeaders(h)
 	return c
 }
@@ -381,12 +444,18 @@ func (c *Client) AddHeaders(h map[string][]string) *Client {
 // These headers will be applied to all requests created from this client instance. Also it can be
 // overridden at request level headers options.
 func (c *Client) SetHeaders(h map[string]string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.header.SetHeaders(h)
 	return c
 }
 
 // Param returns all values of the specified query parameter.
 func (c *Client) Param(key string) []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	tmp := c.params.PeekMulti(key)
 	res := make([]string, 0, len(tmp))
 	for _, v := range tmp {
@@ -399,36 +468,54 @@ func (c *Client) Param(key string) []string {
 // AddParam adds a single query parameter and its value to the client.
 // These params will be applied to all requests created from this client instance.
 func (c *Client) AddParam(key, val string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.params.Add(key, val)
 	return c
 }
 
 // SetParam sets a single query parameter and its value in the client.
 func (c *Client) SetParam(key, val string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.params.Set(key, val)
 	return c
 }
 
 // AddParams adds multiple query parameters and their values to the client.
 func (c *Client) AddParams(m map[string][]string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.params.AddParams(m)
 	return c
 }
 
 // SetParams sets multiple query parameters and their values in the client.
 func (c *Client) SetParams(m map[string]string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.params.SetParams(m)
 	return c
 }
 
 // SetParamsWithStruct sets multiple query parameters and their values using a struct.
 func (c *Client) SetParamsWithStruct(v any) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.params.SetParamsWithStruct(v)
 	return c
 }
 
 // DelParams deletes one or more query parameters and their values from the client.
 func (c *Client) DelParams(key ...string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	for _, v := range key {
 		c.params.Del(v)
 	}
@@ -437,29 +524,44 @@ func (c *Client) DelParams(key ...string) *Client {
 
 // SetUserAgent sets the User-Agent header for the client.
 func (c *Client) SetUserAgent(ua string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.userAgent = ua
 	return c
 }
 
 // SetReferer sets the Referer header for the client.
 func (c *Client) SetReferer(r string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.referer = r
 	return c
 }
 
 // DisablePathNormalizing reports whether path normalizing is disabled for the client.
 func (c *Client) DisablePathNormalizing() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.isPathNormalizingDisabled
 }
 
 // SetDisablePathNormalizing configures the client to disable or enable path normalizing.
 func (c *Client) SetDisablePathNormalizing(disable bool) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.isPathNormalizingDisabled = disable
 	return c
 }
 
 // PathParam returns the value of the specified path parameter. Returns an empty string if it does not exist.
 func (c *Client) PathParam(key string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if val, ok := (*c.path)[key]; ok {
 		return val
 	}
@@ -468,30 +570,45 @@ func (c *Client) PathParam(key string) string {
 
 // SetPathParam sets a single path parameter and its value in the client.
 func (c *Client) SetPathParam(key, val string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.path.SetParam(key, val)
 	return c
 }
 
 // SetPathParams sets multiple path parameters and their values in the client.
 func (c *Client) SetPathParams(m map[string]string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.path.SetParams(m)
 	return c
 }
 
 // SetPathParamsWithStruct sets multiple path parameters and their values using a struct.
 func (c *Client) SetPathParamsWithStruct(v any) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.path.SetParamsWithStruct(v)
 	return c
 }
 
 // DelPathParams deletes one or more path parameters and their values from the client.
 func (c *Client) DelPathParams(key ...string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.path.DelParams(key...)
 	return c
 }
 
 // Cookie returns the value of the specified cookie. Returns an empty string if it does not exist.
 func (c *Client) Cookie(key string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if val, ok := (*c.cookies)[key]; ok {
 		return val
 	}
@@ -500,42 +617,63 @@ func (c *Client) Cookie(key string) string {
 
 // SetCookie sets a single cookie and its value in the client.
 func (c *Client) SetCookie(key, val string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.cookies.SetCookie(key, val)
 	return c
 }
 
 // SetCookies sets multiple cookies and their values in the client.
 func (c *Client) SetCookies(m map[string]string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.cookies.SetCookies(m)
 	return c
 }
 
 // SetCookiesWithStruct sets multiple cookies and their values using a struct.
 func (c *Client) SetCookiesWithStruct(v any) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.cookies.SetCookiesWithStruct(v)
 	return c
 }
 
 // DelCookies deletes one or more cookies and their values from the client.
 func (c *Client) DelCookies(key ...string) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.cookies.DelCookies(key...)
 	return c
 }
 
 // SetTimeout sets the timeout value for the client. This applies to all requests unless overridden at the request level.
 func (c *Client) SetTimeout(t time.Duration) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.timeout = t
 	return c
 }
 
 // Debug enables debug-level logging output.
 func (c *Client) Debug() *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.isDebug = true
 	return c
 }
 
 // DisableDebug disables debug-level logging output.
 func (c *Client) DisableDebug() *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.isDebug = false
 	return c
 }
@@ -556,6 +694,9 @@ func (c *Client) SetStreamResponseBody(enable bool) *Client {
 
 // SetCookieJar sets the cookie jar for the client.
 func (c *Client) SetCookieJar(cookieJar *CookieJar) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.cookieJar = cookieJar
 	return c
 }
@@ -643,6 +784,9 @@ func (c *Client) SetLogger(logger log.CommonLogger) *Client {
 
 // Logger returns the logger instance used by the client.
 func (c *Client) Logger() log.CommonLogger {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.logger
 }
 
@@ -650,6 +794,9 @@ func (c *Client) Logger() log.CommonLogger {
 // and replacing the underlying transport with a new fasthttp.Client so future
 // requests resume with Fiber's standard transport settings.
 func (c *Client) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.transport = newStandardClientTransport(&fasthttp.Client{})
 	c.baseURL = ""
 	c.timeout = 0

--- a/client/client.go
+++ b/client/client.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -142,12 +143,12 @@ func (c *Client) R() *Request {
 	return AcquireRequest().SetClient(c)
 }
 
-// RequestHook returns the user-defined request hooks.
+// RequestHook returns a copy of the user-defined request hooks.
 func (c *Client) RequestHook() []RequestHook {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return c.userRequestHooks
+	return slices.Clone(c.userRequestHooks)
 }
 
 // AddRequestHook adds user-defined request hooks.
@@ -159,12 +160,12 @@ func (c *Client) AddRequestHook(h ...RequestHook) *Client {
 	return c
 }
 
-// ResponseHook returns the user-defined response hooks.
+// ResponseHook returns a copy of the user-defined response hooks.
 func (c *Client) ResponseHook() []ResponseHook {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return c.userResponseHooks
+	return slices.Clone(c.userResponseHooks)
 }
 
 // AddResponseHook adds user-defined response hooks.
@@ -371,12 +372,17 @@ func (c *Client) SetProxyURL(proxyURL string) error {
 	return nil
 }
 
-// RetryConfig returns the current retry configuration.
+// RetryConfig returns a copy of the current retry configuration.
 func (c *Client) RetryConfig() *RetryConfig {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return c.retryConfig
+	if c.retryConfig == nil {
+		return nil
+	}
+
+	cfg := *c.retryConfig
+	return &cfg
 }
 
 // SetRetryConfig sets the retry configuration for the client.

--- a/client/core.go
+++ b/client/core.go
@@ -42,20 +42,7 @@ type core struct {
 
 // getRetryConfig returns a copy of the client's retry configuration.
 func (c *core) getRetryConfig() *RetryConfig {
-	c.client.mu.RLock()
-	defer c.client.mu.RUnlock()
-
-	cfg := c.client.retryConfig
-	if cfg == nil {
-		return nil
-	}
-
-	return &RetryConfig{
-		InitialInterval: cfg.InitialInterval,
-		MaxBackoffTime:  cfg.MaxBackoffTime,
-		Multiplier:      cfg.Multiplier,
-		MaxRetryCount:   cfg.MaxRetryCount,
-	}
+	return c.client.RetryConfig()
 }
 
 // execFunc is the core logic to send the request and receive the response.

--- a/client/core.go
+++ b/client/core.go
@@ -45,7 +45,7 @@ func (c *core) getRetryConfig() *RetryConfig {
 	c.client.mu.RLock()
 	defer c.client.mu.RUnlock()
 
-	cfg := c.client.RetryConfig()
+	cfg := c.client.retryConfig
 	if cfg == nil {
 		return nil
 	}
@@ -202,8 +202,13 @@ func (c *core) timeout() context.CancelFunc {
 
 	if c.req.timeout > 0 {
 		c.ctx, cancel = context.WithTimeout(c.ctx, c.req.timeout)
-	} else if c.client.timeout > 0 {
-		c.ctx, cancel = context.WithTimeout(c.ctx, c.client.timeout)
+	} else {
+		c.client.mu.RLock()
+		timeout := c.client.timeout
+		c.client.mu.RUnlock()
+		if timeout > 0 {
+			c.ctx, cancel = context.WithTimeout(c.ctx, timeout)
+		}
 	}
 
 	return cancel

--- a/client/core_test.go
+++ b/client/core_test.go
@@ -423,6 +423,31 @@ func Test_PreHooks_ReturnsUserHookError(t *testing.T) {
 	require.ErrorIs(t, core.preHooks(), wantErr)
 }
 
+func Test_PreHooks_AllowsUserHookClientConfigMutation(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	client.AddRequestHook(func(c *Client, _ *Request) error {
+		c.SetBaseURL("http://example.com")
+		c.SetPathParam("resource", "users")
+		c.SetParam("page", "1")
+		c.SetHeader("x-fiber-test", "ok")
+		c.SetCookie("session", "abc")
+		return nil
+	})
+
+	core := newCore()
+	core.client = client
+	core.req = AcquireRequest()
+	defer ReleaseRequest(core.req)
+	core.req.SetURL("/:resource")
+
+	require.NoError(t, core.preHooks())
+	require.Equal(t, "http://example.com/users?page=1", core.req.RawRequest.URI().String())
+	require.Equal(t, "ok", string(core.req.RawRequest.Header.Peek("x-fiber-test")))
+	require.Contains(t, string(core.req.RawRequest.Header.Cookie("session")), "abc")
+}
+
 // Test_AfterHooks_ReturnsUserHookError verifies a failing user response hook
 // aborts afterHooks and its error is propagated.
 func Test_AfterHooks_ReturnsUserHookError(t *testing.T) {

--- a/client/hooks.go
+++ b/client/hooks.go
@@ -90,7 +90,7 @@ func parserRequestURL(c *Client, req *Request) error {
 	}
 
 	// Set the URI in the raw request.
-	disablePathNormalizing := c.DisablePathNormalizing() || req.DisablePathNormalizing()
+	disablePathNormalizing := c.isPathNormalizingDisabled || req.DisablePathNormalizing()
 	req.RawRequest.SetRequestURI(uri)
 	req.RawRequest.URI().DisablePathNormalizing = disablePathNormalizing
 	if disablePathNormalizing {


### PR DESCRIPTION
### Motivation
- The removal of client-wide locks allowed concurrent mutation of shared Client configuration from user hooks or handlers while built-in parsers iterate those structures, producing fatal "concurrent map iteration and map write" crashes; runtime protection needed to be restored.

### Description
- Reintroduced synchronization (use of `c.mu.RLock()`/`c.mu.Lock()`) for Client accessors and mutators in `client/client.go` for base URL, headers, query params, path params, cookies, timeout, debug flags, cookie jar, logger, marshal/unmarshal accessors, retry config, and hook accessors so request preparation cannot race with config mutations.
- Adjusted core behavior to avoid self-deadlock by reading internal fields safely when the core already holds the lock: `getRetryConfig` reads the retry struct directly, `timeout` reads `c.client.timeout` under `RLock`, and `parserRequestURL` uses `isPathNormalizingDisabled` when appropriate.
- Added a regression test `Test_PreHooks_AllowsUserHookClientConfigMutation` in `client/core_test.go` to validate that user request hooks may update client config before built-in parsers run and that those updates are applied to the request without deadlocking.

### Testing
- Ran `go test ./client`, which passed: `ok github.com/gofiber/fiber/v3/client 19.861s`.
- Ran the race-focused subset `go test -race ./client -run 'Test_PreHooks_AllowsUserHookClientConfigMutation|Test_PreHooks_DoesNotSerializeConcurrentRequests|Test_AfterHooks_DoesNotSerializeConcurrentRequests'`, which passed: `ok github.com/gofiber/fiber/v3/client 1.189s`.
- Executed repository checks required by the PR guidelines: `make generate` (succeeded), `make betteralign` (succeeded), `make format` (succeeded), `make lint` (succeeded), and `make test` (succeeded: `DONE 3838 tests, 2 skipped`).
- Executed `make audit`, which failed due to `govulncheck` reporting multiple known standard-library vulnerabilities in the active Go toolchain (Go 1.25.1); this is an environment/toolchain issue and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a410d5191408333b3c1654166d5a8d8)