### PR TITLE
⚡ perf: reduce avoidable work in the request hot path

### DIFF
--- a/app.go
+++ b/app.go
@@ -1548,6 +1548,11 @@ func (app *App) init() *App {
 // error handler. Otherwise, it uses the configured error handler for
 // the app, which if not set is the DefaultErrorHandler.
 func (app *App) ErrorHandler(ctx Ctx, err error) error {
+	// Fast path: no mounted sub-apps, so no prefix lookup is needed
+	if len(app.mountFields.appListKeys) == 0 {
+		return app.config.ErrorHandler(ctx, err)
+	}
+
 	var (
 		mountedErrHandler  ErrorHandler
 		mountedPrefixParts int

--- a/ctx.go
+++ b/ctx.go
@@ -365,11 +365,12 @@ func (c *DefaultCtx) ViewBind(vars Map) error {
 // Route returns the matched Route struct.
 func (c *DefaultCtx) Route() *Route {
 	if c.route == nil {
-		// Fallback for fasthttp error handler
+		// Fallback for fasthttp error handler; equals c.Method() without
+		// the variadic call so Route stays within the inlining budget
 		return &Route{
 			path:     c.pathOriginal,
 			Path:     c.pathOriginal,
-			Method:   c.Method(),
+			Method:   c.app.method(c.methodInt),
 			Handlers: emptyRouteHandlers[:],
 			Params:   emptyRouteParams[:],
 		}

--- a/path.go
+++ b/path.go
@@ -520,9 +520,10 @@ func (parser *routeParser) getMatch(detectionPath, path string, params *[maxPara
 			i = segment.Length
 			// is optional part or the const part must match with the given string
 			// check if the end of the segment is an optional slash
+			// the unsigned compare proves 0 <= i <= len(detectionPath), keeping detectionPath[:i] bounds-check free
 			if segment.HasOptionalSlash && partLen == i-1 && detectionPath == segment.Const[:i-1] {
 				i--
-			} else if i > partLen || detectionPath[:i] != segment.Const {
+			} else if uint(i) > uint(len(detectionPath)) || detectionPath[:i] != segment.Const {
 				return false
 			}
 		} else {

--- a/router.go
+++ b/router.go
@@ -232,15 +232,11 @@ func (app *App) next(c *DefaultCtx) (bool, error) {
 	if !ok {
 		tree = app.treeStack[methodInt][0]
 	}
-	lenr := len(tree) - 1
+	indexRoute := max(c.indexRoute+1, 0)
 
-	indexRoute := c.indexRoute
-
-	// Loop over the route stack starting from previous index
-	for indexRoute < lenr {
-		// Increment route index
-		indexRoute++
-
+	// Loop over the route stack starting from previous index;
+	// the clamp above plus the len(tree) guard keep tree[indexRoute] bounds-check free
+	for ; indexRoute < len(tree); indexRoute++ {
 		// Get *Route
 		route := tree[indexRoute]
 
@@ -337,15 +333,11 @@ func (app *App) nextCustom(c CustomCtx) (bool, error) {
 	if !ok {
 		tree = app.treeStack[methodInt][0]
 	}
-	lenr := len(tree) - 1
+	indexRoute := max(c.getIndexRoute()+1, 0)
 
-	indexRoute := c.getIndexRoute()
-
-	// Loop over the route stack starting from previous index
-	for indexRoute < lenr {
-		// Increment route index
-		indexRoute++
-
+	// Loop over the route stack starting from previous index;
+	// the clamp above plus the len(tree) guard keep tree[indexRoute] bounds-check free
+	for ; indexRoute < len(tree); indexRoute++ {
 		// Get *Route
 		route := tree[indexRoute]
 


### PR DESCRIPTION
## Summary

Three small, behavior-preserving optimizations in the request hot path:

- **`app.ErrorHandler`**: return early when no sub-apps are mounted. The mount lookup normalized (copied) the request path on every handler error and every router 404, even though `appListKeys` is empty for non-mounted apps, where the whole prefix loop is dead code. For paths beyond the stack-allocation limit this copy is a heap allocation.
- **`DefaultCtx.Route`**: the `route == nil` fallback called the variadic `c.Method()`, pushing `Route` to inline cost 88 (budget 80). Using `app.method(c.methodInt)` directly, which is what `Method()` resolves to without an override, makes `Route` inlinable into hot callers such as `Params` and `FullPath`.
- **Bounds-check elimination in route matching**: the bucket-scan loops in `next`/`nextCustom` compared the index against a `len(tree)-1` copy, and `getMatch` compared the segment length against a stale local, so the compiler kept bounds checks on `tree[indexRoute]` and `detectionPath[:i]` for every candidate route. Clamping the start index with `max(..., 0)` and comparing unsigned against the live length lets BCE remove both. The cold 405 fallback loops are unchanged because they read the index after the loop.

## Benchmarks

benchstat vs current main, Apple M2 Pro, `-count 10`:

| Benchmark | main | PR | delta |
|---|---|---|---|
| Router_NotFound | 210.3n ± 1% | 202.5n ± 1% | -3.76% (p=0.000) |
| Router_Chain | 117.0n ± 2% | 112.0n ± 2% | -4.31% (p=0.000) |
| Router_Next | 45.86n ± 24% | 42.41n ± 1% | -7.53% (p=0.000) |
| Router_Handler | 79.66n ± 1% | 77.90n ± 1% | -2.21% (p=0.000) |
| Ctx_Params | 54.60n ± 1% | 52.46n ± 1% | -3.92% (p=0.000) |
| Communication_Flow | 37.33n ± 1% | 37.09n ± 1% | -0.64% (p=0.012) |
| Route_Match | 13.17n ± 3% | 13.27n ± 1% | ~ (p=0.125) |

All benchmarks stay at 0 B/op, 0 allocs/op.

## Verification

- `go test .`: 1400 tests pass
- `make lint`: 0 issues
- `-d=ssa/check_bce`: no bounds check left on `tree[indexRoute]` (both hot loops) or `detectionPath[:i]`; the cold 405 loops intentionally keep theirs
- `-gcflags=-m`: `can inline (*DefaultCtx).Route`, inlined at its in-package call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
