### PR TITLE
🐛 bug: restore session isFresh field name

### DIFF
--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -25,7 +25,7 @@ type Session struct {
 	extractor   extractors.Extractor // extractor that supplied the session ID
 	idleTimeout time.Duration        // idleTimeout of this session
 	mu          sync.RWMutex         // Mutex to protect non-data fields
-	fresh       bool                 // if new session
+	isFresh     bool                 // if new session
 }
 
 type absExpirationKeyType int
@@ -61,7 +61,7 @@ func acquireSession() *Session {
 	if s.data == nil {
 		s.data = acquireData()
 	}
-	s.fresh = true
+	s.isFresh = true
 	return s
 }
 
@@ -110,11 +110,11 @@ func releaseSession(s *Session) {
 //
 // Usage:
 //
-//	fresh := s.Fresh()
+//	isFresh := s.Fresh()
 func (s *Session) Fresh() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.fresh
+	return s.isFresh
 }
 
 // ID returns the session ID
@@ -263,7 +263,7 @@ func (s *Session) RegenerateWithContext(ctx context.Context) error {
 		return err
 	}
 
-	// Generate a new session, and set session.fresh to true
+	// Generate a new session, and set session.isFresh to true
 	s.refresh()
 
 	return nil
@@ -314,16 +314,16 @@ func (s *Session) ResetWithContext(ctx context.Context) error {
 	// Expire session
 	s.delSession()
 
-	// Generate a new session, and set session.fresh to true
+	// Generate a new session, and set session.isFresh to true
 	s.refresh()
 
 	return nil
 }
 
-// refresh generates a new session, and sets session.fresh to be true.
+// refresh generates a new session, and sets session.isFresh to be true.
 func (s *Session) refresh() {
 	s.id = s.config.KeyGenerator()
-	s.fresh = true
+	s.isFresh = true
 }
 
 // Save saves the session data and updates the cookie
@@ -450,7 +450,7 @@ func (s *Session) getExtractorInfo() []extractors.Extractor {
 			// so it must not be promoted into cookies/headers (session fixation).
 			// Fresh sessions carry a freshly generated ID, so they may still fall
 			// through to the configured cookie/header sinks below.
-			if !s.fresh {
+			if !s.isFresh {
 				return nil
 			}
 		}

--- a/middleware/session/store.go
+++ b/middleware/session/store.go
@@ -136,7 +136,7 @@ func (s *Store) getSession(c fiber.Ctx) (*Session, error) {
 		selectedExtractor = extractors.Extractor{}
 	}
 
-	fresh := false // Session is not fresh initially; only set to true if we generate a new ID
+	isFresh := false // Session is not fresh initially; only set to true if we generate a new ID
 
 	// Attempt to fetch session data if an ID is provided
 	if id != "" {
@@ -152,7 +152,7 @@ func (s *Store) getSession(c fiber.Ctx) (*Session, error) {
 
 	// Generate a new ID if needed
 	if id == "" {
-		fresh = true // The session is fresh if a new ID is generated
+		isFresh = true // The session is fresh if a new ID is generated
 		id = s.KeyGenerator()
 		c.Locals(sessionIDContextKey, id)
 	}
@@ -165,7 +165,7 @@ func (s *Store) getSession(c fiber.Ctx) (*Session, error) {
 	sess.ctx = c
 	sess.config = s
 	sess.id = id
-	sess.fresh = fresh
+	sess.isFresh = isFresh
 	sess.extractor = selectedExtractor
 
 	// Decode session data if found
@@ -182,7 +182,7 @@ func (s *Store) getSession(c fiber.Ctx) (*Session, error) {
 
 	sess.mu.Unlock()
 
-	if fresh && s.AbsoluteTimeout > 0 {
+	if isFresh && s.AbsoluteTimeout > 0 {
 		sess.setAbsExpiration(time.Now().Add(s.AbsoluteTimeout))
 	} else if sess.isAbsExpired() {
 		if err := sess.Reset(); err != nil {
@@ -318,7 +318,7 @@ func (s *Store) GetByID(ctx context.Context, id string) (*Session, error) {
 
 	sess.config = s
 	sess.id = id
-	sess.fresh = false
+	sess.isFresh = false
 
 	sess.data.Lock()
 	decodeErr := sess.decodeSessionData(rawData)


### PR DESCRIPTION
## Description

PR #4469 renamed the unexported boolean field `Session.isFresh` (and the local
`isFresh` in `Store.getSession`) to `fresh`, dropping the predicate prefix that
makes the value read as a boolean. This restores `isFresh` everywhere it was
shortened.

The public `Fresh()` method is unchanged, so there is no API change.

## Verification

- `go build ./...` and `go vet ./middleware/session/...` pass
- `go test ./middleware/session/...` (146 tests) passes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)