### PR TITLE
🐛 bug: honor duplicate Content-Encoding after empty values

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2926,6 +2926,25 @@ func Test_Ctx_Body_With_Compression_MultiFieldLines(t *testing.T) {
 	require.Equal(t, []byte("double"), c.Body())
 }
 
+// Test_Ctx_Body_With_Compression_EmptyFirstMultiFieldLine verifies that an
+// empty first Content-Encoding field line does not hide later encodings.
+func Test_Ctx_Body_With_Compression_EmptyFirstMultiFieldLine(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	c.Request().Header.Add(HeaderContentEncoding, "")
+	c.Request().Header.Add(HeaderContentEncoding, "gzip")
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write([]byte("john=doe"))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	c.Request().SetBody(buf.Bytes())
+	require.Equal(t, []byte("john=doe"), c.Body())
+}
+
 // Test_Ctx_Fresh_ObsoleteDateFormats verifies that If-Modified-Since values in
 // the obsolete RFC 850 and ANSI C asctime() formats are accepted, as required
 // by RFC 9110 §5.6.7 for any HTTP-date recipient.

--- a/req.go
+++ b/req.go
@@ -161,7 +161,9 @@ func (r *DefaultReq) Body() []byte {
 
 	// Fast path: no Content-Encoding header at all. ContentEncoding uses the
 	// pre-normalized key constant, so absence costs a single cheap lookup.
-	if len(request.Header.ContentEncoding()) == 0 {
+	// An empty value is still a present field line and must be joined with
+	// duplicates below before RFC 9110 empty-list elements are ignored.
+	if request.Header.ContentEncoding() == nil {
 		return r.getBody()
 	}
 


### PR DESCRIPTION
### Motivation
- Fix a regression in `DefaultReq.Body()` where an empty first `Content-Encoding` field line could short-circuit decoding and return compressed bytes instead of joining duplicate header lines per RFC 9110 §5.2.  
- Prevent a remote client from causing middleware, binders, or logging to inspect undecoded bytes by ensuring multi-line `Content-Encoding` values are always joined before splitting and filtering empty list elements.  

### Description
- Change `DefaultReq.Body()` in `req.go` to treat the fasthttp header as absent only when `request.Header.ContentEncoding() == nil`, so an empty-but-present field line is still processed by the multi-line join and splitter.  
- Add a regression test `Test_Ctx_Body_With_Compression_EmptyFirstMultiFieldLine` in `ctx_test.go` which sets `Content-Encoding:` followed by `Content-Encoding: gzip` and asserts the body is decoded.  
- Run formatting and keep the change minimal to avoid touching unrelated generated or alignment code.

### Testing
- Ran the targeted unit test: `go test -run Test_Ctx_Body_With_Compression_EmptyFirstMultiFieldLine ./` — passed.  
- Ran full test suite: `make test` — passed (`DONE 4087 tests, 2 skipped`).  
- Ran `make generate` — passed.  
- Ran `make format` and `make lint` — passed.  
- Ran `make audit` — failed due to `govulncheck` findings in the local Go 1.25.1 standard library/toolchain (unrelated to this change).  
- `make betteralign` reported an unrelated pre-existing struct-alignment suggestion earlier and those generated edits were not applied to keep the security fix minimal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e5db80a388333bca5f761bb5a0830)