### PR TITLE
⚡ perf(req): skip ip.String() alloc in IsProxyTrusted for CIDR-only trust configs

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -10041,6 +10041,25 @@ func Benchmark_Ctx_IsProxyTrusted(b *testing.B) {
 		})
 	})
 
+	// Scenario with CIDR-only trust config (empty exact-IP map). The remote IP
+	// reaches the range check, exercising the guard that skips ip.String().
+	b.Run("WithProxyCheckCIDR", func(b *testing.B) {
+		app := New(Config{
+			TrustProxy: true,
+			TrustProxyConfig: TrustProxyConfig{
+				Proxies: []string{"0.0.0.0/8"},
+			},
+		})
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		c.Request().SetRequestURI("http://google.com/test")
+		c.Request().Header.Set(HeaderXForwardedHost, "google1.com")
+		b.ReportAllocs()
+		for b.Loop() {
+			c.IsProxyTrusted()
+		}
+		app.ReleaseCtx(c)
+	})
+
 	// Scenario with trusted proxy check allow private
 	b.Run("WithProxyCheckAllowPrivate", func(b *testing.B) {
 		app := New(Config{

--- a/req.go
+++ b/req.go
@@ -1380,8 +1380,12 @@ func (r *DefaultReq) IsProxyTrusted() bool {
 		return true
 	}
 
-	if _, trusted := config.TrustProxyConfig.ips[ip.String()]; trusted {
-		return true
+	// Only stringify the IP when there is an exact-match map to look it up in;
+	// ip.String() heap-allocates and is wasted work for CIDR-only configs.
+	if len(config.TrustProxyConfig.ips) > 0 {
+		if _, trusted := config.TrustProxyConfig.ips[ip.String()]; trusted {
+			return true
+		}
 	}
 
 	for _, ipNet := range config.TrustProxyConfig.ranges {


### PR DESCRIPTION
`IsProxyTrusted` looked up `config.TrustProxyConfig.ips[ip.String()]` even when the exact-IP map is empty, so `ip.String()` heap-allocated on every call for the common CIDR-only / range-based trust setup. Behind a load balancer, `IP()`, `Host()`, and `Scheme()` reach this per request. Guard the lookup with `len(ips) > 0`.

Adds a `WithProxyCheckCIDR` benchmark exercising the empty-ips range path.

## Benchmark

`Benchmark_Ctx_IsProxyTrusted/WithProxyCheckCIDR` (CIDR-only trust, remote IP reaches the range check):

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before | ~64-84 | 8 | 1 |
| after | ~27 | 0 | 0 |

Behavior is unchanged: with a non-empty exact-IP map the lookup runs exactly as before (existing `WithProxyCheck` covers that path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)