### PR TITLE
fix(logger): sanitize user-controlled tag values to prevent log injection (#4341)

### DIFF
--- a/middleware/logger/coverage_test.go
+++ b/middleware/logger/coverage_test.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -201,4 +202,161 @@ func Test_Logger_New_TimeDoneUpdater(t *testing.T) {
 	require.NotEmpty(t, rendered)
 	_, parseErr := time.Parse(time.RFC3339Nano, rendered)
 	require.NoError(t, parseErr)
+}
+
+func Test_sanitizeLog(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"hello", "hello"},
+		{"hello\nworld", "hello world"},
+		{"hello\rworld", "hello world"},
+		{"hello\x00world", "hello world"},
+		{"\x1b[31mred\x1b[0m", " [31mred [0m"},
+		{"tab\there", "tab\there"}, // tab is preserved
+		{"clean string", "clean string"},
+		{"\x7fdelete", " delete"},
+	}
+	for _, tt := range tests {
+		require.Equal(t, tt.expected, sanitizeLog(tt.input), "input: %q", tt.input)
+	}
+}
+
+func Test_sanitizeLogBytes(t *testing.T) {
+	tests := []struct {
+		input    []byte
+		expected []byte
+	}{
+		{[]byte(""), []byte("")},
+		{[]byte("hello"), []byte("hello")},
+		{[]byte("hello\nworld"), []byte("hello world")},
+		{[]byte("hello\x00world"), []byte("hello world")},
+		{[]byte("tab\there"), []byte("tab\there")}, // tab is preserved
+		{[]byte("\x7fdelete"), []byte(" delete")},
+	}
+	for _, tt := range tests {
+		original := make([]byte, len(tt.input))
+		copy(original, tt.input)
+		result := sanitizeLogBytes(tt.input)
+		require.Equal(t, tt.expected, result, "input: %q", tt.input)
+		require.Equal(t, original, tt.input, "original should not be mutated")
+	}
+}
+
+func Test_sanitizeLog_ZeroAllocOnCleanInput(t *testing.T) {
+	input := "GET /health?check=true HTTP/1.1"
+	allocs := testing.AllocsPerRun(100, func() {
+		sanitizeLog(input)
+	})
+	require.Equal(t, float64(0), allocs, "sanitizeLog must not allocate on clean input")
+}
+
+func Test_sanitizeLogBytes_ZeroAllocOnCleanInput(t *testing.T) {
+	input := []byte("GET /health?check=true HTTP/1.1")
+	allocs := testing.AllocsPerRun(100, func() {
+		sanitizeLogBytes(input)
+	})
+	require.Equal(t, float64(0), allocs, "sanitizeLogBytes must not allocate on clean input")
+}
+
+func Test_Logger_HeaderInjectionPrevented(t *testing.T) {
+	app := fiber.New()
+	var buf bytes.Buffer
+	app.Use(New(Config{
+		Format: "${reqHeader:X-Evil}\n",
+		Stream: &buf,
+	}))
+	app.Get("/", func(c fiber.Ctx) error { return c.SendStatus(200) })
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Evil", "value\ninjected-header: evil")
+	_, err := app.Test(req)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "value injected-header: evil")
+}
+
+func Test_Logger_QueryInjectionPrevented(t *testing.T) {
+	app := fiber.New()
+	var buf bytes.Buffer
+	app.Use(New(Config{
+		Format: "${query:foo}\n",
+		Stream: &buf,
+	}))
+	app.Get("/", func(c fiber.Ctx) error { return c.SendStatus(200) })
+
+	// Fiber decodes %0a in query param values to a raw newline.
+	req := httptest.NewRequest(http.MethodGet, "/?foo=bar%0ainjected", nil)
+	_, err := app.Test(req)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "bar injected")
+}
+
+func Test_Logger_PathInjectionPrevented(t *testing.T) {
+	app := fiber.New()
+	var buf bytes.Buffer
+	app.Use(New(Config{
+		Format: "${path}\n",
+		Stream: &buf,
+	}))
+	app.Get("/*", func(c fiber.Ctx) error { return c.SendStatus(200) })
+
+	// Fiber does NOT decode %0a in c.Path() — it stays percent-encoded.
+	// The sanitizer must not break the encoded form.
+	req := httptest.NewRequest(http.MethodGet, "/safe%0apath", nil)
+	_, err := app.Test(req)
+	require.NoError(t, err)
+	logged := buf.String()
+	require.NotContains(t, logged, "\n\n", "raw newline must not appear in log")
+	require.Contains(t, logged, "/safe%0apath", "percent-encoded form must be preserved")
+}
+
+func Test_Logger_BodyInjectionPrevented(t *testing.T) {
+	app := fiber.New()
+	var buf bytes.Buffer
+	app.Use(New(Config{
+		Format: "${body}\n",
+		Stream: &buf,
+	}))
+	app.Post("/", func(c fiber.Ctx) error { return c.SendStatus(200) })
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("hello\ninjected"))
+	req.Header.Set("Content-Type", "text/plain")
+	_, err := app.Test(req)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "hello injected")
+}
+
+func Test_Logger_ErrorInjectionPrevented(t *testing.T) {
+	app := fiber.New()
+	var buf bytes.Buffer
+	app.Use(New(Config{
+		Format: "${error}\n",
+		Stream: &buf,
+	}))
+	app.Get("/", func(c fiber.Ctx) error {
+		return errors.New("bad input\ninjected-log: evil")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	_, err := app.Test(req)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "bad input injected-log: evil")
+}
+
+func Benchmark_sanitizeLog_Clean(b *testing.B) {
+	input := "GET /api/v1/users?page=1&limit=10 HTTP/1.1"
+	b.ReportAllocs()
+	for b.Loop() {
+		sanitizeLog(input)
+	}
+}
+
+func Benchmark_sanitizeLog_Dirty(b *testing.B) {
+	input := "GET /api/v1/users?page=1\nX-Injected: evil HTTP/1.1"
+	b.ReportAllocs()
+	for b.Loop() {
+		sanitizeLog(input)
+	}
 }

--- a/middleware/logger/tags.go
+++ b/middleware/logger/tags.go
@@ -10,6 +10,41 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
+// sanitizeLog replaces ASCII control bytes (except tab) with spaces to prevent
+// log injection via user-controlled values such as path, headers, or body.
+func sanitizeLog(s string) string {
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if b != '\t' && (b < 0x20 || b == 0x7f) {
+			out := []byte(s)
+			for j := i; j < len(out); j++ {
+				if out[j] != '\t' && (out[j] < 0x20 || out[j] == 0x7f) {
+					out[j] = ' '
+				}
+			}
+			return string(out)
+		}
+	}
+	return s
+}
+
+// sanitizeLogBytes is sanitizeLog for []byte inputs.
+func sanitizeLogBytes(b []byte) []byte {
+	for i, v := range b {
+		if v != '\t' && (v < 0x20 || v == 0x7f) {
+			out := make([]byte, len(b))
+			copy(out, b)
+			for j := i; j < len(out); j++ {
+				if out[j] != '\t' && (out[j] < 0x20 || out[j] == 0x7f) {
+					out[j] = ' '
+				}
+			}
+			return out
+		}
+	}
+	return b
+}
+
 // Logger variables
 const (
 	TagPid               = "pid"
@@ -91,7 +126,7 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 	// Set default tags
 	tagFunctions := map[string]LogFunc{
 		TagReferer: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return output.WriteString(c.Get(fiber.HeaderReferer))
+			return output.WriteString(sanitizeLog(c.Get(fiber.HeaderReferer)))
 		},
 		TagProtocol: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
 			return output.WriteString(c.Protocol())
@@ -103,25 +138,25 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			return output.WriteString(c.Port())
 		},
 		TagIP: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return output.WriteString(c.IP())
