### PR TITLE
fix(cookie): remove unreachable SameSiteDefaultMode case

### DIFF
--- a/res.go
+++ b/res.go
@@ -323,8 +323,6 @@ func (r *DefaultRes) Cookie(cookie *Cookie) {
 		fcookie.SetSameSite(fasthttp.CookieSameSiteStrictMode)
 	case http.SameSiteNoneMode:
 		fcookie.SetSameSite(fasthttp.CookieSameSiteNoneMode)
-	case http.SameSiteDefaultMode:
-		fcookie.SetSameSite(fasthttp.CookieSameSiteDefaultMode)
 	default:
 		fcookie.SetSameSite(fasthttp.CookieSameSiteDisabled)
 	}


### PR DESCRIPTION
## Summary

A static analysis run flagged `res.go:326` as a dead condition. Verified and confirmed.

In `setCookie`/`Cookie`, the first switch maps the Fiber `SameSite` string onto an `http.SameSite` value. It only ever produces `0` (disabled), `SameSiteLaxMode`, `SameSiteStrictMode`, or `SameSiteNoneMode`. `http.SameSiteDefaultMode` (`= 1`) is never assigned, and nothing mutates `sameSite` between the two switches.

So the `case http.SameSiteDefaultMode` in the fasthttp mapping switch was unreachable. The `0` (disabled) value already falls through to `default` -> `fasthttp.CookieSameSiteDisabled`, so behavior is unchanged.

## Changes

- Remove the dead `case http.SameSiteDefaultMode` branch.

No behavior change; build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)