### PR TITLE
🐛 bug: combine repeated proxy headers for client IP extraction

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -3960,10 +3960,40 @@ func Test_Ctx_IP_ProxyHeader_RepeatedFieldLines(t *testing.T) {
 	fastCtx := &fasthttp.RequestCtx{}
 	fastCtx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
 	c := app.AcquireCtx(fastCtx)
+	defer app.ReleaseCtx(c)
 	c.Request().Header.Add(HeaderXForwardedFor, "9.9.9.9")
 	c.Request().Header.Add(HeaderXForwardedFor, "198.51.100.77, 127.0.0.1")
 
 	require.Equal(t, "198.51.100.77", c.IP())
+}
+
+// Repeated field lines must also be combined when the request is parsed off
+// the wire, not just when the headers are set programmatically.
+func Test_Ctx_IP_ProxyHeader_RepeatedFieldLines_Wire(t *testing.T) {
+	t.Parallel()
+
+	app := New(Config{
+		ProxyHeader:        HeaderXForwardedFor,
+		TrustProxy:         true,
+		EnableIPValidation: true,
+		TrustProxyConfig: TrustProxyConfig{
+			Proxies: []string{"0.0.0.0"},
+		},
+	})
+	app.Get("/", func(c Ctx) error {
+		return c.SendString(c.IP())
+	})
+
+	req := httptest.NewRequest(MethodGet, "/", nil)
+	req.Header.Add(HeaderXForwardedFor, "9.9.9.9")
+	req.Header.Add(HeaderXForwardedFor, "198.51.100.77, 0.0.0.0")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "198.51.100.77", string(body))
 }
 
 func Test_Ctx_IP_ProxyHeader_InvalidIPs(t *testing.T) {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -3984,12 +3984,13 @@ func Test_Ctx_IP_ProxyHeader_RepeatedFieldLines_Wire(t *testing.T) {
 		return c.SendString(c.IP())
 	})
 
-	req := httptest.NewRequest(MethodGet, "/", nil)
+	req := httptest.NewRequest(MethodGet, "/", http.NoBody)
 	req.Header.Add(HeaderXForwardedFor, "9.9.9.9")
 	req.Header.Add(HeaderXForwardedFor, "198.51.100.77, 0.0.0.0")
 
 	resp, err := app.Test(req)
 	require.NoError(t, err)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -3946,6 +3946,26 @@ func Test_Ctx_IP_ProxyHeader_NoTrustedProxies(t *testing.T) {
 	require.Equal(t, "203.0.113.50", c.extractIPFromHeader(HeaderXForwardedFor))
 }
 
