### PR TITLE
Feat/immutable string methods

### DIFF
--- a/app.go
+++ b/app.go
@@ -222,6 +222,14 @@ type Config struct { //nolint:govet // Aligning the struct fields is not necessa
 	// immutable fashion so that these values are available even if you return
 	// from handler.
 	//
+	// Deprecated: Immutable is being phased out. Methods such as
+	// Ctx.OriginalURL, Ctx.Path, Req.Cookies, and Req.FormValue now always
+	// return a detached, immutable string regardless of this setting; use
+	// their *Bytes counterparts (e.g. PathBytes, CookiesBytes) for
+	// zero-allocation, handler-scoped access instead. This flag is kept for
+	// backward compatibility with code paths not yet migrated and will be
+	// removed in a future major version.
+	//
 	// Default: false
 	Immutable bool `json:"immutable"`
 

--- a/ctx.go
+++ b/ctx.go
@@ -301,15 +301,29 @@ func (c *DefaultCtx) setHandlerCtx(ctx CustomCtx) {
 }
 
 // OriginalURL contains the original request URL.
-// Returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting to use the value outside the Handler.
+// The returned string is always a detached, immutable copy that is safe to
+// keep and use after the handler returns, regardless of the deprecated
+// Config.Immutable setting.
+// For zero-allocation access to the raw bytes, use OriginalURLBytes instead.
 func (c *DefaultCtx) OriginalURL() string {
-	return c.app.toString(c.fasthttp.Request.Header.RequestURI())
+	return toStringImmutable(c.fasthttp.Request.Header.RequestURI())
+}
+
+// OriginalURLBytes contains the original request URL as a byte slice.
+// The returned slice aliases the underlying request buffer for
+// zero-allocation access and is only valid within the handler. Do not store
+// any references to it; make a copy (e.g. via utils.CopyBytes) if you need
+// to retain the value after the handler returns.
+func (c *DefaultCtx) OriginalURLBytes() []byte {
+	return c.fasthttp.Request.Header.RequestURI()
 }
 
 // Path returns the path part of the request URL.
 // Optionally, you could override the path.
-// Make copies or use the Immutable setting to use the value outside the Handler.
+// The returned string is always a detached, immutable copy that is safe to
+// keep and use after the handler returns, regardless of the deprecated
+// Config.Immutable setting.
+// For zero-allocation access to the raw bytes, use PathBytes instead.
 func (c *DefaultCtx) Path(override ...string) string {
 	if len(override) != 0 && string(c.path) != override[0] {
 		// Set new path to context
@@ -322,7 +336,28 @@ func (c *DefaultCtx) Path(override ...string) string {
 		// The detection path/tree hash changed; invalidate the lookahead index.
 		c.firstMatchIndex = -1
 	}
-	return c.app.toString(c.path)
+	return toStringImmutable(c.path)
+}
+
+// PathBytes returns the path part of the request URL as a byte slice.
+// Optionally, you could override the path.
+// The returned slice aliases the underlying request buffer for
+// zero-allocation access and is only valid within the handler. Do not store
+// any references to it; make a copy if you need to retain the value after
+// the handler returns.
+func (c *DefaultCtx) PathBytes(override ...string) []byte {
+	if len(override) != 0 && string(c.path) != override[0] {
+		// Set new path to context
+		c.pathOriginal = override[0]
+
+		// Set new path to request context
+		c.fasthttp.Request.URI().SetPath(c.pathOriginal)
+		// Prettify path
+		c.configDependentPaths()
+		// The detection path/tree hash changed; invalidate the lookahead index.
+		c.firstMatchIndex = -1
+	}
+	return c.path
 }
 
 // RequestID returns the request identifier from the response header or request header.

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -90,13 +90,31 @@ type Ctx interface {
 	RestartRouting() error
 	setHandlerCtx(ctx CustomCtx)
 	// OriginalURL contains the original request URL.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the value outside the Handler.
+	// The returned string is always a detached, immutable copy that is safe to
+	// keep and use after the handler returns, regardless of the deprecated
+	// Config.Immutable setting.
+	// For zero-allocation access to the raw bytes, use OriginalURLBytes instead.
 	OriginalURL() string
+	// OriginalURLBytes contains the original request URL as a byte slice.
+	// The returned slice aliases the underlying request buffer for
+	// zero-allocation access and is only valid within the handler. Do not store
+	// any references to it; make a copy (e.g. via utils.CopyBytes) if you need
+	// to retain the value after the handler returns.
+	OriginalURLBytes() []byte
 	// Path returns the path part of the request URL.
 	// Optionally, you could override the path.
-	// Make copies or use the Immutable setting to use the value outside the Handler.
+	// The returned string is always a detached, immutable copy that is safe to
+	// keep and use after the handler returns, regardless of the deprecated
+	// Config.Immutable setting.
+	// For zero-allocation access to the raw bytes, use PathBytes instead.
 	Path(override ...string) string
+	// PathBytes returns the path part of the request URL as a byte slice.
+	// Optionally, you could override the path.
+	// The returned slice aliases the underlying request buffer for
+	// zero-allocation access and is only valid within the handler. Do not store
+	// any references to it; make a copy if you need to retain the value after
+	// the handler returns.
+	PathBytes(override ...string) []byte
 	// RequestID returns the request identifier from the response header or request header.
 	RequestID() string
 	// Req returns a convenience type whose API is limited to operations
@@ -278,8 +296,10 @@ type Ctx interface {
 	// RFC 4647 Extended Filtering.
 	AcceptsLanguagesExtended(offers ...string) string
 	// BodyRaw contains the raw body submitted in a POST request.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
+	// The returned slice aliases the underlying request buffer for
+	// zero-allocation access and is only valid within the handler. Do not store
+	// any references to it; make a copy (e.g. via utils.CopyBytes) if you need
+	// to retain the value after the handler returns.
 	BodyRaw() []byte
 	//nolint:nonamedreturns // gocritic unnamedResult prefers naming decoded body, decode count, and error
 	tryDecodeBodyInOrder(originalBody *[]byte, encodings []string) (body []byte, decodesRealized uint8, err error)
@@ -292,9 +312,18 @@ type Ctx interface {
 	// Cookies are used for getting a cookie value by key.
 	// Defaults to the empty string "" if the cookie doesn't exist.
 	// If a default value is given, it will return that value if the cookie doesn't exist.
-	// The returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the value outside the Handler.
+	// The returned string is always a detached, immutable copy that is safe to
+	// keep and use after the handler returns, regardless of the deprecated
+	// Config.Immutable setting.
+	// For zero-allocation access to the raw bytes, use CookiesBytes instead.
 	Cookies(key string, defaultValue ...string) string
+	// CookiesBytes is used for getting a cookie value by key as a byte slice.
+	// Defaults to nil if the cookie doesn't exist.
+	// The returned slice aliases the underlying request buffer for
+	// zero-allocation access and is only valid within the handler. Do not store
+	// any references to it; make a copy if you need to retain the value after
+	// the handler returns.
+	CookiesBytes(key string) []byte
 	// FormFile returns the first file by key from a MultipartForm.
 	// The multipart form is parsed using the application's BodyLimit to prevent
 	// unbounded memory usage.
@@ -303,11 +332,25 @@ type Ctx interface {
 	// Search is performed in QueryArgs, PostArgs, MultipartForm and FormFile in this particular order.
 	// Defaults to the empty string "" if the form value doesn't exist.
 	// If a default value is given, it will return that value if the form value does not exist.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
+	// The returned string is always a detached, immutable copy that is safe to
+	// keep and use after the handler returns, regardless of the deprecated
+	// Config.Immutable setting.
+	// For zero-allocation access to the raw bytes, use FormValueBytes instead.
 	// When the request is a multipart form, it is parsed using the application's
 	// BodyLimit so the configured limit is consistently enforced.
 	FormValue(key string, defaultValue ...string) string
+	// FormValueBytes returns the first value by key from a MultipartForm as a
+	// byte slice. Search is performed in QueryArgs, PostArgs, MultipartForm and
+	// FormFile in this particular order. Defaults to nil if the form value
+	// doesn't exist.
+	// The returned slice aliases the underlying request buffer for
+	// zero-allocation access and is only valid within the handler (this does
+	// not apply to values sourced from MultipartForm, which are already
+	// detached copies). Do not store any references to it; make a copy if you
+	// need to retain the value after the handler returns.
+	// When the request is a multipart form, it is parsed using the application's
+	// BodyLimit so the configured limit is consistently enforced.
+	FormValueBytes(key string) []byte
 	// Fresh returns true when the response is still “fresh” in the client's cache,
 	// otherwise false is returned to indicate that the client cache is now stale
 	// and the full response should be sent.

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1949,6 +1949,37 @@ func Test_Ctx_Cookies(t *testing.T) {
 	require.Equal(t, "default", c.Req().Cookies("unknown", "default"))
 }
 
+func Test_Ctx_CookiesBytes(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	c.Request().Header.Set("Cookie", "john=doe")
+	require.Equal(t, []byte("doe"), c.Req().CookiesBytes("john"))
+	require.Nil(t, c.Req().CookiesBytes("unknown"))
+}
+
+// Cookies must always return a detached, immutable copy so that it remains
+// valid after the underlying fasthttp request buffers are reused, even when
+// Config.Immutable is left at its default (false).
+func Test_Ctx_Cookies_Immutable(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	c.Request().Header.Set("Cookie", "john=doe")
+	got := c.Req().Cookies("john")
+	require.Equal(t, "doe", got)
+
+	// Mutate the byte slice backing the header value; the previously
+	// returned string must not change.
+	raw := c.Req().CookiesBytes("john")
+	for i := range raw {
+		raw[i] = 'x'
+	}
+	require.Equal(t, "doe", got)
+}
+
 // go test -run Test_Ctx_Format
 func Test_Ctx_Format(t *testing.T) {
 	t.Parallel()
@@ -2730,6 +2761,41 @@ func Test_Ctx_FormValue_NonMultipart(t *testing.T) {
 	require.Equal(t, "carol", c.FormValue("name"))
 	// Key not present + default → default value.
 	require.Equal(t, "fallback", c.FormValue("missing", "fallback"))
+}
+
+func Test_Ctx_FormValueBytes_NonMultipart(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
+
+	c.Request().Header.Set(HeaderContentType, MIMEApplicationForm)
+	c.Request().SetBodyString("name=carol")
+
+	require.Equal(t, []byte("carol"), c.FormValueBytes("name"))
+	require.Nil(t, c.FormValueBytes("missing"))
+}
+
+// FormValue must always return a detached, immutable copy so that it
+// remains valid after the underlying fasthttp request buffers are reused,
+// even when Config.Immutable is left at its default (false).
+func Test_Ctx_FormValue_Immutable(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{}).(*DefaultCtx) //nolint:errcheck,forcetypeassert // not needed
+
+	c.Request().Header.Set(HeaderContentType, MIMEApplicationForm)
+	c.Request().SetBodyString("name=carol")
+
+	got := c.FormValue("name")
+	require.Equal(t, "carol", got)
+
+	raw := c.FormValueBytes("name")
+	for i := range raw {
+		raw[i] = 'x'
+	}
+	require.Equal(t, "carol", got)
 }
 
 func Benchmark_Ctx_Fresh_StaleEtag(b *testing.B) {
@@ -5012,6 +5078,34 @@ func Test_Ctx_OriginalURL(t *testing.T) {
 	require.Equal(t, "http://google.com/test?search=demo", c.OriginalURL())
 }
 
+func Test_Ctx_OriginalURLBytes(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	c.Request().Header.SetRequestURI("http://google.com/test?search=demo")
+	require.Equal(t, []byte("http://google.com/test?search=demo"), c.OriginalURLBytes())
+}
+
+// OriginalURL must always return a detached, immutable copy so that it
+// remains valid after the underlying fasthttp request buffers are reused,
+// even when Config.Immutable is left at its default (false).
+func Test_Ctx_OriginalURL_Immutable(t *testing.T) {
+	t.Parallel()
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	c.Request().Header.SetRequestURI("http://google.com/test?search=demo")
+	got := c.OriginalURL()
+	require.Equal(t, "http://google.com/test?search=demo", got)
+
+	raw := c.OriginalURLBytes()
+	for i := range raw {
+		raw[i] = 'x'
+	}
+	require.Equal(t, "http://google.com/test?search=demo", got)
+}
+
 // go test -race -run Test_Ctx_Params
 func Test_Ctx_Params(t *testing.T) {
 	t.Parallel()
@@ -5175,7 +5269,41 @@ func Test_Ctx_Path(t *testing.T) {
 	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
 }
 
-// go test -run Test_Ctx_Protocol
+func Test_Ctx_PathBytes(t *testing.T) {
+	t.Parallel()
+	app := New()
+	app.Get("/test/:user", func(c Ctx) error {
+		require.Equal(t, []byte("/test/john"), c.PathBytes())
+		require.Equal(t, []byte("/abc/"), c.PathBytes("/abc/"))
+		return nil
+	})
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/test/john", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
+}
+
+// Path must always return a detached, immutable copy so that it remains
+// valid after the underlying fasthttp request buffers are reused, even when
+// Config.Immutable is left at its default (false).
+func Test_Ctx_Path_Immutable(t *testing.T) {
+	t.Parallel()
+	app := New()
+	app.Get("/test/:user", func(c Ctx) error {
+		got := c.Path()
+		require.Equal(t, "/test/john", got)
+
+		raw := c.PathBytes()
+		for i := range raw {
+			raw[i] = 'x'
+		}
+		require.Equal(t, "/test/john", got)
+		return nil
+	})
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/test/john", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
+}
+
 func Test_Ctx_Protocol(t *testing.T) {
 	t.Parallel()
 	app := New()

--- a/req.go
+++ b/req.go
@@ -92,8 +92,10 @@ func (r *DefaultReq) BaseURL() string {
 }
 
 // BodyRaw contains the raw body submitted in a POST request.
-// Returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting instead.
+// The returned slice aliases the underlying request buffer for
+// zero-allocation access and is only valid within the handler. Do not store
+// any references to it; make a copy (e.g. via utils.CopyBytes) if you need
+// to retain the value after the handler returns.
 func (r *DefaultReq) BodyRaw() []byte {
 	return r.getBody()
 }
@@ -383,10 +385,22 @@ func (c *DefaultCtx) AcceptsEventStream() bool {
 // Cookies are used for getting a cookie value by key.
 // Defaults to the empty string "" if the cookie doesn't exist.
 // If a default value is given, it will return that value if the cookie doesn't exist.
-// The returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting to use the value outside the Handler.
+// The returned string is always a detached, immutable copy that is safe to
+// keep and use after the handler returns, regardless of the deprecated
+// Config.Immutable setting.
+// For zero-allocation access to the raw bytes, use CookiesBytes instead.
 func (r *DefaultReq) Cookies(key string, defaultValue ...string) string {
-	return defaultString(r.c.app.toString(r.c.fasthttp.Request.Header.Cookie(key)), defaultValue)
+	return defaultString(toStringImmutable(r.c.fasthttp.Request.Header.Cookie(key)), defaultValue)
+}
+
+// CookiesBytes is used for getting a cookie value by key as a byte slice.
+// Defaults to nil if the cookie doesn't exist.
+// The returned slice aliases the underlying request buffer for
+// zero-allocation access and is only valid within the handler. Do not store
+// any references to it; make a copy if you need to retain the value after
+// the handler returns.
+func (r *DefaultReq) CookiesBytes(key string) []byte {
+	return r.c.fasthttp.Request.Header.Cookie(key)
 }
 
 // Request return the *fasthttp.Request object
@@ -410,11 +424,28 @@ func (r *DefaultReq) FormFile(key string) (*multipart.FileHeader, error) {
 // Search is performed in QueryArgs, PostArgs, MultipartForm and FormFile in this particular order.
 // Defaults to the empty string "" if the form value doesn't exist.
 // If a default value is given, it will return that value if the form value does not exist.
-// Returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting instead.
+// The returned string is always a detached, immutable copy that is safe to
+// keep and use after the handler returns, regardless of the deprecated
+// Config.Immutable setting.
+// For zero-allocation access to the raw bytes, use FormValueBytes instead.
 // When the request is a multipart form, it is parsed using the application's
 // BodyLimit so the configured limit is consistently enforced.
 func (r *DefaultReq) FormValue(key string, defaultValue ...string) string {
+	return defaultString(toStringImmutable(r.FormValueBytes(key)), defaultValue)
+}
+
+// FormValueBytes returns the first value by key from a MultipartForm as a
+// byte slice. Search is performed in QueryArgs, PostArgs, MultipartForm and
+// FormFile in this particular order. Defaults to nil if the form value
+// doesn't exist.
+// The returned slice aliases the underlying request buffer for
+// zero-allocation access and is only valid within the handler (this does
+// not apply to values sourced from MultipartForm, which are already
+// detached copies). Do not store any references to it; make a copy if you
+// need to retain the value after the handler returns.
+// When the request is a multipart form, it is parsed using the application's
+// BodyLimit so the configured limit is consistently enforced.
+func (r *DefaultReq) FormValueBytes(key string) []byte {
 	if r.c.IsMultipart() {
 		// For multipart requests, parse the form using the application's BodyLimit.
 		// fasthttp's FormValue would otherwise re-parse with its default 8 MiB limit,
@@ -422,21 +453,21 @@ func (r *DefaultReq) FormValue(key string, defaultValue ...string) string {
 		//
 		// Preserve the original search order: QueryArgs → PostArgs → MultipartForm.
 		if v := r.c.fasthttp.QueryArgs().Peek(key); len(v) > 0 {
-			return r.c.app.toString(v)
+			return v
 		}
 		if v := r.c.fasthttp.PostArgs().Peek(key); len(v) > 0 {
-			return r.c.app.toString(v)
+			return v
 		}
 		mf, err := r.MultipartForm()
 		if err != nil {
-			return defaultString("", defaultValue)
+			return nil
 		}
 		if vals := mf.Value[key]; len(vals) > 0 {
-			return vals[0]
+			return utils.UnsafeBytes(vals[0])
 		}
-		return defaultString("", defaultValue)
+		return nil
 	}
-	return defaultString(r.c.app.toString(r.c.fasthttp.FormValue(key)), defaultValue)
+	return r.c.fasthttp.FormValue(key)
 }
 
 // Fresh returns true when the response is still “fresh” in the client's cache,
@@ -951,10 +982,21 @@ func (r *DefaultReq) MultipartForm() (*multipart.Form, error) {
 }
 
 // OriginalURL contains the original request URL.
-// Returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting to use the value outside the Handler.
+// The returned string is always a detached, immutable copy that is safe to
+// keep and use after the handler returns, regardless of the deprecated
+// Config.Immutable setting.
+// For zero-allocation access to the raw bytes, use OriginalURLBytes instead.
 func (r *DefaultReq) OriginalURL() string {
-	return r.c.app.toString(r.c.fasthttp.Request.Header.RequestURI())
+	return r.c.OriginalURL()
+}
+
+// OriginalURLBytes contains the original request URL as a byte slice.
+// The returned slice aliases the underlying request buffer for
+// zero-allocation access and is only valid within the handler. Do not store
+// any references to it; make a copy (e.g. via utils.CopyBytes) if you need
+// to retain the value after the handler returns.
+func (r *DefaultReq) OriginalURLBytes() []byte {
+	return r.c.OriginalURLBytes()
 }
 
 // Params is used to get the route parameters.

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -27,8 +27,10 @@ type Req interface {
 	// BaseURL returns (protocol + host + base path).
 	BaseURL() string
 	// BodyRaw contains the raw body submitted in a POST request.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
+	// The returned slice aliases the underlying request buffer for
+	// zero-allocation access and is only valid within the handler. Do not store
+	// any references to it; make a copy (e.g. via utils.CopyBytes) if you need
+	// to retain the value after the handler returns.
 	BodyRaw() []byte
 	//nolint:nonamedreturns // gocritic unnamedResult prefers naming decoded body, decode count, and error
 	tryDecodeBodyInOrder(originalBody *[]byte, encodings []string) (body []byte, decodesRealized uint8, err error)
@@ -44,9 +46,18 @@ type Req interface {
 	// Cookies are used for getting a cookie value by key.
 	// Defaults to the empty string "" if the cookie doesn't exist.
 	// If a default value is given, it will return that value if the cookie doesn't exist.
-	// The returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the value outside the Handler.
+	// The returned string is always a detached, immutable copy that is safe to
+	// keep and use after the handler returns, regardless of the deprecated
+	// Config.Immutable setting.
+	// For zero-allocation access to the raw bytes, use CookiesBytes instead.
 	Cookies(key string, defaultValue ...string) string
+	// CookiesBytes is used for getting a cookie value by key as a byte slice.
+	// Defaults to nil if the cookie doesn't exist.
+	// The returned slice aliases the underlying request buffer for
+	// zero-allocation access and is only valid within the handler. Do not store
+	// any references to it; make a copy if you need to retain the value after
+	// the handler returns.
+	CookiesBytes(key string) []byte
 	// Request return the *fasthttp.Request object
 	// This allows you to use all fasthttp request methods
 	// https://godoc.org/github.com/valyala/fasthttp#Request
@@ -59,11 +70,25 @@ type Req interface {
 	// Search is performed in QueryArgs, PostArgs, MultipartForm and FormFile in this particular order.
 	// Defaults to the empty string "" if the form value doesn't exist.
 	// If a default value is given, it will return that value if the form value does not exist.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
+	// The returned string is always a detached, immutable copy that is safe to
+	// keep and use after the handler returns, regardless of the deprecated
+	// Config.Immutable setting.
+	// For zero-allocation access to the raw bytes, use FormValueBytes instead.
 	// When the request is a multipart form, it is parsed using the application's
 	// BodyLimit so the configured limit is consistently enforced.
 	FormValue(key string, defaultValue ...string) string
+	// FormValueBytes returns the first value by key from a MultipartForm as a
+	// byte slice. Search is performed in QueryArgs, PostArgs, MultipartForm and
+	// FormFile in this particular order. Defaults to nil if the form value
+	// doesn't exist.
+	// The returned slice aliases the underlying request buffer for
+	// zero-allocation access and is only valid within the handler (this does
+	// not apply to values sourced from MultipartForm, which are already
+	// detached copies). Do not store any references to it; make a copy if you
+	// need to retain the value after the handler returns.
+	// When the request is a multipart form, it is parsed using the application's
+	// BodyLimit so the configured limit is consistently enforced.
+	FormValueBytes(key string) []byte
 	// Fresh returns true when the response is still “fresh” in the client's cache,
 	// otherwise false is returned to indicate that the client cache is now stale
 	// and the full response should be sent.
@@ -139,9 +164,17 @@ type Req interface {
 	// This returns a map[string][]string, so given a key, the value will be a string slice.
 	MultipartForm() (*multipart.Form, error)
 	// OriginalURL contains the original request URL.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the value outside the Handler.
+	// The returned string is always a detached, immutable copy that is safe to
+	// keep and use after the handler returns, regardless of the deprecated
+	// Config.Immutable setting.
+	// For zero-allocation access to the raw bytes, use OriginalURLBytes instead.
 	OriginalURL() string
+	// OriginalURLBytes contains the original request URL as a byte slice.
+	// The returned slice aliases the underlying request buffer for
+	// zero-allocation access and is only valid within the handler. Do not store
+	// any references to it; make a copy (e.g. via utils.CopyBytes) if you need
+	// to retain the value after the handler returns.
+	OriginalURLBytes() []byte
 	// Params is used to get the route parameters.
 	// Defaults to empty string "" if the param doesn't exist.
 	// If a default value is given, it will return that value if the param doesn't exist.

--- a/res.go
+++ b/res.go
@@ -690,10 +690,21 @@ func (r *DefaultRes) Location(path string) {
 }
 
 // OriginalURL contains the original request URL.
-// Returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting to use the value outside the Handler.
+// The returned string is always a detached, immutable copy that is safe to
+// keep and use after the handler returns, regardless of the deprecated
+// Config.Immutable setting.
+// For zero-allocation access to the raw bytes, use OriginalURLBytes instead.
 func (r *DefaultRes) OriginalURL() string {
 	return r.c.OriginalURL()
+}
+
+// OriginalURLBytes contains the original request URL as a byte slice.
+// The returned slice aliases the underlying request buffer for
+// zero-allocation access and is only valid within the handler. Do not store
+// any references to it; make a copy (e.g. via utils.CopyBytes) if you need
+// to retain the value after the handler returns.
+func (r *DefaultRes) OriginalURLBytes() []byte {
+	return r.c.OriginalURLBytes()
 }
 
 // Redirect returns the Redirect reference.

--- a/res_interface_gen.go
+++ b/res_interface_gen.go
@@ -90,9 +90,17 @@ type Res interface {
 	// Location sets the response Location HTTP header to the specified path parameter.
 	Location(path string)
 	// OriginalURL contains the original request URL.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the value outside the Handler.
+	// The returned string is always a detached, immutable copy that is safe to
+	// keep and use after the handler returns, regardless of the deprecated
+	// Config.Immutable setting.
+	// For zero-allocation access to the raw bytes, use OriginalURLBytes instead.
 	OriginalURL() string
+	// OriginalURLBytes contains the original request URL as a byte slice.
+	// The returned slice aliases the underlying request buffer for
+	// zero-allocation access and is only valid within the handler. Do not store
+	// any references to it; make a copy (e.g. via utils.CopyBytes) if you need
+	// to retain the value after the handler returns.
+	OriginalURLBytes() []byte
 	// Redirect returns the Redirect reference.
 	// Use Redirect().Status() to set custom redirection status code.
 	// If status is not specified, status defaults to 303 See Other.


### PR DESCRIPTION
## Summary

Addresses #3367 — `OriginalURL()`, `Path()`, `Cookies()`, and `FormValue()`
currently return a `string` that aliases the underlying fasthttp request
buffer unless `Config.Immutable` is enabled. That buffer is reused/mutated
by fasthttp, so the returned string can silently change value after the
handler runs — surprising behavior for a language where strings are
normally immutable.

This PR makes those four methods **always** return a detached, immutable
copy, regardless of `Config.Immutable`, and adds zero-allocation `*Bytes()`
siblings for callers who explicitly want handler-scoped, unsafe access to
the raw bytes (mirroring how `bufio.Scanner.Text()` vs `.Bytes()` works in
the standard library, and matching the pattern `BodyRaw()` already uses).

This follows the narrower of the two designs discussed in the issue thread
(`*Bytes()` sibling methods) rather than introducing a new wrapper type,
to avoid the larger breaking change and stay closer to the Express-like API
surface Fiber aims for.

## Changes

- **`Ctx.OriginalURL()` / `Ctx.Path()`** (`ctx.go`) — always return an
  immutable copy now. Added `Ctx.OriginalURLBytes()` and
  `Ctx.PathBytes(override ...string)` for zero-copy access.
- **`Req.Cookies()` / `Req.FormValue()`** (`req.go`) — same treatment.
  Added `Req.CookiesBytes(key)` and `Req.FormValueBytes(key)`.
- **`Req.BodyRaw()`** doc comment corrected — it already returns `[]byte`
  and was never affected by `Config.Immutable`; the comment was stale.
- **`Req.OriginalURL()` / `Res.OriginalURL()`** wrappers updated to match,
  plus matching `OriginalURLBytes()` wrappers for parity.
- **`Config.Immutable`** (`app.go`) marked `Deprecated` for these methods,
  with a pointer to the `*Bytes` alternatives. The flag is left in place
  for other code paths that still depend on it — removing it fully is a
  larger follow-up, not part of this PR.
- **Generated interface files** (`ctx_interface_gen.go`,
  `req_interface_gen.go`, `res_interface_gen.go`) hand-updated to match,
  since `ifacemaker` wasn't available in the environment this was written
  in. **Please re-run `go generate ./...` (or otherwise verify these
  against a real `ifacemaker` run) before merging.**
- Tests added for every new `*Bytes` method, plus a mutation-based test per
  changed method (`Test_Ctx_OriginalURL_Immutable`,
  `Test_Ctx_Path_Immutable`, `Test_Ctx_Cookies_Immutable`,
  `Test_Ctx_FormValue_Immutable`) that writes into the `*Bytes` slice
  after the fact and asserts the previously-returned string didn't change.

## Not in scope

Per discussion in the issue, this only covers the four methods explicitly
named there. Other string-returning methods that still alias
`app.config.Immutable` (headers, params, etc.) are untouched. A full sweep,
or the `String`/wrapper-type redesign floated later in the thread, is
left for a separate v4 discussion.

## Compatibility note

This is a **behavior change**, not just an additive one: code that relied
on `Config.Immutable = false` (the default) to get zero-copy strings from
`OriginalURL`/`Path`/`Cookies`/`FormValue` will now get a copy instead
(one extra allocation per call). Callers who need the old zero-copy
behavior should switch to the new `*Bytes()` methods.
