### PR TITLE
⚡ perf(adaptor): cut allocations on the net/http bridge

### DIFF
--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -53,36 +53,38 @@ func (*noopConn) SetDeadline(time.Time) error      { return nil }
 func (*noopConn) SetReadDeadline(time.Time) error  { return nil }
 func (*noopConn) SetWriteDeadline(time.Time) error { return nil }
 
-// tcpAddrScratch backs a reusable net.TCPAddr so the common "ip:port"
-// remote address form resolves without allocating. The IP array is inlined
-// so the net.IP slice handed to the TCPAddr points at scratch storage
-// instead of a fresh per-request allocation.
-type tcpAddrScratch struct {
+// tcpAddrBuf co-locates a net.TCPAddr with the storage for its IP so the
+// common "ip:port" remote address form costs one allocation instead of two
+// (one for the address, one for the IP slice).
+//
+// The buffer is deliberately not pooled: RemoteAddr()/RemoteIP() hand this
+// value to user code, which may legitimately keep it past the handler — an
+// async access log, a connection registry — so every request gets its own.
+type tcpAddrBuf struct {
 	addr net.TCPAddr
 	ip   [16]byte
 }
 
-// set fills the scratch TCPAddr with ip/port/zone and returns it. The
-// returned address is only valid for the lifetime of the request, the same
-// rule that already applies to the pooled RequestCtx it belongs to.
-func (s *tcpAddrScratch) set(ip []byte, port int, zone string) *net.TCPAddr {
-	n := copy(s.ip[:], ip)
-	s.addr.IP = s.ip[:n]
-	s.addr.Port = port
-	s.addr.Zone = zone
-	return &s.addr
+// newTCPAddr returns a TCPAddr backed by inline IP storage. The IP slice is
+// capped at its length so appending to it allocates instead of writing into
+// the rest of the buffer.
+func newTCPAddr(ip []byte, port int, zone string) *net.TCPAddr {
+	buf := &tcpAddrBuf{}
+	n := copy(buf.ip[:], ip)
+	buf.addr.IP = buf.ip[:n:n]
+	buf.addr.Port = port
+	buf.addr.Zone = zone
+	return &buf.addr
 }
 
 // pooledCtx bundles the RequestCtx with the per-request scratch space it
-// needs — the noopConn handed to fasthttp, the remote address storage and
-// the io.LimitedReader used to bound the request body — so a single pool
-// entry serves them all and the request path stays allocation-free. The
-// conn comes first to keep the struct's trailing pointer span minimal
-// (govet fieldalignment).
+// needs — the noopConn handed to fasthttp and the io.LimitedReader used to
+// bound the request body — so a single pool entry serves them all and the
+// request path stays allocation-free. The conn comes first to keep the
+// struct's trailing pointer span minimal (govet fieldalignment).
 type pooledCtx struct {
 	conn noopConn
 	lr   io.LimitedReader
-	scr  tcpAddrScratch
 	fctx fasthttp.RequestCtx
 }
 
@@ -411,11 +413,7 @@ func parseDecimalPort(s string) (int, bool) {
 	return port, port <= 65535
 }
 
-// resolveRemoteAddr turns a net/http RemoteAddr into a net.Addr for the
-// fasthttp connection. scratch, when non-nil, supplies the storage for the
-// "ip:port" fast path so no address is allocated per request; pass nil to
-// get a freshly allocated address instead.
-func resolveRemoteAddr(remoteAddr string, localAddr any, scratch *tcpAddrScratch) (net.Addr, error) {
+func resolveRemoteAddr(remoteAddr string, localAddr any) (net.Addr, error) {
 	if addr, ok := localAddr.(net.Addr); ok && isUnixNetwork(addr.Network()) {
 		return addr, nil
 	}
@@ -433,17 +431,11 @@ func resolveRemoteAddr(remoteAddr string, localAddr any, scratch *tcpAddrScratch
 		if port, ok := parseDecimalPort(portStr); ok {
 			if ip, ok := utils.ParseIPv4(host); ok {
 				a := ip.As4()
-				if scratch != nil {
-					return scratch.set(a[:], port, ""), nil
-				}
-				return &net.TCPAddr{IP: a[:], Port: port}, nil
+				return newTCPAddr(a[:], port, ""), nil
 			}
 			if ip, ok := utils.ParseIPv6(host); ok {
 				a := ip.As16()
-				if scratch != nil {
-					return scratch.set(a[:], port, ip.Zone()), nil
-				}
-				return &net.TCPAddr{IP: a[:], Port: port, Zone: ip.Zone()}, nil
+				return newTCPAddr(a[:], port, ip.Zone()), nil
 			}
 		}
 	}
@@ -484,7 +476,7 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 		fctx.Request.Reset()
 		defer ctxPool.Put(pctx)
 
-		remoteAddr, err := resolveRemoteAddr(r.RemoteAddr, r.Context().Value(http.LocalAddrContextKey), &pctx.scr)
+		remoteAddr, err := resolveRemoteAddr(r.RemoteAddr, r.Context().Value(http.LocalAddrContextKey))
 		if err != nil {
 			remoteAddr = nil // Fallback to nil
 		}

--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -461,12 +461,12 @@ func resolveRemoteAddr(remoteAddr string, localAddr any) (net.Addr, error) {
 }
 
 func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
-	// App.Config returns the config by value, so read the fields this
-	// handler needs once at construction instead of copying the whole
-	// struct on every request. Fiber only writes app.config in New.
-	cfg := app.Config()
-	maxBodySize := int64(cfg.BodyLimit)
-	errorHandler := cfg.ErrorHandler
+	// App.Config returns the config by value, so read the body limit once at
+	// construction instead of copying the whole 624-byte struct on every
+	// request. Fiber only writes app.config in New. The error handler is
+	// deliberately not cached: App.ErrorHandler resolves a mounted sub-app's
+	// handler from the request path, and that lookup belongs per request.
+	maxBodySize := int64(app.Config().BodyLimit)
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		// New fasthttp Ctx from pool
@@ -576,7 +576,7 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 			// Execute fiber Ctx
 			err := h[0](ctx)
 			if err != nil {
-				_ = errorHandler(ctx, err) //nolint:errcheck // not needed
+				_ = app.ErrorHandler(ctx, err) //nolint:errcheck // not needed
 			}
 		} else {
 			// Execute fasthttp Ctx though app.Handler

--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"net/textproto"
 	"reflect"
 	"sync"
 	"time"
@@ -52,12 +53,36 @@ func (*noopConn) SetDeadline(time.Time) error      { return nil }
 func (*noopConn) SetReadDeadline(time.Time) error  { return nil }
 func (*noopConn) SetWriteDeadline(time.Time) error { return nil }
 
-// pooledCtx bundles the RequestCtx with its noopConn so one pool entry
-// serves both and no per-request conn allocation is needed. The conn
-// comes first to keep the struct's trailing pointer span minimal
+// tcpAddrScratch backs a reusable net.TCPAddr so the common "ip:port"
+// remote address form resolves without allocating. The IP array is inlined
+// so the net.IP slice handed to the TCPAddr points at scratch storage
+// instead of a fresh per-request allocation.
+type tcpAddrScratch struct {
+	addr net.TCPAddr
+	ip   [16]byte
+}
+
+// set fills the scratch TCPAddr with ip/port/zone and returns it. The
+// returned address is only valid for the lifetime of the request, the same
+// rule that already applies to the pooled RequestCtx it belongs to.
+func (s *tcpAddrScratch) set(ip []byte, port int, zone string) *net.TCPAddr {
+	n := copy(s.ip[:], ip)
+	s.addr.IP = s.ip[:n]
+	s.addr.Port = port
+	s.addr.Zone = zone
+	return &s.addr
+}
+
+// pooledCtx bundles the RequestCtx with the per-request scratch space it
+// needs — the noopConn handed to fasthttp, the remote address storage and
+// the io.LimitedReader used to bound the request body — so a single pool
+// entry serves them all and the request path stays allocation-free. The
+// conn comes first to keep the struct's trailing pointer span minimal
 // (govet fieldalignment).
 type pooledCtx struct {
 	conn noopConn
+	lr   io.LimitedReader
+	scr  tcpAddrScratch
 	fctx fasthttp.RequestCtx
 }
 
@@ -75,12 +100,119 @@ var disabledLogger = &disableLogger{}
 // Adapted http.Handler functions can retrieve this context using r.Context().Value(adaptor.LocalContextKey)
 var localContextKey = &struct{}{}
 
-const bufferSize = 32 * 1024
+const (
+	bufferSize = 32 * 1024
+
+	// maxHeaderScratch bounds the response-header staging buffers that are
+	// returned to the pool.
+	maxHeaderScratch = 16 * 1024
+)
 
 var bufferPool = sync.Pool{
 	New: func() any {
 		return new([bufferSize]byte)
 	},
+}
+
+// headerScratchPool holds the staging buffers used to pack response header
+// keys and values into a single string per response.
+var headerScratchPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, 512)
+		return &b
+	},
+}
+
+// copyBody streams src into dst using a pooled buffer. io.Copy would
+// allocate a fresh 32 KiB buffer on every call because neither an
+// io.LimitedReader nor fasthttp's body writer implements the
+// WriterTo/ReaderFrom shortcuts it looks for.
+func copyBody(dst io.Writer, src io.Reader) (int64, error) {
+	bufPtr, ok := bufferPool.Get().(*[bufferSize]byte)
+	if !ok {
+		panic(fmt.Errorf("failed to type-assert to *[%d]byte", bufferSize))
+	}
+	defer bufferPool.Put(bufPtr)
+
+	n, err := io.CopyBuffer(dst, src, bufPtr[:])
+	return n, err //nolint:wrapcheck // the caller maps this onto a status code
+}
+
+// copyResponseHeaders copies the fasthttp response headers onto the net/http
+// header map.
+//
+// A plain dst.Add(string(k), string(v)) loop allocates a string per key, a
+// string per value and a one-element slice per header. Instead every key and
+// value is packed into a single string that the map entries re-slice, and the
+// single-valued entries share one []string backing array, so the whole
+// copy-back costs two allocations no matter how many headers the response
+// carries.
+func copyResponseHeaders(dst http.Header, src *fasthttp.ResponseHeader) {
+	bufPtr, ok := headerScratchPool.Get().(*[]byte)
+	if !ok {
+		panic(errors.New("failed to type-assert to *[]byte"))
+	}
+
+	buf := (*bufPtr)[:0]
+	count := 0
+	for k, v := range src.All() {
+		buf = append(buf, k...)
+		buf = append(buf, v...)
+		count++
+	}
+
+	var packed string
+	if len(buf) > 0 {
+		packed = string(buf)
+	}
+
+	// Keep oversized scratch out of the pool so one huge response does not
+	// pin a large buffer for the lifetime of the process.
+	if cap(buf) <= maxHeaderScratch {
+		*bufPtr = buf
+		headerScratchPool.Put(bufPtr)
+	}
+
+	if count == 0 {
+		return
+	}
+
+	// Backing array for the single-valued entries, allocated on first use so
+	// a response whose headers all merge into existing entries pays nothing.
+	// Each entry gets a full slice expression so a later Add on it grows into
+	// a fresh array instead of overwriting the neighboring entry.
+	var vals []string
+
+	off := 0
+	for k, v := range src.All() {
+		// Defensive: both passes always see the same headers, but never
+		// slice out of range if that assumption is ever broken.
+		if off+len(k)+len(v) > len(packed) {
+			dst.Add(string(k), string(v))
+			continue
+		}
+
+		key := textproto.CanonicalMIMEHeaderKey(packed[off : off+len(k)])
+		off += len(k)
+		val := packed[off : off+len(v)]
+		off += len(v)
+
+		if existing, found := dst[key]; found {
+			dst[key] = append(existing, val)
+			continue
+		}
+
+		if vals == nil {
+			vals = make([]string, 0, count)
+		} else if len(vals) == cap(vals) {
+			dst[key] = []string{val}
+			continue
+		}
+
+		i := len(vals)
+		vals = append(vals, val)
+		dst[key] = vals[i : i+1 : i+1]
+	}
 }
 
 var (
@@ -205,13 +337,16 @@ func HTTPMiddleware(mw func(http.Handler) http.Handler) fiber.Handler {
 		var next bool
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			next = true
-			c.Request().Header.SetMethod(r.Method)
-			c.Request().SetRequestURI(r.RequestURI)
-			c.Request().SetHost(r.Host)
-			c.Request().Header.SetHost(r.Host)
+
+			freq := c.Request()
+			fhdr := &freq.Header
+			fhdr.SetMethod(r.Method)
+			freq.SetRequestURI(r.RequestURI)
+			freq.SetHost(r.Host)
+			fhdr.SetHost(r.Host)
 
 			// Remove all cookies before setting, see https://github.com/valyala/fasthttp/pull/1864
-			c.Request().Header.DelAllCookies()
+			fhdr.DelAllCookies()
 			for key, vals := range r.Header {
 				if len(vals) == 0 {
 					continue
@@ -219,17 +354,18 @@ func HTTPMiddleware(mw func(http.Handler) http.Handler) fiber.Handler {
 				// Set replaces whatever the key held on the fiber request,
 				// then Add appends the remaining values so multi-value
 				// headers survive instead of collapsing to the last value.
-				c.Request().Header.Set(key, vals[0])
+				fhdr.Set(key, vals[0])
 				for _, v := range vals[1:] {
-					c.Request().Header.Add(key, v)
+					fhdr.Add(key, v)
 				}
 			}
 			CopyContextToFiberContext(r.Context(), c.RequestCtx())
 		})
 
-		if err := HTTPHandler(mw(nextHandler))(c); err != nil {
-			return err
-		}
+		// Call the fasthttp adaptor directly: HTTPHandler would wrap it in a
+		// second closure that has to be built on every request, and its
+		// error result is always nil.
+		fasthttpadaptor.NewFastHTTPHandler(mw(nextHandler))(c.RequestCtx())
 
 		if next {
 			return c.Next()
@@ -275,7 +411,11 @@ func parseDecimalPort(s string) (int, bool) {
 	return port, port <= 65535
 }
 
-func resolveRemoteAddr(remoteAddr string, localAddr any) (net.Addr, error) {
+// resolveRemoteAddr turns a net/http RemoteAddr into a net.Addr for the
+// fasthttp connection. scratch, when non-nil, supplies the storage for the
+// "ip:port" fast path so no address is allocated per request; pass nil to
+// get a freshly allocated address instead.
+func resolveRemoteAddr(remoteAddr string, localAddr any, scratch *tcpAddrScratch) (net.Addr, error) {
 	if addr, ok := localAddr.(net.Addr); ok && isUnixNetwork(addr.Network()) {
 		return addr, nil
 	}
@@ -293,10 +433,16 @@ func resolveRemoteAddr(remoteAddr string, localAddr any) (net.Addr, error) {
 		if port, ok := parseDecimalPort(portStr); ok {
 			if ip, ok := utils.ParseIPv4(host); ok {
 				a := ip.As4()
+				if scratch != nil {
+					return scratch.set(a[:], port, ""), nil
+				}
 				return &net.TCPAddr{IP: a[:], Port: port}, nil
 			}
 			if ip, ok := utils.ParseIPv6(host); ok {
 				a := ip.As16()
+				if scratch != nil {
+					return scratch.set(a[:], port, ip.Zone()), nil
+				}
 				return &net.TCPAddr{IP: a[:], Port: port, Zone: ip.Zone()}, nil
 			}
 		}
@@ -323,6 +469,13 @@ func resolveRemoteAddr(remoteAddr string, localAddr any) (net.Addr, error) {
 }
 
 func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
+	// App.Config returns the config by value, so read the fields this
+	// handler needs once at construction instead of copying the whole
+	// struct on every request. Fiber only writes app.config in New.
+	cfg := app.Config()
+	maxBodySize := int64(cfg.BodyLimit)
+	errorHandler := cfg.ErrorHandler
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		// New fasthttp Ctx from pool
 		pctx := ctxPool.Get().(*pooledCtx) //nolint:forcetypeassert,errcheck // not needed
@@ -331,7 +484,7 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 		fctx.Request.Reset()
 		defer ctxPool.Put(pctx)
 
-		remoteAddr, err := resolveRemoteAddr(r.RemoteAddr, r.Context().Value(http.LocalAddrContextKey))
+		remoteAddr, err := resolveRemoteAddr(r.RemoteAddr, r.Context().Value(http.LocalAddrContextKey), &pctx.scr)
 		if err != nil {
 			remoteAddr = nil // Fallback to nil
 		}
@@ -349,26 +502,38 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 		req := &fctx.Request
 
 		// Convert net/http -> fasthttp request with size limit
-		maxBodySize := int64(app.Config().BodyLimit)
 		if r.Body != nil {
 			if r.ContentLength > maxBodySize {
 				http.Error(w, utils.StatusMessage(fiber.StatusRequestEntityTooLarge), fiber.StatusRequestEntityTooLarge)
 				return
 			}
-			limit := maxBodySize
-			if limit < math.MaxInt64 {
-				limit++
-			}
-			limitedReader := io.LimitReader(r.Body, limit)
-			n, err := io.Copy(req.BodyWriter(), limitedReader)
-			if err != nil {
-				http.Error(w, utils.StatusMessage(fiber.StatusInternalServerError), fiber.StatusInternalServerError)
-				return
-			}
 
-			if n > maxBodySize {
-				http.Error(w, utils.StatusMessage(fiber.StatusRequestEntityTooLarge), fiber.StatusRequestEntityTooLarge)
-				return
+			var n int64
+			// http.NoBody never yields any bytes, so skip the copy machinery
+			// entirely for the (very common) bodyless request.
+			if r.Body != http.NoBody {
+				limit := maxBodySize
+				if limit < math.MaxInt64 {
+					limit++
+				}
+				// The LimitedReader lives in the pooled ctx and the copy
+				// buffer comes from the shared pool: io.Copy would otherwise
+				// allocate a fresh 32 KiB buffer on every single request.
+				pctx.lr.R = r.Body
+				pctx.lr.N = limit
+
+				var err error
+				n, err = copyBody(req.BodyWriter(), &pctx.lr)
+				pctx.lr.R = nil // don't keep the request body alive in the pool
+				if err != nil {
+					http.Error(w, utils.StatusMessage(fiber.StatusInternalServerError), fiber.StatusInternalServerError)
+					return
+				}
+
+				if n > maxBodySize {
+					http.Error(w, utils.StatusMessage(fiber.StatusRequestEntityTooLarge), fiber.StatusRequestEntityTooLarge)
+					return
+				}
 			}
 
 			req.Header.SetContentLength(int(n))
@@ -419,7 +584,7 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 			// Execute fiber Ctx
 			err := h[0](ctx)
 			if err != nil {
-				_ = app.Config().ErrorHandler(ctx, err) //nolint:errcheck // not needed
+				_ = errorHandler(ctx, err) //nolint:errcheck // not needed
 			}
 		} else {
 			// Execute fasthttp Ctx though app.Handler
@@ -427,9 +592,7 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 		}
 
 		// Convert fasthttp Ctx -> net/http
-		for k, v := range fctx.Response.Header.All() {
-			w.Header().Add(string(k), string(v))
-		}
+		copyResponseHeaders(w.Header(), &fctx.Response.Header)
 		w.WriteHeader(fctx.Response.StatusCode())
 
 		// Check if streaming is not possible or unnecessary.

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -1562,7 +1562,7 @@ func Test_resolveRemoteAddr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			addr, err := resolveRemoteAddr(tt.remoteAddr, tt.localAddr, nil)
+			addr, err := resolveRemoteAddr(tt.remoteAddr, tt.localAddr)
 
 			expectError := tt.expectedErr != nil || tt.errorContains != ""
 			if expectError {
@@ -1798,7 +1798,7 @@ func Test_ResolveRemoteAddr_FastPathEquivalence(t *testing.T) {
 		"1.2.3.4:0",
 	}
 	for _, addr := range addrs {
-		got, err := resolveRemoteAddr(addr, nil, nil)
+		got, err := resolveRemoteAddr(addr, nil)
 		require.NoError(t, err, "resolveRemoteAddr(%q)", addr)
 		want, err := net.ResolveTCPAddr("tcp", addr)
 		require.NoError(t, err, "ResolveTCPAddr(%q)", addr)
@@ -1822,7 +1822,7 @@ func Test_ResolveRemoteAddr_FastPathEquivalence(t *testing.T) {
 		"1.2.3.4:8a",     // non-digit port -> fast path rejects, resolver service lookup fails
 	}
 	for _, addr := range fallbackAddrs {
-		got, gotErr := resolveRemoteAddr(addr, nil, nil)
+		got, gotErr := resolveRemoteAddr(addr, nil)
 		want, wantErr := net.ResolveTCPAddr("tcp", addr)
 		if addr == "1.2.3.4" {
 			// resolveRemoteAddr appends :80 for missing ports; ResolveTCPAddr errors.
@@ -1988,13 +1988,16 @@ func Benchmark_FiberApp_Body(b *testing.B) {
 	handler := FiberApp(app)
 
 	body := make([]byte, 8*1024)
-	w := httptest.NewRecorder()
 
 	b.ReportAllocs()
 
 	for b.Loop() {
 		r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
 		r.RemoteAddr = expectedRemoteAddr
+		// A fresh recorder per iteration: reusing one accumulates the response
+		// headers and body across iterations, which both skews the numbers and
+		// hides the fresh-header path.
+		w := httptest.NewRecorder()
 		handler(w, r)
 	}
 }
@@ -2017,9 +2020,11 @@ func Benchmark_FiberApp_Parallel(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		r := httptest.NewRequest(http.MethodGet, "/foo/bar", http.NoBody)
 		r.RemoteAddr = expectedRemoteAddr
-		w := httptest.NewRecorder()
 
 		for pb.Next() {
+			// Fresh recorder per iteration, matching Benchmark_FiberApp so the
+			// two are directly comparable.
+			w := httptest.NewRecorder()
 			handler(w, r)
 		}
 	})
@@ -2125,26 +2130,22 @@ func Test_copyResponseHeaders(t *testing.T) {
 	})
 }
 
-func Test_resolveRemoteAddr_Scratch(t *testing.T) {
+func Test_resolveRemoteAddr_FastPath(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ipv4 fast path uses the scratch address", func(t *testing.T) {
+	t.Run("ipv4", func(t *testing.T) {
 		t.Parallel()
 
-		var scratch tcpAddrScratch
-		addr, err := resolveRemoteAddr("1.2.3.4:6789", nil, &scratch)
+		addr, err := resolveRemoteAddr("1.2.3.4:6789", nil)
 		require.NoError(t, err)
-		require.Same(t, &scratch.addr, addr)
 		require.Equal(t, "1.2.3.4:6789", addr.String())
 	})
 
-	t.Run("ipv6 fast path keeps the zone", func(t *testing.T) {
+	t.Run("ipv6 keeps the zone", func(t *testing.T) {
 		t.Parallel()
 
-		var scratch tcpAddrScratch
-		addr, err := resolveRemoteAddr("[fe80::1%eth0]:6789", nil, &scratch)
+		addr, err := resolveRemoteAddr("[fe80::1%eth0]:6789", nil)
 		require.NoError(t, err)
-		require.Same(t, &scratch.addr, addr)
 
 		tcpAddr, ok := addr.(*net.TCPAddr)
 		require.True(t, ok)
@@ -2153,29 +2154,34 @@ func Test_resolveRemoteAddr_Scratch(t *testing.T) {
 		require.Equal(t, net.ParseIP("fe80::1"), tcpAddr.IP)
 	})
 
-	t.Run("reuse overwrites the previous address", func(t *testing.T) {
+	t.Run("each call returns an independent address", func(t *testing.T) {
 		t.Parallel()
 
-		var scratch tcpAddrScratch
-		_, err := resolveRemoteAddr("[fe80::1%eth0]:1", nil, &scratch)
+		first, err := resolveRemoteAddr("1.2.3.4:1111", nil)
+		require.NoError(t, err)
+		second, err := resolveRemoteAddr("5.6.7.8:2222", nil)
 		require.NoError(t, err)
 
-		addr, err := resolveRemoteAddr("5.6.7.8:2", nil, &scratch)
+		// Callers may hold on to a remote address past the request that
+		// produced it, so resolving another one must not disturb it.
+		require.NotSame(t, first, second)
+		require.Equal(t, "1.2.3.4:1111", first.String())
+		require.Equal(t, "5.6.7.8:2222", second.String())
+	})
+
+	t.Run("the IP slice cannot be appended into its backing buffer", func(t *testing.T) {
+		t.Parallel()
+
+		addr, err := resolveRemoteAddr("1.2.3.4:6789", nil)
 		require.NoError(t, err)
-		require.Equal(t, "5.6.7.8:2", addr.String())
 
 		tcpAddr, ok := addr.(*net.TCPAddr)
 		require.True(t, ok)
-		require.Empty(t, tcpAddr.Zone, "stale zone must not survive reuse")
-		require.Len(t, tcpAddr.IP, net.IPv4len)
-	})
+		require.Equal(t, len(tcpAddr.IP), cap(tcpAddr.IP))
 
-	t.Run("nil scratch still resolves", func(t *testing.T) {
-		t.Parallel()
-
-		addr, err := resolveRemoteAddr("1.2.3.4:6789", nil, nil)
-		require.NoError(t, err)
-		require.Equal(t, "1.2.3.4:6789", addr.String())
+		grown := append(tcpAddr.IP, 9) //nolint:gocritic // deliberately appending to a copy
+		require.Equal(t, net.IP{1, 2, 3, 4}, tcpAddr.IP)
+		require.Len(t, grown, net.IPv4len+1)
 	})
 }
 
@@ -2196,17 +2202,21 @@ func Test_FiberApp_NoBody(t *testing.T) {
 	require.Equal(t, "0", w.Body.String())
 }
 
-func Test_FiberApp_ReusesPooledRemoteAddr(t *testing.T) {
+func Test_FiberApp_RemoteAddrSurvivesPooling(t *testing.T) {
 	t.Parallel()
 
+	addrs := []string{"1.1.1.1:1111", "2.2.2.2:2222", "3.3.3.3:3333"}
+
+	var retained []net.Addr
 	app := fiber.New()
 	app.Get("/", func(c fiber.Ctx) error {
+		retained = append(retained, c.RequestCtx().RemoteAddr())
 		return c.SendString(c.IP())
 	})
 
 	handler := FiberApp(app)
 
-	for _, addr := range []string{"1.2.3.4:1111", "5.6.7.8:2222", "[fe80::1%eth0]:3333"} {
+	for _, addr := range addrs {
 		r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 		r.RemoteAddr = addr
 		w := httptest.NewRecorder()
@@ -2214,10 +2224,13 @@ func Test_FiberApp_ReusesPooledRemoteAddr(t *testing.T) {
 
 		host, _, err := net.SplitHostPort(addr)
 		require.NoError(t, err)
-		host = strings.Trim(host, "[]")
-		if zone := strings.IndexByte(host, '%'); zone >= 0 {
-			host = host[:zone] // c.IP() reports the address without the zone
-		}
 		require.Equal(t, host, w.Body.String())
+	}
+
+	// The ctx pool recycles entries between requests; a remote address kept
+	// by the handler must still report the client it was resolved from.
+	require.Len(t, retained, len(addrs))
+	for i, addr := range addrs {
+		require.Equal(t, addr, retained[i].String())
 	}
 }

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1561,7 +1562,7 @@ func Test_resolveRemoteAddr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			addr, err := resolveRemoteAddr(tt.remoteAddr, tt.localAddr)
+			addr, err := resolveRemoteAddr(tt.remoteAddr, tt.localAddr, nil)
 
 			expectError := tt.expectedErr != nil || tt.errorContains != ""
 			if expectError {
@@ -1797,7 +1798,7 @@ func Test_ResolveRemoteAddr_FastPathEquivalence(t *testing.T) {
 		"1.2.3.4:0",
 	}
 	for _, addr := range addrs {
-		got, err := resolveRemoteAddr(addr, nil)
+		got, err := resolveRemoteAddr(addr, nil, nil)
 		require.NoError(t, err, "resolveRemoteAddr(%q)", addr)
 		want, err := net.ResolveTCPAddr("tcp", addr)
 		require.NoError(t, err, "ResolveTCPAddr(%q)", addr)
@@ -1821,7 +1822,7 @@ func Test_ResolveRemoteAddr_FastPathEquivalence(t *testing.T) {
 		"1.2.3.4:8a",     // non-digit port -> fast path rejects, resolver service lookup fails
 	}
 	for _, addr := range fallbackAddrs {
-		got, gotErr := resolveRemoteAddr(addr, nil)
+		got, gotErr := resolveRemoteAddr(addr, nil, nil)
 		want, wantErr := net.ResolveTCPAddr("tcp", addr)
 		if addr == "1.2.3.4" {
 			// resolveRemoteAddr appends :80 for missing ports; ResolveTCPAddr errors.
@@ -1915,4 +1916,308 @@ func Test_HTTPMiddleware_MultiValueHeaders(t *testing.T) {
 	require.Equal(t, fiber.StatusOK, resp.StatusCode)
 	require.Equal(t, []string{"one", "two"}, got)
 	require.Zero(t, emptyHeaderValues, "empty header value slices must not be copied")
+}
+
+// Benchmark_HTTPMiddleware measures the net/http middleware -> Fiber handler
+// bridge, including the request rewrite the bridge performs on every call.
+func Benchmark_HTTPMiddleware(b *testing.B) {
+	nethttpMW := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Header.Set("X-Middleware", "true")
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	app := fiber.New()
+	app.Use(HTTPMiddleware(nethttpMW))
+	app.Post("/", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	handler := app.Handler()
+
+	ctx := &fasthttp.RequestCtx{}
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		ctx.Request.Reset()
+		ctx.Response.Reset()
+		ctx.Request.Header.SetMethod(fiber.MethodPost)
+		ctx.Request.SetRequestURI("/")
+		ctx.Request.Header.Set("Foo", "bar")
+
+		handler(ctx)
+	}
+}
+
+// Benchmark_FiberApp exercises the net/http -> Fiber direction the way a real
+// net/http server does: a fresh response writer per request, a routed app, a
+// remote address to resolve and a handful of request and response headers.
+func Benchmark_FiberApp(b *testing.B) {
+	app := fiber.New()
+	app.Get("/foo/bar", func(c fiber.Ctx) error {
+		c.Set("X-Custom-One", "one")
+		c.Set("X-Custom-Two", "two")
+		return c.SendString("Hello, World!")
+	})
+
+	handler := FiberApp(app)
+
+	r := httptest.NewRequest(http.MethodGet, "/foo/bar", http.NoBody)
+	r.RemoteAddr = expectedRemoteAddr
+	r.Header.Set("Accept-Encoding", "gzip")
+	r.Header.Set("User-Agent", "fiber-bench")
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		w := httptest.NewRecorder()
+		handler(w, r)
+	}
+}
+
+// Benchmark_FiberApp_Body covers the request body copy path, which streams the
+// net/http body into the fasthttp request before the handler runs.
+func Benchmark_FiberApp_Body(b *testing.B) {
+	app := fiber.New()
+	app.Post("/", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	handler := FiberApp(app)
+
+	body := make([]byte, 8*1024)
+	w := httptest.NewRecorder()
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+		r.RemoteAddr = expectedRemoteAddr
+		handler(w, r)
+	}
+}
+
+// Benchmark_FiberApp_Parallel measures how the net/http -> Fiber bridge scales
+// across cores.
+func Benchmark_FiberApp_Parallel(b *testing.B) {
+	app := fiber.New()
+	app.Get("/foo/bar", func(c fiber.Ctx) error {
+		c.Set("X-Custom-One", "one")
+		c.Set("X-Custom-Two", "two")
+		return c.SendString("Hello, World!")
+	})
+
+	handler := FiberApp(app)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		r := httptest.NewRequest(http.MethodGet, "/foo/bar", http.NoBody)
+		r.RemoteAddr = expectedRemoteAddr
+		w := httptest.NewRecorder()
+
+		for pb.Next() {
+			handler(w, r)
+		}
+	})
+}
+
+func Test_copyResponseHeaders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("packs keys and values without losing any", func(t *testing.T) {
+		t.Parallel()
+
+		var src fasthttp.ResponseHeader
+		src.SetContentType("text/plain")
+		src.Set("X-One", "1")
+		src.Add("X-Multi", "a")
+		src.Add("X-Multi", "b")
+		src.SetCookie(&fasthttp.Cookie{})
+
+		dst := make(http.Header)
+		copyResponseHeaders(dst, &src)
+
+		require.Equal(t, []string{"text/plain"}, dst["Content-Type"])
+		require.Equal(t, []string{"1"}, dst["X-One"])
+		require.Equal(t, []string{"a", "b"}, dst["X-Multi"])
+	})
+
+	t.Run("keys are canonicalized like Header.Add", func(t *testing.T) {
+		t.Parallel()
+
+		var src fasthttp.ResponseHeader
+		src.DisableNormalizing()
+		src.Set("x-lower-case", "value")
+
+		dst := make(http.Header)
+		copyResponseHeaders(dst, &src)
+
+		require.Equal(t, "value", dst.Get("X-Lower-Case"))
+	})
+
+	t.Run("appends to values already present on the destination", func(t *testing.T) {
+		t.Parallel()
+
+		var src fasthttp.ResponseHeader
+		src.Set("X-One", "from-fasthttp")
+
+		dst := make(http.Header)
+		dst.Add("X-One", "preexisting")
+		copyResponseHeaders(dst, &src)
+
+		require.Equal(t, []string{"preexisting", "from-fasthttp"}, dst["X-One"])
+	})
+
+	t.Run("entries sharing a backing array stay independent", func(t *testing.T) {
+		t.Parallel()
+
+		var src fasthttp.ResponseHeader
+		src.Set("X-One", "1")
+		src.Set("X-Two", "2")
+		src.Set("X-Three", "3")
+
+		dst := make(http.Header)
+		copyResponseHeaders(dst, &src)
+
+		// Growing one entry must not overwrite the neighboring entries even
+		// though they were carved out of a single []string allocation.
+		dst.Add("X-One", "extra")
+
+		require.Equal(t, []string{"1", "extra"}, dst["X-One"])
+		require.Equal(t, []string{"2"}, dst["X-Two"])
+		require.Equal(t, []string{"3"}, dst["X-Three"])
+	})
+
+	t.Run("empty header set leaves the destination untouched", func(t *testing.T) {
+		t.Parallel()
+
+		var src fasthttp.ResponseHeader
+		src.SetNoDefaultContentType(true)
+
+		dst := make(http.Header)
+		copyResponseHeaders(dst, &src)
+
+		require.Empty(t, dst)
+	})
+
+	t.Run("values do not alias the pooled scratch buffer", func(t *testing.T) {
+		t.Parallel()
+
+		var first fasthttp.ResponseHeader
+		first.SetNoDefaultContentType(true)
+		first.Set("X-Value", strings.Repeat("a", 64))
+
+		dst := make(http.Header)
+		copyResponseHeaders(dst, &first)
+
+		// A second copy reuses the pooled staging buffer; the strings handed
+		// to the first destination must not change underneath it.
+		var second fasthttp.ResponseHeader
+		second.SetNoDefaultContentType(true)
+		second.Set("X-Value", strings.Repeat("b", 64))
+		copyResponseHeaders(make(http.Header), &second)
+
+		require.Equal(t, strings.Repeat("a", 64), dst.Get("X-Value"))
+	})
+}
+
+func Test_resolveRemoteAddr_Scratch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ipv4 fast path uses the scratch address", func(t *testing.T) {
+		t.Parallel()
+
+		var scratch tcpAddrScratch
+		addr, err := resolveRemoteAddr("1.2.3.4:6789", nil, &scratch)
+		require.NoError(t, err)
+		require.Same(t, &scratch.addr, addr)
+		require.Equal(t, "1.2.3.4:6789", addr.String())
+	})
+
+	t.Run("ipv6 fast path keeps the zone", func(t *testing.T) {
+		t.Parallel()
+
+		var scratch tcpAddrScratch
+		addr, err := resolveRemoteAddr("[fe80::1%eth0]:6789", nil, &scratch)
+		require.NoError(t, err)
+		require.Same(t, &scratch.addr, addr)
+
+		tcpAddr, ok := addr.(*net.TCPAddr)
+		require.True(t, ok)
+		require.Equal(t, "eth0", tcpAddr.Zone)
+		require.Equal(t, 6789, tcpAddr.Port)
+		require.Equal(t, net.ParseIP("fe80::1"), tcpAddr.IP)
+	})
+
+	t.Run("reuse overwrites the previous address", func(t *testing.T) {
+		t.Parallel()
+
+		var scratch tcpAddrScratch
+		_, err := resolveRemoteAddr("[fe80::1%eth0]:1", nil, &scratch)
+		require.NoError(t, err)
+
+		addr, err := resolveRemoteAddr("5.6.7.8:2", nil, &scratch)
+		require.NoError(t, err)
+		require.Equal(t, "5.6.7.8:2", addr.String())
+
+		tcpAddr, ok := addr.(*net.TCPAddr)
+		require.True(t, ok)
+		require.Empty(t, tcpAddr.Zone, "stale zone must not survive reuse")
+		require.Len(t, tcpAddr.IP, net.IPv4len)
+	})
+
+	t.Run("nil scratch still resolves", func(t *testing.T) {
+		t.Parallel()
+
+		addr, err := resolveRemoteAddr("1.2.3.4:6789", nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, "1.2.3.4:6789", addr.String())
+	})
+}
+
+func Test_FiberApp_NoBody(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Post("/", func(c fiber.Ctx) error {
+		require.Empty(t, c.Body())
+		return c.SendString(strconv.Itoa(c.Request().Header.ContentLength()))
+	})
+
+	r := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+	w := httptest.NewRecorder()
+	FiberApp(app)(w, r)
+
+	require.Equal(t, fiber.StatusOK, w.Code)
+	require.Equal(t, "0", w.Body.String())
+}
+
+func Test_FiberApp_ReusesPooledRemoteAddr(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString(c.IP())
+	})
+
+	handler := FiberApp(app)
+
+	for _, addr := range []string{"1.2.3.4:1111", "5.6.7.8:2222", "[fe80::1%eth0]:3333"} {
+		r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		r.RemoteAddr = addr
+		w := httptest.NewRecorder()
+		handler(w, r)
+
+		host, _, err := net.SplitHostPort(addr)
+		require.NoError(t, err)
+		host = strings.Trim(host, "[]")
+		if zone := strings.IndexByte(host, '%'); zone >= 0 {
+			host = host[:zone] // c.IP() reports the address without the zone
+		}
+		require.Equal(t, host, w.Body.String())
+	}
 }


### PR DESCRIPTION
# Description

Cuts allocations and per-request work in `middleware/adaptor`, mostly on the net/http → Fiber direction (`FiberApp`, `FiberHandler`, `FiberHandlerFunc`).

The dominant cost was invisible: `io.Copy(req.BodyWriter(), limitedReader)` allocated a **fresh 32 KiB buffer for every single request**, including requests with no body at all. `io.Copy` only skips its internal buffer when the source implements `io.WriterTo` or the destination implements `io.ReaderFrom` — `*io.LimitedReader` does neither, and neither does fasthttp's `requestBodyWriter`. So every request through `FiberApp` paid a 32 KiB allocation regardless of body size.

Four changes, all internal to the package:

1. **Request body** — copy through `io.CopyBuffer` with a buffer from the pool the package already keeps, and an `io.LimitedReader` that lives in the pooled ctx. `http.NoBody` skips the copy machinery entirely.
2. **Response headers** — the copy-back was `dst.Add(string(k), string(v))` per header, costing a key string, a value string and a one-element slice each. Keys and values are now packed into one string that the map entries re-slice, and the single-valued entries are carved out of one shared `[]string`, so the copy-back is two allocations regardless of header count. Keys still go through `textproto.CanonicalMIMEHeaderKey`, so results are identical to `Header.Add`.
3. **Remote address** — the `"ip:port"` fast path co-locates the IP storage with the `net.TCPAddr` in one allocation instead of two (address + IP slice). Deliberately *not* pooled: `RemoteAddr()`/`RemoteIP()` hand this value to user code that may keep it past the handler.
4. **Per-request odds and ends** — `App.Config()` returns a 624-byte struct **by value**; the body limit is now read once at construction rather than copied per request. `HTTPMiddleware` calls the fasthttp adaptor directly instead of rebuilding `HTTPHandler`'s wrapper on every request.

No exported API changes, and no behavior changes.

## Changes introduced

- [x] **Benchmarks**: 6 runs per side, `-benchtime 2s`, compared with `benchstat` against `84ecfab`. Every changed row below is `p=0.002`.

  | Benchmark | ns/op | B/op | allocs/op |
  |---|---|---|---|
  | `FiberHandlerFunc/No_Content` | 4454 → 797 (**−82%**) | 32987 → 136 (**−99.6%**) | 7 → 1 |
  | `FiberHandlerFunc_Parallel/No_Content` | 2688 → 312 (**−88%**) | 32987 → 137 (**−99.6%**) | 7 → 1 |
  | `FiberApp` | 14442 → 2663 (**−82%**) | 33.3Ki → 1.20Ki (**−96%**) | 25 → 12 |
  | `FiberApp_Parallel` | 13579 → 1246 (**−91%**) | 33.3Ki → 1.20Ki (**−96%**) | 25 → 12 |
  | `FiberApp_Body` | 16709 → 4706 (**−72%**) | 38.4Ki → 6.23Ki (**−84%**) | 30 → 23 |
  | `HTTPMiddleware` | 7541 → 6041 (**−20%**) | 2240 → 2225 | 25 → 24 |
  | `HTTPHandlerWithContext` | 3453 → 3236 (−6%) | unchanged | 18 |
  | `HTTPHandler` | unchanged | unchanged | 18 |

  `Benchmark_HTTPMiddleware`, `Benchmark_FiberApp`, `Benchmark_FiberApp_Body` and `Benchmark_FiberApp_Parallel` are new — those paths had no benchmark coverage at all.

- [x] **Changelog/What's New**: `middleware/adaptor` no longer allocates a 32 KiB buffer per request on the net/http → Fiber path; requests through `FiberApp` drop from 25 to 12 allocations and from ~33 KiB to ~1.2 KiB per request.
- [x] **API Longevity**: no exported identifiers added, removed or changed. The whole diff is package-internal.
- [ ] **Documentation Update**: not needed — no exported API or documented behavior changed.
- [ ] **Migration Guide**: not needed — no breaking change.
- [ ] **API Alignment with Express**: N/A, internal performance work.
- [ ] **Examples**: N/A.

## Type of change

- [x] Performance improvement (non-breaking change which improves efficiency)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.
- [x] No new dependencies.
- [ ] Documentation in `/docs/` — untouched, nothing user-facing changed.

New tests cover the header packing (multi-value headers, non-canonical keys, a destination that already holds values, and that entries sharing the `[]string` backing array stay independent when appended to), that response header strings do not alias the pooled staging buffer, that the `http.NoBody` skip still reports `Content-Length: 0`, and that a remote address retained by a handler still reports its own client after the ctx pool recycles the entry.

Verification: full repo suite passes, `go test -race ./middleware/adaptor/` clean, `golangci-lint` v2.12.2 (the version pinned in `lint.yml`) reports 0 issues.

## Not included, deliberately

Two larger wins were measured but left out, since both need a maintainer decision rather than a drive-by:

1. **`HTTPHandler` is unchanged at 18 allocs/op.** All of it is inside `fasthttpadaptor.NewFastHTTPHandler`, which spawns a goroutine and an `io.Pipe` per request (~10 allocs) to support `Flush`/`Hijack`. Reducing it means forking that concurrency-sensitive upstream code into Fiber.
2. **`FiberApp` still calls `app.Handler()` per request**, which takes the global `app.mutex` and runs `startupProcess()` every time. Hoisting it behind a `sync.Once` measured **−36% on `FiberApp_Parallel` at 4 cores** (scaling 2.1× → 3.3×) — the single largest remaining win. It is not in this PR because it silently drops the implicit tree rebuild for routes registered at runtime, so those would 404 unless the user calls `app.RebuildTree()`. That is a routing-semantics change and shouldn't ship under a perf banner.