### PR TITLE
test(ctx): restore global parser decoder after SetParserDecoder tests (fixes shuffle/-race flakes)

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -680,7 +680,7 @@ func Test_Ctx_BodyParser_InvalidRequestData(t *testing.T) {
 }
 
 func Test_Ctx_BodyParser_IndexTooLarge(t *testing.T) {
-	defer SetParserDecoder(ParserConfig{IgnoreUnknownKeys: true})
+	defer SetParserDecoder(ParserConfig{IgnoreUnknownKeys: true, ZeroEmpty: true})
 	SetParserDecoder(ParserConfig{IgnoreUnknownKeys: false})
 	type RequestBody struct {
 		NestedContent []*struct {
@@ -741,6 +741,9 @@ func Test_Ctx_BodyParser_WithSetParserDecoder(t *testing.T) {
 		Converter:  timeConverter,
 	}
 
+	// restore the package-default decoder afterwards so this global change does
+	// not leak into other (parallel) parser tests
+	defer SetParserDecoder(ParserConfig{IgnoreUnknownKeys: true, ZeroEmpty: true})
 	SetParserDecoder(ParserConfig{
 		IgnoreUnknownKeys: true,
 		ParserType:        []ParserType{customTime},
@@ -4906,6 +4909,9 @@ func Test_Ctx_QueryParser_WithSetParserDecoder(t *testing.T) {
 		Converter:  nonRFCConverter,
 	}
 
+	// restore the package-default decoder afterwards so this global change does
+	// not leak into other (parallel) parser tests
+	defer SetParserDecoder(ParserConfig{IgnoreUnknownKeys: true, ZeroEmpty: true})
 	SetParserDecoder(ParserConfig{
 		IgnoreUnknownKeys: true,
 		ParserType:        []ParserType{nonRFCTime},
@@ -5261,6 +5267,9 @@ func Test_Ctx_ReqHeaderParser_WithSetParserDecoder(t *testing.T) {
 		Converter:  nonRFCConverter,
 	}
 
+	// restore the package-default decoder afterwards so this global change does
+	// not leak into other (parallel) parser tests
+	defer SetParserDecoder(ParserConfig{IgnoreUnknownKeys: true, ZeroEmpty: true})
 	SetParserDecoder(ParserConfig{
 		IgnoreUnknownKeys: true,
 		ParserType:        []ParserType{nonRFCTime},


### PR DESCRIPTION
## Summary

Fixes the root cause of the deterministic `-race`/`-shuffle` failures in the
root-package tests (the red `Race` job introduced in #4497, and the parser
failures seen on #4495's run):

```
--- FAIL: Test_Ctx_QueryParser
--- FAIL: Test_Ctx_QueryParserUsingTag
--- FAIL: Test_Ctx_ReqHeaderParser
--- FAIL: Test_Ctx_ReqHeaderParserUsingTag
```

## Root cause

`SetParserDecoder()` mutates the **package-global** `decoderPoolMap`. The
`*_WithSetParserDecoder` tests (and `Test_Ctx_BodyParser_IndexTooLarge`) set a
custom `ParserConfig` but never restore the default. These tests run in the
serial phase, so the mutated global decoder leaks into the **parallel**
`Test_Ctx_QueryParser` / `Test_Ctx_ReqHeaderParser` tests, which then decode
with the wrong config (custom alias tag / converter) and fail. Source order
happened to hide it; `go test -shuffle` exposes it deterministically.

## Fix

Restore the package default (`IgnoreUnknownKeys: true, ZeroEmpty: true`, the
value set in `ctx.go`'s `init`) via `defer` in each mutating test.
`Test_Ctx_BodyParser_IndexTooLarge`'s existing `defer` was also incomplete (it
dropped `ZeroEmpty: true`) and is corrected.

Test-only, 1 file.

## Verification

```
go test . -run 'Test_Ctx_(QueryParser|ReqHeaderParser|BodyParser)' -race -shuffle=on
```
passes 5/5, and the shuffle seeds that previously failed (e.g. seed 2) now pass.

Once merged, the non-blocking `Race` job goes green (its only deterministic
failure was these tests). Rare, unrelated flaky data races may still surface
there occasionally; those are separate follow-ups.

## Type of change

- [x] Bug fix (test isolation; no production code change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
