### PR TITLE
docs(faq): troubleshooting entry for the "id <= evictCount" (hpack/gRPC) panic

### DIFF
--- a/docs/extra/faq.md
+++ b/docs/extra/faq.md
@@ -198,3 +198,24 @@ For details on how to:
 * Convert `fiber.Ctx` to `http.Request`
 
 See the dedicated documentation: [Adaptor Documentation](../middleware/adaptor.md).
+
+## Troubleshooting common errors
+
+Crashes that surface in unrelated packages, with stack traces that never mention Fiber, usually trace back to a context value kept past the handler. The cases below name the symptom so a search for the panic text lands here.
+
+### Panic `id (N) <= evictCount (M)` (hpack / HTTP/2 / gRPC) {#panic-id-evictcount-hpack-grpc}
+
+This is not a bug in Fiber, gRPC, or `golang.org/x/net/http2`. It means a Fiber zero-copy context value (a header from `c.Get`, or `c.Query`, `c.Params`, `c.Cookies`, `c.Body`) was kept past the handler. Fiber reuses the request buffer on the next request, so the retained bytes change underneath whatever stored them. See [Zero Allocation](../intro.md#zero-allocation) for the underlying behavior.
+
+A common trigger is forwarding a header into a long-lived gRPC / HTTP/2 client's `metadata`. The value is held in the connection's HPACK dynamic table and later mutates, crashing the process inside the HPACK encoder, in a stack trace that never mentions Fiber:
+
+```text
+panic: id (N) <= evictCount (M)
+    golang.org/x/net/http2/hpack.(*headerFieldTable).idToIndex
+    ...
+    google.golang.org/grpc/internal/transport.(*loopyWriter).writeHeader
+```
+
+The crash is decoupled from your handler in both time and call stack, so ordinary tests and even the `-race` detector usually miss it.
+
+The fix is to detach the value before you keep it: copy it with `utils.CopyString` (or `strings.Clone`), or enable [`Immutable`](../api/fiber.md#immutable). A full reproduction is in [gofiber/fiber#4464](https://github.com/gofiber/fiber/issues/4464).


### PR DESCRIPTION
## Summary

Adds a **Troubleshooting common errors** section to the FAQ, with a first entry
for the `id (N) <= evictCount (M)` panic from `golang.org/x/net/http2/hpack`.

Retaining a Fiber zero-copy context value (`c.Get`, `c.Query`, `c.Params`,
`c.Cookies`, `c.Body`) past the handler, typically by forwarding a header into a
long-lived gRPC / HTTP/2 client's metadata, corrupts the connection's HPACK
dynamic table when the request buffer is reused, crashing the process. The stack
trace never mentions Fiber, so the issue keeps getting re-filed.

The Zero Allocation docs already document the cause and the fix (copy, or
`Immutable`). This is a searchable signpost from the symptom: the entry names the
panic text and links back to Zero Allocation, so a web search for the panic lands
on the existing guidance. The entry has a stable anchor
(`#panic-id-evictcount-hpack-grpc`) so issues can deep-link to it.

Docs-only. Placed in the FAQ rather than the intro callout so the welcome page
stays general; `gofiber/docs` picks this up via the docs sync.

Refs #4464. A full self-contained reproduction is linked from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
