### PR TITLE
🐛 fix: URL-encode query values in `Redirect.Route`

### DIFF
--- a/redirect.go
+++ b/redirect.go
@@ -366,7 +366,10 @@ func (r *Redirect) Route(name string, config ...RedirectConfig) error {
 			first = false
 			queryText.WriteString(k)
 			queryText.WriteByte('=')
-			queryText.WriteString(v)
+			// Escape the value so characters like &, =, # or + don't break the
+			// query string. Keys are left as-is to preserve the nested-key
+			// convention (e.g. `data[0][name]`) used elsewhere.
+			queryText.WriteString(url.QueryEscape(v))
 		}
 
 		return r.To(location + "?" + r.c.app.toString(queryText.Bytes()))

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -115,6 +115,30 @@ func Test_Redirect_Route_WithParams_WithQueries(t *testing.T) {
 	require.Equal(t, url.Values{"data[0][name]": []string{"john"}, "data[0][age]": []string{"10"}, "test": []string{"doe"}}, location.Query())
 }
 
+// go test -run Test_Redirect_Route_WithQueries_SpecialChars
+func Test_Redirect_Route_WithQueries_SpecialChars(t *testing.T) {
+	t.Parallel()
+	app := New()
+	app.Get("/user/:name", func(c Ctx) error {
+		return c.JSON(c.Params("name"))
+	}).Name("user")
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	err := c.Redirect().Route("user", RedirectConfig{
+		Params:  Map{"name": "fiber"},
+		Queries: map[string]string{"q": "a&b=c"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, StatusSeeOther, c.Response().StatusCode())
+
+	location, err := url.Parse(string(c.Response().Header.Peek(HeaderLocation)))
+	require.NoError(t, err, "url.Parse(location)")
+	require.Equal(t, "/user/fiber", location.Path)
+	// The value must survive as a single query parameter, not be split into
+	// `q=a` and `b=c`.
+	require.Equal(t, url.Values{"q": []string{"a&b=c"}}, location.Query())
+}
+
 // go test -run Test_Redirect_Route_WithOptionalParams
 func Test_Redirect_Route_WithOptionalParams(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Closes #4526

### Problem
`Redirect.Route()` built the query string from `RedirectConfig.Queries` without escaping values, so a value containing `&`, `=`, `#`, or `+` produced a malformed URL:

```go
c.Redirect().Route("dest", fiber.RedirectConfig{Queries: map[string]string{"q": "a&b=c"}})
// Location: /dest?q=a&b=c  -> parsed by the server as q=a AND b=c (two params)
```

### Fix
Escape values with `url.QueryEscape` (`net/url` is already imported). Keys are intentionally left unescaped to preserve fiber's nested-key convention (`data[0][name]`) that existing tests and routes rely on — happy to also escape keys if you'd prefer.

### Tests
Added `Test_Redirect_Route_WithQueries_SpecialChars` (value `a&b=c` must survive as a single query param). It fails on `master` and passes with this change; the existing `Test_Redirect_Route_WithParams_WithQueries` (bracket keys) still passes. `gofmt`/`go vet` clean.
