### PR TITLE
🐛 fix(app): deliver real error to OnPostShutdown and stop double-firing

### DIFF
--- a/app.go
+++ b/app.go
@@ -1325,7 +1325,12 @@ func (app *App) ShutdownWithContext(ctx context.Context) error {
 
 	// Execute the Shutdown hook
 	app.hooks.executeOnPreShutdownHooks()
-	defer app.hooks.executeOnPostShutdownHooks(err)
+	// Wrap in a closure so err is read when the deferred call runs, not when it
+	// is registered. Passing err directly would capture its value (nil) at
+	// registration time, so the hooks would never see the shutdown error.
+	defer func() {
+		app.hooks.executeOnPostShutdownHooks(err)
+	}()
 
 	err = app.server.ShutdownWithContext(ctx)
 	return err

--- a/listen.go
+++ b/listen.go
@@ -606,18 +606,13 @@ func (app *App) printRoutesMessage() {
 func (app *App) gracefulShutdown(ctx context.Context, cfg *ListenConfig) {
 	<-ctx.Done()
 
-	var err error
-
+	// Shutdown / ShutdownWithTimeout both run through ShutdownWithContext, which
+	// fires the OnPostShutdown hooks (with the shutdown error) from its own defer.
+	// Firing them again here would deliver every hook twice, so the error is left
+	// to reach the hooks through that single path.
 	if cfg != nil && cfg.ShutdownTimeout != 0 {
-		err = app.ShutdownWithTimeout(cfg.ShutdownTimeout) //nolint:contextcheck // TODO: Implement it
+		_ = app.ShutdownWithTimeout(cfg.ShutdownTimeout) //nolint:contextcheck,errcheck // error is surfaced via OnPostShutdown hooks
 	} else {
-		err = app.Shutdown() //nolint:contextcheck // TODO: Implement it
+		_ = app.Shutdown() //nolint:contextcheck,errcheck // error is surfaced via OnPostShutdown hooks
 	}
-
-	if err != nil {
-		app.hooks.executeOnPostShutdownHooks(err)
-		return
-	}
-
-	app.hooks.executeOnPostShutdownHooks(nil)
 }

--- a/listen_test.go
+++ b/listen_test.go
@@ -59,6 +59,7 @@ func testGracefulShutdown(t *testing.T, shutdownTimeout time.Duration) {
 	var mu sync.Mutex
 	var shutdown bool
 	var receivedErr error
+	var postShutdownCalls int
 
 	app := New()
 	app.Get("/", func(c Ctx) error {
@@ -74,6 +75,7 @@ func testGracefulShutdown(t *testing.T, shutdownTimeout time.Duration) {
 		defer mu.Unlock()
 		shutdown = true
 		receivedErr = err
+		postShutdownCalls++
 		return nil
 	})
 
@@ -170,7 +172,12 @@ func testGracefulShutdown(t *testing.T, shutdownTimeout time.Duration) {
 
 	mu.Lock()
 	require.True(t, shutdown)
+	// OnPostShutdown must fire exactly once. It previously fired twice: once from
+	// ShutdownWithContext's defer and again from gracefulShutdown.
+	require.Equal(t, 1, postShutdownCalls, "OnPostShutdown should fire exactly once")
 	if shutdownTimeout == 1*time.Nanosecond {
+		// The single fire must carry the real shutdown error. The defer used to
+		// capture err by value at registration time, so hooks always saw nil.
 		require.Error(t, receivedErr)
 		require.ErrorIs(t, receivedErr, context.DeadlineExceeded)
 	}


### PR DESCRIPTION
# Description

Fixes two linked bugs in the shutdown hook lifecycle reported in the issue.

**1. OnPostShutdown always received nil error.** `ShutdownWithContext` registered the hook call as `defer app.hooks.executeOnPostShutdownHooks(err)`. Go evaluates deferred call arguments at registration time, so `err` was captured as its current value (nil) before `app.server.ShutdownWithContext(ctx)` ran. Every `OnPostShutdown` hook therefore received nil, even when shutdown failed (for example with `context.DeadlineExceeded`). Wrapping the call in a closure makes `err` read when the deferred function runs.

**2. Hooks fired twice.** `gracefulShutdown` called `executeOnPostShutdownHooks` again after `Shutdown` / `ShutdownWithTimeout` returned. Both of those route through `ShutdownWithContext`, whose defer already fires the hooks, so every hook ran twice on the graceful path: first with the stale nil, then with the real error. Since the defer is the single path that also covers a direct `app.Shutdown()` call (not just the `Listen` graceful path), the duplicate calls in `gracefulShutdown` are the ones removed; the error still reaches the hooks through `ShutdownWithContext`.

Fixes #4523

## Changes introduced

- `app.go` — wrap the `executeOnPostShutdownHooks(err)` defer in a closure so the shutdown error is read at call time instead of captured as nil at registration time.
- `listen.go` — drop the duplicate `executeOnPostShutdownHooks` calls in `gracefulShutdown`; the hooks now fire exactly once, from `ShutdownWithContext`, with the real error.
- `listen_test.go` — extend `testGracefulShutdown` to assert `OnPostShutdown` fires exactly once and that the single call carries the real shutdown error. Verified this fails on `main` (the counter observes 2) and passes with the fix.

- [ ] Benchmarks: not applicable (correctness fix, no hot-path change).
- [ ] Documentation Update: not needed; `ListenConfig.ShutdownTimeout` already documents that `OnPostShutdown` is called with the error, which now actually holds.
- [x] Changelog/What's New: `OnPostShutdown` hooks now receive the actual shutdown error and are invoked once per shutdown instead of twice.
- [ ] Migration Guide: not applicable.
- [ ] API Alignment with Express: not applicable.
- [x] API Longevity: no signature changes; only the hook's delivered error value and call count are corrected to match the documented behavior.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that no new dependencies are introduced.
