### PR TITLE
🐛 bug: preserve published route buckets during rebuilds

### DIFF
--- a/app.go
+++ b/app.go
@@ -108,7 +108,6 @@ type App struct {
 	customBinders []CustomBinder
 	// Route stack divided by HTTP methods and route prefixes. Build-time only:
 	// requests go through treeIndex. It survives between rebuilds because
-	// reuseRouteBucket recycles the previous build's buckets out of it, and
 	// buildLookahead reads it to index the same buckets next() will scan.
 	treeStack []map[int][]*Route
 	// Request-time view of treeStack: one flat, open-addressed index per HTTP

--- a/app.go
+++ b/app.go
@@ -107,8 +107,10 @@ type App struct {
 	// custom binders
 	customBinders []CustomBinder
 	// Route stack divided by HTTP methods and route prefixes. Build-time only:
-	// requests go through treeIndex. It survives between rebuilds because
-	// buildLookahead reads it to index the same buckets next() will scan.
+	// requests go through treeIndex. Each build replaces it with freshly
+	// allocated buckets rather than refilling the previous ones, so a published
+	// tree stays immutable; it is retained as a field because buildLookahead
+	// reads it to index the same buckets next() will scan.
 	treeStack []map[int][]*Route
 	// Request-time view of treeStack: one flat, open-addressed index per HTTP
 	// method, rebuilt with the tree (see routeTree in router.go). Held by

--- a/router.go
+++ b/router.go
@@ -1209,10 +1209,28 @@ func (app *App) buildTree() *App {
 			prefixCounts[treePaths[i]]++
 		}
 
+		// Carve this build's buckets out of one allocation. The arena is fresh
+		// per build, so a published bucket is never written through; a bucket
+		// per make() would give the same guarantee, but one allocation keeps a
+		// rebuild's alloc count flat as routes are added.
+		//
+		// Each bucket is a three-index slice whose cap is exactly what the
+		// append loop below puts in it, so a bucket cannot reach its
+		// neighbour: appending past that cap reallocates instead of writing
+		// into the next window.
+		total := globalCount
+		for _, count := range prefixCounts {
+			total += count + globalCount
+		}
+		arena := make([]*Route, total)
+
 		tsMap := make(map[int][]*Route, len(prefixCounts)+1)
-		tsMap[0] = make([]*Route, 0, globalCount)
+		tsMap[0] = arena[0:0:globalCount]
+		off := globalCount
 		for treePath, count := range prefixCounts {
-			tsMap[treePath] = make([]*Route, 0, count+globalCount)
+			end := off + count + globalCount
+			tsMap[treePath] = arena[off:off:end]
+			off = end
 		}
 
 		for i, route := range routes {

--- a/router.go
+++ b/router.go
@@ -1216,7 +1216,7 @@ func (app *App) buildTree() *App {
 		//
 		// Each bucket is a three-index slice whose cap is exactly what the
 		// append loop below puts in it, so a bucket cannot reach its
-		// neighbour: appending past that cap reallocates instead of writing
+		// neighbor: appending past that cap reallocates instead of writing
 		// into the next window.
 		total := globalCount
 		for _, count := range prefixCounts {

--- a/router.go
+++ b/router.go
@@ -131,13 +131,10 @@ const routeTreeHashMul = 0x9E3779B1
 // the index existed — so this restores the parity that assigning treeStack's
 // map pointer used to provide.
 //
-// The buckets themselves are still recycled by reuseRouteBucket, so this does
-// not make RebuildTree safe against in-flight requests and nothing here should
-// be read as claiming it does. A rebuild appends over the backing array the
-// published tree points at, so a scan in progress can observe a bucket
-// mid-rewrite; publishing is also an unsynchronized store, so a reader is not
-// guaranteed to see a rebuild at all, or to see one method's tree and another's
-// from the same build. RebuildTree's own doc states the contract.
+// The buckets are freshly allocated for each build so a published tree remains
+// immutable while a request scans it. Publishing is still an unsynchronized
+// store, however, so this does not make RebuildTree safe for concurrent use;
+// RebuildTree's own doc states the contract.
 func buildRouteTree(buckets map[int][]*Route) *routeTree {
 	tree := &routeTree{globals: buckets[0]}
 
@@ -1212,11 +1209,10 @@ func (app *App) buildTree() *App {
 			prefixCounts[treePaths[i]]++
 		}
 
-		prevBuckets := app.treeStack[method]
 		tsMap := make(map[int][]*Route, len(prefixCounts)+1)
-		tsMap[0] = reuseRouteBucket(prevBuckets, 0, globalCount)
+		tsMap[0] = make([]*Route, 0, globalCount)
 		for treePath, count := range prefixCounts {
-			tsMap[treePath] = reuseRouteBucket(prevBuckets, treePath, count+globalCount)
+			tsMap[treePath] = make([]*Route, 0, count+globalCount)
 		}
 
 		for i, route := range routes {
@@ -1256,11 +1252,4 @@ func (app *App) buildTree() *App {
 // three bytes, and therefore the hash, unchanged.
 func dropsOptionalSlashBelowTreeHash(seg *routeSegment) bool {
 	return seg.HasOptionalSlash && len(seg.Const) == maxDetectionPaths
-}
-
-func reuseRouteBucket(prev map[int][]*Route, key, capHint int) []*Route {
-	if bucket, ok := prev[key]; ok && cap(bucket) >= capHint {
-		return bucket[:0]
-	}
-	return make([]*Route, 0, capHint)
 }

--- a/router_test.go
+++ b/router_test.go
@@ -4344,7 +4344,7 @@ func Test_RebuildTree_PreservesPublishedBuckets(t *testing.T) {
 
 // Test_BuildTree_BucketsAreExactlyFull guards the invariant the shared bucket
 // arena rests on: every bucket's cap is exactly what buildTree appends to it.
-// Slack would leave a bucket able to grow into the neighbouring window, which
+// Slack would leave a bucket able to grow into the neighboring window, which
 // is the cross-bucket write the fresh-arena rule exists to prevent.
 func Test_BuildTree_BucketsAreExactlyFull(t *testing.T) {
 	t.Parallel()

--- a/router_test.go
+++ b/router_test.go
@@ -4342,6 +4342,31 @@ func Test_RebuildTree_PreservesPublishedBuckets(t *testing.T) {
 	require.Equal(t, []string{"/aa/first", "/aa/last"}, routeTreePaths(rebuilt))
 }
 
+// Test_BuildTree_BucketsAreExactlyFull guards the invariant the shared bucket
+// arena rests on: every bucket's cap is exactly what buildTree appends to it.
+// Slack would leave a bucket able to grow into the neighbouring window, which
+// is the cross-bucket write the fresh-arena rule exists to prevent.
+func Test_BuildTree_BucketsAreExactlyFull(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	app.Use("/", testEmptyHandler)
+	app.Get("/aa/first", testEmptyHandler)
+	app.Get("/aa/second", testEmptyHandler)
+	app.Get("/bb/only", testEmptyHandler)
+	app.Post("/aa/first", testEmptyHandler)
+	app.Get("/x", testEmptyHandler)
+	app.startupProcess()
+
+	for method, buckets := range app.treeStack {
+		for treeHash, bucket := range buckets {
+			require.Equal(t, len(bucket), cap(bucket),
+				"method %d bucket %d: cap must equal len so appends cannot cross into the next bucket",
+				method, treeHash)
+		}
+	}
+}
+
 // routeTreePaths returns the normalized paths of a tree bucket's routes, so
 // assertions report path names instead of route pointers.
 func routeTreePaths(routes []*Route) []string {

--- a/router_test.go
+++ b/router_test.go
@@ -4327,13 +4327,29 @@ func Test_RebuildTree_PreservesPublishedBuckets(t *testing.T) {
 	method := app.methodInt(MethodGet)
 	treeHash := int('/')<<16 | int('a')<<8 | int('a')
 	published := app.treeIndex[method].lookup(treeHash)
+	require.Equal(t, []string{"/aa/first", "/aa/removed", "/aa/last"}, routeTreePaths(published))
 	want := append([]*Route(nil), published...)
-	require.NotEmpty(t, published)
 
 	app.RemoveRoute("/aa/removed", MethodGet)
 	app.RebuildTree()
 
+	// The bucket the previous build published is what an in-flight request may
+	// still be scanning, so the rebuild must not have written through it.
 	require.Equal(t, want, published)
+
+	// The rebuild must still take effect: the new bucket drops the route.
+	rebuilt := app.treeIndex[method].lookup(treeHash)
+	require.Equal(t, []string{"/aa/first", "/aa/last"}, routeTreePaths(rebuilt))
+}
+
+// routeTreePaths returns the normalized paths of a tree bucket's routes, so
+// assertions report path names instead of route pointers.
+func routeTreePaths(routes []*Route) []string {
+	paths := make([]string, len(routes))
+	for i, route := range routes {
+		paths[i] = route.path
+	}
+	return paths
 }
 
 // Test_Route_PrefixFilter_UnconstrainedShapes covers the guards in

--- a/router_test.go
+++ b/router_test.go
@@ -4313,6 +4313,29 @@ func Test_RouteTree_SlotSpreadsAcrossLargeTables(t *testing.T) {
 	}
 }
 
+// Test_RebuildTree_PreservesPublishedBuckets ensures rebuilding cannot rewrite
+// the backing arrays that an in-flight request may still be scanning.
+func Test_RebuildTree_PreservesPublishedBuckets(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	app.Get("/aa/first", testEmptyHandler)
+	app.Get("/aa/removed", testEmptyHandler)
+	app.Get("/aa/last", testEmptyHandler)
+	app.startupProcess()
+
+	method := app.methodInt(MethodGet)
+	treeHash := int('/')<<16 | int('a')<<8 | int('a')
+	published := app.treeIndex[method].lookup(treeHash)
+	want := append([]*Route(nil), published...)
+	require.NotEmpty(t, published)
+
+	app.RemoveRoute("/aa/removed", MethodGet)
+	app.RebuildTree()
+
+	require.Equal(t, want, published)
+}
+
 // Test_Route_PrefixFilter_UnconstrainedShapes covers the guards in
 // computePrefixFilter that disable the filter when a route's first segment
 // constrains nothing.


### PR DESCRIPTION
### Motivation
- A recent change began recycling previous route buckets (reusing backing arrays) when rebuilding the route tree, which allows an in-flight request scanning a previously published bucket to observe mid-rewrite mutations and produce route confusion. 
- The intent is to restore an invariant that published route buckets remain immutable for readers while keeping `RebuildTree` documented as not safe for concurrent use.

### Description
- Allocate fresh per-build buckets in `buildTree` (use `make([]*Route, 0, ...)`) instead of recycling previous buckets and remove the recycling path so published trees are not overwritten in-place. 
- Remove the `reuseRouteBucket` recycling helper and update comments/docstrings in `router.go` and `app.go` to reflect that published buckets remain immutable during a rebuild while `RebuildTree` itself is still not concurrency-safe. 
- Add `Test_RebuildTree_PreservesPublishedBuckets` in `router_test.go` to assert that a captured published bucket is unchanged after removing a route and calling `RebuildTree`.

### Testing
- Ran the focused regression test `go test ./ -run Test_RebuildTree_PreservesPublishedBuckets -count=1`, which passed. 
- Ran `make generate`, which completed successfully. 
- Ran `make format` and `make lint`, both completed successfully with no lint issues. 
- Ran the full test suite via `make test`, which passed (4,244 tests, 2 skips reported). 
- Ran `make audit`, where `go mod verify` and `go vet ./...` passed but `govulncheck` reported vulnerabilities in the environment Go standard library (Go 1.25.1); this is an environment/system-level report and not caused by the change. 
- Ran `make betteralign`, which reported pre-existing struct layout suggestions for hot-path `Route` and `path.go`; those automatic rewrites were intentionally reverted because `Route` field order is load-bearing for performance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a694cd32b808333980af6279db0e40d)