### PR TITLE
⚡ perf(res): skip Accept join allocation in Format emptiness check

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2099,6 +2099,34 @@ func Test_Ctx_Format_NoAcceptDefaultFirst(t *testing.T) {
 	require.NotEqual(t, "default", c.GetRespHeader(HeaderContentType))
 }
 
+func Test_Ctx_Format_AcceptEmptyAndMultiLine(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	var accepted string
+	handler := func(mediaType string) ResFmt {
+		return ResFmt{MediaType: mediaType, Handler: func(_ Ctx) error {
+			accepted = mediaType
+			return nil
+		}}
+	}
+
+	// A single empty Accept line is an empty combined view: treated as absent.
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	c.Request().Header.Set(HeaderAccept, "")
+	err := c.Format(handler("application/json"), handler("text/html"))
+	require.NoError(t, err)
+	require.Equal(t, "application/json", accepted)
+
+	// Multiple Accept lines negotiate on the combined view (RFC 9110 Section 5.2).
+	c = app.AcquireCtx(&fasthttp.RequestCtx{})
+	c.Request().Header.Add(HeaderAccept, "text/plain;q=0.5")
+	c.Request().Header.Add(HeaderAccept, "text/html")
+	err = c.Format(handler("application/json"), handler("text/html"))
+	require.NoError(t, err)
+	require.Equal(t, "text/html", accepted)
+}
+
 func Benchmark_Ctx_Format(b *testing.B) {
 	app := New()
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})

--- a/res.go
+++ b/res.go
@@ -434,9 +434,11 @@ func (r *DefaultRes) Format(handlers ...ResFmt) error {
 
 	r.Vary(HeaderAccept)
 
-	// Consider all Accept field lines combined (RFC 9110 Section 5.2), the
-	// same view Accepts negotiates on below.
-	if len(joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderAccept))) == 0 {
+	// Absent means the combined Accept view (RFC 9110 Section 5.2) is empty:
+	// no field line, or a single empty one. Checked on the raw lines to skip
+	// the join allocation that multi-line headers would pay.
+	accepts := r.c.fasthttp.Request.Header.PeekAll(HeaderAccept)
+	if len(accepts) == 0 || (len(accepts) == 1 && len(accepts[0]) == 0) {
 		// Without an Accept header the client accepts any media type
 		// (RFC 9110 Section 12.5.1), so pick the first non-default handler and
 		// use its media type. The literal "default" is not a media type and


### PR DESCRIPTION
## Summary

`Format()` joined all Accept field lines just to test whether the combined view is empty; with a multi-line Accept header that join heap-allocates for a length check whose result is discarded.

## Changes

- Check the raw lines instead: the combined view is empty exactly when there is no Accept line or a single empty one (a join of 2+ lines always contains at least the separator byte).
- New `Test_Ctx_Format_AcceptEmptyAndMultiLine` pins the single-empty-line (treated as absent) and multi-line negotiation behavior.

## Testing

1480 core tests pass, `make lint` clean; `Benchmark_Ctx_Format` unchanged (the single-line path never allocated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)