### PR TITLE
🐛 fix(ctx): compare Accept media type case-insensitively

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -361,7 +361,7 @@ func acceptsOfferType(spec, offerType string, specParams headerParams) bool {
 		mimetype = utils.GetMIME(offerMime) // extension
 	}
 
-	if spec == mimetype {
+	if utils.EqualFold(spec, mimetype) {
 		// Accept: <MIME_type>/<MIME_subtype>
 		return paramsMatch(specParams, offerParams)
 	}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -49,6 +49,11 @@ func Test_Utils_GetOffer(t *testing.T) {
 	require.Equal(t, `text/plain;a="1;b=2\",text/plain"`, getOffer([]byte(`text/plain;a="1;b=2\",text/plain";q=0.9`), acceptsOfferType, `text/plain;a=1;b=2`, `text/plain;a="1;b=2\",text/plain"`))
 	require.Equal(t, "text/plain;A=CAPS", getOffer([]byte(`text/plain;a="caPs"`), acceptsOfferType, "text/plain;A=CAPS"))
 
+	// The media type and subtype tokens are case-insensitive (RFC 9110 8.3.1)
+	require.Equal(t, "application/json", getOffer([]byte("Application/JSON"), acceptsOfferType, "application/json"))
+	require.Equal(t, "Application/JSON", getOffer([]byte("application/json"), acceptsOfferType, "Application/JSON"))
+	require.Equal(t, "text/plain;a=1", getOffer([]byte("Text/Plain;a=1"), acceptsOfferType, "text/plain;a=1"))
+
 	// Priority
 	require.Equal(t, "text/plain", getOffer([]byte("text/plain"), acceptsOfferType, "text/plain", "text/plain;a=1"))
 	require.Equal(t, "text/plain;a=1", getOffer([]byte("text/plain"), acceptsOfferType, "text/plain;a=1", "", "text/plain"))


### PR DESCRIPTION
During content negotiation using `Accepts`, the `acceptsOfferType` function compared the parsed `Accept` media type against the offer using a case-sensitive equality check (`==`).

```go
if spec == mimetype {
```

The request `Accept: Application/JSON` did not match an `application/json` offer, resulting in `Accepts("application/json")` returning an empty string.

According to RFC 9110 8.3.1, type, subtype, and parameter name tokens are case-insensitive. The rest of this file already adheres to this requirement:
- the sibling `acceptsOffer` (used for `AcceptsCharsets`/`AcceptsEncodings`) matches with `utils.EqualFold`
- the `<type>/*` wildcard branch of `acceptsOfferType` itself uses `utils.EqualFold`
- `paramsMatch` compares parameter names and values with `utils.EqualFold`

The exact-match line used `==`. This has been changed to `utils.EqualFold(spec, mimetype)` for consistency.
### Test

Extended `Test_Utils_GetOffer` with mixed-case type/subtype cases (mixed-case in the header vs a lowercase offer, and the reverse, plus one with a parameter). Verified they fail on the old `==` (`getOffer([]byte("Application/JSON"), acceptsOfferType, "application/json")` returns `""`) and pass with the fix. `gofmt` and `go vet` clean.