### PR TITLE
🐛 bug: Fix the normalization of the leading slash in the root path for fs.FS static serving

### DIFF
--- a/middleware/static/static.go
+++ b/middleware/static/static.go
@@ -159,9 +159,9 @@ func New(root string, cfg ...Config) fiber.Handler {
 	var rootIsFile bool
 
 	// adjustments for io/fs compatibility: io/fs paths are always relative and
-	// slash-rooted, so a leading slash (e.g. "/" or "/dist") is never a valid
+	// slash-separated, so a leading slash (e.g. "/" or "/dist") is never a valid
 	// fs path and makes isFile's fs.FS.Open fail, which sends every request to
-	// PathNotFound. Strip it and treat an empty result as the fs root ".".
+	// the PathNotFound handler. Strip it and treat an empty result as the fs root ".".
 	if config.FS != nil {
 		root = strings.TrimLeft(root, "/")
 		if root == "" {

--- a/middleware/static/static.go
+++ b/middleware/static/static.go
@@ -158,9 +158,15 @@ func New(root string, cfg ...Config) fiber.Handler {
 	var rootCheckErr error
 	var rootIsFile bool
 
-	// adjustments for io/fs compatibility
-	if config.FS != nil && root == "" {
-		root = "."
+	// adjustments for io/fs compatibility: io/fs paths are always relative and
+	// slash-rooted, so a leading slash (e.g. "/" or "/dist") is never a valid
+	// fs path and makes isFile's fs.FS.Open fail, which sends every request to
+	// PathNotFound. Strip it and treat an empty result as the fs root ".".
+	if config.FS != nil {
+		root = strings.TrimLeft(root, "/")
+		if root == "" {
+			root = "."
+		}
 	}
 
 	return func(c fiber.Ctx) error {

--- a/middleware/static/static_test.go
+++ b/middleware/static/static_test.go
@@ -797,6 +797,51 @@ func Test_Static_FS_MissingRootDoesNotFallback(t *testing.T) {
 	require.Equal(t, fiber.StatusNotFound, resp.StatusCode, "Status code")
 }
 
+func Test_Static_FS_RootLeadingSlash(t *testing.T) {
+	t.Parallel()
+
+	expectedIndexBody, err := os.ReadFile(filepath.Clean("../../.github/testdata/fs/index.html"))
+	require.NoError(t, err)
+
+	expectedCSSBody, err := os.ReadFile(filepath.Clean("../../.github/testdata/fs/css/style.css"))
+	require.NoError(t, err)
+
+	// A leading slash is not a valid io/fs path, so "/" and "/css" must be
+	// treated as the fs root and the "css" subdirectory respectively instead
+	// of sending every request to PathNotFound.
+	cases := []struct {
+		name     string
+		root     string
+		target   string
+		wantBody string
+		wantType string
+	}{
+		{name: "slash root serves index", root: "/", target: "/index.html", wantBody: string(expectedIndexBody), wantType: fiber.MIMETextHTMLCharsetUTF8},
+		{name: "slash root serves nested", root: "/", target: "/css/style.css", wantBody: string(expectedCSSBody), wantType: fiber.MIMETextCSSCharsetUTF8},
+		{name: "slash subdir serves file", root: "/css", target: "/style.css", wantBody: string(expectedCSSBody), wantType: fiber.MIMETextCSSCharsetUTF8},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := fiber.New()
+			app.Use("/", New(tc.root, Config{
+				FS: os.DirFS("../../.github/testdata/fs"),
+			}))
+
+			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, tc.target, http.NoBody))
+			require.NoError(t, err, "app.Test(req)")
+			require.Equal(t, fiber.StatusOK, resp.StatusCode, "Status code")
+			require.Equal(t, tc.wantType, resp.Header.Get(fiber.HeaderContentType))
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantBody, string(body))
+		})
+	}
+}
+
 func Test_isFile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# Description

Fixes #4499. Serving an `fs.FS` with a leading-slash root (e.g. `static.New("/", static.Config{FS: sub})`) returns 404 for every asset on v3.3/v3.4, while it worked on v3.2.

`New` only normalizes an **empty** root to `"."` for `fs.FS` backends:

```go
if config.FS != nil && root == "" {
    root = "."
}
```

A root of `"/"` (or `"/dist"`) is not a valid `io/fs` path — `fs.ValidPath("/")` is `false` — so `isFile` → `fs.FS.Open("/")` fails, `rootCheckErr` is set, and `PathRewrite` rewrites every request to the not-found sentinel:

```go
if rootCheckErr != nil && fileServer.FS != nil {
    return []byte(invalidPathSentinel)
}
```

In v3.2 the `isFile` error was ignored (`if check, err := isFile(...); err == nil`) and there was no sentinel, so the request proceeded. The sentinel added afterwards turned the ignored error into a hard 404, which is the regression reported in #4499.

## Reproduction

```go
fsys := fstest.MapFS{"index.html": {Data: []byte("INDEX")}}
app := fiber.New()
app.Use("/", static.New("/", static.Config{FS: fsys}))
// GET /index.html → v3.2: 200 "INDEX"  |  v3.3/v3.4: 404 "Not Found"
```

## Changes introduced

- When a filesystem is configured, strip leading slashes from `root` and fall back to `"."` when nothing remains, so `"/"` behaves like `""` and `"/dist"` like `"dist"`.
- The change is guarded by `config.FS != nil`, so string/`os` roots are untouched. Only leading slashes are trimmed, so a genuinely missing root like `"missing"` still returns 404 without falling back to the fs root (`Test_Static_FS_MissingRootDoesNotFallback` and `Test_Static_FS_RootDirectoryEnforced` still pass).

- [ ] Documentation Update: not needed — the docs already recommend `""`; this makes the equivalent `"/"` work instead of silently 404ing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added a unit test (`Test_Static_FS_RootLeadingSlash`) that fails before and passes after the change.
- [x] `go test ./middleware/static/...`, `go vet`, `gofmt`, and `golangci-lint run ./middleware/static/...` (0 issues) all pass locally.