+			return output.WriteString(sanitizeLog(c.IP()))
 		},
 		TagIPs: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return output.WriteString(c.Get(fiber.HeaderXForwardedFor))
+			return output.WriteString(sanitizeLog(c.Get(fiber.HeaderXForwardedFor)))
 		},
 		TagHost: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return output.WriteString(c.Hostname())
+			return output.WriteString(sanitizeLog(c.Hostname()))
 		},
 		TagPath: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return output.WriteString(c.Path())
+			return output.WriteString(sanitizeLog(c.Path()))
 		},
 		TagURL: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return output.WriteString(c.OriginalURL())
+			return output.WriteString(sanitizeLog(c.OriginalURL()))
 		},
 		TagUA: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return output.WriteString(c.Get(fiber.HeaderUserAgent))
+			return output.WriteString(sanitizeLog(c.Get(fiber.HeaderUserAgent)))
 		},
 		TagBody: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return output.Write(c.Body())
+			return output.Write(sanitizeLogBytes(c.Body()))
 		},
 		TagBytesReceived: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
 			return appendInt(output, c.Request().Header.ContentLength())
@@ -133,7 +168,7 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			return output.WriteString(c.Route().Path)
 		},
 		TagResBody: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return output.Write(c.Response().Body())
+			return output.Write(sanitizeLogBytes(c.Response().Body()))
 		},
 		TagReqHeaders: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
 			out := make(map[string][]string)
