### PR TITLE
🐛 bug: stop the cache from charging its own latency as response age

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -758,7 +758,9 @@ func New(config ...Config) fiber.Handler {
 					expiration = time.Nanosecond
 					expiresParseError = true
 				} else {
-					expiration = expiresAt.Sub(cfg.now())
+					// Measured from the receipt timestamp, not a fresh read, so the
+					// lifetime stays anchored to the same instant as Date and e.exp
+					expiration = expiresAt.Sub(now)
 				}
 				expirationSource = expirationSourceExpires
 			}
@@ -781,8 +783,8 @@ func New(config ...Config) fiber.Handler {
 			return nil
 		}
 
-		// Reuse the timestamp the Date header was stamped with: reading the clock
-		// again here charges fiber's own processing time to the response as age
+		// Reuse the receipt timestamp the Date header was clamped against: a
+		// fresh read here charges Fiber's own processing time to the response as age
 		responseTS := nowUnix
 
 		maxAgeSeconds := uint64(time.Duration(math.MaxInt64) / time.Second)

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -781,8 +781,9 @@ func New(config ...Config) fiber.Handler {
 			return nil
 		}
 
-		ts = safeUnixSeconds(cfg.now())
-		responseTS := max(ts, nowUnix)
+		// Reuse the timestamp the Date header was stamped with: reading the clock
+		// again here charges fiber's own processing time to the response as age
+		responseTS := nowUnix
 
 		maxAgeSeconds := uint64(time.Duration(math.MaxInt64) / time.Second)
 		var ageDuration time.Duration
@@ -818,7 +819,7 @@ func New(config ...Config) fiber.Handler {
 		e.exp = responseTS + uint64(remainingExpiration.Seconds())
 		e.ttl = uint64(expiration.Seconds())
 		if expiresParseError {
-			e.exp = ts + 1
+			e.exp = responseTS + 1
 		}
 
 		// Store entry in heap (space already reserved in eviction phase)

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -2389,6 +2389,25 @@ func Test_CacheStoreDoesNotAgeItsOwnResponse(t *testing.T) {
 	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
 }
 
+func Test_CacheStoreExpiresAnchoredToDate(t *testing.T) {
+	t.Parallel()
+
+	// An Expires lifetime must be measured from the instant the Date header is
+	// anchored to, or clock reads inside the store phase consume it.
+	clock := &tickingClock{now: time.Now().Truncate(time.Second)}
+	app := fiber.New()
+	app.Use(New(Config{clock: clock.Now}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderExpires, clock.Now().Add(2*time.Second).UTC().Format(http.TimeFormat))
+		return c.SendString("cached")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
+}
+
 func Test_CacheSMaxAgeOverridesMaxAgeWhenShorter(t *testing.T) {
 	t.Parallel()
 

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -54,6 +54,20 @@ func (c *testClock) Add(d time.Duration) {
 	c.now = c.now.Add(d)
 }
 
+// tickingClock advances a second on every read, so any clock read the store
+// phase performs after the Date header was stamped surfaces as phantom age.
+type tickingClock struct {
+	now time.Time
+	mu  sync.Mutex
+}
+
+func (c *tickingClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(time.Second)
+	return c.now
+}
+
 type failingCacheStorage struct {
 	data map[string][]byte
 	errs map[string]error
@@ -2354,6 +2368,25 @@ func Test_CacheInvalidExpiresStoredAsStale(t *testing.T) {
 	require.Equal(t, "body3", string(body))
 	require.Contains(t, storage.data, expectedKey)
 	require.Contains(t, storage.data, expectedKey+"_body")
+}
+
+func Test_CacheStoreDoesNotAgeItsOwnResponse(t *testing.T) {
+	t.Parallel()
+
+	// A response fiber just generated has age 0, so a one-second lifetime has to
+	// survive the store phase no matter how much time passes inside it.
+	clock := &tickingClock{now: time.Now().Truncate(time.Second)}
+	app := fiber.New()
+	app.Use(New(Config{clock: clock.Now}))
+
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set(fiber.HeaderCacheControl, "max-age=1")
+		return c.SendString("cached")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, cacheMiss, resp.Header.Get("X-Cache"))
 }
 
 func Test_CacheSMaxAgeOverridesMaxAgeWhenShorter(t *testing.T) {


### PR DESCRIPTION
# Description

While storing a response, the cache middleware read the clock a third time right before the freshness calculation:

```go
ts = safeUnixSeconds(cfg.now())      // cache.go:784
responseTS := max(ts, nowUnix)
```

`e.date` was stamped from the earlier read (`nowUnix`, cache.go:713), and the apparent age is derived from `responseTS - e.date`. Every second boundary crossed between those two reads was therefore billed to the response as age and subtracted from its freshness lifetime in `remainingExpiration = expiration - ageDuration`. A response Fiber has just generated has an age of zero, so this charges Fiber's own processing latency to the client's freshness budget.

With a short lifetime the entry is not merely shortened, it is dropped: `remainingExpiration <= 0` sets `X-Cache: unreachable` and returns without storing. A `max-age=1` response was therefore cacheable or not depending on machine load rather than on the request.

RFC 9111 4.2.3 measures `apparent_age` from the time the response was received, so the store phase now reuses the single timestamp the `Date` header was stamped with. Age arriving from upstream is unaffected: when `e.date` is parsed from an upstream `Date` header, `responseTS - e.date` still reflects real age.

## Changes introduced

- `middleware/cache/cache.go`: drop the third clock read, derive `responseTS` from the timestamp the `Date` header was stamped with, and use it for the `expiresParseError` expiry as well.
- Test: `Test_CacheStoreDoesNotAgeItsOwnResponse` drives the middleware with a clock that advances a second on every read, so any clock read the store phase performs after stamping `Date` shows up as phantom age. Verified red before the fix (`unreachable`) and green after (`miss`).
- Benchmarks: none, this removes one clock read per cached response and is not measurable.

Two related notes:

- #4575 raises `Test_CacheMaxStaleRespectsProxyRevalidateSharedAuth` to `s-maxage=2` as a workaround for exactly this bug. Once this lands, that test can go back to a one-second lifetime, and the same latent exposure in `Test_CacheOnlyIfCachedStaleNotServed`, `Test_CacheMaxStaleRespectsMustRevalidate` and `Test_CacheStaleResponseAddsWarning110` disappears.
- #4492 touches these lines but only renames `ts` to `storeTS`; the extra clock read survives there unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)
