### PR TITLE
🐛 fix(proxy): correctly classify IPv6 transition addresses in upstream validation

### DIFF
--- a/middleware/proxy/security.go
+++ b/middleware/proxy/security.go
@@ -601,9 +601,9 @@ func newGuardedClientDialerWithTimeout(orig fasthttp.DialFuncWithTimeout, dialDu
 // isBlockedIP reports whether ip falls inside a range that proxy
 // upstreams must not reach by default. Loopback, unspecified, RFC 1918
 // private, link-local (including the 169.254.169.254 cloud-metadata
-// address), multicast, and RFC 6598 CGNAT ranges are blocked. IPv4-compatible
-// and NAT64 IPv6 wrappers are unwrapped so a blocked IPv4 cannot be smuggled
-// past as an IPv6 literal.
+// address), multicast, and RFC 6598 CGNAT ranges are blocked. IPv4-compatible,
+// NAT64, 6to4, and Teredo IPv6 wrappers are unwrapped so a blocked IPv4 cannot
+// be smuggled past as an IPv6 literal.
 func isBlockedIP(ip net.IP) bool {
 	if ip == nil {
 		return true
@@ -616,20 +616,27 @@ func isBlockedIP(ip net.IP) bool {
 	if v4 := ip.To4(); v4 != nil && v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
 		return true
 	}
-	// Look through IPv4-compatible (::a.b.c.d) and NAT64 (64:ff9b::a.b.c.d)
-	// IPv6 wrappers to the embedded IPv4 and apply the same blocklist. Some
-	// stacks route these to the embedded address, so a private target could
-	// otherwise be reached via such a literal (the IPv4-mapped ::ffff:a.b.c.d
-	// form is already handled above because net.IP.To4 exposes it).
+	// Look through IPv4-compatible (::a.b.c.d), NAT64 (64:ff9b::a.b.c.d and
+	// the 64:ff9b:1::/48 local-use prefix), 6to4 (2002::/16), and Teredo
+	// (2001:0000::/32) IPv6 wrappers to the embedded IPv4 and apply the same
+	// blocklist. Some stacks route these to the embedded address, so a private
+	// target could otherwise be reached via such a literal (the IPv4-mapped
+	// ::ffff:a.b.c.d form is already handled above because net.IP.To4 exposes
+	// it).
 	if embedded := embeddedIPv4(ip); embedded != nil && isBlockedIP(embedded) {
 		return true
 	}
 	return false
 }
 
-// embeddedIPv4 returns the IPv4 address embedded in an IPv4-compatible IPv6
-// address (::a.b.c.d, RFC 4291) or a well-known-prefix NAT64 address
-// (64:ff9b::a.b.c.d, RFC 6052), or nil for anything else. The IPv4-mapped
+// embeddedIPv4 returns the IPv4 address embedded in an IPv6 transition
+// address, or nil for anything else. Recognized forms are the IPv4-compatible
+// address (::a.b.c.d, RFC 4291), the NAT64 well-known prefix
+// (64:ff9b::a.b.c.d, RFC 6052) and its local-use counterpart (64:ff9b:1::/48,
+// RFC 8215), 6to4 (2002::/16, RFC 3056), and Teredo (2001:0000::/32,
+// RFC 4380). Each embeds an IPv4 address inside a globally-routable IPv6
+// literal, so unwrapping them lets isBlockedIP apply the IPv4 blocklist and
+// stops a private target from being smuggled past the guard. The IPv4-mapped
 // form (::ffff:a.b.c.d) is deliberately excluded here: net.IP.To4 already
 // surfaces its IPv4, so isBlockedIP checks it directly.
 func embeddedIPv4(ip net.IP) net.IP {
@@ -637,10 +644,25 @@ func embeddedIPv4(ip net.IP) net.IP {
 	if ip16 == nil || ip.To4() != nil {
 		return nil
 	}
-	// NAT64 well-known prefix 64:ff9b::/96.
+	// NAT64 well-known prefix 64:ff9b::/96 (RFC 6052).
 	if ip16[0] == 0x00 && ip16[1] == 0x64 && ip16[2] == 0xff && ip16[3] == 0x9b &&
 		allZero(ip16[4:12]) {
 		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+	}
+	// NAT64 local-use prefix 64:ff9b:1::/48 (RFC 8215): the trailing 32 bits
+	// carry the embedded IPv4 address.
+	if ip16[0] == 0x00 && ip16[1] == 0x64 && ip16[2] == 0xff && ip16[3] == 0x9b &&
+		ip16[4] == 0x00 && ip16[5] == 0x01 {
+		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+	}
+	// 6to4 2002::/16 (RFC 3056): the IPv4 gateway sits in bytes [2:6].
+	if ip16[0] == 0x20 && ip16[1] == 0x02 {
+		return net.IPv4(ip16[2], ip16[3], ip16[4], ip16[5])
+	}
+	// Teredo 2001:0000::/32 (RFC 4380): the client IPv4 is stored in the
+	// trailing 32 bits, obfuscated by a bitwise NOT.
+	if ip16[0] == 0x20 && ip16[1] == 0x01 && ip16[2] == 0x00 && ip16[3] == 0x00 {
+		return net.IPv4(ip16[12]^0xff, ip16[13]^0xff, ip16[14]^0xff, ip16[15]^0xff)
 	}
 	// IPv4-compatible ::a.b.c.d (first 12 bytes zero). :: and ::1 have already
 	// been classified above, so treat any remaining all-zero-prefix address as

--- a/middleware/proxy/security.go
+++ b/middleware/proxy/security.go
@@ -682,13 +682,15 @@ func isBlockedIPv6TransitionRange(ip net.IP) bool {
 //   - ISATAP (RFC 5214) — interface identifier 00-00-5E-FE or 02-00-5E-FE
 //     followed by the embedded IPv4 in the trailing 32 bits. The prefix is an
 //     ordinary global one, so there is no dedicated range to block wholesale.
+//   - SIIT IPv4-translated ::ffff:0:0/96 (RFC 2765) — 0xffff marker in bytes
+//     [8:10], zero in [10:12], embedded IPv4 in the trailing 32 bits.
 //   - IPv4-compatible ::a.b.c.d (RFC 4291) — trailing 32 bits.
 //
 // Deprecated tunneling / local-use ranges with operator-dependent embedding
 // offsets (6to4, Teredo, NAT64 local-use) are intentionally NOT unwrapped here;
 // isBlockedIPv6TransitionRange blocks them wholesale instead. The IPv4-mapped
-// form (::ffff:a.b.c.d) is also excluded: net.IP.To4 already surfaces its
-// IPv4, so isBlockedIP checks it directly.
+// form (::ffff:a.b.c.d, 0xffff marker in bytes [10:12]) is also excluded:
+// net.IP.To4 already surfaces its IPv4, so isBlockedIP checks it directly.
 func embeddedIPv4(ip net.IP) net.IP {
 	ip16 := ip.To16()
 	if ip16 == nil || ip.To4() != nil {
@@ -704,6 +706,15 @@ func embeddedIPv4(ip net.IP) net.IP {
 	// universal/local bit in ip16[8]) precedes the embedded IPv4.
 	if ip16[9] == 0x00 && ip16[10] == 0x5e && ip16[11] == 0xfe &&
 		(ip16[8] == 0x00 || ip16[8] == 0x02) {
+		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+	}
+	// SIIT IPv4-translated ::ffff:0:a.b.c.d (RFC 2765, prefix ::ffff:0:0/96):
+	// the 0xffff marker sits in bytes [8:10] with [10:12] zero, and the
+	// embedded IPv4 is the trailing 32 bits. This is distinct from the
+	// IPv4-mapped form (::ffff:a.b.c.d, marker in bytes [10:12]) that
+	// net.IP.To4 already exposes, so it is unwrapped here.
+	if allZero(ip16[:8]) && ip16[8] == 0xff && ip16[9] == 0xff &&
+		ip16[10] == 0x00 && ip16[11] == 0x00 {
 		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
 	}
 	// IPv4-compatible ::a.b.c.d (first 12 bytes zero). :: and ::1 have already

--- a/middleware/proxy/security.go
+++ b/middleware/proxy/security.go
@@ -601,9 +601,16 @@ func newGuardedClientDialerWithTimeout(orig fasthttp.DialFuncWithTimeout, dialDu
 // isBlockedIP reports whether ip falls inside a range that proxy
 // upstreams must not reach by default. Loopback, unspecified, RFC 1918
 // private, link-local (including the 169.254.169.254 cloud-metadata
-// address), multicast, and RFC 6598 CGNAT ranges are blocked. IPv4-compatible,
-// NAT64, 6to4, and Teredo IPv6 wrappers are unwrapped so a blocked IPv4 cannot
-// be smuggled past as an IPv6 literal.
+// address), multicast, and RFC 6598 CGNAT ranges are blocked.
+//
+// IPv6 transition addresses are handled in two ways so a blocked IPv4 cannot
+// be smuggled past as an IPv6 literal. Deprecated tunneling and local-use
+// ranges (6to4, Teredo, NAT64 local-use) are blocked in their entirety by
+// isBlockedIPv6TransitionRange — their embedded IPv4 sits at an
+// operator-dependent offset, and none has a legitimate use as a proxy
+// upstream. The remaining wrappers whose embedded IPv4 is unambiguous and may
+// legitimately be public (NAT64 well-known prefix, IPv4-compatible, ISATAP)
+// are unwrapped by embeddedIPv4 and re-checked against the same blocklist.
 func isBlockedIP(ip net.IP) bool {
 	if ip == nil {
 		return true
@@ -616,29 +623,72 @@ func isBlockedIP(ip net.IP) bool {
 	if v4 := ip.To4(); v4 != nil && v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
 		return true
 	}
-	// Look through IPv4-compatible (::a.b.c.d), NAT64 (64:ff9b::a.b.c.d and
-	// the 64:ff9b:1::/48 local-use prefix), 6to4 (2002::/16), and Teredo
-	// (2001:0000::/32) IPv6 wrappers to the embedded IPv4 and apply the same
-	// blocklist. Some stacks route these to the embedded address, so a private
-	// target could otherwise be reached via such a literal (the IPv4-mapped
-	// ::ffff:a.b.c.d form is already handled above because net.IP.To4 exposes
-	// it).
+	// Block deprecated / local-use IPv6 transition ranges wholesale (see the
+	// helper for the rationale). Done before the embeddedIPv4 unwrap because
+	// their embedded IPv4 offset is not fixed.
+	if isBlockedIPv6TransitionRange(ip) {
+		return true
+	}
+	// Look through the unambiguous wrappers to the embedded IPv4 and apply the
+	// same blocklist. Some stacks route these to the embedded address, so a
+	// private target could otherwise be reached via such a literal (the
+	// IPv4-mapped ::ffff:a.b.c.d form is already handled above because
+	// net.IP.To4 exposes it).
 	if embedded := embeddedIPv4(ip); embedded != nil && isBlockedIP(embedded) {
 		return true
 	}
 	return false
 }
 
+// isBlockedIPv6TransitionRange reports whether ip belongs to an IPv6
+// transition range that must be blocked in its entirety:
+//
+//   - 6to4         2002::/16        (RFC 3056) — deprecated by RFC 7526.
+//   - Teredo       2001:0000::/32   (RFC 4380) — a private IPv4 can hide in
+//     either the un-obfuscated server field (bytes [4:8]) or the obfuscated
+//     client field (bytes [12:16]).
+//   - NAT64 local  64:ff9b:1::/48   (RFC 8215) — local-use only; RFC 8215 §3
+//     forbids it on the public Internet, and RFC 6052 lets the embedded IPv4
+//     sit anywhere from a /32 to a /96 boundary.
+//
+// Because the embedded IPv4 offset depends on operator configuration,
+// unwrapping a single position would leave a bypass; blocking the whole range
+// is both safer and simpler. This mirrors the CIDR-level handling in Gitea's
+// and Coder's SSRF guards.
+func isBlockedIPv6TransitionRange(ip net.IP) bool {
+	ip16 := ip.To16()
+	if ip16 == nil || ip.To4() != nil {
+		return false
+	}
+	switch {
+	case ip16[0] == 0x20 && ip16[1] == 0x02: // 6to4 2002::/16
+		return true
+	case ip16[0] == 0x20 && ip16[1] == 0x01 && ip16[2] == 0x00 && ip16[3] == 0x00: // Teredo 2001:0000::/32
+		return true
+	case ip16[0] == 0x00 && ip16[1] == 0x64 && ip16[2] == 0xff && ip16[3] == 0x9b &&
+		ip16[4] == 0x00 && ip16[5] == 0x01: // NAT64 local-use 64:ff9b:1::/48
+		return true
+	}
+	return false
+}
+
 // embeddedIPv4 returns the IPv4 address embedded in an IPv6 transition
-// address, or nil for anything else. Recognized forms are the IPv4-compatible
-// address (::a.b.c.d, RFC 4291), the NAT64 well-known prefix
-// (64:ff9b::a.b.c.d, RFC 6052) and its local-use counterpart (64:ff9b:1::/48,
-// RFC 8215), 6to4 (2002::/16, RFC 3056), and Teredo (2001:0000::/32,
-// RFC 4380). Each embeds an IPv4 address inside a globally-routable IPv6
-// literal, so unwrapping them lets isBlockedIP apply the IPv4 blocklist and
-// stops a private target from being smuggled past the guard. The IPv4-mapped
-// form (::ffff:a.b.c.d) is deliberately excluded here: net.IP.To4 already
-// surfaces its IPv4, so isBlockedIP checks it directly.
+// address, or nil for anything else. It only handles wrappers whose embedded
+// IPv4 has a fixed, unambiguous offset and can legitimately be a public host:
+//
+//   - NAT64 well-known prefix 64:ff9b::/96 (RFC 6052) — defined only at /96,
+//     so the embedded IPv4 is always the trailing 32 bits and is commonly used
+//     to reach public IPv4 hosts from IPv6-only networks.
+//   - ISATAP (RFC 5214) — interface identifier 00-00-5E-FE or 02-00-5E-FE
+//     followed by the embedded IPv4 in the trailing 32 bits. The prefix is an
+//     ordinary global one, so there is no dedicated range to block wholesale.
+//   - IPv4-compatible ::a.b.c.d (RFC 4291) — trailing 32 bits.
+//
+// Deprecated tunneling / local-use ranges with operator-dependent embedding
+// offsets (6to4, Teredo, NAT64 local-use) are intentionally NOT unwrapped here;
+// isBlockedIPv6TransitionRange blocks them wholesale instead. The IPv4-mapped
+// form (::ffff:a.b.c.d) is also excluded: net.IP.To4 already surfaces its
+// IPv4, so isBlockedIP checks it directly.
 func embeddedIPv4(ip net.IP) net.IP {
 	ip16 := ip.To16()
 	if ip16 == nil || ip.To4() != nil {
@@ -649,20 +699,12 @@ func embeddedIPv4(ip net.IP) net.IP {
 		allZero(ip16[4:12]) {
 		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
 	}
-	// NAT64 local-use prefix 64:ff9b:1::/48 (RFC 8215): the trailing 32 bits
-	// carry the embedded IPv4 address.
-	if ip16[0] == 0x00 && ip16[1] == 0x64 && ip16[2] == 0xff && ip16[3] == 0x9b &&
-		ip16[4] == 0x00 && ip16[5] == 0x01 {
+	// ISATAP (RFC 5214): interface identifier ::0:5efe:a.b.c.d or
+	// ::200:5efe:a.b.c.d — the 5e:fe marker (with the IANA OUI and the
+	// universal/local bit in ip16[8]) precedes the embedded IPv4.
+	if ip16[9] == 0x00 && ip16[10] == 0x5e && ip16[11] == 0xfe &&
+		(ip16[8] == 0x00 || ip16[8] == 0x02) {
 		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
-	}
-	// 6to4 2002::/16 (RFC 3056): the IPv4 gateway sits in bytes [2:6].
-	if ip16[0] == 0x20 && ip16[1] == 0x02 {
-		return net.IPv4(ip16[2], ip16[3], ip16[4], ip16[5])
-	}
-	// Teredo 2001:0000::/32 (RFC 4380): the client IPv4 is stored in the
-	// trailing 32 bits, obfuscated by a bitwise NOT.
-	if ip16[0] == 0x20 && ip16[1] == 0x01 && ip16[2] == 0x00 && ip16[3] == 0x00 {
-		return net.IPv4(ip16[12]^0xff, ip16[13]^0xff, ip16[14]^0xff, ip16[15]^0xff)
 	}
 	// IPv4-compatible ::a.b.c.d (first 12 bytes zero). :: and ::1 have already
 	// been classified above, so treat any remaining all-zero-prefix address as

--- a/middleware/proxy/security_test.go
+++ b/middleware/proxy/security_test.go
@@ -31,36 +31,41 @@ func Test_Security_IsBlockedIP(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]bool{
-		"127.0.0.1":            true,
-		"::1":                  true,
-		"0.0.0.0":              true,
-		"10.0.0.1":             true,
-		"172.16.0.1":           true,
-		"192.168.1.1":          true,
-		"169.254.169.254":      true, // AWS metadata
-		"100.64.0.1":           true, // CGNAT
-		"224.0.0.1":            true, // multicast
-		"::ffff:127.0.0.1":     true, // IPv4-mapped loopback
-		"::ffff:10.0.0.1":      true, // IPv4-mapped private
-		"::127.0.0.1":          true, // IPv4-compatible loopback
-		"::10.0.0.1":           true, // IPv4-compatible private
-		"64:ff9b::7f00:1":      true, // NAT64 127.0.0.1
-		"64:ff9b::a00:1":       true, // NAT64 10.0.0.1
-		"64:ff9b::a9fe:a9fe":   true, // NAT64 169.254.169.254 (metadata)
-		"64:ff9b:1::a9fe:a9fe": true, // NAT64 local-use 169.254.169.254 (metadata)
-		"64:ff9b:1::a00:1":     true, // NAT64 local-use 10.0.0.1
-		"2002:a9fe:a9fe::":     true, // 6to4 169.254.169.254 (metadata)
-		"2002:a00:1::":         true, // 6to4 10.0.0.1
-		"2002:7f00:1::":        true, // 6to4 127.0.0.1
-		"2001::5601:5601":      true, // Teredo 169.254.169.254 (metadata, client bits inverted a9fe:a9fe)
-		"2001::f5ff:fffe":      true, // Teredo 10.0.0.1 (client bits inverted 0a00:0001)
-		"8.8.8.8":              false,
-		"1.1.1.1":              false,
-		"93.184.216.34":        false, // example.com
-		"64:ff9b::808:808":     false, // NAT64 8.8.8.8 (public → allowed)
-		"64:ff9b:1::808:808":   false, // NAT64 local-use 8.8.8.8 (public → allowed)
-		"2002:808:808::":       false, // 6to4 8.8.8.8 (public → allowed)
-		"2606:4700:4700::1111": false, // public IPv6 (Cloudflare)
+		"127.0.0.1":                true,
+		"::1":                      true,
+		"0.0.0.0":                  true,
+		"10.0.0.1":                 true,
+		"172.16.0.1":               true,
+		"192.168.1.1":              true,
+		"169.254.169.254":          true,  // AWS metadata
+		"100.64.0.1":               true,  // CGNAT
+		"224.0.0.1":                true,  // multicast
+		"::ffff:127.0.0.1":         true,  // IPv4-mapped loopback
+		"::ffff:10.0.0.1":          true,  // IPv4-mapped private
+		"::127.0.0.1":              true,  // IPv4-compatible loopback
+		"::10.0.0.1":               true,  // IPv4-compatible private
+		"64:ff9b::7f00:1":          true,  // NAT64 WKP 127.0.0.1
+		"64:ff9b::a00:1":           true,  // NAT64 WKP 10.0.0.1
+		"64:ff9b::a9fe:a9fe":       true,  // NAT64 WKP 169.254.169.254 (metadata)
+		"64:ff9b:1::a9fe:a9fe":     true,  // NAT64 local-use prefix (blocked wholesale, RFC 8215)
+		"64:ff9b:1::a00:1":         true,  // NAT64 local-use prefix (blocked wholesale)
+		"64:ff9b:1::808:808":       true,  // NAT64 local-use prefix (blocked wholesale even for public embed)
+		"2002:a9fe:a9fe::":         true,  // 6to4 (blocked wholesale, RFC 3056/7526)
+		"2002:a00:1::":             true,  // 6to4 (blocked wholesale)
+		"2002:7f00:1::":            true,  // 6to4 (blocked wholesale)
+		"2002:808:808::":           true,  // 6to4 (blocked wholesale even for public embed)
+		"2001::5601:5601":          true,  // Teredo (blocked wholesale, client field)
+		"2001::f5ff:fffe":          true,  // Teredo (blocked wholesale)
+		"2001:0:a00:1::":           true,  // Teredo (blocked wholesale, private server field bytes [4:8])
+		"2001::808:808":            true,  // Teredo (blocked wholesale even for public embed)
+		"2001:db8::5efe:a9fe:a9fe": true,  // ISATAP 169.254.169.254 (metadata)
+		"2001:db8::200:5efe:a00:1": true,  // ISATAP 10.0.0.1 (global-scope u/g bit)
+		"2001:db8::5efe:808:808":   false, // ISATAP 8.8.8.8 (public → allowed)
+		"8.8.8.8":                  false,
+		"1.1.1.1":                  false,
+		"93.184.216.34":            false, // example.com
+		"64:ff9b::808:808":         false, // NAT64 WKP 8.8.8.8 (public → allowed)
+		"2606:4700:4700::1111":     false, // public IPv6 (Cloudflare)
 	}
 	for raw, blocked := range cases {
 		t.Run(raw, func(t *testing.T) {

--- a/middleware/proxy/security_test.go
+++ b/middleware/proxy/security_test.go
@@ -61,6 +61,10 @@ func Test_Security_IsBlockedIP(t *testing.T) {
 		"2001:db8::5efe:a9fe:a9fe": true,  // ISATAP 169.254.169.254 (metadata)
 		"2001:db8::200:5efe:a00:1": true,  // ISATAP 10.0.0.1 (global-scope u/g bit)
 		"2001:db8::5efe:808:808":   false, // ISATAP 8.8.8.8 (public → allowed)
+		"::ffff:0:7f00:1":          true,  // SIIT IPv4-translated 127.0.0.1
+		"::ffff:0:a00:1":           true,  // SIIT IPv4-translated 10.0.0.1
+		"::ffff:0:a9fe:a9fe":       true,  // SIIT IPv4-translated 169.254.169.254 (metadata)
+		"::ffff:0:808:808":         false, // SIIT IPv4-translated 8.8.8.8 (public → allowed)
 		"8.8.8.8":                  false,
 		"1.1.1.1":                  false,
 		"93.184.216.34":            false, // example.com

--- a/middleware/proxy/security_test.go
+++ b/middleware/proxy/security_test.go
@@ -47,10 +47,19 @@ func Test_Security_IsBlockedIP(t *testing.T) {
 		"64:ff9b::7f00:1":      true, // NAT64 127.0.0.1
 		"64:ff9b::a00:1":       true, // NAT64 10.0.0.1
 		"64:ff9b::a9fe:a9fe":   true, // NAT64 169.254.169.254 (metadata)
+		"64:ff9b:1::a9fe:a9fe": true, // NAT64 local-use 169.254.169.254 (metadata)
+		"64:ff9b:1::a00:1":     true, // NAT64 local-use 10.0.0.1
+		"2002:a9fe:a9fe::":     true, // 6to4 169.254.169.254 (metadata)
+		"2002:a00:1::":         true, // 6to4 10.0.0.1
+		"2002:7f00:1::":        true, // 6to4 127.0.0.1
+		"2001::5601:5601":      true, // Teredo 169.254.169.254 (metadata, client bits inverted a9fe:a9fe)
+		"2001::f5ff:fffe":      true, // Teredo 10.0.0.1 (client bits inverted 0a00:0001)
 		"8.8.8.8":              false,
 		"1.1.1.1":              false,
 		"93.184.216.34":        false, // example.com
 		"64:ff9b::808:808":     false, // NAT64 8.8.8.8 (public → allowed)
+		"64:ff9b:1::808:808":   false, // NAT64 local-use 8.8.8.8 (public → allowed)
+		"2002:808:808::":       false, // 6to4 8.8.8.8 (public → allowed)
 		"2606:4700:4700::1111": false, // public IPv6 (Cloudflare)
 	}
 	for raw, blocked := range cases {


### PR DESCRIPTION
# Description

By default the proxy middleware only connects upstreams to public addresses and refuses non-public ones (loopback, unspecified, RFC 1918 private, link-local, multicast, and RFC 6598 CGNAT). That decision is made in `isBlockedIP`.

Several IPv6 "transition" formats embed an IPv4 address inside an IPv6 literal (6to4, Teredo, the NAT64 prefixes, ISATAP, SIIT, and the IPv4-compatible/mapped forms). `isBlockedIP` only recognized two of them — IPv4-compatible `::a.b.c.d` and the NAT64 well-known prefix `64:ff9b::/96` — so the remaining forms were classified inconsistently with the IPv4 they wrap. For example `::ffff:0:7f00:1` and `2002:7f00:1::` both encode `127.0.0.1`, yet were treated as ordinary public IPv6 while the bare `127.0.0.1` was correctly refused.

This PR makes the classifier handle the full set of well-known, fixed-prefix embeddings so the same result is produced regardless of which IPv6 form is used to write the address.

## Changes introduced

- Added `isBlockedIPv6TransitionRange` to reject the deprecated / local-use ranges in their entirety, where the embedded IPv4 offset is operator-dependent and there is no legitimate use as an upstream: 6to4 `2002::/16` (RFC 3056, deprecated by RFC 7526), Teredo `2001:0000::/32` (RFC 4380), and the NAT64 local-use prefix `64:ff9b:1::/48` (RFC 8215, local-use only).
- Extended `embeddedIPv4` to unwrap the embedded IPv4 (and re-apply the same classification) for the forms whose offset is fixed and unambiguous and may legitimately be public: NAT64 well-known prefix `64:ff9b::/96` (RFC 6052), ISATAP (RFC 5214), SIIT IPv4-translated `::ffff:0:0/96` (RFC 2765), and IPv4-compatible `::a.b.c.d` (RFC 4291). The IPv4-mapped form `::ffff:a.b.c.d` continues to be handled directly since `net.IP.To4` surfaces it.
- Extended `Test_Security_IsBlockedIP` with cases for every form above — non-public embeddings are refused, public embeddings (e.g. `8.8.8.8` wrapped as 6to4/NAT64/ISATAP/SIIT) remain allowed.

Behavior note: an upstream literal in the wholesale-blocked ranges (6to4, Teredo, NAT64 local-use) that wraps a *public* IPv4 is now refused. These are deprecated tunneling / local-use ranges that do not appear as real upstream targets, so this should not affect legitimate usage.

- [ ] Benchmarks: no change to hot paths; classification is a handful of extra byte comparisons on the existing validation path.
- [ ] Documentation Update: no user-facing API change.
- [ ] Changelog/What's New: worth a line under bug fixes.
- [ ] Migration Guide: not needed.
- [ ] API Alignment with Express: n/a.
- [ ] API Longevity: no signature changes; internal helpers only.
- [ ] Examples: n/a.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes.
- [x] Ensured that new and existing unit tests pass locally with the changes (`go test ./middleware/proxy/`, including `-race`).
- [x] No new dependencies introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)