### PR TITLE
♻️ Refactor: Optimize CSRF trusted subdomain matching

### DIFF
--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -377,10 +377,8 @@ func originMatchesHost(c fiber.Ctx, trustedOrigins []string, trustedSubOrigins [
 		return nil
 	}
 
-	for _, trustedSubOrigin := range trustedSubOrigins {
-		if trustedSubOrigin.match(origin) {
-			return nil
-		}
+	if matchSubdomainOrigin(trustedSubOrigins, origin) {
+		return nil
 	}
 
 	return ErrOriginNoMatch
@@ -410,10 +408,8 @@ func refererMatchesHost(c fiber.Ctx, trustedOrigins []string, trustedSubOrigins 
 		return nil
 	}
 
-	for _, trustedSubOrigin := range trustedSubOrigins {
-		if trustedSubOrigin.match(refererOrigin) {
-			return nil
-		}
+	if matchSubdomainOrigin(trustedSubOrigins, refererOrigin) {
+		return nil
 	}
 
 	return ErrRefererNoMatch

--- a/middleware/csrf/helpers.go
+++ b/middleware/csrf/helpers.go
@@ -66,6 +66,29 @@ func (s subdomain) match(o string) bool {
 		return false
 	}
 
+	return s.matchNormalized(o)
+}
+
+func matchSubdomainOrigin(subdomains []subdomain, origin string) bool {
+	if len(subdomains) == 0 {
+		return false
+	}
+
+	isValid, normalizedOrigin := normalizeOrigin(origin)
+	if !isValid || normalizedOrigin != origin {
+		return false
+	}
+
+	for _, sub := range subdomains {
+		if sub.matchNormalized(origin) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (s subdomain) matchNormalized(o string) bool {
 	// Not a subdomain if not long enough for a dot separator.
 	if len(o) < len(s.prefix)+len(s.suffix)+1 {
 		return false

--- a/middleware/csrf/helpers_test.go
+++ b/middleware/csrf/helpers_test.go
@@ -185,6 +185,87 @@ func Benchmark_CSRF_SubdomainMatch(b *testing.B) {
 	}
 }
 
+func benchSubdomains(n int) []subdomain {
+	subs := make([]subdomain, n)
+	for i := range subs {
+		subs[i] = subdomain{prefix: "https://", suffix: "example.com"}
+	}
+	return subs
+}
+
+func Benchmark_CSRF_SubdomainMatch_PerPatternNormalize(b *testing.B) {
+	subdomains := benchSubdomains(16)
+	origin := "https://api.service.example.org"
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		for _, sub := range subdomains {
+			isValid, normalized := normalizeOrigin(origin)
+			if isValid && normalized == origin && sub.matchNormalized(origin) {
+				break
+			}
+		}
+	}
+}
+
+func Benchmark_CSRF_MatchSubdomainOrigin(b *testing.B) {
+	subdomains := benchSubdomains(16)
+	origin := "https://api.service.example.org"
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		matchSubdomainOrigin(subdomains, origin)
+	}
+}
+
+func Test_CSRF_MatchSubdomainOrigin(t *testing.T) {
+	t.Parallel()
+
+	subdomains := []subdomain{
+		{prefix: "https://", suffix: "example.net"},
+		{prefix: "https://", suffix: "example.org"},
+		{prefix: "https://", suffix: "example.com"},
+	}
+
+	tests := []struct {
+		name     string
+		origin   string
+		expected bool
+	}{
+		{
+			name:     "matches later pattern",
+			origin:   "https://api.service.example.com",
+			expected: true,
+		},
+		{
+			name:     "rejects invalid origin once",
+			origin:   "https://user@api.example.com",
+			expected: false,
+		},
+		{
+			name:     "rejects non-normalized origin",
+			origin:   "https://API.service.example.com",
+			expected: false,
+		},
+		{
+			name:     "rejects unmatched origin",
+			origin:   "https://api.service.example.dev",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := matchSubdomainOrigin(subdomains, tt.origin)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func Test_CSRF_Security_CompareConstantTime(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# Description

This PR optimizes CSRF trusted subdomain origin matching.

When `TrustedOrigins` contains wildcard subdomain entries, the CSRF middleware previously normalized the request origin once per trusted wildcard candidate. This change keeps the existing behavior but normalizes the request origin once before scanning the wildcard entries, reducing repeated parsing and allocations on the trusted-origin matching path.

Fixes #

## Changes introduced

- [x] Benchmarks: Added benchmarks comparing the previous per-pattern normalization path with the new single-normalization helper.
  - Previous-style path: ~4128-4186 ns/op, 2816 B/op, 32 allocs/op
  - New helper path: ~370-374 ns/op, 176 B/op, 2 allocs/op
- [ ] Documentation Update: Not applicable. This is an internal performance optimization with no public API or behavior changes.
- [ ] Changelog/What's New: Not applicable.
- [ ] Migration Guide: Not required. No user-facing API or configuration changes.
- [ ] API Alignment with Express: Not applicable. No API changes.
- [x] API Longevity: The existing `TrustedOrigins` behavior is preserved; the change only adjusts internal matching to avoid repeated normalization.
- [ ] Examples: Not applicable. Existing CSRF `TrustedOrigins` usage remains unchanged.

## Type of change

- [x] Performance improvement (non-breaking change which improves efficiency)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [ ] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [ ] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.