### PR TITLE
🐛 fix: `NewErrorf` keeps all args when first isn't a format string

### DIFF
--- a/app.go
+++ b/app.go
@@ -1240,8 +1240,9 @@ func NewErrorf(code int, message ...any) *Error {
 		if format, ok := message[0].(string); ok {
 			msg = fmt.Sprintf(format, message[1:]...)
 		} else {
-			// If the first arg isn’t a string, fall back.
-			msg = fmt.Sprint(message[0])
+			// If the first arg isn’t a format string, stringify all of them
+			// instead of dropping everything after the first.
+			msg = fmt.Sprint(message...)
 		}
 	}
 

--- a/app_test.go
+++ b/app_test.go
@@ -2036,10 +2036,16 @@ func Test_NewErrorf_Format(t *testing.T) {
 			want: "odd 1%!(EXTRA int=2, int=3)",
 		},
 		{
-			name: "≥2 args but first not string",
+			name: "≥2 args but first not string keeps all args",
 			code: StatusBadRequest,
 			in:   args{errors.New("boom"), 42},
-			want: "boom",
+			want: "boom 42",
+		},
+		{
+			name: "≥2 args, first non-string followed by string",
+			code: StatusInternalServerError,
+			in:   args{42, "extra details"},
+			want: "42extra details",
 		},
 	}
 


### PR DESCRIPTION
Closes #4525

### Problem
`NewErrorf` dropped all arguments after the first when the first argument wasn't a string:

```go
err := fiber.NewErrorf(fiber.StatusInternalServerError, 42, "extra details")
// err.Message == "42"   ← "extra details" silently dropped
```

The `default` (2+ args) branch fell back to `fmt.Sprint(message[0])`, ignoring `message[1:]`.

### Fix
Use `fmt.Sprint(message...)` so every argument is stringified instead of only the first.

### Tests
Updated `Test_NewErrorf_Format`: the existing `{errors.New("boom"), 42}` case now expects `"boom 42"` (it previously asserted the buggy `"boom"`), and added `{42, "extra details"}` → `"42extra details"`. Both fail on `master` and pass with this change. `gofmt`/`go vet` clean.
