### PR TITLE
🐛 fix: accept full float64 range in `float` route constraint

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -244,7 +244,7 @@ type floatConstraintType struct{}
 
 func (floatConstraintType) Name() string { return ConstraintFloat }
 func (floatConstraintType) Execute(param string, _ []any) bool {
-	_, err := strconv.ParseFloat(param, 32)
+	_, err := strconv.ParseFloat(param, 64)
 	return err == nil
 }
 

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -119,6 +119,10 @@ func Test_ConstraintExecute_FloatConstraint(t *testing.T) {
 
 	handler := floatConstraintType{}
 	require.True(t, handler.Execute("3.14", nil))
+	// Values within the float64 range but outside float32 must be accepted.
+	require.True(t, handler.Execute("1e308", nil))
+	require.True(t, handler.Execute("3.5e38", nil))
+	require.True(t, handler.Execute("-1.7976931348623157e308", nil))
 	require.False(t, handler.Execute("abc", nil))
 }
 


### PR DESCRIPTION
Closes #4522

### Problem
The `float` route constraint validated params with `strconv.ParseFloat(param, 32)` (bitSize 32). Valid floating-point values outside the float32 range were therefore rejected, and routes using `<float>` returned **404 instead of 200** for perfectly valid numbers:

```go
app.Get("/price/:val<float>", h)
// GET /price/1e308  -> 404 (should be 200)
```

`1e308`, `3.5e38`, and `-1.7976931348623157e308` are all valid `float64` values but overflow `float32`.

### Fix
Parse with bitSize 64, so a constraint named `float` accepts any valid `float64` — consistent with what users expect.

### Tests
Extended `Test_ConstraintExecute_FloatConstraint` with float64-range values. The new cases fail on `master` (bitSize 32) and pass with this change. `gofmt` and `go vet` are clean.