@@ -145,10 +180,10 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			for k, v := range out {
 				reqHeaders = append(reqHeaders, k+"="+strings.Join(v, ","))
 			}
-			return output.WriteString(strings.Join(reqHeaders, "&"))
+			return output.WriteString(sanitizeLog(strings.Join(reqHeaders, "&")))
 		},
 		TagQueryStringParams: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return output.WriteString(c.Request().URI().QueryArgs().String())
+			return output.WriteString(sanitizeLog(c.Request().URI().QueryArgs().String()))
 		},
 
 		TagBlack: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
@@ -189,30 +224,30 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			return output.WriteString("-")
 		},
 		TagReqHeader: func(output Buffer, c fiber.Ctx, _ *Data, extraParam string) (int, error) {
-			return output.WriteString(c.Get(extraParam))
+			return output.WriteString(sanitizeLog(c.Get(extraParam)))
 		},
 		TagRespHeader: func(output Buffer, c fiber.Ctx, _ *Data, extraParam string) (int, error) {
-			return output.WriteString(c.GetRespHeader(extraParam))
+			return output.WriteString(sanitizeLog(c.GetRespHeader(extraParam)))
 		},
 		TagQuery: func(output Buffer, c fiber.Ctx, _ *Data, extraParam string) (int, error) {
-			return output.WriteString(fiber.Query[string](c, extraParam))
+			return output.WriteString(sanitizeLog(fiber.Query[string](c, extraParam)))
 		},
 		TagForm: func(output Buffer, c fiber.Ctx, _ *Data, extraParam string) (int, error) {
-			return output.WriteString(c.FormValue(extraParam))
+			return output.WriteString(sanitizeLog(c.FormValue(extraParam)))
 		},
 		TagCookie: func(output Buffer, c fiber.Ctx, _ *Data, extraParam string) (int, error) {
-			return output.WriteString(c.Cookies(extraParam))
+			return output.WriteString(sanitizeLog(c.Cookies(extraParam)))
 		},
 		TagLocals: func(output Buffer, c fiber.Ctx, _ *Data, extraParam string) (int, error) {
 			switch v := c.Locals(extraParam).(type) {
 			case []byte:
-				return output.Write(v)
+				return output.Write(sanitizeLogBytes(v))
 			case string:
-				return output.WriteString(v)
+				return output.WriteString(sanitizeLog(v))
 			case nil:
 				return 0, nil
 			default:
-				return fmt.Fprintf(output, "%v", v)
+				return output.WriteString(sanitizeLog(fmt.Sprintf("%v", v)))
 			}
 		},
 		TagStatus: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {

--- a/middleware/logger/tags.go
+++ b/middleware/logger/tags.go
@@ -10,8 +10,12 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
-// sanitizeLog replaces ASCII control bytes (except tab) with spaces to prevent
-// log injection via user-controlled values such as path, headers, or body.
+// sanitizeLog replaces ASCII control bytes (except horizontal tab) with a
+// space to prevent log injection / CRLF attacks via user-controlled values
+// such as paths, headers, query parameters, and request/response bodies.
+// The replacement strategy is intentionally simple: one bad byte → one space,
+// preserving field widths and avoiding multi-byte expansion.
+// Clean inputs are returned as-is with zero allocations.
 func sanitizeLog(s string) string {
 	for i := 0; i < len(s); i++ {
 		b := s[i]
@@ -28,18 +32,13 @@ func sanitizeLog(s string) string {
 	return s
 }
 
-// sanitizeLogBytes is sanitizeLog for []byte inputs.
+// sanitizeLogBytes is the []byte variant of sanitizeLog.
+// The original slice is never modified; a new slice is returned only when
+// a control byte is found. Clean inputs are returned as-is (zero allocation).
 func sanitizeLogBytes(b []byte) []byte {
-	for i, v := range b {
+	for _, v := range b {
 		if v != '\t' && (v < 0x20 || v == 0x7f) {
-			out := make([]byte, len(b))
-			copy(out, b)
-			for j := i; j < len(out); j++ {
-				if out[j] != '\t' && (out[j] < 0x20 || out[j] == 0x7f) {
-					out[j] = ' '
-				}
-			}
-			return out
+			return []byte(sanitizeLog(string(b)))
 		}
 	}
 	return b
@@ -183,7 +182,7 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			return output.WriteString(sanitizeLog(strings.Join(reqHeaders, "&")))
 		},
 		TagQueryStringParams: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return output.WriteString(sanitizeLog(c.Request().URI().QueryArgs().String()))
+			return output.WriteString(sanitizeLog(string(c.Request().URI().QueryString())))
 		},
 
 		TagBlack: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
@@ -217,9 +216,9 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			if data.ChainErr != nil {
 				if cfg.areColorsEnabled {
 					colors := c.App().Config().ColorScheme
-					return fmt.Fprintf(output, "%s%s%s", colors.Red, data.ChainErr.Error(), colors.Reset)
+					return fmt.Fprintf(output, "%s%s%s", colors.Red, sanitizeLog(data.ChainErr.Error()), colors.Reset)
 				}
-				return output.WriteString(data.ChainErr.Error())
+				return output.WriteString(sanitizeLog(data.ChainErr.Error()))
 			}
 			return output.WriteString("-")
 		},


### PR DESCRIPTION
Closes #4341

## What this PR does

Adds sanitization of all user-controlled values written by the logger middleware to prevent log injection / CRLF attacks. An attacker who can control a header, query parameter, path, body, cookie, form value, or error message could otherwise inject fake log lines.

All bytes `< 0x20` (except horizontal tab `\t`) and `0x7f` are replaced with a single space `' '`. Tabs are preserved to avoid breaking tab-delimited log formats.

## Tags sanitized

`referer`, `ip`, `ips`, `host`, `path`, `url`, `ua`, `body`, `resBody`, `reqHeaders`, `queryParams`, `error`, `reqHeader:*`, `respHeader:*`, `query:*`, `form:*`, `cookie:*`, `locals:*`

## Why the previous attempt was rejected — and how each point is fixed

| Rejection reason | Fix |
|---|---|
| Duplicate logic between `sanitizeLog` / `sanitizeLogBytes` | `sanitizeLogBytes` scans bytes directly — no string conversion on clean path |
| `sanitizeLogBytes` converted to string twice on clean path | Fixed: bytes scanned first, conversion only happens when a bad byte is found |
| `TagError` not sanitized | `data.ChainErr.Error()` is now sanitized in both color and non-color paths |
| Missing unit tests | Full table-driven tests covering empty string, `\n`, `\r`, `\x00`, DEL, ANSI sequences, tab preservation |
| Fragile mutation test | Uses `copy` before call, asserts original slice unchanged after |
| No allocation proof | `testing.AllocsPerRun(100, ...)` asserts 0 allocs for both functions on clean input |
| Insufficient injection coverage | End-to-end tests via real Fiber app + `httptest` for: header, query param, path, body, error |

## Important: Fiber percent-encoding behaviour

`c.Path()` and `c.Request().URI().QueryString()` return **percent-encoded** values — `%0a` stays as the three characters `%`, `0`, `a` and is never decoded to a raw newline. The path injection test explicitly asserts this: the encoded form is preserved in the log and no raw newline appears. The real injection vectors are values that Fiber **does** decode (query param values via `c.Query()`, headers, body, cookies, form fields).

## Performance

Clean inputs (no control bytes) return the original string/slice with **zero allocations** — proven with `testing.AllocsPerRun`:

```
Benchmark_sanitizeLog_Clean   13260548   89 ns/op    0 B/op   0 allocs/op
Benchmark_sanitizeLog_Dirty    6594576  184 ns/op  128 B/op   2 allocs/op
```

## Checklist
- [x] Tests pass: `go test ./middleware/logger/...`
- [x] Zero allocations on clean input proven with `AllocsPerRun`
- [x] No new config flags or structured logging changes
- [x] Focused change — only `tags.go` and `coverage_test.go` modified