### PR TITLE
⚡ perf(ctx): restore Route inlining lost in the RFC 9110 changes

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -376,9 +376,9 @@ func (c *DefaultCtx) Route() *Route {
 	return c.route
 }
 
-// routeFallback builds the synthetic route for the fasthttp error handler;
-// Method uses the same resolution as c.Method() (including the raw-header
-// fallback for unregistered methods) so the two accessors always agree.
+// routeFallback builds the synthetic route for the fasthttp error handler.
+// Its Method field is resolved like c.Method() (including the raw-header
+// fallback for unregistered methods) so Route and Method always agree.
 // Never inlined: inlining it would push Route over the inlining budget.
 //
 //go:noinline

--- a/ctx.go
+++ b/ctx.go
@@ -370,18 +370,26 @@ func (c *DefaultCtx) ViewBind(vars Map) error {
 // Route returns the matched Route struct.
 func (c *DefaultCtx) Route() *Route {
 	if c.route == nil {
-		// Fallback for fasthttp error handler; uses the same method
-		// resolution as c.Method() (including the raw-header fallback for
-		// unregistered methods) so the two accessors always agree.
-		return &Route{
-			path:     c.pathOriginal,
-			Path:     c.pathOriginal,
-			Method:   currentMethod(c),
-			Handlers: emptyRouteHandlers[:],
-			Params:   emptyRouteParams[:],
-		}
+		// Cold path kept out of line so Route stays within the inlining budget.
+		return c.routeFallback()
 	}
 	return c.route
+}
+
+// routeFallback builds the synthetic route for the fasthttp error handler;
+// Method uses the same resolution as c.Method() (including the raw-header
+// fallback for unregistered methods) so the two accessors always agree.
+// Never inlined: inlining it would push Route over the inlining budget.
+//
+//go:noinline
+func (c *DefaultCtx) routeFallback() *Route {
+	return &Route{
+		path:     c.pathOriginal,
+		Path:     c.pathOriginal,
+		Method:   currentMethod(c),
+		Handlers: emptyRouteHandlers[:],
+		Params:   emptyRouteParams[:],
+	}
 }
 
 // FullPath returns the matched route path, including any group prefixes.


### PR DESCRIPTION
## Summary

#4494 replaced `app.method(c.methodInt)` with `currentMethod(c)` inside the `route == nil` fallback of `Route()`, pushing its inline cost from 37 to 83 (budget 80). `Route()` stopped inlining at its hot call sites, so every `Params()`/`FullPath()` call paid a full function call for a nil check plus a field load. This restores the state #4490 established.

## Changes

- Move the cold fallback into a `routeFallback()` helper marked `//go:noinline`; extraction alone is not enough, the inliner folds a cheap helper right back in.
- A comment in `Route()` marks the inlining constraint so it does not get lost again.

## Verification

- `go build -gcflags=-m`: `can inline (*DefaultCtx).Route`, inlined again at the `FullPath` and `Params` call sites.
- `Benchmark_Ctx_Params` (M2 Pro, n=10): 54.59ns -> 52.36ns, **-4.07%** (p=0.002), 0 allocs before and after.
- 1479 core tests pass, `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)