### PR TITLE
🐛 fix(idempotency): release MemoryLock keys on unlock

### DIFF
--- a/middleware/idempotency/locker.go
+++ b/middleware/idempotency/locker.go
@@ -10,43 +10,58 @@ type Locker interface {
 	Unlock(key string) error
 }
 
+type countedLock struct {
+	mu     sync.Mutex
+	locked int
+}
+
 type MemoryLock struct {
 	mu sync.Mutex
 
-	keys map[string]*sync.Mutex
+	keys map[string]*countedLock
 }
 
 func (l *MemoryLock) Lock(key string) error {
 	l.mu.Lock()
-	mu, ok := l.keys[key]
+	lock, ok := l.keys[key]
 	if !ok {
-		mu = new(sync.Mutex)
-		l.keys[key] = mu
+		lock = new(countedLock)
+		l.keys[key] = lock
 	}
+	lock.locked++
 	l.mu.Unlock()
 
-	mu.Lock()
+	lock.mu.Lock()
 
 	return nil
 }
 
 func (l *MemoryLock) Unlock(key string) error {
 	l.mu.Lock()
-	mu, ok := l.keys[key]
-	l.mu.Unlock()
+	lock, ok := l.keys[key]
 	if !ok {
 		// This happens if we try to unlock an unknown key
+		l.mu.Unlock()
 		return nil
 	}
+	l.mu.Unlock()
 
-	mu.Unlock()
+	lock.mu.Unlock()
+
+	l.mu.Lock()
+	lock.locked--
+	if lock.locked <= 0 {
+		// No waiters left, so drop the entry instead of leaking one mutex per key
+		delete(l.keys, key)
+	}
+	l.mu.Unlock()
 
 	return nil
 }
 
 func NewMemoryLock() *MemoryLock {
 	return &MemoryLock{
-		keys: make(map[string]*sync.Mutex),
+		keys: make(map[string]*countedLock),
 	}
 }
 

--- a/middleware/idempotency/locker_internal_test.go
+++ b/middleware/idempotency/locker_internal_test.go
@@ -1,0 +1,56 @@
+package idempotency
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/gofiber/fiber/v2/utils"
+)
+
+func (l *MemoryLock) size() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return len(l.keys)
+}
+
+// go test -run Test_MemoryLock_NoKeyLeak
+func Test_MemoryLock_NoKeyLeak(t *testing.T) {
+	t.Parallel()
+
+	const keys = 1000
+
+	l := NewMemoryLock()
+
+	for i := 0; i < keys; i++ {
+		key := strconv.Itoa(i)
+		utils.AssertEqual(t, nil, l.Lock(key))
+		utils.AssertEqual(t, nil, l.Unlock(key))
+	}
+	utils.AssertEqual(t, 0, l.size())
+
+	// Contended keys must drain too, once the last holder released them.
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for j := 0; j < keys; j++ {
+				key := strconv.Itoa(j)
+				if err := l.Lock(key); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := l.Unlock(key); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	utils.AssertEqual(t, 0, l.size())
+}


### PR DESCRIPTION
## Description

Backport of #3263 to v2.

`MemoryLock.Unlock` released the per-key mutex but never removed the map entry, so
every unique `X-Idempotency-Key` permanently retained one `*sync.Mutex` plus its key
string. An unauthenticated client can exhaust process memory by sending unique
36-character keys to any route behind `idempotency.New()`, since the default
`KeyHeaderValidate` checks length only.

Reported as GHSA-c5qf-v26h-rp5r (medium severity), affecting all v2 releases up to
v2.52.13. v3 has been fixed since #3263 (Dec 2024); v2 never received the backport.

## Fix

Reference-count each key: `Lock` increments under `l.mu`, `Unlock` decrements and
deletes the entry only once the count reaches zero. A plain `delete` in `Unlock`
would be incorrect, because it drops an entry that other goroutines are still
blocked on. The logic is identical to the version shipped in v3.

## Verification

The advisory PoC was run verbatim against both builds, 50,000 POSTs with unique keys:

| build | `MemoryLock.keys` retained | heap delta after forced GC |
| --- | --- | --- |
| v2.52.13 | 50000 | 286 B/key |
| this PR | 0 | 187 B/key |

The remaining 187 B/key is the response cache (`cfg.Storage`), which is TTL swept
(`Lifetime` 30 min, `GCInterval` 15 min), so it is bounded rather than leaked.

New regression test `Test_MemoryLock_NoKeyLeak` asserts the map drains to zero after
1000 sequential and 16x1000 contended lock/unlock cycles. The package passes under
`-race`.

## Changes introduced

- [x] Bugfix: resolves a memory-exhaustion DoS in the idempotency middleware.
- [x] Tests: regression test covering sequential and contended key release.
