### PR TITLE
🐛 fix(proxy): guard runtime helpers against DNS-rebinding

### DIFF
--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -143,29 +143,62 @@ var (
 	errNilGlobalProxyClient   = errors.New("proxy: global client is nil, set a non-nil client with proxy.WithClient")
 )
 
+// guardMu serializes installation of the dial-time SSRF guard onto a
+// client. guardedClients records the *fasthttp.Client values whose Dial
+// has already been wrapped, so ensureClientGuarded wraps each exactly
+// once — a second wrap would compose the guard with itself and re-resolve
+// on every dial for no benefit.
+var (
+	guardMu        sync.Mutex
+	guardedClients = map[*fasthttp.Client]struct{}{}
+)
+
+// ensureClientGuarded installs the policy-aware dial-time SSRF guard on cli
+// exactly once. Every dispatch path funnels through here before it calls
+// cli.Do, so the wrap — performed under guardMu — establishes a
+// happens-before edge to every later read of cli.Dial by fasthttp; the
+// field is therefore never mutated concurrently with a dial. The guard
+// composes with any dialer the caller already set (see
+// newGuardedClientDialer).
+func ensureClientGuarded(cli *fasthttp.Client) {
+	guardMu.Lock()
+	defer guardMu.Unlock()
+	if _, ok := guardedClients[cli]; ok {
+		return
+	}
+	cli.Dial = newGuardedClientDialer(cli.Dial, cli.DialDualStack)
+	guardedClients[cli] = struct{}{}
+}
+
 func init() {
+	ensureClientGuarded(defaultClient)
 	client.Store(defaultClient)
 }
 
 // WithClient sets the global proxy client.
 // This function should be called before Do and Forward.
+//
+// The supplied client is fitted with the dial-time SSRF guard (composing
+// with any Dial it already carries) so requests dispatched through it
+// re-validate the resolved IP at connect time, matching the default
+// client's behavior.
 func WithClient(cli *fasthttp.Client) {
 	if cli == nil {
 		panic("proxy: WithClient requires a non-nil *fasthttp.Client")
 	}
 
+	ensureClientGuarded(cli)
 	client.Store(cli)
 }
 
 // Forward performs the given http request and fills the given http response.
 // This method will return a fiber.Handler
 //
