### PR TITLE
🐛 fix: de-flake the clock-sensitive tests

### DIFF
--- a/internal/clocktest/clocktest.go
+++ b/internal/clocktest/clocktest.go
@@ -1,0 +1,29 @@
+// Package clocktest lets tests wait on the cached, second-granularity clock
+// that fiber's memory storages and rate-limit windows are measured against.
+package clocktest
+
+import (
+	"time"
+
+	"github.com/gofiber/utils/v2"
+)
+
+// SleepPast waits out ttl in wall time and then blocks until utils.Timestamp()
+// has advanced by ttl too.
+//
+// Expiry is compared against that cached timestamp, and the goroutine
+// refreshing it once per second can be scheduled well over a second late on a
+// loaded machine, so a wall-clock sleep alone leaves entries live past their
+// TTL often enough to turn CI red.
+func SleepPast(ttl time.Duration) {
+	utils.StartTimeStampUpdater() // no-op when already running
+	from := utils.Timestamp()
+
+	time.Sleep(ttl + 100*time.Millisecond)
+
+	want := from + uint32(ttl.Seconds())
+	deadline := time.Now().Add(10 * time.Second)
+	for utils.Timestamp() < want && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/internal/clocktest/clocktest.go
+++ b/internal/clocktest/clocktest.go
@@ -3,19 +3,22 @@
 package clocktest
 
 import (
+	"testing"
 	"time"
 
 	"github.com/gofiber/utils/v2"
 )
 
 // SleepPast waits out ttl in wall time and then blocks until utils.Timestamp()
-// has advanced by ttl too.
+// has advanced by ttl truncated to whole seconds, the granularity the storages
+// compare expiry against.
 //
 // Expiry is compared against that cached timestamp, and the goroutine
 // refreshing it once per second can be scheduled well over a second late on a
 // loaded machine, so a wall-clock sleep alone leaves entries live past their
 // TTL often enough to turn CI red.
-func SleepPast(ttl time.Duration) {
+func SleepPast(tb testing.TB, ttl time.Duration) {
+	tb.Helper()
 	utils.StartTimeStampUpdater() // no-op when already running
 	from := utils.Timestamp()
 
@@ -25,5 +28,10 @@ func SleepPast(ttl time.Duration) {
 	deadline := time.Now().Add(10 * time.Second)
 	for utils.Timestamp() < want && time.Now().Before(deadline) {
 		time.Sleep(5 * time.Millisecond)
+	}
+
+	// A silent return here would surface as a confusing "not expired" assertion
+	if now := utils.Timestamp(); now < want {
+		tb.Fatalf("cached clock stuck at %d, want %d after waiting out %s", now, want, ttl)
 	}
 }

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -2562,7 +2562,10 @@ func Test_CacheMaxStaleRespectsProxyRevalidateSharedAuth(t *testing.T) {
 	var count int
 	app.Get("/", func(c fiber.Ctx) error {
 		count++
-		c.Set(fiber.HeaderCacheControl, "s-maxage=1, proxy-revalidate")
+		// s-maxage=2, not 1: the store phase reads cfg.now() twice and charges the
+		// whole second in between as apparent age, so a one-second lifetime can be
+		// consumed entirely and the entry reported unreachable instead of cached.
+		c.Set(fiber.HeaderCacheControl, "s-maxage=2, proxy-revalidate")
 		return c.SendString(strconv.Itoa(count))
 	})
 
@@ -2573,7 +2576,7 @@ func Test_CacheMaxStaleRespectsProxyRevalidateSharedAuth(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
 
-	time.Sleep(1500 * time.Millisecond)
+	time.Sleep(2500 * time.Millisecond)
 
 	req = httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
 	req.Header.Set(fiber.HeaderAuthorization, "Bearer abc")

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -447,7 +447,7 @@ func Test_CSRF_ExpiredToken(t *testing.T) {
 	require.Equal(t, 200, ctx.Response.StatusCode())
 
 	// Wait for the token to expire on the cached clock the storage compares against
-	clocktest.SleepPast(idleTimeout)
+	clocktest.SleepPast(t, idleTimeout)
 
 	// Expired CSRF token
 	ctx.Request.Reset()

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/extractors"
+	"github.com/gofiber/fiber/v3/internal/clocktest"
 	"github.com/gofiber/fiber/v3/internal/loggertest"
 	"github.com/gofiber/fiber/v3/internal/redact"
 	fiberlog "github.com/gofiber/fiber/v3/log"
@@ -417,8 +418,10 @@ func Test_CSRF_ExpiredToken(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
 
+	const idleTimeout = 1 * time.Second
+
 	app.Use(New(Config{
-		IdleTimeout: 1 * time.Second,
+		IdleTimeout: idleTimeout,
 	}))
 
 	app.Post("/", func(c fiber.Ctx) error {
@@ -443,8 +446,8 @@ func Test_CSRF_ExpiredToken(t *testing.T) {
 	h(ctx)
 	require.Equal(t, 200, ctx.Response.StatusCode())
 
-	// Wait for the token to expire
-	time.Sleep(1250 * time.Millisecond)
+	// Wait for the token to expire on the cached clock the storage compares against
+	clocktest.SleepPast(idleTimeout)
 
 	// Expired CSRF token
 	ctx.Request.Reset()
@@ -520,7 +523,7 @@ func Test_CSRF_ExpiredToken_WithSession(t *testing.T) {
 	h(ctx)
 	require.Equal(t, 200, ctx.Response.StatusCode())
 
-	// Wait for the token to expire
+	// Wait for the token to expire (session-backed tokens carry a real-clock expiry)
 	time.Sleep(1*time.Second + 100*time.Millisecond)
 
 	// Expired CSRF token

--- a/middleware/limiter/limiter_test.go
+++ b/middleware/limiter/limiter_test.go
@@ -126,7 +126,7 @@ func sleepForRetryAfter(t *testing.T, resp *http.Response) {
 
 	// Window accounting reads the cached second clock, so wall time alone is not
 	// enough: a late timestamp updater keeps the old window current.
-	clocktest.SleepPast(delay)
+	clocktest.SleepPast(t, delay)
 }
 
 func newContextRecorderLimiterStorage() *contextRecorderLimiterStorage {

--- a/middleware/limiter/limiter_test.go
+++ b/middleware/limiter/limiter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/internal/clocktest"
 	"github.com/gofiber/fiber/v3/internal/storage/memory"
 )
 
@@ -123,7 +124,9 @@ func sleepForRetryAfter(t *testing.T, resp *http.Response) {
 		delay = minDelay
 	}
 
-	time.Sleep(delay + 500*time.Millisecond)
+	// Window accounting reads the cached second clock, so wall time alone is not
+	// enough: a late timestamp updater keeps the old window current.
+	clocktest.SleepPast(delay)
 }
 
 func newContextRecorderLimiterStorage() *contextRecorderLimiterStorage {

--- a/middleware/recover/recover.go
+++ b/middleware/recover/recover.go
@@ -8,8 +8,10 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
+// Must not start with "panic: ": the panic was recovered, and that exact prefix
+// makes gotestsum treat the whole run as crashed and skip --rerun-fails.
 func defaultStackTraceHandler(_ fiber.Ctx, e any) {
-	fmt.Fprintf(os.Stderr, "panic: %v\n\n%s\n", e, debug.Stack())
+	fmt.Fprintf(os.Stderr, "recovered panic: %v\n\n%s\n", e, debug.Stack())
 }
 
 // DefaultPanicHandler returns r directly if it's an error, and creates a new one with the %v verb otherwise.

--- a/middleware/recover/recover_test.go
+++ b/middleware/recover/recover_test.go
@@ -3,8 +3,11 @@ package recover //nolint:predeclared // TODO: Rename to some non-builtin
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
@@ -103,4 +106,26 @@ func Test_Recover_EnableStackTrace(t *testing.T) {
 	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/panic", http.NoBody))
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+}
+
+// Not parallel: swaps os.Stderr to capture what the default handler writes.
+func Test_Recover_DefaultStackTraceHandlerOutput(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	orig := os.Stderr
+	os.Stderr = w
+	defaultStackTraceHandler(nil, "Hi, I'm an error!")
+	os.Stderr = orig
+	require.NoError(t, w.Close())
+
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	require.Contains(t, string(out), "recovered panic: Hi, I'm an error!")
+	require.Contains(t, string(out), "goroutine")
+	// gotestsum reads a leading "panic: " as a crashed run and then skips
+	// --rerun-fails for every package, so the recovered panic must not use it.
+	require.False(t, strings.HasPrefix(string(out), "panic: "), "output must not look like a fatal panic")
 }

--- a/middleware/recover/recover_test.go
+++ b/middleware/recover/recover_test.go
@@ -115,8 +115,9 @@ func Test_Recover_DefaultStackTraceHandlerOutput(t *testing.T) {
 
 	orig := os.Stderr
 	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
 	defaultStackTraceHandler(nil, "Hi, I'm an error!")
-	os.Stderr = orig
 	require.NoError(t, w.Close())
 
 	out, err := io.ReadAll(r)

--- a/middleware/session/middleware_test.go
+++ b/middleware/session/middleware_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/extractors"
+	"github.com/gofiber/fiber/v3/internal/clocktest"
 	"github.com/gofiber/fiber/v3/internal/loggertest"
 	fiberlog "github.com/gofiber/fiber/v3/log"
 	"github.com/gofiber/fiber/v3/middleware/logger"
@@ -480,11 +481,13 @@ func Test_Session_WithConfig(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
 
+	const idleTimeout = 1 * time.Second
+
 	app.Use(New(Config{
 		Next: func(c fiber.Ctx) bool {
 			return c.Get("key") == "value"
 		},
-		IdleTimeout: 1 * time.Second,
+		IdleTimeout: idleTimeout,
 		Extractor:   extractors.FromCookie("session_id_test"),
 		KeyGenerator: func() string {
 			return "test"
@@ -573,8 +576,8 @@ func Test_Session_WithConfig(t *testing.T) {
 	h(ctx)
 	require.Equal(t, fiber.StatusInternalServerError, ctx.Response.StatusCode())
 
-	// Test idle timeout
-	time.Sleep(1200 * time.Millisecond)
+	// Test idle timeout, waiting on the cached clock the storage compares against
+	clocktest.SleepPast(idleTimeout)
 	ctx = &fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fiber.MethodGet)
 	ctx.Request.Header.SetCookie("session_id_test", token)

--- a/middleware/session/middleware_test.go
+++ b/middleware/session/middleware_test.go
@@ -577,7 +577,7 @@ func Test_Session_WithConfig(t *testing.T) {
 	require.Equal(t, fiber.StatusInternalServerError, ctx.Response.StatusCode())
 
 	// Test idle timeout, waiting on the cached clock the storage compares against
-	clocktest.SleepPast(idleTimeout)
+	clocktest.SleepPast(t, idleTimeout)
 	ctx = &fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fiber.MethodGet)
 	ctx.Request.Header.SetCookie("session_id_test", token)

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/extractors"
+	"github.com/gofiber/fiber/v3/internal/clocktest"
 	"github.com/gofiber/fiber/v3/internal/storage/memory"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -891,9 +892,9 @@ func Test_Session_Save_IdleTimeout(t *testing.T) {
 		name := sess.Get("name")
 		require.Equal(t, "john", name, "session should contain the saved value before expiration")
 
-		// just to make sure the session has been expired
-		// Add extra buffer time to ensure expiration is processed
-		time.Sleep(sessionDuration + (100 * time.Millisecond))
+		// Wait on the cached clock the storage compares against, not just the
+		// wall clock, or a late timestamp updater keeps the session alive.
+		clocktest.SleepPast(sessionDuration)
 
 		sess.Release()
 
@@ -1769,8 +1770,10 @@ func Test_Session_Fresh_Flag_Bug(t *testing.T) {
 func Test_Session_CSRF_Scenario(t *testing.T) {
 	t.Parallel()
 
+	const idleTimeout = 2 * time.Second // Longer timeout to ensure session persists
+
 	store := NewStore(Config{
-		IdleTimeout: 2 * time.Second, // Longer timeout to ensure session persists
+		IdleTimeout: idleTimeout,
 	})
 	app := fiber.New()
 
@@ -1805,8 +1808,8 @@ func Test_Session_CSRF_Scenario(t *testing.T) {
 	sess2.Release()
 	app.ReleaseCtx(ctx2)
 
-	// Wait for session to expire
-	time.Sleep(2200 * time.Millisecond)
+	// Wait for session to expire on the cached clock the storage compares against
+	clocktest.SleepPast(idleTimeout)
 
 	// Simulate: POST request with expired session
 	// This is the scenario the user reported - session data is gone

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -894,7 +894,7 @@ func Test_Session_Save_IdleTimeout(t *testing.T) {
 
 		// Wait on the cached clock the storage compares against, not just the
 		// wall clock, or a late timestamp updater keeps the session alive.
-		clocktest.SleepPast(sessionDuration)
+		clocktest.SleepPast(t, sessionDuration)
 
 		sess.Release()
 
@@ -1809,7 +1809,7 @@ func Test_Session_CSRF_Scenario(t *testing.T) {
 	app.ReleaseCtx(ctx2)
 
 	// Wait for session to expire on the cached clock the storage compares against
-	clocktest.SleepPast(idleTimeout)
+	clocktest.SleepPast(t, idleTimeout)
 
 	// Simulate: POST request with expired session
 	// This is the scenario the user reported - session data is gone

--- a/middleware/timeout/timeout_test.go
+++ b/middleware/timeout/timeout_test.go
@@ -63,9 +63,13 @@ func TestTimeout_Exceeded(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
 
+	// The handler sleep and the bound below are spread far apart on purpose: a
+	// tight bound measures runner load, not early return.
+	const handlerSleep = 2 * time.Second
+
 	// This handler listens for context cancelation and returns early when timeout occurs.
 	app.Get("/slow", New(func(c fiber.Ctx) error {
-		if err := sleepWithContext(c.Context(), 200*time.Millisecond, context.DeadlineExceeded); err != nil {
+		if err := sleepWithContext(c.Context(), handlerSleep, context.DeadlineExceeded); err != nil {
 			return err
 		}
 		return c.SendString("Should never get here")
@@ -77,8 +81,8 @@ func TestTimeout_Exceeded(t *testing.T) {
 	elapsed := time.Since(start)
 	require.NoError(t, err, "app.Test(req) should not fail")
 	require.Equal(t, fiber.StatusRequestTimeout, resp.StatusCode, "Expected 408 Request Timeout")
-	// Handler should return shortly after timeout (not wait full 200ms)
-	require.Less(t, elapsed, 150*time.Millisecond, "handler should return early on context cancelation")
+	// Handler should return on cancelation, well before its own sleep elapses.
+	require.Less(t, elapsed, handlerSleep/2, "handler should return early on context cancelation")
 }
 
 // TestTimeout_ContextPropagation verifies that the timeout context is properly


### PR DESCRIPTION
# Description

`main` has been going red on isolated test failures for months, and the retry that
should absorb them was never running. This fixes both.

**Cause 1, the cached clock.** The memory storages compare entry expiry against
`utils.Timestamp()`, a Unix second refreshed by a background 1s ticker, not against the
wall clock. Under `-race` on a loaded runner that goroutine's store lands up to 1.6s late,
and >100ms late on about half the ticks, so expiry can lag its nominal TTL by roughly two
seconds. Every test that slept `TTL + 100..500ms` and then asserted expiry was flaky by
construction.

Reproduced at the storage level in 2 of 24 rounds (TTL=5s, 5.1s sleep), and at test level
as the exact failures seen on main in 2 of 8 rounds under `GOMAXPROCS=2` with in-process
CPU load. Zero of 8 with the fix. Note the load has to be in-process, an external load
generator does not starve Go's own scheduler and shows nothing.

**Cause 2, dead reruns.** `test.yml` sets `rerun-fails: '2'`, but every run aborted with
`rerun aborted because previous run had a suspected panic and some test may not have run`.
gotestsum flags a package as panicked the moment any output line starts with `panic: `
(`testjson/execution.go` `addOutput`) and `cmd/rerunfails.go` skips the rerun if any
package is flagged. The recover middleware wrote exactly that prefix for a panic it had
just recovered, so one line cost the whole 4248-test suite its retries.

Affected runs: [30523196027](https://github.com/gofiber/fiber/actions/runs/30523196027),
[30397573119](https://github.com/gofiber/fiber/actions/runs/30397573119),
[28373765289](https://github.com/gofiber/fiber/actions/runs/28373765289),
[28302993228](https://github.com/gofiber/fiber/actions/runs/28302993228),
[28206382069](https://github.com/gofiber/fiber/actions/runs/28206382069).

## Changes introduced

**`test(session,csrf,limiter)`** Add `internal/clocktest.SleepPast`, which sleeps the TTL
and then waits for the cached clock to catch up, and use it where that clock is what
decides. Sleeping longer is not a fix, the updater delay has no upper bound.

I checked per call site which clock actually governs, because the helper shortens the
wall-clock margin and that is only safe where the cached clock decides:

| path | clock |
| --- | --- |
| session idle timeout (`Save` to `Storage.Set(.., idleTimeout)`) | cached |
| session absolute timeout (`absExpiration`) | real `time.Now()` |
| csrf without `Session` (`storageManager`, `internal/memory`) | cached |
| csrf with `Session` (`token.Expiration.Before(time.Now())`) | real `time.Now()` |
| limiter windows (`cfg.currentSecond()`) | cached, no `time.Now()` at all |

The two real-clock paths are deliberately left on a plain `time.Sleep`.

**`test(cache)`** `Test_CacheMaxStaleRespectsProxyRevalidateSharedAuth` failed with
expected `miss`, actual `unreachable`. A different mechanism: the store phase reads
`cfg.now()` twice (`cache.go:714` and `cache.go:784`) and charges the whole second in
between as the response's apparent age, which consumes a one-second lifetime entirely.
Raising it to two seconds makes the test immune without changing what it asserts.

**`test(timeout)`** `TestTimeout_Exceeded` bounded elapsed at 150ms against a 50ms timeout
and a 200ms handler sleep, and failed at 150.78ms. Only 100ms of headroom meant it
measured runner load, not early return. Handler sleep to 2s, bound at half of it.

**`fix(recover)`** Prefix the default stack trace with `recovered`, and pin it with a test
that captures the output through an `os.Pipe` and asserts it no longer looks fatal.

## Open question for maintainers

The cache double clock read is a real bug, not just a test annoyance, and I did not touch
it here. A response with `max-age=1` fails to be cached at all whenever the store phase
crosses a second boundary, because `responseTS - e.date` charges fiber's own processing
latency as response age. RFC 9111 defines apparent age against the same response event,
so measuring it from a later clock read manufactures age out of nothing.

Deterministic reproduction through the injectable clock: a request makes three `cfg.now()`
calls, and moving the boundary to just after the second one turns a `max-age=1` store into
`unreachable` every time.

Fixing it is about two lines (measure the age against `nowUnix`, keep `responseTS` as the
expiry anchor) and would remove the same latent exposure from
`Test_CacheOnlyIfCachedStaleNotServed`, `Test_CacheMaxStaleRespectsMustRevalidate` and
`Test_CacheStaleResponseAddsWarning110`, which all assert a cache miss on a `max-age=1`
store. It also lets the workaround in this PR be reverted. I left it out because it
changes RFC-adjacent freshness math and deserves its own change with its own regression
test. Happy to open that separately.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

Note for the release notes: `recover`'s default `StackTraceHandler` now writes
`recovered panic: ...` instead of `panic: ...` to stderr. Not an API change and the
format was never documented, but anyone grepping their logs for that prefix will notice.
`EnableStackTrace` defaults to `false`, so most users never see the line at all.

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community. (none added)
- [ ] Updated the documentation in the `/docs/` directory. Not needed, `docs/middleware/recover.md` documents `EnableStackTrace` and `StackTraceHandler` but not the output format.
- [ ] Benchmarks. Not applicable, no hot-path code changed.

## Verification

- Full suite `-race -count=1 -shuffle=on` green, `gofmt` and `go vet` clean.
- A/B under the reproducing harness (`GOMAXPROCS=2`, in-process load, `-race -count=8`):
  3 failures before, 0 after. recover package 20x `-race -shuffle=on`.
- gotestsum v1.13.0 with a deliberately failing test: before `rerun aborted`, after
  `re-run 1` and `re-run 2` both ran, `DONE 3 runs` over the full suite.
- `grep -c '^panic: '` over the whole suite output is now 0.

One honest gap: `Test_CSRF_ExpiredToken` held 8 of 8 in the before state under the same
harness that reliably broke the session tests, so I could not reproduce that one locally.
Its 250ms margin makes it a rarer variant of the same class. The evidence there is the
code path (`internal/memory`, cached clock) plus the CI signature from run 28206382069
(`expected 403, actual 200`, token not expired).

The limiter failures that harness produces (`app.Test` timeouts on tests with 200-300ms
`Expiration`) are pre-existing. They reproduce identically without this change, none sit
at a `sleepForRetryAfter` call site, and none appear in CI history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
