### PR TITLE
⚡ perf(cors): fold preflight Vary calls into one header scan

### DIFF
--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -175,9 +175,9 @@ func New(config ...Config) fiber.Handler {
 
 		// Response to OPTIONS request should not be cached but,
 		// some caching can be configured to cache such responses.
-		// To Avoid poisoning the cache, we include the Vary header
-		// of preflight responses. A single variadic Vary call per branch:
-		// every Vary call scans all response headers.
+		// To avoid poisoning the cache, we include the Vary header
+		// of preflight responses, set in a single variadic Vary call
+		// per branch since every Vary call scans all response headers.
 		if cfg.AllowPrivateNetwork && c.Get(fiber.HeaderAccessControlRequestPrivateNetwork) == "true" {
 			c.Vary(fiber.HeaderAccessControlRequestMethod, fiber.HeaderAccessControlRequestHeaders, fiber.HeaderAccessControlRequestPrivateNetwork, fiber.HeaderOrigin)
 			c.Set(fiber.HeaderAccessControlAllowPrivateNetwork, "true")

--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -176,14 +176,14 @@ func New(config ...Config) fiber.Handler {
 		// Response to OPTIONS request should not be cached but,
 		// some caching can be configured to cache such responses.
 		// To Avoid poisoning the cache, we include the Vary header
-		// of preflight responses:
-		c.Vary(fiber.HeaderAccessControlRequestMethod)
-		c.Vary(fiber.HeaderAccessControlRequestHeaders)
+		// of preflight responses. A single variadic Vary call per branch:
+		// every Vary call scans all response headers.
 		if cfg.AllowPrivateNetwork && c.Get(fiber.HeaderAccessControlRequestPrivateNetwork) == "true" {
-			c.Vary(fiber.HeaderAccessControlRequestPrivateNetwork)
+			c.Vary(fiber.HeaderAccessControlRequestMethod, fiber.HeaderAccessControlRequestHeaders, fiber.HeaderAccessControlRequestPrivateNetwork, fiber.HeaderOrigin)
 			c.Set(fiber.HeaderAccessControlAllowPrivateNetwork, "true")
+		} else {
+			c.Vary(fiber.HeaderAccessControlRequestMethod, fiber.HeaderAccessControlRequestHeaders, fiber.HeaderOrigin)
 		}
-		c.Vary(fiber.HeaderOrigin)
 
 		setPreflightHeaders(c, allowOrigin, maxAge, &cfg)
 


### PR DESCRIPTION
## Summary

Since the RFC 9110 changes every `Vary()` call combines all response-header field lines via a full `VisitAll` scan. The preflight path issued 3-4 sequential single-field `Vary()` calls per OPTIONS request, repeating that scan and rebuilding the growing Vary value each time.

## Changes

- One variadic `Vary()` call per branch (with/without private network). Header output is byte-identical: `appendUniqueValues` appends the fields in the same order with the same dedup either way.

## Benchmarks

M2 Pro, n=10: `Benchmark_CORS_NewHandlerPreflight` -16.6%, `...SingleOrigin` -17.0%, `...Wildcard` -18.2% (geomean **-17.3%**), allocs **5 -> 3** per op.

## Testing

100 cors tests pass, `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)