### PR TITLE
🐛 bug: answer healthcheck HEAD probes with the GET status

### DIFF
--- a/docs/middleware/healthcheck.md
+++ b/docs/middleware/healthcheck.md
@@ -57,7 +57,7 @@ app.Get(healthcheck.StartupEndpoint, healthcheck.New())
 app.Get("/healthz", healthcheck.New())
 ```
 
-The middleware responds only to GET. Use `app.All` to expose a probe on every method; other methods fall through to the next handler:
+The middleware responds to GET and HEAD, where HEAD returns the same status code without a body. Use `app.All` to expose a probe on every method; other methods fall through to the next handler:
 
 ```go
 app.All("/healthz", healthcheck.New())

--- a/middleware/healthcheck/healthcheck.go
+++ b/middleware/healthcheck/healthcheck.go
@@ -20,7 +20,7 @@ func New(config ...Config) fiber.Handler {
 			return c.Next()
 		}
 
-		if c.Method() != fiber.MethodGet {
+		if c.Method() != fiber.MethodGet && c.Method() != fiber.MethodHead {
 			return c.Next()
 		}
 

--- a/middleware/healthcheck/healthcheck_test.go
+++ b/middleware/healthcheck/healthcheck_test.go
@@ -163,6 +163,35 @@ func Test_HealthCheck_Custom_Nested(t *testing.T) {
 	shouldGiveOK(t, app, "/probe/ready/")
 }
 
+func Test_HealthCheck_Head(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Get(LivenessEndpoint, New())
+	app.Get(ReadinessEndpoint, New(Config{
+		Probe: func(_ fiber.Ctx) bool {
+			return false
+		},
+	}))
+
+	// HEAD must mirror the GET status (RFC 9110 9.3.2) with an empty body
+	for _, tc := range []struct {
+		path   string
+		status int
+	}{
+		{path: LivenessEndpoint, status: fiber.StatusOK},
+		{path: ReadinessEndpoint, status: fiber.StatusServiceUnavailable},
+	} {
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodHead, tc.path, http.NoBody))
+		require.NoError(t, err)
+		require.Equal(t, tc.status, resp.StatusCode, "path: "+tc.path)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Empty(t, body)
+	}
+}
+
 func Test_HealthCheck_Next(t *testing.T) {
 	t.Parallel()
 

--- a/middleware/healthcheck/healthcheck_test.go
+++ b/middleware/healthcheck/healthcheck_test.go
@@ -173,6 +173,7 @@ func Test_HealthCheck_Head(t *testing.T) {
 			return false
 		},
 	}))
+	app.All("/healthz", New())
 
 	// HEAD must mirror the GET status (RFC 9110 9.3.2) with an empty body
 	for _, tc := range []struct {
@@ -182,14 +183,30 @@ func Test_HealthCheck_Head(t *testing.T) {
 		{path: LivenessEndpoint, status: fiber.StatusOK},
 		{path: ReadinessEndpoint, status: fiber.StatusServiceUnavailable},
 	} {
+		getResp, err := app.Test(httptest.NewRequest(fiber.MethodGet, tc.path, http.NoBody))
+		require.NoError(t, err)
+		require.NoError(t, getResp.Body.Close())
+		require.Equal(t, tc.status, getResp.StatusCode, "path: "+tc.path)
+
 		resp, err := app.Test(httptest.NewRequest(fiber.MethodHead, tc.path, http.NoBody))
 		require.NoError(t, err)
-		require.Equal(t, tc.status, resp.StatusCode, "path: "+tc.path)
+		require.Equal(t, getResp.StatusCode, resp.StatusCode, "path: "+tc.path)
+		// Date is left out, fasthttp refreshes its cached value once per second
+		for _, name := range []string{fiber.HeaderContentType, fiber.HeaderContentLength} {
+			require.Equal(t, getResp.Header.Get(name), resp.Header.Get(name), "path: "+tc.path+" header: "+name)
+		}
+
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		require.NoError(t, resp.Body.Close())
 		require.Empty(t, body)
 	}
+
+	// Everything but GET and HEAD keeps falling through to the next handler
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodPost, "/healthz", http.NoBody))
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, fiber.StatusNotFound, resp.StatusCode)
 }
 
 func Test_HealthCheck_Next(t *testing.T) {


### PR DESCRIPTION
# Description

`healthcheck.New()` returned `c.Next()` for every method except GET, so a `HEAD /livez` ended up in the 404 handler while `GET /livez` answered 200. Since v3 auto-registers a HEAD twin for every GET route (`DisableHeadAutoRegister`), the HEAD request does reach the probe handler and the guard is what breaks it. RFC 9110 9.3.2 wants HEAD to answer with the GET status and no body, and fasthttp already drops the body on the wire, so the existing GET path can serve HEAD unchanged.

healthcheck was also the only outlier here: `static`, `favicon` and `envvar` all accept GET and HEAD.

Measured on `main` before the fix:

| Registration | GET | HEAD |
| --- | --- | --- |
| `app.Get(healthcheck.LivenessEndpoint, healthcheck.New())` | 200 | 404 |
| `app.All("/livez", healthcheck.New())` | 200 | 404 |
| `app.Get("/livez", plainHandler)` | 200 | 200 |

Fixes #4574

## Changes introduced

- `middleware/healthcheck`: let HEAD through the same probe path as GET; other methods still fall through to the next handler.
- Test: `Test_HealthCheck_Head` asserts 200 for a healthy probe, 503 for an unhealthy one, and an empty body in both cases.
- Documentation Update: `docs/middleware/healthcheck.md` no longer claims the middleware responds only to GET.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)
- [x] Documentation update (changes to documentation)