+func Test_Ctx_IP_ProxyHeader_RepeatedFieldLines(t *testing.T) {
+	t.Parallel()
+
+	app := New(Config{
+		ProxyHeader:        HeaderXForwardedFor,
+		TrustProxy:         true,
+		EnableIPValidation: true,
+		TrustProxyConfig: TrustProxyConfig{
+			Proxies: []string{"127.0.0.1"},
+		},
+	})
+	fastCtx := &fasthttp.RequestCtx{}
+	fastCtx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
+	c := app.AcquireCtx(fastCtx)
+	c.Request().Header.Add(HeaderXForwardedFor, "9.9.9.9")
+	c.Request().Header.Add(HeaderXForwardedFor, "198.51.100.77, 127.0.0.1")
+
+	require.Equal(t, "198.51.100.77", c.IP())
+}
+
 func Test_Ctx_IP_ProxyHeader_InvalidIPs(t *testing.T) {
 	t.Parallel()
 	app := New(Config{

--- a/helpers.go
+++ b/helpers.go
@@ -606,16 +606,16 @@ func (j *joinedHeaderValue) visit(k, v []byte) {
 }
 
 // peekJoinedRequestHeader returns the combined value of every field line for
-// key in a single pass over the request headers, plus whether the field
-// occurred on more than one line. Unlike PeekAll it performs no per-call key
-// normalization. Concrete (non-generic) so the visitor stays on the stack.
-func peekJoinedRequestHeader(h *fasthttp.RequestHeader, key string) ([]byte, bool) {
+// key in a single pass over the request headers. Unlike PeekAll it performs no
+// per-call key normalization. Concrete (non-generic) so the visitor stays on
+// the stack.
+func peekJoinedRequestHeader(h *fasthttp.RequestHeader, key string) []byte {
 	j := joinedHeaderValue{key: key}
 	// VisitAll (not the replacement All) keeps this zero-alloc: All returns
 	// an iterator closure that escapes to the heap on every call. The SA1019
 	// deprecation is suppressed for helpers.go in .golangci.yml.
 	h.VisitAll(j.visit)
-	return j.combined, j.multi
+	return j.combined
 }
 
 // peekJoinedResponseHeader is peekJoinedRequestHeader for response headers.

--- a/helpers.go
+++ b/helpers.go
@@ -614,6 +614,12 @@ func peekJoinedRequestHeader(h *fasthttp.RequestHeader, key string) []byte {
 	// VisitAll (not the replacement All) keeps this zero-alloc: All returns
 	// an iterator closure that escapes to the heap on every call. The SA1019
 	// deprecation is suppressed for helpers.go in .golangci.yml.
+	//
+	// VisitAllInOrder is deliberately not used: it reparses rawHeaders, which
+	// only holds headers read off the wire, so headers set programmatically
+	// (e.g. by net/http adaptors) would be missed entirely. VisitAll already
+	// preserves the relative order of repeated field lines sharing a key,
+	// which is all this helper needs; it only reorders across distinct keys.
 	h.VisitAll(j.visit)
 	return j.combined
 }

--- a/req.go
+++ b/req.go
@@ -166,7 +166,7 @@ func (r *DefaultReq) Body() []byte {
 
 	// Get Content-Encoding header. Multiple field lines form one combined
 	// list (RFC 9110 Section 5.2), so join them before splitting.
-	encodedBytes, _ := peekJoinedRequestHeader(&request.Header, HeaderContentEncoding)
+	encodedBytes := peekJoinedRequestHeader(&request.Header, HeaderContentEncoding)
 	headerEncoding = utils.UnsafeString(utilsbytes.UnsafeToLower(encodedBytes))
 
 	// Split and get the encodings list, in order to attend the
@@ -649,7 +649,7 @@ func (r *DefaultReq) IP() string {
 func (r *DefaultReq) extractIPsFromHeader(header string) []string {
 	// TODO: Reuse the c.extractIPFromHeader func somehow in here
 
-	headerValue := r.Get(header)
+	headerValue := proxyHeaderValue(r, header)
 
 	// We can't know how many IPs we will return, but we will try to guess with this constant division.
 	// Counting ',' makes function slower for about 50ns in general case.
@@ -713,10 +713,10 @@ func (r *DefaultReq) extractIPFromHeader(header string) string {
 	app := r.c.app
 
 	if !app.config.EnableIPValidation {
-		return r.Get(header)
+		return proxyHeaderValue(r, header)
 	}
 
-	headerValue := r.Get(header)
+	headerValue := proxyHeaderValue(r, header)
 	hasTrustedProxyConfig := r.hasTrustedProxyConfig()
 	if !hasTrustedProxyConfig {
 		start := 0
@@ -766,6 +766,14 @@ func (r *DefaultReq) extractIPFromHeader(header string) string {
 		return ip.String()
 	}
 	return ""
+}
+
+// proxyHeaderValue combines repeated proxy header field lines as required by
+// RFC 9110 Section 5.2. This ensures security-sensitive IP extraction sees the
+// complete chain when an adapter or proxy preserves separate field lines.
+func proxyHeaderValue(r *DefaultReq, header string) string {
+	value := peekJoinedRequestHeader(&r.c.fasthttp.Request.Header, header)
+	return r.c.app.toString(value)
 }
 
 func isValidProxyIP(ipStr string) bool {


### PR DESCRIPTION
### Motivation

- The adaptor preserved repeated net/http header field lines (e.g. multiple `X-Forwarded-For` lines) but Fiber's IP extraction read only a single stored header value, allowing an attacker-provided first field line to mask the trusted proxy chain. 
- The intent is to make proxy-header parsing RFC 9110-compliant (combine repeated field lines) so the right-to-left trusted-proxy walk sees the full, comma-folded chain.

### Description

- Combine repeated request header field lines before parsing proxy headers by adding `peekJoinedRequestHeader` usage and a `proxyHeaderValue` helper to produce the RFC 9110-combined header string used for IP extraction. 
- Replace direct `Request.Header.Peek`/`r.Get` uses in proxy-sensitive code paths with `proxyHeaderValue` so `extractIPFromHeader` and `extractIPsFromHeader` operate on the folded header value. 
- Simplify `peekJoinedRequestHeader` return signature (zero-allocation fast-path preserved for single-line headers) and update callers such as `Body()` to the new API. 
- Add `Test_Ctx_IP_ProxyHeader_RepeatedFieldLines` to `ctx_test.go` which exercises a repeated `X-Forwarded-For` case and ensures the trusted proxy's appended chain is not hidden by an attacker-controlled first field line.

### Testing

- Ran `make generate`, `make betteralign`, `make format`, and `make lint`, and they completed successfully with no lint issues. 
- `make audit` completed `go mod verify`/`go vet` but `govulncheck` reported 26 vulnerabilities in the environment's Go 1.25.1 standard library (toolchain/environment limitation), causing `make audit` to fail for reasons unrelated to the patch. 
- Ran the full test suite with `make test` which passed (4,200 tests, 1 expected skip) under the race detector. 
- Ran the new regression test `go test -run 'Test_Ctx_IP_ProxyHeader_RepeatedFieldLines' -count=1` which passed. 
- Ran the micro-benchmark `go test -run '^$' -bench '^Benchmark_Ctx_IP_With_ProxyHeader_and_IP_Validation$' -benchmem -count=3 .` which passed (~138–145 ns/op, 0 B/op, 0 allocs/op).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6399711c98833393e016188ab7fcbd)