### PR TITLE
🐛 fix(rewrite,redirect): anchor rules to the start of the path

### DIFF
--- a/middleware/redirect/redirect.go
+++ b/middleware/redirect/redirect.go
@@ -17,7 +17,11 @@ func New(config ...Config) fiber.Handler {
 	cfg.rulesRegex = map[*regexp.Regexp]string{}
 	for k, v := range cfg.Rules {
 		k = strings.ReplaceAll(k, "*", "(.*)")
-		k += "$"
+		// Anchor both ends so a rule matches the whole path. Without the leading
+		// "^" the pattern matches any suffix, so a request can be redirected by a
+		// rule whose path it only happens to end with (e.g. "/old" would also
+		// redirect "/very/old"). See issue #4476.
+		k = "^" + k + "$"
 		cfg.rulesRegex[regexp.MustCompile(k)] = v
 	}
 

--- a/middleware/redirect/redirect_test.go
+++ b/middleware/redirect/redirect_test.go
@@ -130,6 +130,38 @@ func Test_Redirect(t *testing.T) {
 	}
 }
 
+// Test_Redirect_StartAnchor verifies that a rule only matches from the start of
+// the path, so a request is not redirected by a rule whose path it merely ends
+// with (issue #4476).
+func Test_Redirect_StartAnchor(t *testing.T) {
+	app := fiber.New()
+	app.Use(New(Config{
+		Rules: map[string]string{
+			"/old": "/new",
+		},
+		StatusCode: fiber.StatusMovedPermanently,
+	}))
+	app.Get("/very/old", func(c fiber.Ctx) error {
+		return c.SendString("not redirected")
+	})
+
+	// The rule matches the whole path and redirects.
+	req, err := http.NewRequestWithContext(context.Background(), fiber.MethodGet, "/old", http.NoBody)
+	require.NoError(t, err)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusMovedPermanently, resp.StatusCode)
+	require.Equal(t, "/new", resp.Header.Get("Location"))
+
+	// A path that only ends with the rule path must not be redirected.
+	req, err = http.NewRequestWithContext(context.Background(), fiber.MethodGet, "/very/old", http.NoBody)
+	require.NoError(t, err)
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Empty(t, resp.Header.Get("Location"))
+}
+
 func Test_Next(t *testing.T) {
 	// Case 1 : Next function always returns true
 	app := *fiber.New()

--- a/middleware/redirect/redirect_test.go
+++ b/middleware/redirect/redirect_test.go
@@ -134,6 +134,8 @@ func Test_Redirect(t *testing.T) {
 // the path, so a request is not redirected by a rule whose path it merely ends
 // with (issue #4476).
 func Test_Redirect_StartAnchor(t *testing.T) {
+	t.Parallel()
+
 	app := fiber.New()
 	app.Use(New(Config{
 		Rules: map[string]string{

--- a/middleware/rewrite/rewrite.go
+++ b/middleware/rewrite/rewrite.go
@@ -16,7 +16,10 @@ func New(config ...Config) fiber.Handler {
 	cfg.rulesRegex = map[*regexp.Regexp]string{}
 	for k, v := range cfg.Rules {
 		k = strings.ReplaceAll(k, "*", "(.*)")
-		k += "$"
+		// Anchor both ends so a rule matches the whole path. Without the leading
+		// "^" the pattern matches any suffix, so a rule fires on unrelated routes
+		// (e.g. "/users/*" would also rewrite "/api/users/1"). See issue #4476.
+		k = "^" + k + "$"
 		cfg.rulesRegex[regexp.MustCompile(k)] = v
 	}
 	// Middleware function

--- a/middleware/rewrite/rewrite_test.go
+++ b/middleware/rewrite/rewrite_test.go
@@ -176,6 +176,8 @@ func Test_Rewrite(t *testing.T) {
 // the path, so a rule does not fire on an unrelated route that merely contains
 // the rule path as a suffix (issue #4476).
 func Test_Rewrite_StartAnchor(t *testing.T) {
+	t.Parallel()
+
 	app := fiber.New()
 	app.Use(New(Config{
 		Rules: map[string]string{

--- a/middleware/rewrite/rewrite_test.go
+++ b/middleware/rewrite/rewrite_test.go
@@ -172,6 +172,44 @@ func Test_Rewrite(t *testing.T) {
 	require.Equal(t, fiber.StatusNotFound, resp.StatusCode)
 }
 
+// Test_Rewrite_StartAnchor verifies that a rule only matches from the start of
+// the path, so a rule does not fire on an unrelated route that merely contains
+// the rule path as a suffix (issue #4476).
+func Test_Rewrite_StartAnchor(t *testing.T) {
+	app := fiber.New()
+	app.Use(New(Config{
+		Rules: map[string]string{
+			"/users/*": "/u/$1",
+		},
+	}))
+	app.Get("/u/:id", func(c fiber.Ctx) error {
+		return c.SendString("rewritten:" + c.Params("id"))
+	})
+	app.Get("/api/users/:id", func(c fiber.Ctx) error {
+		return c.SendString("api:" + c.Params("id"))
+	})
+
+	// The rule matches from the start of the path and is rewritten.
+	req, err := http.NewRequestWithContext(context.Background(), fiber.MethodGet, "/users/1", http.NoBody)
+	require.NoError(t, err)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, "rewritten:1", string(body))
+
+	// A path that only contains the rule path as a suffix must not be rewritten.
+	req, err = http.NewRequestWithContext(context.Background(), fiber.MethodGet, "/api/users/1", http.NoBody)
+	require.NoError(t, err)
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, "api:1", string(body))
+}
+
 func Benchmark_Rewrite(b *testing.B) {
 	// Helper function to create a new Fiber app with rewrite middleware
 	createApp := func(config Config) *fiber.App {


### PR DESCRIPTION
# Description

The `rewrite` and `redirect` middlewares build each rule's regex by replacing `*` with `(.*)` and appending `$`, but never anchor the start of the path. Without a leading `^` the pattern matches any suffix, so a rule fires on unrelated routes:

- `rewrite` rule `/users/*` also rewrites `/api/users/1`.
- `redirect` rule `/old` also redirects `/very/old` (a request gets redirected by a rule whose path it only happens to end with).

This anchors both ends (`^...$`) so a rule matches the whole path. The middlewares already appended `$`, so the intent was a full-path match; only the start anchor was missing.

Fixes #4476

## Changes introduced

- `middleware/rewrite`: prepend `^` when compiling each rule regex.
- `middleware/redirect`: prepend `^` when compiling each rule regex.
- Regression tests in both packages: a rule matches from the start (`/users/1` -> rewritten, `/old` -> redirected) but no longer fires on a path that merely ends with the rule (`/api/users/1`, `/very/old`). Both new tests fail on `main` and pass with this change.

- [ ] Benchmarks: No benchmark changes; the existing rule-matching benchmarks are unaffected (one extra anchor character per compiled rule, no per-request cost).
- [ ] Documentation Update: None required; this corrects behavior to match the existing `$`-anchored intent and the echo middleware it is based on (which anchors at the start).
- [ ] Changelog/What's New: Bug fix - rewrite/redirect rules now anchor to the start of the path.
- [ ] Migration Guide: A rule that previously relied on suffix matching will no longer fire mid-path; such matches were unintended (the reported bug).
- [ ] API Alignment with Express: No public API change.
- [ ] API Longevity: No signature or config change; behavior only.
- [ ] Examples: Covered by the new tests.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [x] Conducted a self-review of the code and provided comments for the anchoring rationale.
- [x] Added unit tests to validate the fix (with fail-on-`main` confirmation).
- [x] Ensured that new and existing unit tests pass locally (`go test ./middleware/rewrite/... ./middleware/redirect/...`).
- [x] `gofmt` and `go vet` clean.

Note: I also flagged in the issue that rule strings are not escaped before compilation (regex metacharacters in a rule like `/v1.0/*` are interpreted as regex). I kept this PR to the anchoring fix to stay minimal; happy to address escaping in a follow-up if wanted.
