### PR TITLE
test(proxy): fix data race and flaky deadline test breaking v2 CI

### DIFF
--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -249,8 +249,9 @@ func Test_Proxy_Forward_WithTlsConfig(t *testing.T) {
 	addr := ln.Addr().String()
 	clientTLSConf := &tls.Config{InsecureSkipVerify: true} //nolint:gosec // We're in a test func, so this is fine
 
-	// disable certificate verification
-	WithTlsConfig(clientTLSConf)
+	// disable certificate verification by swapping the whole global client
+	// (WithTlsConfig mutates the shared client's field and races with parallel proxy tests)
+	WithClient(&fasthttp.Client{TLSConfig: clientTLSConf})
 	app.Use(Forward("https://" + addr + "/tlsfwd"))
 
 	go func() { utils.AssertEqual(t, nil, app.Listener(ln)) }()
@@ -565,7 +566,9 @@ func Test_Proxy_DoDeadline_PastDeadline(t *testing.T) {
 
 	app := fiber.New()
 	app.Get("/test", func(c *fiber.Ctx) error {
-		return DoDeadline(c, "http://"+addr, time.Now().Add(time.Second))
+		// Deadline is longer than app.Test's 1000ms timeout so the test timeout
+		// deterministically fires first (avoids two coincident 1s timers racing).
+		return DoDeadline(c, "http://"+addr, time.Now().Add(2*time.Second))
 	})
 
 	_, err1 := app.Test(httptest.NewRequest(fiber.MethodGet, "/test", nil))


### PR DESCRIPTION
## Summary

The `v2` branch CI has been red for every PR (surfaced while checking #4495).
The failures are two **pre-existing** issues in `middleware/proxy` tests,
tripped by `go test -race` on newer Go versions (1.22.x/1.23.x) and on Windows.
This is a **test-only** fix; there are no production or public-API changes.

The `panic: Hi, I'm an error!` seen in the logs is a red herring - it is just
the `debug.Stack()` output of `Test_Recover_EnableStackTrace`, not a crash.

## Root cause & fix

**1. Data race in `Test_Proxy_Forward_WithTlsConfig`**

`WithTlsConfig()` mutates the field `client.TLSConfig` on the package-global
`client` with no synchronization, while fasthttp concurrently reads that same
field from parallel proxy tests (e.g. `Test_Proxy_DoDeadline_PastDeadline`):

```
WARNING: DATA RACE
Write ... proxy.WithTlsConfig()            proxy.go:121  (Test_Proxy_Forward_WithTlsConfig)
Previous read ... fasthttp (*Client).Do    client.go:510 (via DoDeadline)
```

Fix: swap the whole global client atomically via
`WithClient(&fasthttp.Client{TLSConfig: ...})` (pointer swap under the existing
lock) instead of mutating a shared field. This mirrors how `v3` solved it
(v3 replaced the `WithTlsConfig` usage with `WithClient`). The deprecated
public `WithTlsConfig` API is left untouched - no breaking change on v2.

**2. Flaky timing in `Test_Proxy_DoDeadline_PastDeadline`**

The `DoDeadline` deadline (`1s`) equalled `app.Test`'s default `1000ms`
timeout, so two coincident timers raced (~1 in 8 runs failed with no data
race). Fix: bump the deadline to `2s` so `app.Test`'s timeout fires first
deterministically - the same approach as v3
(`app.Test` timeout `<` `DoDeadline` deadline).

## Test

Verified locally on `origin/v2` with the fix:

```
go test ./middleware/proxy/ -race -count=1 -shuffle=on   # 12/12 green
go vet ./middleware/proxy/                                # clean
```

Before the fix the data race reproduced deterministically and the deadline
test flaked; after it, 12 consecutive `-race -shuffle` runs pass.

## Out of scope

The separate `Analyse`/CodeQL job failure
(`CodeQL analyses from advanced configurations cannot be processed when the
default setup is enabled`) is a repo-settings conflict (default CodeQL setup
vs. the advanced `codeql-analysis.yml`) and can only be resolved by a repo
admin - it is unrelated to these test failures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
