### PR TITLE
🐛 bug: preserve proxy empty-query URL semantics

### DIFF
--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -115,6 +115,11 @@ type Ctx interface {
 	ViewBind(vars Map) error
 	// Route returns the matched Route struct.
 	Route() *Route
+	// routeFallback builds the synthetic route for the fasthttp error handler.
+	// Its Method field is resolved like c.Method() (including the raw-header
+	// fallback for unregistered methods) so Route and Method always agree.
+	// Never inlined: inlining it would push Route over the inlining budget.
+	routeFallback() *Route
 	// FullPath returns the matched route path, including any group prefixes.
 	FullPath() string
 	// Matched returns true if the current request path was matched by the router.

--- a/middleware/proxy/config.go
+++ b/middleware/proxy/config.go
@@ -9,8 +9,6 @@ import (
 )
 
 // Config defines the config for middleware.
-//
-//nolint:govet // struct layout favors readability/grouping over field alignment
 type Config struct {
 	// Next defines a function to skip this middleware when returned true.
 	//
@@ -34,6 +32,13 @@ type Config struct {
 	// Note that Servers, Timeout, WriteBufferSize, ReadBufferSize, TLSConfig
 	// and DialDualStack will not be used if the client are set.
 	Client *fasthttp.LBClient
+
+	// SecurityPolicy overrides the default SSRF, redirect, and
+	// hop-by-hop header rules for this balancer. When nil, the
+	// package-level policy set via WithSecurityPolicy is used.
+	//
+	// Optional. Default: nil
+	SecurityPolicy *SecurityPolicy
 
 	// Servers defines a list of <scheme>://<host> HTTP servers,
 	//
@@ -62,6 +67,14 @@ type Config struct {
 	// Per-connection buffer size for responses' writing.
 	WriteBufferSize int
 
+	// MaxResponseBodySize bounds the size (in bytes) of upstream
+	// responses accepted by the proxy. Responses larger than this are
+	// rejected to protect the proxy from memory exhaustion. Zero
+	// preserves fasthttp's default unlimited behavior.
+	//
+	// Optional. Default: 0
+	MaxResponseBodySize int
+
 	// KeepConnectionHeader keeps the "Connection" header when set to true.
 	//
 	// Note: even when KeepConnectionHeader is true, other RFC 7230 §6.1
@@ -80,21 +93,6 @@ type Config struct {
 	//
 	// Optional. Default: false
 	DialDualStack bool
-
-	// SecurityPolicy overrides the default SSRF, redirect, and
-	// hop-by-hop header rules for this balancer. When nil, the
-	// package-level policy set via WithSecurityPolicy is used.
-	//
-	// Optional. Default: nil
-	SecurityPolicy *SecurityPolicy
-
-	// MaxResponseBodySize bounds the size (in bytes) of upstream
-	// responses accepted by the proxy. Responses larger than this are
-	// rejected to protect the proxy from memory exhaustion. Zero
-	// preserves fasthttp's default unlimited behavior.
-	//
-	// Optional. Default: 0
-	MaxResponseBodySize int
 }
 
 const defaultMaxConnsPerHost = 1024

--- a/middleware/proxy/security.go
+++ b/middleware/proxy/security.go
@@ -605,6 +605,7 @@ func baseIsPlainOrigin(base *url.URL) bool {
 		base.RawPath == "" &&
 		base.User == nil &&
 		base.RawQuery == "" &&
+		!base.ForceQuery &&
 		base.Fragment == "" &&
 		base.Opaque == ""
 }
@@ -645,6 +646,11 @@ func canFastJoinPath(requestPath string) bool {
 		case '?', '#':
 			if !inPath {
 				// Repeated path/query separator — let slow path handle.
+				return false
+			}
+			if i == len(requestPath)-1 {
+				// Empty query/fragment markers are not represented in the
+				// slow path's output, so fall back to preserve behavior.
 				return false
 			}
 			inPath = false

--- a/middleware/proxy/security_test.go
+++ b/middleware/proxy/security_test.go
@@ -473,7 +473,7 @@ func Test_Security_JoinUpstreamPath_EmptyQueryMarkersUseSlowPath(t *testing.T) {
 	base, err := parseUpstream("http://upstream.example")
 	require.NoError(t, err)
 	require.Equal(t, "http://upstream.example/foo", joinUpstreamPath(base, "/foo?"))
-}
+	require.Equal(t, "http://upstream.example/foo", joinUpstreamPath(base, "/foo#"))
 
 func Test_Security_SecureTLSConfig_DefaultMinVersion(t *testing.T) {
 	t.Parallel()

--- a/middleware/proxy/security_test.go
+++ b/middleware/proxy/security_test.go
@@ -474,6 +474,7 @@ func Test_Security_JoinUpstreamPath_EmptyQueryMarkersUseSlowPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "http://upstream.example/foo", joinUpstreamPath(base, "/foo?"))
 	require.Equal(t, "http://upstream.example/foo", joinUpstreamPath(base, "/foo#"))
+}
 
 func Test_Security_SecureTLSConfig_DefaultMinVersion(t *testing.T) {
 	t.Parallel()

--- a/middleware/proxy/security_test.go
+++ b/middleware/proxy/security_test.go
@@ -462,6 +462,19 @@ func Test_Security_JoinUpstreamPath_PreservesQuery(t *testing.T) {
 	require.Equal(t, "http://upstream.example/x?y=1&z=2", out)
 }
 
+func Test_Security_JoinUpstreamPath_EmptyQueryMarkersUseSlowPath(t *testing.T) {
+	t.Parallel()
+
+	baseWithEmptyQuery, err := parseUpstream("http://upstream.example?")
+	require.NoError(t, err)
+	require.True(t, baseWithEmptyQuery.ForceQuery)
+	require.Equal(t, "http://upstream.example/foo?", joinUpstreamPath(baseWithEmptyQuery, "/foo"))
+
+	base, err := parseUpstream("http://upstream.example")
+	require.NoError(t, err)
+	require.Equal(t, "http://upstream.example/foo", joinUpstreamPath(base, "/foo?"))
+}
+
 func Test_Security_SecureTLSConfig_DefaultMinVersion(t *testing.T) {
 	t.Parallel()
 	out := secureTLSConfig(nil)


### PR DESCRIPTION
### Motivation
- Fix a behavioral regression introduced by a fast-path optimization in `joinUpstreamPath` that caused upstream bases with an empty-query marker and request paths ending with `?`/`#` to produce different URL strings than the prior `url.Parse` + `URL.String` slow path.

### Description
- Exclude upstream bases carrying `url.URL.ForceQuery` from the fast splice by adding `!base.ForceQuery` to `baseIsPlainOrigin` in `middleware/proxy/security.go` so such bases take the slow path.
- Make `canFastJoinPath` reject trailing `?` or `#` markers so request paths like `/foo?` or `/foo#` fall through to the slow path and preserve prior canonicalization.
- Add `Test_Security_JoinUpstreamPath_EmptyQueryMarkersUseSlowPath` regression test covering both an upstream with `?` and a request path with a trailing `?` in `middleware/proxy/security_test.go`.
- Regenerate the `Ctx` interface and apply required alignment/formatting updates and minor `Config` field reordering from `make generate`/`make betteralign` in `ctx_interface_gen.go` and `middleware/proxy/config.go`.

### Testing
- Executed `go test ./middleware/proxy -run 'Test_Security_JoinUpstreamPath_(PreservesQuery|EmptyQueryMarkersUseSlowPath)'` which passed (example output: `ok github.com/gofiber/fiber/v3/middleware/proxy 0.040s`).
- Ran `make audit` under the default `go1.25.1` which failed due to `govulncheck` reporting stdlib issues, and then ran `GOVERSION=go1.25.11 make audit` which completed successfully with `No vulnerabilities found.`.
- Ran `make generate`, `make betteralign`, `make format`, and `make lint`, each of which completed successfully (notably `make lint` reported `0 issues`).
- Ran `make test` which completed successfully across the repository with `DONE 4087 tests, 1 skipped in 196.422s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e58169a848333a2b84ab28f1a5688)