### PR TITLE
🐛 fix(etag): skip Server-Sent Events responses

### DIFF
--- a/middleware/etag/etag.go
+++ b/middleware/etag/etag.go
@@ -5,6 +5,7 @@ import (
 	"hash/crc32"
 	"math"
 	"slices"
+	"strings"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/utils/v2"
@@ -58,6 +59,12 @@ func New(config ...Config) fiber.Handler {
 		// Return err if next handler returns one
 		if err := c.Next(); err != nil {
 			return err
+		}
+
+		// Never generate ETags for Server-Sent Events: hashing the body would
+		// materialize the stream and break real-time delivery.
+		if isEventStream(c) {
+			return nil
 		}
 
 		// Don't generate ETags for invalid responses
@@ -141,6 +148,17 @@ func etagWeakMatch(a, b []byte) bool {
 	}
 
 	return bytes.Equal(a, b)
+}
+
+// isEventStream reports whether the response is a Server-Sent Events stream.
+// Such responses must be passed through untouched: buffering the body to hash
+// it would break real-time delivery.
+func isEventStream(c fiber.Ctx) bool {
+	ct := c.GetRespHeader(fiber.HeaderContentType)
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	return utils.EqualFold(utils.TrimSpace(ct), fiber.MIMETextEventStream)
 }
 
 // appendUint appends n to dst and returns the extended dst.

--- a/middleware/etag/etag_test.go
+++ b/middleware/etag/etag_test.go
@@ -2,6 +2,7 @@ package etag
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -45,6 +46,43 @@ func Test_ETag_SSE(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "data: hello\n\n", string(body))
+}
+
+// failOnReadStream is a body stream whose Read fails, proving the middleware
+// never materializes it.
+type failOnReadStream struct{ readCalls int }
+
+func (s *failOnReadStream) Read(_ []byte) (int, error) {
+	s.readCalls++
+	return 0, errors.New("stream should not be read")
+}
+
+// go test -run Test_ETag_SSE_Stream
+// A real SSE stream must pass through untouched: hashing the body would
+// materialize the stream and break real-time delivery. The middleware must add
+// no ETag and leave the response a stream. The content type carries a charset
+// param to exercise the media-type strip in isEventStream.
+func Test_ETag_SSE_Stream(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	app.Use(New())
+
+	stream := &failOnReadStream{}
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderContentType, fiber.MIMETextEventStream+"; charset=utf-8")
+		c.Status(fiber.StatusOK)
+		c.Response().SetBodyStream(stream, -1)
+		return nil
+	})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.SetMethod(fiber.MethodGet)
+	fctx.Request.SetRequestURI("/")
+	app.Handler()(fctx)
+
+	require.True(t, fctx.Response.IsBodyStream())
+	require.Zero(t, stream.readCalls)
+	require.Empty(t, string(fctx.Response.Header.Peek(fiber.HeaderETag)))
 }
 
 // go test -run Test_ETag_SkipError

--- a/middleware/etag/etag_test.go
+++ b/middleware/etag/etag_test.go
@@ -27,6 +27,26 @@ func Test_ETag_Next(t *testing.T) {
 	require.Equal(t, fiber.StatusNotFound, resp.StatusCode)
 }
 
+// go test -run Test_ETag_SSE
+func Test_ETag_SSE(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	app.Use(New())
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderContentType, fiber.MIMETextEventStream)
+		return c.SendString("data: hello\n\n")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Empty(t, resp.Header.Get(fiber.HeaderETag))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "data: hello\n\n", string(body))
+}
+
 // go test -run Test_ETag_SkipError
 func Test_ETag_SkipError(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
# Description

The ETag middleware runs after the handler and reads the full response body via `c.Response().Body()` to compute the hash. For a Server-Sent Events (SSE) response the body is a stream, so materializing it to hash it buffers the stream and breaks real-time delivery (the client never receives incremental events, and an infinite stream would hang).

This PR makes the ETag middleware detect SSE responses by their `text/event-stream` content type and pass them through untouched — no ETag is generated and the stream is left intact.

Content-type detection is used deliberately instead of a blanket `c.Response().IsBodyStream()` check: a regular streamed response (e.g. `SendStream`/`SendFile`) is a body stream too, and skipping *all* streams would change existing behavior beyond the SSE case. Targeting `text/event-stream` fixes the SSE breakage without any regression for other responses.

Fixes # (issue)

## Changes introduced

- [ ] Benchmarks: N/A — the new path is a single content-type comparison on the response header, before any body access.
- [ ] Documentation Update: N/A.
- [ ] Changelog/What's New: ETag middleware now skips `text/event-stream` (SSE) responses instead of materializing the stream.
- [ ] Migration Guide: N/A — no API change.
- [ ] API Alignment with Express: N/A.
- [ ] API Longevity: No config or signature change; purely internal guard.
- [ ] Examples: N/A.

Details:
- Added an `isEventStream` helper that reads the response `Content-Type`, strips any `; charset=...` parameter, and compares case-insensitively against `fiber.MIMETextEventStream`.
- The ETag handler returns early (no ETag) when the response is an SSE stream.
- Added `Test_ETag_SSE` verifying that an SSE response gets no `ETag` header and its body is delivered unchanged.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes (`go test ./middleware/etag/` → all pass).
- [x] Verified no new dependencies are introduced.
- [x] Aimed for optimal performance with minimal allocations (single header read + comparison, no body materialization).