-// SSRF note: like the other runtime helpers, Forward validates the
-// upstream host against the active SecurityPolicy up front but dispatches
-// through the shared/user-supplied client, which re-resolves the name.
-// It does not re-validate the resolved IP at dial time, so a
-// rebinding-capable resolver is not fully mitigated here — use Balancer
-// (with AllowPrivateIPs=false) for dial-time DNS-rebinding protection.
+// SSRF note: Forward validates the upstream host against the active
+// SecurityPolicy up front and, when AllowPrivateIPs is false, re-validates
+// the resolved IP at dial time via the guard installed on the dispatching
+// client, so a rebinding-capable resolver cannot swap a public answer for
+// a private one between validation and connection.
 func Forward(addr string, clients ...*fasthttp.Client) fiber.Handler {
 	return func(c fiber.Ctx) error {
 		c.Request().Header.Set("X-Real-IP", c.IP())
@@ -177,11 +210,11 @@ func Forward(addr string, clients ...*fasthttp.Client) fiber.Handler {
 // This method can be used within a fiber.Handler
 //
 // SSRF note: the upstream host is validated against the active
-// SecurityPolicy before the request is sent, but the request is then
-// dispatched through the shared/user-supplied *fasthttp.Client, which
-// re-resolves the host without re-validating the resolved IP at dial
-// time. Against a rebinding-capable resolver this leaves a check/use
-// window; only Balancer (with AllowPrivateIPs=false) guards the dial.
+// SecurityPolicy before the request is sent, and when AllowPrivateIPs is
+// false the resolved IP is re-validated at dial time by the guard
+// installed on the dispatching *fasthttp.Client. The connection therefore
+// targets exactly the address that passed the blocklist, so a
+// rebinding-capable resolver cannot slip a private IP past the check.
 func Do(c fiber.Ctx, addr string, clients ...*fasthttp.Client) error {
 	return doAction(c, addr, func(cli *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response, _ *url.URL) error {
 		return cli.Do(req, resp)
@@ -196,11 +229,10 @@ func Do(c fiber.Ctx, addr string, clients ...*fasthttp.Client) error {
 // Unless AllowHTTPSDowngrade is enabled, redirects from an HTTPS origin
 // to a plaintext HTTP target are rejected with ErrRedirectDowngrade.
 //
-// SSRF note: every hop's host is validated against the policy, but the
-// requests are dispatched through the shared/user-supplied client, which
-// re-resolves each host without re-validating the resolved IP at dial
-// time. Against a rebinding-capable resolver this leaves a check/use
-// window; only Balancer (with AllowPrivateIPs=false) guards the dial.
+// SSRF note: every hop's host is validated against the policy, and when
+// AllowPrivateIPs is false each dial is re-validated by the guard on the
+// dispatching client — so per-hop redirects (including cross-host ones)
+// cannot be rebound to a private IP between validation and connection.
 func DoRedirects(c fiber.Ctx, addr string, maxRedirectsCount int, clients ...*fasthttp.Client) error {
 	policy := currentSecurityPolicy()
 	return doActionWithPolicy(c, addr, policy, func(cli *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response, u *url.URL) error {
@@ -211,8 +243,8 @@ func DoRedirects(c fiber.Ctx, addr string, maxRedirectsCount int, clients ...*fa
 // DoDeadline performs the given request and waits for response until the given deadline.
 // This method can be used within a fiber.Handler
 //
-// SSRF note: carries the same dial-time DNS-rebinding limitation as Do
-// (up-front host validation only, no validated-IP dial guard).
+// SSRF note: same protection as Do — up-front host validation plus the
+// dial-time validated-IP guard when AllowPrivateIPs is false.
 func DoDeadline(c fiber.Ctx, addr string, deadline time.Time, clients ...*fasthttp.Client) error {
 	return doAction(c, addr, func(cli *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response, _ *url.URL) error {
 		return cli.DoDeadline(req, resp, deadline)
@@ -222,8 +254,8 @@ func DoDeadline(c fiber.Ctx, addr string, deadline time.Time, clients ...*fastht
 // DoTimeout performs the given request and waits for response during the given timeout duration.
 // This method can be used within a fiber.Handler
 //
-// SSRF note: carries the same dial-time DNS-rebinding limitation as Do
-// (up-front host validation only, no validated-IP dial guard).
+// SSRF note: same protection as Do — up-front host validation plus the
+// dial-time validated-IP guard when AllowPrivateIPs is false.
 func DoTimeout(c fiber.Ctx, addr string, timeout time.Duration, clients ...*fasthttp.Client) error {
 	return doAction(c, addr, func(cli *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response, _ *url.URL) error {
 		return cli.DoTimeout(req, resp, timeout)
@@ -257,6 +289,13 @@ func doActionWithPolicy(
 	if err != nil {
 		return err
 	}
+
+	// Install the dial-time SSRF guard on whichever client dispatches this
+	// request (default, WithClient override, or per-call variadic). The
+	// validateUpstream call below only checks the host up front; the guard
+	// re-validates the resolved IP at connect time, closing the
+	// DNS-rebinding window. Idempotent — each client is wrapped once.
+	ensureClientGuarded(cli)
 
 	// Clone addr once at the parse boundary instead of cloning u.Scheme
 	// and u.String() individually after the fact. url.Parse fills u's
@@ -438,11 +477,10 @@ func selectClient(globalClient *fasthttp.Client, clients ...*fasthttp.Client) (*
 // per request. Each request also re-validates the host against the
 // current policy before dispatch.
 //
-// SSRF note: that per-request validation is an up-front host check only.
-// The request is dispatched through the shared/user-supplied client,
-// which re-resolves the host without re-validating the resolved IP at
-// dial time, so a rebinding-capable resolver is not fully mitigated
-// here. Only Balancer (with AllowPrivateIPs=false) guards the dial.
+// SSRF note: the per-request validation is an up-front host check, and
+// when AllowPrivateIPs is false the dispatching client's dial-time guard
+// re-validates the resolved IP at connect time — so a rebinding-capable
+// resolver cannot reach a private address through this handler.
 func DomainForward(hostname, addr string, clients ...*fasthttp.Client) fiber.Handler {
 	base, err := validateUpstream(addr, currentSecurityPolicy())
 	if err != nil {
@@ -496,10 +534,10 @@ func (r *urlRoundrobin) get() *url.URL {
 // handler construction. A misconfigured entry panics at startup.
 //
 // SSRF note: despite the name, this helper dispatches through the
-// shared/user-supplied client (not a Balancer HostClient), so it carries
-// the same dial-time DNS-rebinding limitation as Do — up-front host
-// validation only, no validated-IP dial guard. Use Balancer for
-// dial-time protection.
+// shared/user-supplied client rather than a Balancer HostClient, but it
+// gets the same protection as Do — up-front host validation plus the
+// dial-time validated-IP guard on the dispatching client when
+// AllowPrivateIPs is false.
 func BalancerForward(servers []string, clients ...*fasthttp.Client) fiber.Handler {
 	if len(servers) == 0 {
 		panic("Servers cannot be empty")

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -162,41 +162,58 @@ func guardConfigureClient(hc *fasthttp.HostClient) error {
 // used to detect whether a client's ConfigureClient is already our guard.
 var guardHookPtr = reflect.ValueOf(guardConfigureClient).Pointer()
 
-// composedGuards records clients whose own ConfigureClient we have already
-// wrapped, so a client passed repeatedly is composed with only once (a
-// second wrap would nest the guard on every request). Only clients that
-// carry a pre-existing ConfigureClient are stored here; the common case
-// (nil ConfigureClient) is handled by identity and never retains a client.
-var composedGuards sync.Map // map[*fasthttp.Client]struct{}
+// guardMu serializes the read-modify-write of a client's ConfigureClient in
+// ensureClientGuarded. Serializing the whole operation (rather than a
+// LoadOrStore flag) guarantees the guard is actually installed on the field
+// before any concurrent guarder observes the client as "handled", closing
+// the check/install window a second caller could otherwise dispatch
+// through. composedGuards records clients whose own ConfigureClient we have
+// already wrapped, so a client passed repeatedly is composed with only once
+// (a second wrap would nest the guard on every request); it is consulted
+// only under guardMu.
+var (
+	guardMu        sync.Mutex
+	composedGuards = map[*fasthttp.Client]struct{}{}
+)
 
-// ensureClientGuarded installs the SSRF guard on cli via its
-// ConfigureClient hook. Installation is idempotent and, for the common
-// case, lock-free and non-retaining; only a client that already carries its
-// own ConfigureClient takes the sync.Map path so the guard composes with it
-// exactly once.
+// ensureClientGuarded installs the SSRF guard on cli via its ConfigureClient
+// hook. It is invoked at registration for the default client (init) and
+// WithClient clients — before either is used — and on the dispatch path only
+// for a per-call variadic client (the global client is already guarded), so
+// the common no-variadic request path pays nothing here.
 //
-// Guarantee scope: the default client (guarded in init) and WithClient
-// clients (guarded before use) are fully protected. A client supplied as a
-// per-call variadic argument is guarded on first use — but a host it had
-// already dialed keeps its cached, pre-hook HostClient, and mutating a
-// client shared with concurrent non-proxy use is inherently racy. For a
-// full guarantee with a custom client, register it via WithClient before
-// first use, or hand the proxy a dedicated client.
+// Guarantee scope: the default client and WithClient clients are fully
+// protected. A client supplied as a per-call variadic argument is guarded on
+// first use — but a host it had already dialed keeps its cached, pre-hook
+// HostClient, and mutating a client shared with concurrent non-proxy use is
+// inherently racy. For a full guarantee with a custom client, register it
+// via WithClient before first use, or hand the proxy a dedicated client.
 func ensureClientGuarded(cli *fasthttp.Client) {
+	guardMu.Lock()
+	defer guardMu.Unlock()
+
 	existing := cli.ConfigureClient
 	if existing == nil {
 		cli.ConfigureClient = guardConfigureClient
 		return
 	}
 	if reflect.ValueOf(existing).Pointer() == guardHookPtr {
-		return // already guarded
+		return // already our guard
 	}
-	if _, done := composedGuards.LoadOrStore(cli, struct{}{}); done {
-		return
+	if _, done := composedGuards[cli]; done {
+		return // already composed with the user's hook
 	}
+	// Run the user's hook first, then install the guard, so the guard wraps
+	// whatever Dial/DialTimeout the user's hook finally sets — otherwise a
+	// hook that assigns hc.Dial would overwrite the guard and reopen the
+	// SSRF hole.
+	composedGuards[cli] = struct{}{}
 	cli.ConfigureClient = func(hc *fasthttp.HostClient) error {
+		if err := existing(hc); err != nil {
+			return err
+		}
 		installHostClientGuard(hc)
-		return existing(hc)
+		return nil
 	}
 }
 
@@ -319,12 +336,14 @@ func doActionWithPolicy(
 		return err
 	}
 
-	// Install the dial-time SSRF guard on whichever client dispatches this
-	// request (default, WithClient override, or per-call variadic). The
-	// validateUpstream call below only checks the host up front; the guard
-	// re-validates the resolved IP at connect time, closing the
-	// DNS-rebinding window. Idempotent — each client is wrapped once.
-	ensureClientGuarded(cli)
+	// The global client (default or WithClient) is guarded at registration,
+	// so only a per-call variadic override needs guarding here. Skipping the
+	// global client keeps the common request path free of the guard lock.
+	// The guard re-validates the resolved IP at dial time; the
+	// validateUpstream call below is only the up-front host check.
+	if len(clients) != 0 {
+		ensureClientGuarded(cli)
+	}
 
 	// Clone addr once at the parse boundary instead of cloning u.Scheme
 	// and u.String() individually after the fact. url.Parse fills u's

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"errors"
 	"net/url"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -143,31 +144,60 @@ var (
 	errNilGlobalProxyClient   = errors.New("proxy: global client is nil, set a non-nil client with proxy.WithClient")
 )
 
-// guardMu serializes installation of the dial-time SSRF guard onto a
-// client. guardedClients records the *fasthttp.Client values whose Dial
-// has already been wrapped, so ensureClientGuarded wraps each exactly
-// once — a second wrap would compose the guard with itself and re-resolve
-// on every dial for no benefit.
-var (
-	guardMu        sync.Mutex
-	guardedClients = map[*fasthttp.Client]struct{}{}
-)
+// guardConfigureClient is the fasthttp ConfigureClient hook that installs
+// the dial-time SSRF guard on every HostClient a *fasthttp.Client creates.
+// Running at HostClient creation (rather than mutating Client.Dial) means
+// the guard is present before the first dial to each host and covers both
+// the Dial and DialTimeout code paths. It is a stable package-level
+// function value — not a closure — so ensureClientGuarded can recognize an
+// already-guarded client by identity, keeping installation idempotent
+// without retaining a reference to the client (which would pin it, and its
+// connection pool, for the process lifetime).
+func guardConfigureClient(hc *fasthttp.HostClient) error {
+	installHostClientGuard(hc)
+	return nil
+}
 
-// ensureClientGuarded installs the policy-aware dial-time SSRF guard on cli
-// exactly once. Every dispatch path funnels through here before it calls
-// cli.Do, so the wrap — performed under guardMu — establishes a
-// happens-before edge to every later read of cli.Dial by fasthttp; the
-// field is therefore never mutated concurrently with a dial. The guard
-// composes with any dialer the caller already set (see
-// newGuardedClientDialer).
+// guardHookPtr is the code pointer of guardConfigureClient, computed once,
+// used to detect whether a client's ConfigureClient is already our guard.
+var guardHookPtr = reflect.ValueOf(guardConfigureClient).Pointer()
+
+// composedGuards records clients whose own ConfigureClient we have already
+// wrapped, so a client passed repeatedly is composed with only once (a
+// second wrap would nest the guard on every request). Only clients that
+// carry a pre-existing ConfigureClient are stored here; the common case
+// (nil ConfigureClient) is handled by identity and never retains a client.
+var composedGuards sync.Map // map[*fasthttp.Client]struct{}
+
+// ensureClientGuarded installs the SSRF guard on cli via its
+// ConfigureClient hook. Installation is idempotent and, for the common
+// case, lock-free and non-retaining; only a client that already carries its
+// own ConfigureClient takes the sync.Map path so the guard composes with it
+// exactly once.
+//
+// Guarantee scope: the default client (guarded in init) and WithClient
+// clients (guarded before use) are fully protected. A client supplied as a
+// per-call variadic argument is guarded on first use — but a host it had
+// already dialed keeps its cached, pre-hook HostClient, and mutating a
+// client shared with concurrent non-proxy use is inherently racy. For a
+// full guarantee with a custom client, register it via WithClient before
+// first use, or hand the proxy a dedicated client.
 func ensureClientGuarded(cli *fasthttp.Client) {
-	guardMu.Lock()
-	defer guardMu.Unlock()
-	if _, ok := guardedClients[cli]; ok {
+	existing := cli.ConfigureClient
+	if existing == nil {
+		cli.ConfigureClient = guardConfigureClient
 		return
 	}
-	cli.Dial = newGuardedClientDialer(cli.Dial, cli.DialDualStack)
-	guardedClients[cli] = struct{}{}
+	if reflect.ValueOf(existing).Pointer() == guardHookPtr {
+		return // already guarded
+	}
+	if _, done := composedGuards.LoadOrStore(cli, struct{}{}); done {
+		return
+	}
+	cli.ConfigureClient = func(hc *fasthttp.HostClient) error {
+		installHostClientGuard(hc)
+		return existing(hc)
+	}
 }
 
 func init() {
@@ -176,12 +206,11 @@ func init() {
 }
 
 // WithClient sets the global proxy client.
-// This function should be called before Do and Forward.
-//
-// The supplied client is fitted with the dial-time SSRF guard (composing
-// with any Dial it already carries) so requests dispatched through it
-// re-validate the resolved IP at connect time, matching the default
-// client's behavior.
+// This function should be called before Do and Forward — doing so installs
+// the dial-time SSRF guard (via the client's ConfigureClient hook,
+// composing with any hook it already carries) before the client dials any
+// host, so requests dispatched through it re-validate the resolved IP at
+// connect time, matching the default client's behavior.
 func WithClient(cli *fasthttp.Client) {
 	if cli == nil {
 		panic("proxy: WithClient requires a non-nil *fasthttp.Client")

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -167,10 +167,16 @@ var guardHookPtr = reflect.ValueOf(guardConfigureClient).Pointer()
 // LoadOrStore flag) guarantees the guard is actually installed on the field
 // before any concurrent guarder observes the client as "handled", closing
 // the check/install window a second caller could otherwise dispatch
-// through. composedGuards records clients whose own ConfigureClient we have
-// already wrapped, so a client passed repeatedly is composed with only once
-// (a second wrap would nest the guard on every request); it is consulted
-// only under guardMu.
+// through.
+//
+// composedGuards records clients whose own ConfigureClient we wrapped, so a
+// client passed repeatedly is composed with only once (a second wrap would
+// nest the guard on every request). It is consulted only under guardMu.
+// Clients with a nil ConfigureClient — the overwhelming majority — take the
+// identity path below and are NOT stored, so no reference to them is
+// retained. Only a client that carries its own ConfigureClient is retained,
+// one entry per distinct client; reuse such clients (fasthttp's own
+// guidance) or register them via WithClient so this stays bounded.
 var (
 	guardMu        sync.Mutex
 	composedGuards = map[*fasthttp.Client]struct{}{}
@@ -180,7 +186,10 @@ var (
 // hook. It is invoked at registration for the default client (init) and
 // WithClient clients — before either is used — and on the dispatch path only
 // for a per-call variadic client (the global client is already guarded), so
-// the common no-variadic request path pays nothing here.
+// the common no-variadic request path never reaches this lock. A handler
+// built with a fixed variadic client (e.g. Forward(addr, cli)) does take
+// guardMu once per request; that is a deliberate correctness-over-throughput
+// choice (an unlocked fast path would race a first-time writer).
 //
 // Guarantee scope: the default client and WithClient clients are fully
 // protected. A client supplied as a per-call variadic argument is guarded on

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -270,6 +270,14 @@ func Forward(addr string, clients ...*fasthttp.Client) fiber.Handler {
 // installed on the dispatching *fasthttp.Client. The connection therefore
 // targets exactly the address that passed the blocklist, so a
 // rebinding-capable resolver cannot slip a private IP past the check.
+//
+// The guard is installed via the client's ConfigureClient hook, which only
+// affects HostClients created after installation. The default client and
+// WithClient clients are guarded before first use; a client supplied as a
+// per-call variadic override is guarded on first use, so a host it had
+// already dialed keeps a cached, pre-guard HostClient. For a full guarantee
+// with a custom client, register it via WithClient (or pass a dedicated,
+// unused client) before first use.
 func Do(c fiber.Ctx, addr string, clients ...*fasthttp.Client) error {
 	return doAction(c, addr, func(cli *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response, _ *url.URL) error {
 		return cli.Do(req, resp)

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -144,52 +144,57 @@ var (
 	errNilGlobalProxyClient   = errors.New("proxy: global client is nil, set a non-nil client with proxy.WithClient")
 )
 
-// guardConfigureClient is the fasthttp ConfigureClient hook that installs
-// the dial-time SSRF guard on every HostClient a *fasthttp.Client creates.
-// Running at HostClient creation (rather than mutating Client.Dial) means
-// the guard is present before the first dial to each host and covers both
-// the Dial and DialTimeout code paths. It is a stable package-level
-// function value — not a closure — so ensureClientGuarded can recognize an
-// already-guarded client by identity, keeping installation idempotent
-// without retaining a reference to the client (which would pin it, and its
-// connection pool, for the process lifetime).
-func guardConfigureClient(hc *fasthttp.HostClient) error {
+// guardedConfigureClient composes a client's optional pre-existing
+// ConfigureClient hook with the dial-time SSRF guard. It is installed on a
+// *fasthttp.Client as the bound method value (&guardedConfigureClient{…}).run,
+// which fasthttp calls once per HostClient it creates — so the guard is
+// present before the first dial to each host and covers both the Dial and
+// DialTimeout code paths.
+//
+// The bound method's code pointer is stable across receivers (unlike a
+// closure's), so ensureClientGuarded recognizes an already-guarded client by
+// identity — no package-level map keyed by the client, which would pin the
+// client and its connection pool for the process lifetime. The struct is
+// referenced only from the client's own ConfigureClient field, so it is
+// collected together with the client.
+type guardedConfigureClient struct {
+	// orig is the caller's ConfigureClient hook, or nil. It runs before the
+	// guard so the guard wraps whatever Dial/DialTimeout it finally sets —
+	// running it after would let a hook that assigns hc.Dial overwrite the
+	// guard and reopen the SSRF hole.
+	orig func(hc *fasthttp.HostClient) error
+}
+
+func (g *guardedConfigureClient) run(hc *fasthttp.HostClient) error {
+	if g.orig != nil {
+		if err := g.orig(hc); err != nil {
+			return err
+		}
+	}
 	installHostClientGuard(hc)
 	return nil
 }
 
-// guardHookPtr is the code pointer of guardConfigureClient, computed once,
-// used to detect whether a client's ConfigureClient is already our guard.
-var guardHookPtr = reflect.ValueOf(guardConfigureClient).Pointer()
+// guardHookPtr is the code pointer shared by every guardedConfigureClient.run
+// method value, used to detect whether a client is already guarded.
+var guardHookPtr = reflect.ValueOf((&guardedConfigureClient{}).run).Pointer()
 
 // guardMu serializes the read-modify-write of a client's ConfigureClient in
-// ensureClientGuarded. Serializing the whole operation (rather than a
-// LoadOrStore flag) guarantees the guard is actually installed on the field
-// before any concurrent guarder observes the client as "handled", closing
-// the check/install window a second caller could otherwise dispatch
-// through.
-//
-// composedGuards records clients whose own ConfigureClient we wrapped, so a
-// client passed repeatedly is composed with only once (a second wrap would
-// nest the guard on every request). It is consulted only under guardMu.
-// Clients with a nil ConfigureClient — the overwhelming majority — take the
-// identity path below and are NOT stored, so no reference to them is
-// retained. Only a client that carries its own ConfigureClient is retained,
-// one entry per distinct client; reuse such clients (fasthttp's own
-// guidance) or register them via WithClient so this stays bounded.
-var (
-	guardMu        sync.Mutex
-	composedGuards = map[*fasthttp.Client]struct{}{}
-)
+// ensureClientGuarded, so a concurrent guarder cannot write the field mid
+// update or observe it half-installed.
+var guardMu sync.Mutex
 
 // ensureClientGuarded installs the SSRF guard on cli via its ConfigureClient
-// hook. It is invoked at registration for the default client (init) and
-// WithClient clients — before either is used — and on the dispatch path only
-// for a per-call variadic client (the global client is already guarded), so
-// the common no-variadic request path never reaches this lock. A handler
-// built with a fixed variadic client (e.g. Forward(addr, cli)) does take
-// guardMu once per request; that is a deliberate correctness-over-throughput
-// choice (an unlocked fast path would race a first-time writer).
+// hook, exactly once (idempotent: a client already carrying the guard method
+// is left untouched). It composes with any hook the client already has,
+// without retaining a reference to the client. It is invoked at registration
+// for the default client (init) and WithClient clients — before either is
+// used — and on the dispatch path only for a per-call variadic client (the
+// global client is already guarded), so the common no-variadic request path
+// never reaches this lock. A handler built with a fixed variadic client (e.g.
+// Forward(addr, cli)) does take guardMu once per request; that is a deliberate
+// correctness-over-throughput choice (an unlocked fast path would race a
+// first-time writer).
 //
 // Guarantee scope: the default client and WithClient clients are fully
 // protected. A client supplied as a per-call variadic argument is guarded on
@@ -202,28 +207,10 @@ func ensureClientGuarded(cli *fasthttp.Client) {
 	defer guardMu.Unlock()
 
 	existing := cli.ConfigureClient
-	if existing == nil {
-		cli.ConfigureClient = guardConfigureClient
-		return
+	if existing != nil && reflect.ValueOf(existing).Pointer() == guardHookPtr {
+		return // already guarded (directly or composed with a user hook)
 	}
-	if reflect.ValueOf(existing).Pointer() == guardHookPtr {
-		return // already our guard
-	}
-	if _, done := composedGuards[cli]; done {
-		return // already composed with the user's hook
-	}
-	// Run the user's hook first, then install the guard, so the guard wraps
-	// whatever Dial/DialTimeout the user's hook finally sets — otherwise a
-	// hook that assigns hc.Dial would overwrite the guard and reopen the
-	// SSRF hole.
-	composedGuards[cli] = struct{}{}
-	cli.ConfigureClient = func(hc *fasthttp.HostClient) error {
-		if err := existing(hc); err != nil {
-			return err
-		}
-		installHostClientGuard(hc)
-		return nil
-	}
+	cli.ConfigureClient = (&guardedConfigureClient{orig: existing}).run
 }
 
 func init() {

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -528,11 +528,12 @@ func selectClient(globalClient *fasthttp.Client, clients ...*fasthttp.Client) (*
 // DomainForward performs an http request based on the given domain and populates the given http response.
 // This method will return a fiber.Handler.
 //
-// The upstream addr is validated at handler construction (matches the
-// Balancer contract): scheme allowlist, SSRF block, and URL parsing all
-// run once. Misconfigured addresses panic at startup instead of failing
-// per request. Each request also re-validates the host against the
-// current policy before dispatch.
+// The upstream addr is validated at handler construction: scheme allowlist,
+// SSRF block, and URL parsing all run once. Unlike Balancer (which defers
+// DNS to dial time to survive transient resolver failures at startup), this
+// construction check resolves the host, so a misconfigured or unresolvable
+// addr panics at startup instead of failing per request. Each request also
+// re-validates the host against the current policy before dispatch.
 //
 // SSRF note: the per-request validation is an up-front host check, and
 // when AllowPrivateIPs is false the dispatching client's dial-time guard

--- a/middleware/proxy/security.go
+++ b/middleware/proxy/security.go
@@ -86,10 +86,16 @@ type SecurityPolicy struct {
 	// time. Balancer installs a guarded Dial on each HostClient it builds;
 	// the runtime helpers — Do, DoRedirects, DoTimeout, DoDeadline,
 	// Forward, DomainForward, BalancerForward — install the same guard on
-	// the shared/user-supplied *fasthttp.Client they dispatch through. The
-	// only unguarded path is a custom Balancer Config.Client
-	// (*fasthttp.LBClient): its underlying dialers are the caller's
-	// responsibility.
+	// the shared/user-supplied *fasthttp.Client they dispatch through.
+	//
+	// The default client and clients registered via WithClient are guarded
+	// before first use and are fully protected. A client passed as a
+	// per-call variadic argument is guarded on first use, so any host it had
+	// already dialed keeps a cached, pre-guard HostClient; register such a
+	// client via WithClient (or hand the proxy a dedicated, unused client)
+	// for the full guarantee. The only path with no guard at all is a custom
+	// Balancer Config.Client (*fasthttp.LBClient): its underlying dialers
+	// are the caller's responsibility.
 	AllowPrivateIPs bool
 
 	// AllowHTTPSDowngrade permits proxy.DoRedirects to follow redirects

--- a/middleware/proxy/security.go
+++ b/middleware/proxy/security.go
@@ -481,53 +481,98 @@ func dialValidatedIPs(ips []net.IP, host, port string, dialDualStack bool, dial 
 	return nil, lastErr
 }
 
-// newGuardedClientDialer wraps orig with a policy-aware SSRF guard for use
-// on a shared *fasthttp.Client.Dial. Unlike newSSRFDialer — whose blocking
-// is unconditional because Balancer only installs it when the policy
-// forbids private IPs — this dialer is consulted by clients that outlive a
-// single policy snapshot, so it re-reads the active global policy on every
-// dial:
+// installHostClientGuard fits hc with the policy-aware, dial-time SSRF
+// guard. It is installed through fasthttp.Client.ConfigureClient, which
+// runs once per HostClient at creation — so the guard is present before the
+// first dial to that host and, crucially, covers BOTH dial code paths:
+// fasthttp's callDialFunc prefers DialTimeout over Dial, so guarding only
+// Dial would let a client that sets DialTimeout dial unvalidated. We wrap
+// DialTimeout when present (preserving its per-request timeout) and always
+// wrap Dial so the nil-DialTimeout and default-dialer paths are guarded too.
+func installHostClientGuard(hc *fasthttp.HostClient) {
+	if hc.DialTimeout != nil {
+		hc.DialTimeout = newGuardedClientDialerWithTimeout(hc.DialTimeout, hc.DialDualStack)
+	}
+	hc.Dial = newGuardedClientDialer(hc.Dial, hc.DialDualStack)
+}
+
+// guardedDial is the shared core of both dialer guards. When the active
+// policy allows private IPs the caller has opted into internal targets, so
+// it delegates unchanged. Otherwise it resolves and validates the host,
+// then dials the exact validated IP via dialValidated — closing the
+// DNS-rebinding check/use window the up-front validateUpstream lookup
+// leaves open. The policy is read fresh on every dial because a shared
+// client outlives any single policy snapshot.
 //
-//   - When AllowPrivateIPs is true the caller has opted into internal
-//     targets, so the guard delegates: it calls orig when set, otherwise
-//     fasthttp's default dialer, preserving the pre-guard behavior.
-//   - Otherwise it resolves and validates the host, then dials the exact
-//     validated IP (through orig when set), closing the DNS-rebinding
-//     check/use window that the up-front validateUpstream lookup leaves
-//     open.
+//nolint:revive // dialDualStack mirrors fasthttp.Client.DialDualStack
+func guardedDial(
+	addr string,
+	dialDualStack bool,
+	delegate func(addr string) (net.Conn, error),
+	dialValidated ssrfDialFunc,
+) (net.Conn, error) {
+	if currentSecurityPolicy().AllowPrivateIPs {
+		return delegate(addr)
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("proxy: invalid dial address %q: %w", addr, err)
+	}
+	ips, err := resolveAndValidateHost(host)
+	if err != nil {
+		return nil, err
+	}
+	return dialValidatedIPs(ips, host, port, dialDualStack, dialValidated)
+}
+
+// newGuardedClientDialer wraps orig with the SSRF guard. Unlike
+// newSSRFDialer — whose blocking is unconditional because Balancer only
+// installs it when the policy forbids private IPs — this dialer is
+// consulted by clients that outlive a single policy snapshot, so it
+// re-reads the active global policy on every dial. When the caller supplied
+// their own dialer it is run after validation so custom transport is
+// preserved while the connection still targets the validated address; when
+// orig is nil the fasthttp default dialer is used.
 //
 //nolint:revive // dialDualStack mirrors fasthttp.Client.DialDualStack
 func newGuardedClientDialer(orig fasthttp.DialFunc, dialDualStack bool) fasthttp.DialFunc {
 	dialer := &net.Dialer{Timeout: dnsLookupTimeout}
-	return func(addr string) (net.Conn, error) {
-		if currentSecurityPolicy().AllowPrivateIPs {
-			if orig != nil {
-				return orig(addr)
-			}
-			if dialDualStack {
-				return fasthttp.DialDualStack(addr)
-			}
-			return fasthttp.Dial(addr)
-		}
-		host, port, err := net.SplitHostPort(addr)
-		if err != nil {
-			return nil, fmt.Errorf("proxy: invalid dial address %q: %w", addr, err)
-		}
-		ips, err := resolveAndValidateHost(host)
-		if err != nil {
-			return nil, err
-		}
-		// Dial the validated IP directly. When the caller supplied their
-		// own dialer, run it after validation so custom transport (proxies,
-		// timeouts) is preserved while the connection still targets the
-		// address that passed the blocklist.
-		dial := dialer.Dial
+	delegate := func(addr string) (net.Conn, error) {
 		if orig != nil {
-			dial = func(_, address string) (net.Conn, error) {
-				return orig(address)
-			}
+			return orig(addr)
 		}
-		return dialValidatedIPs(ips, host, port, dialDualStack, dial)
+		if dialDualStack {
+			return fasthttp.DialDualStack(addr)
+		}
+		return fasthttp.Dial(addr)
+	}
+	dialValidated := func(_, address string) (net.Conn, error) {
+		if orig != nil {
+			return orig(address)
+		}
+		return dialer.Dial("tcp", address)
+	}
+	return func(addr string) (net.Conn, error) {
+		return guardedDial(addr, dialDualStack, delegate, dialValidated)
+	}
+}
+
+// newGuardedClientDialerWithTimeout is the DialFuncWithTimeout counterpart
+// of newGuardedClientDialer. orig is always non-nil here (installed only
+// when the HostClient already carries a DialTimeout), and the per-request
+// timeout is threaded through both the delegate and the validated dial so
+// the caller's timeout semantics survive the guard.
+//
+//nolint:revive // dialDualStack mirrors fasthttp.Client.DialDualStack
+func newGuardedClientDialerWithTimeout(orig fasthttp.DialFuncWithTimeout, dialDualStack bool) fasthttp.DialFuncWithTimeout {
+	return func(addr string, timeout time.Duration) (net.Conn, error) {
+		delegate := func(a string) (net.Conn, error) {
+			return orig(a, timeout)
+		}
+		dialValidated := func(_, address string) (net.Conn, error) {
+			return orig(address, timeout)
+		}
+		return guardedDial(addr, dialDualStack, delegate, dialValidated)
 	}
 }
 

--- a/middleware/proxy/security.go
+++ b/middleware/proxy/security.go
@@ -131,9 +131,18 @@ func DefaultSecurityPolicy() SecurityPolicy {
 // mutation by the caller.
 var activePolicy atomic.Pointer[SecurityPolicy]
 
+// dnsResolver is the resolver used for SSRF validation lookups. It defaults
+// to net.DefaultResolver and is only ever swapped by tests, atomically, so a
+// concurrent validation lookup never races the swap. Tests use this seam
+// rather than mutating the process-global net.DefaultResolver — which
+// fasthttp and the net package read from background dial goroutines, making a
+// direct swap a data race under -race.
+var dnsResolver atomic.Pointer[net.Resolver]
+
 func init() {
 	def := DefaultSecurityPolicy()
 	activePolicy.Store(&def)
+	dnsResolver.Store(net.DefaultResolver)
 }
 
 // normalizePolicy returns a copy of policy whose AllowedSchemes slice is
@@ -384,7 +393,7 @@ func validateHostForSSRF(host string) error {
 	// Bound the lookup so a slow resolver cannot stall the caller.
 	ctx, cancel := context.WithTimeout(context.Background(), dnsLookupTimeout)
 	defer cancel()
-	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	addrs, err := dnsResolver.Load().LookupIPAddr(ctx, host)
 	if err != nil {
 		return fmt.Errorf("%w: %s lookup failed: %w", ErrUpstreamHostBlocked, host, err)
 	}
@@ -434,7 +443,7 @@ func resolveAndValidateHost(host string) ([]net.IP, error) {
 	} else {
 		ctx, cancel := context.WithTimeout(context.Background(), dnsLookupTimeout)
 		defer cancel()
-		resolved, lerr := net.DefaultResolver.LookupIPAddr(ctx, host)
+		resolved, lerr := dnsResolver.Load().LookupIPAddr(ctx, host)
 		if lerr != nil {
 			return nil, fmt.Errorf("%w: %s lookup failed: %w", ErrUpstreamHostBlocked, host, lerr)
 		}

--- a/middleware/proxy/security.go
+++ b/middleware/proxy/security.go
@@ -545,9 +545,16 @@ func guardedDial(
 // installs it when the policy forbids private IPs — this dialer is
 // consulted by clients that outlive a single policy snapshot, so it
 // re-reads the active global policy on every dial. When the caller supplied
-// their own dialer it is run after validation so custom transport is
-// preserved while the connection still targets the validated address; when
-// orig is nil the fasthttp default dialer is used.
+// their own dialer it is run in both paths so custom transport is preserved
+// while a blocked-policy connection still targets the validated address.
+//
+// When orig is nil the two paths differ, matching newSSRFDialer: the
+// delegate (private-IPs-allowed) path hands the raw address to fasthttp's
+// default dialer (Dial/DialDualStack), while the validated (blocked-policy)
+// path connects to the already-checked IP with a net.Dialer bounded by
+// dnsLookupTimeout — fasthttp.Dial is not reused there because the target is
+// a literal IP that needs no re-resolution and the explicit timeout bounds
+// the connect.
 //
 //nolint:revive // dialDualStack mirrors fasthttp.Client.DialDualStack
 func newGuardedClientDialer(orig fasthttp.DialFunc, dialDualStack bool) fasthttp.DialFunc {

--- a/middleware/proxy/security.go
+++ b/middleware/proxy/security.go
@@ -80,15 +80,16 @@ type SecurityPolicy struct {
 	// to SSRF attacks against internal services such as cloud
 	// metadata endpoints. Default: false.
 	//
-	// DNS-rebinding scope: when false, Balancer re-validates the resolved
-	// IP at dial time (it installs a guarded Dial on each HostClient it
-	// constructs), which closes the check/use window a malicious resolver
-	// could exploit. The runtime helpers — Do, DoRedirects, DoTimeout,
-	// DoDeadline, Forward, DomainForward, BalancerForward — validate the
-	// host up front but then dispatch through the shared/user-supplied
-	// *fasthttp.Client, which re-resolves the name without the guard.
-	// Against a rebinding-capable resolver they are therefore not fully
-	// mitigated; see the note on those functions.
+	// DNS-rebinding scope: when false, the resolved IP is re-validated at
+	// dial time, not only up front, so a malicious resolver cannot swap a
+	// public answer (seen during validation) for a private one at connect
+	// time. Balancer installs a guarded Dial on each HostClient it builds;
+	// the runtime helpers — Do, DoRedirects, DoTimeout, DoDeadline,
+	// Forward, DomainForward, BalancerForward — install the same guard on
+	// the shared/user-supplied *fasthttp.Client they dispatch through. The
+	// only unguarded path is a custom Balancer Config.Client
+	// (*fasthttp.LBClient): its underlying dialers are the caller's
+	// responsibility.
 	AllowPrivateIPs bool
 
 	// AllowHTTPSDowngrade permits proxy.DoRedirects to follow redirects
@@ -478,6 +479,56 @@ func dialValidatedIPs(ips []net.IP, host, port string, dialDualStack bool, dial 
 		lastErr = fmt.Errorf("%w: %s has no usable address", ErrUpstreamHostBlocked, host)
 	}
 	return nil, lastErr
+}
+
+// newGuardedClientDialer wraps orig with a policy-aware SSRF guard for use
+// on a shared *fasthttp.Client.Dial. Unlike newSSRFDialer — whose blocking
+// is unconditional because Balancer only installs it when the policy
+// forbids private IPs — this dialer is consulted by clients that outlive a
+// single policy snapshot, so it re-reads the active global policy on every
+// dial:
+//
+//   - When AllowPrivateIPs is true the caller has opted into internal
+//     targets, so the guard delegates: it calls orig when set, otherwise
+//     fasthttp's default dialer, preserving the pre-guard behavior.
+//   - Otherwise it resolves and validates the host, then dials the exact
+//     validated IP (through orig when set), closing the DNS-rebinding
+//     check/use window that the up-front validateUpstream lookup leaves
+//     open.
+//
+//nolint:revive // dialDualStack mirrors fasthttp.Client.DialDualStack
+func newGuardedClientDialer(orig fasthttp.DialFunc, dialDualStack bool) fasthttp.DialFunc {
+	dialer := &net.Dialer{Timeout: dnsLookupTimeout}
+	return func(addr string) (net.Conn, error) {
+		if currentSecurityPolicy().AllowPrivateIPs {
+			if orig != nil {
+				return orig(addr)
+			}
+			if dialDualStack {
+				return fasthttp.DialDualStack(addr)
+			}
+			return fasthttp.Dial(addr)
+		}
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("proxy: invalid dial address %q: %w", addr, err)
+		}
+		ips, err := resolveAndValidateHost(host)
+		if err != nil {
+			return nil, err
+		}
+		// Dial the validated IP directly. When the caller supplied their
+		// own dialer, run it after validation so custom transport (proxies,
+		// timeouts) is preserved while the connection still targets the
+		// address that passed the blocklist.
+		dial := dialer.Dial
+		if orig != nil {
+			dial = func(_, address string) (net.Conn, error) {
+				return orig(address)
+			}
+		}
+		return dialValidatedIPs(ips, host, port, dialDualStack, dial)
+	}
 }
 
 // isBlockedIP reports whether ip falls inside a range that proxy

--- a/middleware/proxy/security.go
+++ b/middleware/proxy/security.go
@@ -579,7 +579,9 @@ func newGuardedClientDialerWithTimeout(orig fasthttp.DialFuncWithTimeout, dialDu
 // isBlockedIP reports whether ip falls inside a range that proxy
 // upstreams must not reach by default. Loopback, unspecified, RFC 1918
 // private, link-local (including the 169.254.169.254 cloud-metadata
-// address), multicast, and RFC 6598 CGNAT ranges are blocked.
+// address), multicast, and RFC 6598 CGNAT ranges are blocked. IPv4-compatible
+// and NAT64 IPv6 wrappers are unwrapped so a blocked IPv4 cannot be smuggled
+// past as an IPv6 literal.
 func isBlockedIP(ip net.IP) bool {
 	if ip == nil {
 		return true
@@ -592,7 +594,48 @@ func isBlockedIP(ip net.IP) bool {
 	if v4 := ip.To4(); v4 != nil && v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
 		return true
 	}
+	// Look through IPv4-compatible (::a.b.c.d) and NAT64 (64:ff9b::a.b.c.d)
+	// IPv6 wrappers to the embedded IPv4 and apply the same blocklist. Some
+	// stacks route these to the embedded address, so a private target could
+	// otherwise be reached via such a literal (the IPv4-mapped ::ffff:a.b.c.d
+	// form is already handled above because net.IP.To4 exposes it).
+	if embedded := embeddedIPv4(ip); embedded != nil && isBlockedIP(embedded) {
+		return true
+	}
 	return false
+}
+
+// embeddedIPv4 returns the IPv4 address embedded in an IPv4-compatible IPv6
+// address (::a.b.c.d, RFC 4291) or a well-known-prefix NAT64 address
+// (64:ff9b::a.b.c.d, RFC 6052), or nil for anything else. The IPv4-mapped
+// form (::ffff:a.b.c.d) is deliberately excluded here: net.IP.To4 already
+// surfaces its IPv4, so isBlockedIP checks it directly.
+func embeddedIPv4(ip net.IP) net.IP {
+	ip16 := ip.To16()
+	if ip16 == nil || ip.To4() != nil {
+		return nil
+	}
+	// NAT64 well-known prefix 64:ff9b::/96.
+	if ip16[0] == 0x00 && ip16[1] == 0x64 && ip16[2] == 0xff && ip16[3] == 0x9b &&
+		allZero(ip16[4:12]) {
+		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+	}
+	// IPv4-compatible ::a.b.c.d (first 12 bytes zero). :: and ::1 have already
+	// been classified above, so treat any remaining all-zero-prefix address as
+	// a wrapper around its trailing IPv4.
+	if allZero(ip16[:12]) {
+		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+	}
+	return nil
+}
+
+func allZero(b []byte) bool {
+	for _, x := range b {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // secureTLSConfig returns a clone of cfg with a TLS 1.2 floor. The

--- a/middleware/proxy/security_rebinding_test.go
+++ b/middleware/proxy/security_rebinding_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -399,4 +400,86 @@ func Test_Security_NewGuardedClientDialer_DelegatesWhenPrivateAllowed(t *testing
 	conn, err := dial(ln.Addr().String())
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
+}
+
+// Test_Security_NewGuardedClientDialer_DelegatesDualStack covers the
+// AllowPrivateIPs delegate branch with DialDualStack enabled (fasthttp's
+// DialDualStack fallback).
+func Test_Security_NewGuardedClientDialer_DelegatesDualStack(t *testing.T) {
+	policy := DefaultSecurityPolicy()
+	policy.AllowPrivateIPs = true
+	withSecurityPolicyForTest(t, policy)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close() //nolint:errcheck // best-effort close
+
+	conn, err := newGuardedClientDialer(nil, true)(ln.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+}
+
+// Test_Security_NewGuardedClientDialer_RejectsMalformedAddr covers the
+// SplitHostPort error branch of guardedDial.
+func Test_Security_NewGuardedClientDialer_RejectsMalformedAddr(t *testing.T) {
+	withSecurityPolicyForTest(t, DefaultSecurityPolicy()) // AllowPrivateIPs == false
+
+	_, err := newGuardedClientDialer(nil, false)("no-port-here")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrUpstreamHostBlocked)
+}
+
+// Test_Security_NewGuardedClientDialerWithTimeout_Delegates covers the
+// DialFuncWithTimeout guard's delegate branch: when private IPs are allowed
+// it forwards the raw addr and timeout to the caller's dialer.
+func Test_Security_NewGuardedClientDialerWithTimeout_Delegates(t *testing.T) {
+	policy := DefaultSecurityPolicy()
+	policy.AllowPrivateIPs = true
+	withSecurityPolicyForTest(t, policy)
+
+	var got string
+	orig := func(addr string, _ time.Duration) (net.Conn, error) {
+		got = addr
+		return stubConn{addr: addr}, nil
+	}
+	conn, err := newGuardedClientDialerWithTimeout(orig, false)("10.0.0.1:80", time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Equal(t, "10.0.0.1:80", got)
+}
+
+// Test_Security_NewGuardedClientDialerWithTimeout_ValidatedDialsThrough covers
+// the strict-policy path of the DialFuncWithTimeout guard: a hostname that
+// resolves to a public IP is validated and dialed through the caller's
+// timeout dialer at the exact resolved IP.
+func Test_Security_NewGuardedClientDialerWithTimeout_ValidatedDialsThrough(t *testing.T) {
+	withSecurityPolicyForTest(t, DefaultSecurityPolicy()) // AllowPrivateIPs == false
+
+	dnsAddr, _ := startRebindingDNS(t, net.IPv4(198, 51, 100, 7), net.IPv4(198, 51, 100, 7))
+	withRebindingResolver(t, dnsAddr)
+
+	var got string
+	orig := func(addr string, _ time.Duration) (net.Conn, error) {
+		got = addr
+		return stubConn{addr: addr}, nil
+	}
+	conn, err := newGuardedClientDialerWithTimeout(orig, false)("public.test:80", time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Equal(t, "198.51.100.7:80", got, "must dial the validated resolved IP")
+}
+
+// Test_Security_EnsureClientGuarded_ComposePropagatesError verifies the
+// composed hook surfaces an error from the user's existing ConfigureClient.
+func Test_Security_EnsureClientGuarded_ComposePropagatesError(t *testing.T) {
+	withSecurityPolicyForTest(t, DefaultSecurityPolicy()) // AllowPrivateIPs == false
+
+	wantErr := errors.New("configure boom")
+	cli := &fasthttp.Client{
+		ConfigureClient: func(_ *fasthttp.HostClient) error { return wantErr },
+	}
+	ensureClientGuarded(cli)
+
+	err := cli.ConfigureClient(&fasthttp.HostClient{})
+	require.ErrorIs(t, err, wantErr)
 }

--- a/middleware/proxy/security_rebinding_test.go
+++ b/middleware/proxy/security_rebinding_test.go
@@ -33,7 +33,7 @@ func startRebindingDNS(t *testing.T, firstIP, rebindIP net.IP) string {
 
 	var (
 		mu       sync.Mutex
-		answered bool
+		answered = map[string]bool{}
 	)
 
 	go func() {
@@ -56,12 +56,16 @@ func startRebindingDNS(t *testing.T, firstIP, rebindIP net.IP) string {
 
 			var answer net.IP
 			if q.Type == dnsmessage.TypeA {
+				// Track "first answer" per queried name so a stray lookup for
+				// some other name cannot consume the target name's public
+				// (validation-time) answer and mask a broken dial-time guard.
+				name := q.Name.String()
 				mu.Lock()
-				if answered {
+				if answered[name] {
 					answer = rebindIP
 				} else {
 					answer = firstIP
-					answered = true
+					answered[name] = true
 				}
 				mu.Unlock()
 			}
@@ -158,6 +162,12 @@ func Test_Security_Do_BlocksDNSRebinding(t *testing.T) {
 			}
 			return Do(c, target, cli)
 		},
+		// DoRedirects dispatches through the same guarded client; the first
+		// hop's dial must be blocked. Pins that the redirect path (and its
+		// per-hop cli.Do) is guarded too.
+		"DoRedirects": func(c fiber.Ctx, target string) error {
+			return DoRedirects(c, target, 3)
+		},
 	}
 
 	for name, do := range dispatch {
@@ -232,18 +242,56 @@ func Test_Security_NewGuardedClientDialer_ComposesWithOrig(t *testing.T) {
 	require.Equal(t, "203.0.113.5:80", got)
 }
 
+// Test_Security_NewGuardedClientDialer_AllowsValidatedHostname is the
+// positive-path counterpart to the rebinding test: under the strict policy, a
+// hostname that resolves to a public (non-blocked) address must resolve,
+// validate, and dial through to that exact IP — proving the guard does not
+// over-block legitimate upstreams. Every end-to-end suite test runs with
+// AllowPrivateIPs=true (the delegate branch), so this is the only coverage of
+// the resolve→validate→dial success path.
+func Test_Security_NewGuardedClientDialer_AllowsValidatedHostname(t *testing.T) {
+	withSecurityPolicyForTest(t, DefaultSecurityPolicy()) // AllowPrivateIPs == false
+
+	// Resolver maps the name to a public IP on every answer (no rebinding).
+	dnsAddr := startRebindingDNS(t, net.IPv4(198, 51, 100, 7), net.IPv4(198, 51, 100, 7))
+	withRebindingResolver(t, dnsAddr)
+
+	var got string
+	orig := func(addr string) (net.Conn, error) {
+		got = addr
+		return stubConn{addr: addr}, nil
+	}
+
+	dial := newGuardedClientDialer(orig, false)
+	conn, err := dial("public.test:80")
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Equal(t, "198.51.100.7:80", got, "must dial the validated resolved IP")
+}
+
 // Test_Security_EnsureClientGuarded_ComposesAndIsIdempotent verifies that
 // installing the guard on a client that already carries its own
-// ConfigureClient hook composes with it (the original still runs) and that
-// repeated installation does not nest the wrapper — each HostClient gets the
-// guard and the original hook exactly once.
+// ConfigureClient hook composes with it (the original still runs, exactly
+// once, not nested on repeated installs) AND that the guard is the outermost
+// dialer even when the user's hook installs its own hc.Dial — i.e. the
+// composition order is existing-then-guard. A guard-then-existing order would
+// let the user's dialer overwrite the guard and reopen the SSRF hole, so this
+// test is the regression guard for that ordering.
 func Test_Security_EnsureClientGuarded_ComposesAndIsIdempotent(t *testing.T) {
 	withSecurityPolicyForTest(t, DefaultSecurityPolicy()) // AllowPrivateIPs == false
 
 	called := 0
+	userDialed := false
 	cli := &fasthttp.Client{
-		ConfigureClient: func(_ *fasthttp.HostClient) error {
+		ConfigureClient: func(hc *fasthttp.HostClient) error {
 			called++
+			// A user hook that installs its own (unguarded) dialer — the
+			// canonical reason to use ConfigureClient. The guard must run
+			// after this and wrap it.
+			hc.Dial = func(addr string) (net.Conn, error) {
+				userDialed = true
+				return stubConn{addr: addr}, nil
+			}
 			return nil
 		},
 	}
@@ -256,9 +304,51 @@ func Test_Security_EnsureClientGuarded_ComposesAndIsIdempotent(t *testing.T) {
 	require.Equal(t, 1, called, "original ConfigureClient must run exactly once per HostClient")
 	require.NotNil(t, hc.Dial, "guard must install a dial-time Dial")
 
-	// The installed Dial must block a loopback target under the strict policy.
+	// A loopback target must be blocked BEFORE the user's dialer runs: proves
+	// the guard wraps the user's final Dial (order is existing-then-guard).
 	_, err := hc.Dial("127.0.0.1:80")
 	require.ErrorIs(t, err, ErrUpstreamHostBlocked)
+	require.False(t, userDialed, "guard must reject a blocked IP before delegating to the user's dialer")
+
+	// A validated (public) target must delegate through to the user's dialer.
+	_, err = hc.Dial("203.0.113.9:80") // TEST-NET-3, not blocked
+	require.NoError(t, err)
+	require.True(t, userDialed, "guard must delegate an allowed IP to the user's dialer")
+}
+
+// Test_Security_EnsureClientGuarded_ConcurrentIsSafe pins that guarding the
+// same client from many goroutines is race-free (run under -race) and
+// idempotent, for both the nil-ConfigureClient and pre-existing-hook paths.
+// Regression guard for the serializing mutex in ensureClientGuarded.
+func Test_Security_EnsureClientGuarded_ConcurrentIsSafe(t *testing.T) {
+	withSecurityPolicyForTest(t, DefaultSecurityPolicy()) // AllowPrivateIPs == false
+
+	cases := map[string]func(*fasthttp.HostClient) error{
+		"nil ConfigureClient":          nil,
+		"pre-existing ConfigureClient": func(_ *fasthttp.HostClient) error { return nil },
+	}
+
+	for name, hook := range cases {
+		t.Run(name, func(t *testing.T) {
+			cli := &fasthttp.Client{ConfigureClient: hook}
+
+			var wg sync.WaitGroup
+			for range 32 {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					ensureClientGuarded(cli)
+				}()
+			}
+			wg.Wait()
+
+			hc := &fasthttp.HostClient{}
+			require.NoError(t, cli.ConfigureClient(hc))
+			require.NotNil(t, hc.Dial)
+			_, err := hc.Dial("127.0.0.1:80")
+			require.ErrorIs(t, err, ErrUpstreamHostBlocked)
+		})
+	}
 }
 
 // Test_Security_InstallHostClientGuard_GuardsDialTimeout verifies both dial

--- a/middleware/proxy/security_rebinding_test.go
+++ b/middleware/proxy/security_rebinding_test.go
@@ -1,0 +1,240 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+// startRebindingDNS starts a loopback UDP DNS server that answers A queries
+// for any name. The very first A answer is firstIP (a public-looking
+// address that passes the SSRF blocklist); every A answer after that is
+// rebindIP (the "internal" target). AAAA queries are answered with an empty
+// NODATA response so the Go resolver falls back to the A record. This
+// reproduces a classic DNS-rebinding resolver: safe on the validation
+// lookup, hostile on the dial-time lookup. It returns the server's
+// "host:port" address.
+func startRebindingDNS(t *testing.T, firstIP, rebindIP net.IP) string {
+	t.Helper()
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pc.Close() })
+
+	var (
+		mu       sync.Mutex
+		answered bool
+	)
+
+	go func() {
+		buf := make([]byte, 512)
+		for {
+			n, addr, rerr := pc.ReadFrom(buf)
+			if rerr != nil {
+				return // listener closed
+			}
+
+			var p dnsmessage.Parser
+			hdr, perr := p.Start(buf[:n])
+			if perr != nil {
+				continue
+			}
+			q, perr := p.Question()
+			if perr != nil {
+				continue
+			}
+
+			var answer net.IP
+			if q.Type == dnsmessage.TypeA {
+				mu.Lock()
+				if answered {
+					answer = rebindIP
+				} else {
+					answer = firstIP
+					answered = true
+				}
+				mu.Unlock()
+			}
+
+			resp, berr := buildDNSResponse(hdr.ID, q, answer)
+			if berr != nil {
+				continue
+			}
+			_, _ = pc.WriteTo(resp, addr)
+		}
+	}()
+
+	return pc.LocalAddr().String()
+}
+
+// buildDNSResponse serializes a DNS reply echoing the question. When ip is
+// a non-nil IPv4 address an A record is included; otherwise the reply is a
+// NODATA answer (used for AAAA queries).
+func buildDNSResponse(id uint16, q dnsmessage.Question, ip net.IP) ([]byte, error) {
+	b := dnsmessage.NewBuilder(nil, dnsmessage.Header{
+		ID:            id,
+		Response:      true,
+		Authoritative: true,
+	})
+	b.EnableCompression()
+	if err := b.StartQuestions(); err != nil {
+		return nil, err
+	}
+	if err := b.Question(q); err != nil {
+		return nil, err
+	}
+	if err := b.StartAnswers(); err != nil {
+		return nil, err
+	}
+	if v4 := ip.To4(); v4 != nil {
+		var a [4]byte
+		copy(a[:], v4)
+		if err := b.AResource(dnsmessage.ResourceHeader{
+			Name:  q.Name,
+			Type:  dnsmessage.TypeA,
+			Class: dnsmessage.ClassINET,
+		}, dnsmessage.AResource{A: a}); err != nil {
+			return nil, err
+		}
+	}
+	return b.Finish()
+}
+
+// withRebindingResolver points net.DefaultResolver at the fake DNS server
+// at dnsAddr for the duration of t, restoring the previous resolver via
+// t.Cleanup. Tests using it must not call t.Parallel: net.DefaultResolver
+// is process-global.
+func withRebindingResolver(t *testing.T, dnsAddr string) {
+	t.Helper()
+	prev := net.DefaultResolver
+	net.DefaultResolver = &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "udp", dnsAddr)
+		},
+	}
+	t.Cleanup(func() { net.DefaultResolver = prev })
+}
+
+// Test_Security_Do_BlocksDNSRebinding is the regression test for the
+// DNS-rebinding SSRF: the up-front validation lookup sees a public IP and
+// passes, but the dial-time guard re-resolves the name, sees the rebound
+// loopback address, and blocks the connection before the "internal" server
+// is reached. Covered for both the shared default client and a per-call
+// custom client (proving auto-guarding covers user-supplied clients).
+func Test_Security_Do_BlocksDNSRebinding(t *testing.T) {
+	// Not parallel: mutates the global resolver and security policy.
+	withSecurityPolicyForTest(t, DefaultSecurityPolicy()) // AllowPrivateIPs == false
+
+	// dispatch names the client path under test. Each subtest gets a fresh
+	// fake DNS server (fresh rebinding state) so the up-front lookup always
+	// sees the public answer and the block genuinely happens at dial time —
+	// not because a shared resolver already flipped to the loopback answer.
+	dispatch := map[string]func(c fiber.Ctx, target string) error{
+		"default client": func(c fiber.Ctx, target string) error {
+			return Do(c, target)
+		},
+		"custom client": func(c fiber.Ctx, target string) error {
+			return Do(c, target, &fasthttp.Client{})
+		},
+	}
+
+	for name, do := range dispatch {
+		t.Run(name, func(t *testing.T) {
+			// The "internal" service the attacker wants to reach.
+			_, internalAddr := createProxyTestServerIPv4(t, func(c fiber.Ctx) error {
+				return c.SendString("SECRET_INTERNAL_DATA")
+			})
+			_, internalPort, err := net.SplitHostPort(internalAddr)
+			require.NoError(t, err)
+
+			// 1st A answer is public TEST-NET-2 (passes the blocklist); every
+			// A answer after that is loopback (the internal port).
+			dnsAddr := startRebindingDNS(t, net.IPv4(198, 51, 100, 1), net.IPv4(127, 0, 0, 1))
+			withRebindingResolver(t, dnsAddr)
+
+			target := "http://rebind.test:" + internalPort + "/"
+
+			app := fiber.New()
+			app.Get("/", func(c fiber.Ctx) error { return do(c, target) })
+
+			resp, err := app.Test(
+				httptest.NewRequest(fiber.MethodGet, "/", http.NoBody),
+				fiber.TestConfig{Timeout: 10 * time.Second, FailOnTimeout: false},
+			)
+			require.NoError(t, err)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+
+			// The dial-time guard must reject the rebound loopback address,
+			// so the internal secret is never proxied back.
+			require.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+			require.NotContains(t, string(body), "SECRET_INTERNAL_DATA")
+			require.Contains(t, string(body), "blocked")
+		})
+	}
+}
+
+// Test_Security_NewGuardedClientDialer_BlocksWhenPrivateDisallowed verifies
+// the composable client guard rejects loopback targets — literal and
+// hostname — when the active policy forbids private IPs.
+func Test_Security_NewGuardedClientDialer_BlocksWhenPrivateDisallowed(t *testing.T) {
+	withSecurityPolicyForTest(t, DefaultSecurityPolicy()) // AllowPrivateIPs == false
+
+	dial := newGuardedClientDialer(nil, false)
+
+	_, err := dial("127.0.0.1:80")
+	require.ErrorIs(t, err, ErrUpstreamHostBlocked)
+
+	_, err = dial("localhost:80")
+	require.ErrorIs(t, err, ErrUpstreamHostBlocked)
+}
+
+// Test_Security_NewGuardedClientDialer_ComposesWithOrig verifies that, for
+// an allowed (public) target, the guard dials the validated address through
+// the caller-supplied dialer instead of establishing its own connection.
+func Test_Security_NewGuardedClientDialer_ComposesWithOrig(t *testing.T) {
+	withSecurityPolicyForTest(t, DefaultSecurityPolicy()) // AllowPrivateIPs == false
+
+	var got string
+	orig := func(addr string) (net.Conn, error) {
+		got = addr
+		return stubConn{addr: addr}, nil
+	}
+
+	dial := newGuardedClientDialer(orig, false)
+	conn, err := dial("203.0.113.5:80") // TEST-NET-3, not blocked
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Equal(t, "203.0.113.5:80", got)
+}
+
+// Test_Security_NewGuardedClientDialer_DelegatesWhenPrivateAllowed verifies
+// that when the operator opts into private targets the guard delegates to a
+// normal dial, so loopback connections still succeed.
+func Test_Security_NewGuardedClientDialer_DelegatesWhenPrivateAllowed(t *testing.T) {
+	policy := DefaultSecurityPolicy()
+	policy.AllowPrivateIPs = true
+	withSecurityPolicyForTest(t, policy)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+
+	dial := newGuardedClientDialer(nil, false)
+	conn, err := dial(ln.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+}

--- a/middleware/proxy/security_rebinding_test.go
+++ b/middleware/proxy/security_rebinding_test.go
@@ -125,20 +125,22 @@ func buildDNSResponse(id uint16, q *dnsmessage.Question, ip net.IP) ([]byte, err
 	return out, nil
 }
 
-// withRebindingResolver points net.DefaultResolver at the fake DNS server
-// at dnsAddr for the duration of t, restoring the previous resolver via
-// t.Cleanup. Tests using it must not call t.Parallel: net.DefaultResolver
-// is process-global.
+// withRebindingResolver points the proxy's SSRF-validation resolver at the
+// fake DNS server at dnsAddr for the duration of t, restoring the previous
+// resolver via t.Cleanup. It swaps the package's atomic dnsResolver seam
+// rather than the process-global net.DefaultResolver, so it does not race the
+// DNS lookups other tests' background dial goroutines perform. Tests using it
+// must not call t.Parallel: the seam is process-global.
 func withRebindingResolver(t *testing.T, dnsAddr string) {
 	t.Helper()
-	prev := net.DefaultResolver
-	net.DefaultResolver = &net.Resolver{
+	prev := dnsResolver.Load()
+	dnsResolver.Store(&net.Resolver{
 		PreferGo: true,
 		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, "udp", dnsAddr)
 		},
-	}
-	t.Cleanup(func() { net.DefaultResolver = prev })
+	})
+	t.Cleanup(func() { dnsResolver.Store(prev) })
 }
 
 // Test_Security_Do_BlocksDNSRebinding is the regression test for the

--- a/middleware/proxy/security_rebinding_test.go
+++ b/middleware/proxy/security_rebinding_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,19 +18,23 @@ import (
 )
 
 // startRebindingDNS starts a loopback UDP DNS server that answers A queries
-// for any name. The very first A answer is firstIP (a public-looking
-// address that passes the SSRF blocklist); every A answer after that is
-// rebindIP (the "internal" target). AAAA queries are answered with an empty
-// NODATA response so the Go resolver falls back to the A record. This
-// reproduces a classic DNS-rebinding resolver: safe on the validation
-// lookup, hostile on the dial-time lookup. It returns the server's
-// "host:port" address.
-func startRebindingDNS(t *testing.T, firstIP, rebindIP net.IP) string {
+// for any name. The very first A answer for a given name is firstIP (a
+// public-looking address that passes the SSRF blocklist); every A answer
+// after that is rebindIP (the "internal" target). AAAA queries are answered
+// with an empty NODATA response so the Go resolver falls back to the A
+// record. This reproduces a classic DNS-rebinding resolver: safe on the
+// validation lookup, hostile on the dial-time lookup. It returns the
+// server's "host:port" address and a counter of A queries served, which a
+// test can assert is >= 2 to prove the block happened at dial time (a second
+// lookup) rather than up front (the first, public, lookup).
+func startRebindingDNS(t *testing.T, firstIP, rebindIP net.IP) (string, *atomic.Int64) {
 	t.Helper()
 
 	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = pc.Close() })
+
+	aQueries := &atomic.Int64{}
 
 	var (
 		mu       sync.Mutex
@@ -56,6 +61,7 @@ func startRebindingDNS(t *testing.T, firstIP, rebindIP net.IP) string {
 
 			var answer net.IP
 			if q.Type == dnsmessage.TypeA {
+				aQueries.Add(1)
 				// Track "first answer" per queried name so a stray lookup for
 				// some other name cannot consume the target name's public
 				// (validation-time) answer and mask a broken dial-time guard.
@@ -78,7 +84,7 @@ func startRebindingDNS(t *testing.T, firstIP, rebindIP net.IP) string {
 		}
 	}()
 
-	return pc.LocalAddr().String()
+	return pc.LocalAddr().String(), aQueries
 }
 
 // buildDNSResponse serializes a DNS reply echoing the question. When ip is
@@ -181,7 +187,7 @@ func Test_Security_Do_BlocksDNSRebinding(t *testing.T) {
 
 			// 1st A answer is public TEST-NET-2 (passes the blocklist); every
 			// A answer after that is loopback (the internal port).
-			dnsAddr := startRebindingDNS(t, net.IPv4(198, 51, 100, 1), net.IPv4(127, 0, 0, 1))
+			dnsAddr, aQueries := startRebindingDNS(t, net.IPv4(198, 51, 100, 1), net.IPv4(127, 0, 0, 1))
 			withRebindingResolver(t, dnsAddr)
 
 			target := "http://rebind.test:" + internalPort + "/"
@@ -204,6 +210,12 @@ func Test_Security_Do_BlocksDNSRebinding(t *testing.T) {
 			require.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
 			require.NotContains(t, string(body), "SECRET_INTERNAL_DATA")
 			require.Contains(t, string(body), "blocked")
+			// >= 2 A lookups proves the up-front validation lookup (public,
+			// allowed) happened AND a second dial-time lookup (rebound,
+			// blocked) happened — i.e. the block is genuinely at dial time,
+			// not an up-front block masking a broken guard.
+			require.GreaterOrEqual(t, aQueries.Load(), int64(2),
+				"expected an up-front and a dial-time DNS lookup")
 		})
 	}
 }
@@ -253,7 +265,7 @@ func Test_Security_NewGuardedClientDialer_AllowsValidatedHostname(t *testing.T) 
 	withSecurityPolicyForTest(t, DefaultSecurityPolicy()) // AllowPrivateIPs == false
 
 	// Resolver maps the name to a public IP on every answer (no rebinding).
-	dnsAddr := startRebindingDNS(t, net.IPv4(198, 51, 100, 7), net.IPv4(198, 51, 100, 7))
+	dnsAddr, _ := startRebindingDNS(t, net.IPv4(198, 51, 100, 7), net.IPv4(198, 51, 100, 7))
 	withRebindingResolver(t, dnsAddr)
 
 	var got string

--- a/middleware/proxy/security_rebinding_test.go
+++ b/middleware/proxy/security_rebinding_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -32,7 +33,7 @@ func startRebindingDNS(t *testing.T, firstIP, rebindIP net.IP) (string, *atomic.
 
 	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = pc.Close() })
+	t.Cleanup(func() { pc.Close() }) //nolint:errcheck // best-effort close in cleanup
 
 	aQueries := &atomic.Int64{}
 
@@ -76,11 +77,11 @@ func startRebindingDNS(t *testing.T, firstIP, rebindIP net.IP) (string, *atomic.
 				mu.Unlock()
 			}
 
-			resp, berr := buildDNSResponse(hdr.ID, q, answer)
+			resp, berr := buildDNSResponse(hdr.ID, &q, answer)
 			if berr != nil {
 				continue
 			}
-			_, _ = pc.WriteTo(resp, addr)
+			pc.WriteTo(resp, addr) //nolint:errcheck // best-effort UDP reply
 		}
 	}()
 
@@ -90,7 +91,7 @@ func startRebindingDNS(t *testing.T, firstIP, rebindIP net.IP) (string, *atomic.
 // buildDNSResponse serializes a DNS reply echoing the question. When ip is
 // a non-nil IPv4 address an A record is included; otherwise the reply is a
 // NODATA answer (used for AAAA queries).
-func buildDNSResponse(id uint16, q dnsmessage.Question, ip net.IP) ([]byte, error) {
+func buildDNSResponse(id uint16, q *dnsmessage.Question, ip net.IP) ([]byte, error) {
 	b := dnsmessage.NewBuilder(nil, dnsmessage.Header{
 		ID:            id,
 		Response:      true,
@@ -98,13 +99,13 @@ func buildDNSResponse(id uint16, q dnsmessage.Question, ip net.IP) ([]byte, erro
 	})
 	b.EnableCompression()
 	if err := b.StartQuestions(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("dns build questions: %w", err)
 	}
-	if err := b.Question(q); err != nil {
-		return nil, err
+	if err := b.Question(*q); err != nil {
+		return nil, fmt.Errorf("dns build question: %w", err)
 	}
 	if err := b.StartAnswers(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("dns build answers: %w", err)
 	}
 	if v4 := ip.To4(); v4 != nil {
 		var a [4]byte
@@ -114,10 +115,14 @@ func buildDNSResponse(id uint16, q dnsmessage.Question, ip net.IP) ([]byte, erro
 			Type:  dnsmessage.TypeA,
 			Class: dnsmessage.ClassINET,
 		}, dnsmessage.AResource{A: a}); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("dns build A record: %w", err)
 		}
 	}
-	return b.Finish()
+	out, err := b.Finish()
+	if err != nil {
+		return nil, fmt.Errorf("dns build finish: %w", err)
+	}
+	return out, nil
 }
 
 // withRebindingResolver points net.DefaultResolver at the fake DNS server
@@ -161,11 +166,7 @@ func Test_Security_Do_BlocksDNSRebinding(t *testing.T) {
 		// guarded: fasthttp's callDialFunc prefers DialTimeout, so a guard
 		// that wrapped only Dial would leave this path unvalidated.
 		"custom client with DialTimeout": func(c fiber.Ctx, target string) error {
-			cli := &fasthttp.Client{
-				DialTimeout: func(addr string, timeout time.Duration) (net.Conn, error) {
-					return fasthttp.DialTimeout(addr, timeout)
-				},
-			}
+			cli := &fasthttp.Client{DialTimeout: fasthttp.DialTimeout}
 			return Do(c, target, cli)
 		},
 		// DoRedirects dispatches through the same guarded client; the first
@@ -346,11 +347,9 @@ func Test_Security_EnsureClientGuarded_ConcurrentIsSafe(t *testing.T) {
 
 			var wg sync.WaitGroup
 			for range 32 {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					ensureClientGuarded(cli)
-				}()
+				})
 			}
 			wg.Wait()
 
@@ -370,11 +369,7 @@ func Test_Security_EnsureClientGuarded_ConcurrentIsSafe(t *testing.T) {
 func Test_Security_InstallHostClientGuard_GuardsDialTimeout(t *testing.T) {
 	withSecurityPolicyForTest(t, DefaultSecurityPolicy()) // AllowPrivateIPs == false
 
-	hc := &fasthttp.HostClient{
-		DialTimeout: func(addr string, timeout time.Duration) (net.Conn, error) {
-			return fasthttp.DialTimeout(addr, timeout)
-		},
-	}
+	hc := &fasthttp.HostClient{DialTimeout: fasthttp.DialTimeout}
 	installHostClientGuard(hc)
 
 	require.NotNil(t, hc.DialTimeout)
@@ -396,7 +391,7 @@ func Test_Security_NewGuardedClientDialer_DelegatesWhenPrivateAllowed(t *testing
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer func() { _ = ln.Close() }()
+	defer ln.Close() //nolint:errcheck // best-effort close
 
 	dial := newGuardedClientDialer(nil, false)
 	conn, err := dial(ln.Addr().String())

--- a/middleware/proxy/security_rebinding_test.go
+++ b/middleware/proxy/security_rebinding_test.go
@@ -147,6 +147,17 @@ func Test_Security_Do_BlocksDNSRebinding(t *testing.T) {
 		"custom client": func(c fiber.Ctx, target string) error {
 			return Do(c, target, &fasthttp.Client{})
 		},
+		// A client that configures DialTimeout instead of Dial must still be
+		// guarded: fasthttp's callDialFunc prefers DialTimeout, so a guard
+		// that wrapped only Dial would leave this path unvalidated.
+		"custom client with DialTimeout": func(c fiber.Ctx, target string) error {
+			cli := &fasthttp.Client{
+				DialTimeout: func(addr string, timeout time.Duration) (net.Conn, error) {
+					return fasthttp.DialTimeout(addr, timeout)
+				},
+			}
+			return Do(c, target, cli)
+		},
 	}
 
 	for name, do := range dispatch {
@@ -219,6 +230,58 @@ func Test_Security_NewGuardedClientDialer_ComposesWithOrig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	require.Equal(t, "203.0.113.5:80", got)
+}
+
+// Test_Security_EnsureClientGuarded_ComposesAndIsIdempotent verifies that
+// installing the guard on a client that already carries its own
+// ConfigureClient hook composes with it (the original still runs) and that
+// repeated installation does not nest the wrapper — each HostClient gets the
+// guard and the original hook exactly once.
+func Test_Security_EnsureClientGuarded_ComposesAndIsIdempotent(t *testing.T) {
+	withSecurityPolicyForTest(t, DefaultSecurityPolicy()) // AllowPrivateIPs == false
+
+	called := 0
+	cli := &fasthttp.Client{
+		ConfigureClient: func(_ *fasthttp.HostClient) error {
+			called++
+			return nil
+		},
+	}
+
+	ensureClientGuarded(cli)
+	ensureClientGuarded(cli) // must not wrap a second time
+
+	hc := &fasthttp.HostClient{}
+	require.NoError(t, cli.ConfigureClient(hc))
+	require.Equal(t, 1, called, "original ConfigureClient must run exactly once per HostClient")
+	require.NotNil(t, hc.Dial, "guard must install a dial-time Dial")
+
+	// The installed Dial must block a loopback target under the strict policy.
+	_, err := hc.Dial("127.0.0.1:80")
+	require.ErrorIs(t, err, ErrUpstreamHostBlocked)
+}
+
+// Test_Security_InstallHostClientGuard_GuardsDialTimeout verifies both dial
+// entry points are guarded: a HostClient that carries DialTimeout has it
+// wrapped (fasthttp prefers DialTimeout over Dial), and the wrapped func
+// blocks a loopback target under the strict policy.
+func Test_Security_InstallHostClientGuard_GuardsDialTimeout(t *testing.T) {
+	withSecurityPolicyForTest(t, DefaultSecurityPolicy()) // AllowPrivateIPs == false
+
+	hc := &fasthttp.HostClient{
+		DialTimeout: func(addr string, timeout time.Duration) (net.Conn, error) {
+			return fasthttp.DialTimeout(addr, timeout)
+		},
+	}
+	installHostClientGuard(hc)
+
+	require.NotNil(t, hc.DialTimeout)
+	_, err := hc.DialTimeout("127.0.0.1:80", time.Second)
+	require.ErrorIs(t, err, ErrUpstreamHostBlocked)
+
+	require.NotNil(t, hc.Dial)
+	_, err = hc.Dial("127.0.0.1:80")
+	require.ErrorIs(t, err, ErrUpstreamHostBlocked)
 }
 
 // Test_Security_NewGuardedClientDialer_DelegatesWhenPrivateAllowed verifies

--- a/middleware/proxy/security_test.go
+++ b/middleware/proxy/security_test.go
@@ -31,18 +31,27 @@ func Test_Security_IsBlockedIP(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]bool{
-		"127.0.0.1":       true,
-		"::1":             true,
-		"0.0.0.0":         true,
-		"10.0.0.1":        true,
-		"172.16.0.1":      true,
-		"192.168.1.1":     true,
-		"169.254.169.254": true, // AWS metadata
-		"100.64.0.1":      true, // CGNAT
-		"224.0.0.1":       true, // multicast
-		"8.8.8.8":         false,
-		"1.1.1.1":         false,
-		"93.184.216.34":   false, // example.com
+		"127.0.0.1":            true,
+		"::1":                  true,
+		"0.0.0.0":              true,
+		"10.0.0.1":             true,
+		"172.16.0.1":           true,
+		"192.168.1.1":          true,
+		"169.254.169.254":      true, // AWS metadata
+		"100.64.0.1":           true, // CGNAT
+		"224.0.0.1":            true, // multicast
+		"::ffff:127.0.0.1":     true, // IPv4-mapped loopback
+		"::ffff:10.0.0.1":      true, // IPv4-mapped private
+		"::127.0.0.1":          true, // IPv4-compatible loopback
+		"::10.0.0.1":           true, // IPv4-compatible private
+		"64:ff9b::7f00:1":      true, // NAT64 127.0.0.1
+		"64:ff9b::a00:1":       true, // NAT64 10.0.0.1
+		"64:ff9b::a9fe:a9fe":   true, // NAT64 169.254.169.254 (metadata)
+		"8.8.8.8":              false,
+		"1.1.1.1":              false,
+		"93.184.216.34":        false, // example.com
+		"64:ff9b::808:808":     false, // NAT64 8.8.8.8 (public → allowed)
+		"2606:4700:4700::1111": false, // public IPv6 (Cloudflare)
 	}
 	for raw, blocked := range cases {
 		t.Run(raw, func(t *testing.T) {


### PR DESCRIPTION
# Description

`middleware/proxy`'s `SecurityPolicy` (default `AllowPrivateIPs: false`) is documented as blocking SSRF against loopback, RFC 1918, link-local, CGNAT, and cloud-metadata addresses. In practice that guarantee only held for `Balancer`, which installs a dial-time guard (`newSSRFDialer`) that re-validates the resolved IP atomically with the connection.

Every other public entry point — `Do`, `DoRedirects`, `DoTimeout`, `DoDeadline`, `Forward`, `DomainForward`, `BalancerForward` — validated the host only **once, up front**, then dispatched through a shared/user-supplied `*fasthttp.Client` whose own dialer re-resolved the hostname independently, with no validation. A rebinding resolver that answers with a public IP on the first lookup and a private IP on the second passed the up-front check and then connected to the private address anyway (classic DNS rebinding / check-use gap).

This PR closes that gap for all runtime helpers by giving them the same **dial-time** re-validation `Balancer` already has, so `AllowPrivateIPs=false` genuinely blocks rebinding for every entry point.

Fixes the DNS-rebinding SSRF in `proxy.Do/Forward/DoRedirects/DoTimeout/DoDeadline/DomainForward/BalancerForward` (☢️ Bug).

## How the guard is installed

The guard rides on fasthttp's `Client.ConfigureClient` hook, which runs **once per `HostClient` at creation** — so it is present before the first dial to each host and, crucially, covers **both** dial code paths (`callDialFunc` prefers `DialTimeout` over `Dial`, so guarding only `Dial` would leave a `DialTimeout`-configured client unvalidated).

- `installHostClientGuard` wraps both `hc.DialTimeout` (preserving its per-request timeout) and `hc.Dial`.
- `guardedDial` (shared core) + `newGuardedClientDialer` / `newGuardedClientDialerWithTimeout`: when `AllowPrivateIPs` is true the guard delegates unchanged; otherwise it resolves the host, rejects the whole resolution on any blocked IP, and dials the **exact validated IP** (through the caller's dialer when set). Policy is read fresh on every dial, since a client outlives any single policy snapshot. Reuses `resolveAndValidateHost` and `dialValidatedIPs`.
- `ensureClientGuarded` installs the hook idempotently, serialized under a mutex so the guard is in place before any concurrent guarder observes the client. It composes with a user's existing `ConfigureClient` (running the user hook **first**, then the guard, so a hook that sets its own `hc.Dial` cannot overwrite the guard). Wired into `init` (default client) and `WithClient` before first use, and on the dispatch path only for a per-call variadic client (the global client is already guarded, so the common request path stays lock-free). Clients with a nil `ConfigureClient` are matched by identity and never retained.

Because a pooled keep-alive connection is always bound to an already-validated IP, connection reuse cannot be rebound; only a fresh dial reaches a new IP, and every fresh dial runs the guard. The only path left to the caller is a custom `Balancer` `Config.Client` (`*fasthttp.LBClient`), whose underlying dialers are not reachable for wrapping — documented on `SecurityPolicy.AllowPrivateIPs`.

As defense-in-depth, `isBlockedIP` now also unwraps IPv4-compatible (`::a.b.c.d`) and NAT64 (`64:ff9b::a.b.c.d`) IPv6 literals to the embedded IPv4 and applies the same blocklist (the IPv4-mapped `::ffff:` form was already covered), so a private target can't be smuggled past as an IPv6 literal.

## Changes introduced

- `middleware/proxy/security.go`: `installHostClientGuard`, `guardedDial`, `newGuardedClientDialer`, `newGuardedClientDialerWithTimeout`; harden `isBlockedIP` with `embeddedIPv4`/`allZero`; update `SecurityPolicy.AllowPrivateIPs` docs.
- `middleware/proxy/proxy.go`: `guardConfigureClient`/`ensureClientGuarded` plumbing (mutex-serialized, identity-idempotent), wired into `init`/`WithClient`/`doActionWithPolicy`; refresh the per-helper SSRF doc comments and the `DomainForward` construction-validation note.
- **Tests** (`security_rebinding_test.go`, `security_test.go`):
  - DNS-rebinding regression via an in-process fake resolver (public answer first, loopback after) asserting the internal server is never reached — for the default client, a per-call custom client, a client configured with `DialTimeout`, and `DoRedirects`; plus a DNS A-query counter asserting the block happens at **dial time**, not up front.
  - Unit tests for the dialers (block loopback, delegate when private allowed, compose with a caller dialer, validated-hostname dials through to the resolved IP), `ConfigureClient` compose/ordering + idempotency, a `-race` concurrency regression test, and extended `isBlockedIP` coverage (IPv4-mapped / IPv4-compatible / NAT64, private blocked, public allowed).
- [ ] Benchmarks: none added. The common no-variadic request path takes no new lock; the guard adds one resolve + validated dial per new connection when `AllowPrivateIPs=false` (mirrors the existing `Balancer` guard).
- [ ] Documentation Update: doc comments in the changed files only; no `/docs/` changes.
- [ ] Changelog/What's New: security fix — SSRF/DNS-rebinding protection now applies to all proxy runtime helpers, not just `Balancer`.
- [ ] Migration Guide: none — behavior only changes for previously-unprotected SSRF cases under the secure default.
- [ ] API Alignment with Express: n/a.
- [ ] API Longevity: no public API/signature changes; the guard is internal.
- [ ] Examples: n/a.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness) — security bug fix, no public API change.

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes.
- [x] Ensured that new and existing unit tests pass locally (`go test -race ./middleware/proxy/...`, `go vet`, `gofmt`).
- [x] No new dependencies (`golang.org/x/net/dns/dnsmessage`, used only in tests, was already a direct module dependency).
- [ ] Updated the documentation in `/docs/` (not applicable — no user-facing docs affected).
- [ ] Provided benchmarks for the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)