### PR TITLE
fix(limiter): floor sub-second expiration in fixed window

### DIFF
--- a/middleware/limiter/limiter_fixed.go
+++ b/middleware/limiter/limiter_fixed.go
@@ -3,6 +3,7 @@ package limiter
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/utils/v2"
@@ -43,6 +44,13 @@ func (FixedWindow) New(cfg *Config) fiber.Handler {
 			expirationDuration = ConfigDefault.Expiration
 		}
 		expiration := uint64(expirationDuration.Seconds())
+		if expiration == 0 {
+			// Floor sub-second durations to 1 s: a zero-width window resets on every
+			// request (making the limiter unable to accumulate hits), and a sub-second
+			// storage TTL evicts the entry before the next request arrives.
+			expiration = 1
+			expirationDuration = time.Second
+		}
 
 		// Get key from request
 		key := cfg.KeyGenerator(c)

--- a/middleware/limiter/limiter_test.go
+++ b/middleware/limiter/limiter_test.go
@@ -1863,3 +1863,36 @@ func Test_Config_currentSecond_NegativeClock(t *testing.T) {
 	cfg.clock = func() time.Time { return time.Unix(42, 0) }
 	require.Equal(t, uint64(42), cfg.currentSecond())
 }
+
+// Test_Limiter_Fixed_SubSecondExpiration verifies that a sub-second ExpirationFunc
+// does not truncate to zero, which would cause e.exp = ts+0 = ts and reset the
+// window on every request — making the limiter never accumulate hits.
+func Test_Limiter_Fixed_SubSecondExpiration(t *testing.T) {
+	t.Parallel()
+
+	clock := newTestClock(time.Now().Truncate(time.Second))
+	app := fiber.New()
+	app.Use(New(Config{
+		Max:               3,
+		LimiterMiddleware: FixedWindow{},
+		clock:             clock.Now,
+		ExpirationFunc: func(_ fiber.Ctx) time.Duration {
+			return 500 * time.Millisecond // sub-second: truncates to 0 without the fix
+		},
+	}))
+	app.Get("/", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusOK) })
+
+	// First 3 requests must succeed
+	for i := range 3 {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, fiber.StatusOK, resp.StatusCode, "request %d should be allowed", i+1)
+	}
+
+	// 4th request must be rate-limited
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusTooManyRequests, resp.StatusCode, "4th request should be rate-limited")
+}


### PR DESCRIPTION
## Description

`FixedWindow` computes the window length as:

```go
expiration := uint64(expirationDuration.Seconds())
```

Any positive sub-second `ExpirationFunc` value truncates to `0`. This causes two compounding failures:

1. `e.exp = ts + 0 = ts` — the window expires on every single request, so hits never accumulate and the limiter never fires
2. `manager.set` receives the original sub-second TTL, evicting the entry from storage before the next request arrives

The result: a limiter configured with e.g. `ExpirationFunc: func(...) time.Duration { return 500*time.Millisecond }` allows unlimited requests regardless of `Max`.

## Fix

```go
if expiration == 0 {
    expiration = 1
    expirationDuration = time.Second
}
```

This is the follow-up to #4564, which explicitly noted FixedWindow has the same truncation bug.

## Testing

- `Test_Limiter_Fixed_SubSecondExpiration` fails before this fix, passes after
- Uses `testClock` for deterministic window boundaries (no wall-clock races)
- Confirmed with `-race`

## Checklist
- [x] `go test ./middleware/limiter/... -race` passes
- [x] Only `limiter_fixed.go` and `limiter_test.go` modified
- [x] No API or config changes