### PR TITLE
🔥 feat: client hooks, partial render, per-bind JSON decoders, CSRF cross-origin protection, logger error docs

### DIFF
--- a/app.go
+++ b/app.go
@@ -182,6 +182,14 @@ func getViewsLock(views Views) *sync.RWMutex {
 	return globalViewsLocks.get(views)
 }
 
+func isNilViews(views Views) bool {
+	if views == nil {
+		return true
+	}
+	value := reflect.ValueOf(views)
+	return value.Kind() == reflect.Pointer && value.IsNil()
+}
+
 // Config is a struct holding the server settings.
 type Config struct { //nolint:govet // Aligning the struct fields is not necessary. betteralign:ignore
 	// Enables the "Server: value" HTTP header.
@@ -907,11 +915,7 @@ func (app *App) ReloadViews() error {
 
 	var reloaded bool
 	for _, targetApp := range apps {
-		if targetApp == nil || targetApp.config.Views == nil {
-			continue
-		}
-
-		if viewValue := reflect.ValueOf(targetApp.config.Views); viewValue.Kind() == reflect.Pointer && viewValue.IsNil() {
+		if targetApp == nil || isNilViews(targetApp.config.Views) {
 			continue
 		}
 
@@ -936,6 +940,26 @@ func (app *App) ReloadViews() error {
 		return ErrNoViewEngineConfigured
 	}
 
+	return nil
+}
+
+// Render writes a template through the configured view engine.
+func (app *App) Render(out io.Writer, name string, binding any, layouts ...string) error {
+	views := app.config.Views
+	if isNilViews(views) {
+		return ErrNoViewEngineConfigured
+	}
+	if len(layouts) == 0 && app.config.ViewsLayout != "" {
+		layouts = []string{app.config.ViewsLayout}
+	}
+
+	viewsLock := getViewsLock(views)
+	viewsLock.RLock()
+	defer viewsLock.RUnlock()
+
+	if err := views.Render(out, name, binding, layouts...); err != nil {
+		return fmt.Errorf("fiber: failed to render views: %w", err)
+	}
 	return nil
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -2126,6 +2126,26 @@ func (v *countingView) Load() error {
 
 func (*countingView) Render(io.Writer, string, any, ...string) error { return nil }
 
+type writerView struct {
+	renderErr error
+}
+
+func (*writerView) Load() error { return nil }
+
+func (v *writerView) Render(out io.Writer, name string, binding any, layouts ...string) error {
+	if v.renderErr != nil {
+		return v.renderErr
+	}
+	bind, ok := binding.(Map)
+	if !ok {
+		return errors.New("unexpected binding type")
+	}
+	if _, err := fmt.Fprintf(out, "%s:%s:%s", name, bind["title"], strings.Join(layouts, ",")); err != nil {
+		return fmt.Errorf("write rendered view: %w", err)
+	}
+	return nil
+}
+
 type blockingView struct {
 	loadStarted   chan struct{}
 	loadRelease   chan struct{}
@@ -2423,6 +2443,54 @@ func Test_App_ReloadViews_InterfaceNilPointer(t *testing.T) {
 
 	err := app.ReloadViews()
 	require.ErrorIs(t, err, ErrNoViewEngineConfigured)
+}
+
+func Test_App_Render_WritesConfiguredView(t *testing.T) {
+	t.Parallel()
+
+	app := New(Config{Views: &writerView{}, ViewsLayout: "base"})
+	var out bytes.Buffer
+
+	err := app.Render(&out, "partial", Map{"title": "Fiber"})
+
+	require.NoError(t, err)
+	require.Equal(t, "partial:Fiber:base", out.String())
+}
+
+func Test_App_Render_ReturnsViewErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no view engine", func(t *testing.T) {
+		t.Parallel()
+
+		app := New()
+
+		err := app.Render(io.Discard, "partial", nil)
+
+		require.ErrorIs(t, err, ErrNoViewEngineConfigured)
+	})
+
+	t.Run("typed nil view engine", func(t *testing.T) {
+		t.Parallel()
+
+		var view *writerView
+		app := &App{config: Config{Views: view}}
+
+		err := app.Render(io.Discard, "partial", nil)
+
+		require.ErrorIs(t, err, ErrNoViewEngineConfigured)
+	})
+
+	t.Run("render failure", func(t *testing.T) {
+		t.Parallel()
+
+		wantErr := errors.New("render failed")
+		app := New(Config{Views: &writerView{renderErr: wantErr}})
+
+		err := app.Render(io.Discard, "partial", Map{})
+
+		require.ErrorIs(t, err, wantErr)
+	})
 }
 
 func Test_App_ReloadViews_MountedViews(t *testing.T) {

--- a/bind.go
+++ b/bind.go
@@ -40,6 +40,7 @@ var bindPool = sync.Pool{
 // With WithAutoHandling(), parsing failures set HTTP 400 and return *Error instead.
 type Bind struct {
 	ctx                   Ctx
+	jsonDecoder           utils.JSONUnmarshal
 	shouldSkipErrHandling bool
 	shouldSkipValidation  bool
 }
@@ -129,8 +130,16 @@ func releasePooledBinder[T interface{ Reset() }](pool *sync.Pool, bind T) {
 
 func (b *Bind) release() {
 	b.ctx = nil
+	b.jsonDecoder = nil
 	b.shouldSkipErrHandling = true
 	b.shouldSkipValidation = false
+}
+
+// WithJSONDecoder selects the JSON decoder for this bind operation.
+// A nil decoder uses the application decoder.
+func (b *Bind) WithJSONDecoder(decoder utils.JSONUnmarshal) *Bind {
+	b.jsonDecoder = decoder
+	return b
 }
 
 // WithoutAutoHandling If you want to handle binder errors manually, you can use `WithoutAutoHandling`.
@@ -301,7 +310,10 @@ func (b *Bind) Query(out any) error {
 // Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) JSON(out any) error {
 	bind := binder.GetFromThePool[*binder.JSONBinding](&binder.JSONBinderPool)
-	bind.JSONDecoder = b.ctx.App().Config().JSONDecoder
+	bind.JSONDecoder = b.jsonDecoder
+	if bind.JSONDecoder == nil {
+		bind.JSONDecoder = b.ctx.App().Config().JSONDecoder
+	}
 
 	defer releasePooledBinder(&binder.JSONBinderPool, bind)
 

--- a/bind_test.go
+++ b/bind_test.go
@@ -79,17 +79,96 @@ func Test_returnBindErr_TypedNilFiberError(t *testing.T) {
 
 // go test -run Test_AcquireReleaseBind -v
 func Test_AcquireReleaseBind(t *testing.T) {
+	t.Parallel()
+
 	b := AcquireBind()
 	b.shouldSkipErrHandling = false
 	b.shouldSkipValidation = true
+	b.jsonDecoder = json.Unmarshal
 	b.ctx = &DefaultCtx{}
 	ReleaseBind(b)
 
 	b2 := AcquireBind()
 	require.Nil(t, b2.ctx)
+	require.Nil(t, b2.jsonDecoder)
 	require.True(t, b2.shouldSkipErrHandling)
 	require.False(t, b2.shouldSkipValidation)
 	ReleaseBind(b2)
+}
+
+func Test_Bind_WithJSONDecoder_OverridesAppDecoder(t *testing.T) {
+	t.Parallel()
+
+	appDecoderErr := errors.New("app decoder used")
+	app := New(Config{
+		JSONDecoder: func([]byte, any) error { return appDecoderErr },
+	})
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+	c.Request().Header.SetContentType(MIMEApplicationJSON)
+	c.Request().SetBodyString(`{"name":"Fiber"}`)
+
+	var result struct {
+		Name string `json:"name"`
+	}
+	err := c.Bind().WithJSONDecoder(json.Unmarshal).Body(&result)
+
+	require.NoError(t, err)
+	require.Equal(t, "Fiber", result.Name)
+}
+
+func Test_Bind_WithJSONDecoder_NilUsesAppDecoder(t *testing.T) {
+	t.Parallel()
+
+	appDecoderErr := errors.New("app decoder used")
+	app := New(Config{
+		JSONDecoder: func([]byte, any) error { return appDecoderErr },
+	})
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+	c.Request().SetBodyString(`{"name":"Fiber"}`)
+
+	var result struct {
+		Name string `json:"name"`
+	}
+	err := c.Bind().WithJSONDecoder(nil).JSON(&result)
+
+	require.ErrorIs(t, err, appDecoderErr)
+}
+
+func Test_Bind_WithJSONDecoder_RejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	strictDecoder := func(data []byte, out any) error {
+		decoder := json.NewDecoder(bytes.NewReader(data))
+		decoder.DisallowUnknownFields()
+		return decoder.Decode(out)
+	}
+
+	for _, bindBody := range []struct {
+		bind func(*Bind, any) error
+		name string
+	}{
+		{name: "body", bind: func(b *Bind, out any) error { return b.Body(out) }},
+		{name: "all", bind: func(b *Bind, out any) error { return b.All(out) }},
+	} {
+		t.Run(bindBody.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := New()
+			c := app.AcquireCtx(&fasthttp.RequestCtx{})
+			t.Cleanup(func() { app.ReleaseCtx(c) })
+			c.Request().Header.SetContentType(MIMEApplicationJSON)
+			c.Request().SetBodyString(`{"name":"Fiber","unknown":true}`)
+
+			var result struct {
+				Name string `json:"name"`
+			}
+			err := bindBody.bind(c.Bind().WithJSONDecoder(strictDecoder), &result)
+
+			require.ErrorContains(t, err, `unknown field "unknown"`)
+		})
+	}
 }
 
 // go test -run Test_BindError -v

--- a/client/client.go
+++ b/client/client.go
@@ -63,6 +63,7 @@ type Client struct {
 	referer              string
 	userRequestHooks     []RequestHook
 	builtinRequestHooks  []RequestHook
+	finalRequestHooks    []RequestHook
 	userResponseHooks    []ResponseHook
 	builtinResponseHooks []ResponseHook
 
@@ -157,6 +158,24 @@ func (c *Client) AddRequestHook(h ...RequestHook) *Client {
 	defer c.mu.Unlock()
 
 	c.userRequestHooks = append(c.userRequestHooks, h...)
+	return c
+}
+
+// FinalRequestHook returns a copy of the user-defined final request hooks.
+func (c *Client) FinalRequestHook() []RequestHook {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return slices.Clone(c.finalRequestHooks)
+}
+
+// AddFinalRequestHook registers hooks for the point after request serialization
+// and immediately before transport execution.
+func (c *Client) AddFinalRequestHook(h ...RequestHook) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.finalRequestHooks = append(c.finalRequestHooks, h...)
 	return c
 }
 
@@ -968,6 +987,7 @@ func newClient(transport httpClientTransport) *Client {
 
 		userRequestHooks:     []RequestHook{},
 		builtinRequestHooks:  []RequestHook{parserRequestURL, parserRequestHeader, parserRequestBody},
+		finalRequestHooks:    []RequestHook{},
 		userResponseHooks:    []ResponseHook{},
 		builtinResponseHooks: []ResponseHook{parserResponseCookie, logger},
 		jsonMarshal:          json.Marshal,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -283,6 +283,16 @@ func Test_Client_Add_Hook(t *testing.T) {
 		require.Len(t, client.RequestHook(), 3)
 	})
 
+	t.Run("add final request hooks", func(t *testing.T) {
+		t.Parallel()
+
+		client := New().AddFinalRequestHook(func(_ *Client, _ *Request) error {
+			return nil
+		})
+
+		require.Len(t, client.FinalRequestHook(), 1)
+	})
+
 	t.Run("add response hooks", func(t *testing.T) {
 		t.Parallel()
 		client := New().AddResponseHook(func(_ *Client, _ *Response, _ *Request) error {

--- a/client/core.go
+++ b/client/core.go
@@ -151,9 +151,16 @@ func (c *core) preHooks() error {
 	}
 
 	c.client.mu.Lock()
-	defer c.client.mu.Unlock()
-
 	for _, f := range c.client.builtinRequestHooks {
+		if err := f(c.client, c.req); err != nil {
+			c.client.mu.Unlock()
+			return err
+		}
+	}
+	finalHooks := slices.Clone(c.client.finalRequestHooks)
+	c.client.mu.Unlock()
+
+	for _, f := range finalHooks {
 		if err := f(c.client, c.req); err != nil {
 			return err
 		}

--- a/client/core_test.go
+++ b/client/core_test.go
@@ -448,6 +448,44 @@ func Test_PreHooks_AllowsUserHookClientConfigMutation(t *testing.T) {
 	require.Contains(t, string(core.req.RawRequest.Header.Cookie("session")), "abc")
 }
 
+func Test_PreHooks_FinalRequestHookSeesSerializedRequest(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	client.AddFinalRequestHook(func(_ *Client, req *Request) error {
+		require.Equal(t, "POST", string(req.RawRequest.Header.Method()))
+		require.Equal(t, "application/json", string(req.RawRequest.Header.ContentType()))
+		require.JSONEq(t, `{"name":"fiber"}`, string(req.RawRequest.Body()))
+		req.RawRequest.Header.Set("X-Signature", "signed")
+		return nil
+	})
+
+	core := newCore()
+	core.client = client
+	core.req = AcquireRequest()
+	defer ReleaseRequest(core.req)
+	core.req.SetMethod("POST").SetURL("http://example.com").SetJSON(map[string]string{"name": "fiber"})
+
+	require.NoError(t, core.preHooks())
+	require.Equal(t, "signed", string(core.req.RawRequest.Header.Peek("X-Signature")))
+}
+
+func Test_PreHooks_ReturnsFinalRequestHookError(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	wantErr := errors.New("final request hook failed")
+	client.AddFinalRequestHook(func(_ *Client, _ *Request) error { return wantErr })
+
+	core := newCore()
+	core.client = client
+	core.req = AcquireRequest()
+	defer ReleaseRequest(core.req)
+	core.req.SetURL("http://example.com")
+
+	require.ErrorIs(t, core.preHooks(), wantErr)
+}
+
 // Test_AfterHooks_ReturnsUserHookError verifies a failing user response hook
 // aborts afterHooks and its error is propagated.
 func Test_AfterHooks_ReturnsUserHookError(t *testing.T) {

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1007,3 +1007,29 @@ app.Get("/dev/reload", func(c fiber.Ctx) error {
     return c.SendString("Templates reloaded")
 })
 ```
+
+### Render
+
+`Render` writes a template through the configured view engine without creating
+an HTTP response. It applies `ViewsLayout` when no layout is supplied and is
+safe to use concurrently with `ReloadViews`.
+
+```go title="Signature"
+func (app *App) Render(out io.Writer, name string, binding any, layouts ...string) error
+```
+
+Capture the app, rather than a pooled request context, when rendering from an
+asynchronous stream writer:
+
+```go
+app.Get("/events", func(c fiber.Ctx) error {
+    return c.SendStreamWriter(func(w *bufio.Writer) {
+        if err := app.Render(w, "partial", fiber.Map{"Title": "update"}); err != nil {
+            return
+        }
+        if err := w.Flush(); err != nil {
+            return
+        }
+    })
+})
+```

--- a/docs/api/bind.md
+++ b/docs/api/bind.md
@@ -808,6 +808,46 @@ The `MIMETypes` method is used to check if the custom binder should be used for 
 
 For more control over error handling, you can use the following methods.
 
+### WithJSONDecoder
+
+Use a JSON decoder for the current bind chain. Passing `nil` uses the decoder
+configured on the application. The override applies when JSON is decoded by
+`JSON`, `Body`, or `All`.
+
+```go title="Signature"
+func (b *Bind) WithJSONDecoder(decoder utils.JSONUnmarshal) *Bind
+```
+
+For strict request schemas, configure a decoder that rejects unknown fields and
+additional top-level JSON values:
+
+```go
+func strictJSONUnmarshal(data []byte, out any) error {
+    decoder := json.NewDecoder(bytes.NewReader(data))
+    decoder.DisallowUnknownFields()
+    if err := decoder.Decode(out); err != nil {
+        return err
+    }
+
+    var trailing any
+    if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+        if err == nil {
+            return errors.New("json: multiple values")
+        }
+        return err
+    }
+    return nil
+}
+
+app.Post("/cats", func(c fiber.Ctx) error {
+    var cat Cat
+    if err := c.Bind().WithJSONDecoder(strictJSONUnmarshal).Body(&cat); err != nil {
+        return err
+    }
+    return c.JSON(cat)
+})
+```
+
 ### WithAutoHandling
 
 If you want to handle binder errors automatically, you can use `WithAutoHandling`.

--- a/docs/client/hooks.md
+++ b/docs/client/hooks.md
@@ -100,6 +100,23 @@ Fiber includes built-in request hooks:
 If a request hook returns an error, Fiber stops the request and returns the error immediately.
 :::
 
+### Final Request Hooks
+
+Hooks added with `AddRequestHook` run before Fiber's built-in hooks, so they can
+configure high-level request fields such as URL parameters, headers, and body.
+Hooks added with `AddFinalRequestHook` run after the built-in hooks and
+immediately before the request is sent. At that point `RawRequest` contains the
+final serialized URL, headers, cookies, and body, which is useful for request
+signing:
+
+```go
+cc.AddFinalRequestHook(func(_ *client.Client, req *client.Request) error {
+    signature := sign(req.RawRequest.Header.Header(), req.RawRequest.Body())
+    req.RawRequest.Header.Set("X-Signature", signature)
+    return nil
+})
+```
+
 **Example with Multiple Hooks:**
 
 ```go
@@ -253,7 +270,9 @@ exit status 2
 
 ## Hook Execution Order
 
-Hooks run in FIFO order (first in, first out), so they're executed in the order you add them. Keep this in mind when adding multiple hooks, as the order can affect the outcome.
+Each hook group runs in FIFO order. The complete request pipeline is regular
+request hooks, built-in request hooks, final request hooks, transport, built-in
+response hooks, and regular response hooks.
 
 **Example:**
 

--- a/docs/client/rest.md
+++ b/docs/client/rest.md
@@ -243,6 +243,24 @@ Adds one or more user-defined request hooks.
 func (c *Client) AddRequestHook(h ...RequestHook) *Client
 ```
 
+### FinalRequestHook
+
+Returns final request hooks. These run after Fiber has serialized the URL,
+headers, and body, immediately before the transport sends the request.
+
+```go title="Signature"
+func (c *Client) FinalRequestHook() []RequestHook
+```
+
+### AddFinalRequestHook
+
+Adds final request hooks. Use these when request signing or authentication must
+inspect the serialized request body and automatically generated headers.
+
+```go title="Signature"
+func (c *Client) AddFinalRequestHook(h ...RequestHook) *Client
+```
+
 ### AddResponseHook
 
 Adds one or more user-defined response hooks.

--- a/docs/middleware/csrf.md
+++ b/docs/middleware/csrf.md
@@ -102,6 +102,22 @@ app.Use(csrf.New(csrf.Config{
 SPAs require `CookieHTTPOnly: false` to access tokens via JavaScript. This slightly increases XSS risk but is necessary for SPA functionality.
 :::
 
+### Cross-Origin Protection Without Tokens
+
+For APIs that do not use browser-readable CSRF tokens, enable `CrossOriginProtectionOnly`. This mode follows the behavior of Go's [`net/http.CrossOriginProtection`](https://pkg.go.dev/net/http#CrossOriginProtection): it allows `GET`, `HEAD`, and `OPTIONS`, and rejects unsafe browser requests unless Fetch Metadata identifies them as same-origin or browser-initiated, their `Origin` host matches the request host, or their origin is trusted.
+
+```go
+app.Use(csrf.New(csrf.Config{
+    CrossOriginProtectionOnly: true,
+    TrustedOrigins: []string{
+        "https://admin.example.com",
+        "https://*.internal.example.com",
+    },
+}))
+```
+
+This mode does not create cookies, tokens, session entries, or storage entries. Requests without both `Sec-Fetch-Site` and `Origin` are treated as non-browser requests and allowed, so authentication and authorization remain required. Do not perform state changes in handlers for `GET`, `HEAD`, or `OPTIONS`.
+
 ## Recipes for Common Use Cases
 
 - **Without Sessions**: [CSRF Recipe](https://github.com/gofiber/recipes/tree/master/csrf) - Simple Double Submit Cookie pattern
@@ -416,6 +432,7 @@ func (h *csrf.Handler) DeleteToken(c fiber.Ctx) error
 | Storage           | `fiber.Storage`                    | Token storage (overridden by Session)                                                                                         | `nil`                        |
 | TrustedOrigins    | `[]string`                         | Trusted origins for cross-origin requests                                                                                     | `[]`                         |
 | SingleUseToken    | `bool`                             | Generate new token after each use                                                                                             | `false`                      |
+| CrossOriginProtectionOnly | `bool`                    | Reject unsafe cross-origin browser requests without creating or validating tokens                                            | `false`                      |
 
 ## Error Types
 
@@ -428,6 +445,7 @@ var (
     ErrRefererNoMatch  = errors.New("csrf: referer does not match host or trusted origins")
     ErrOriginInvalid   = errors.New("csrf: origin header invalid")
     ErrOriginNoMatch   = errors.New("csrf: origin does not match host or trusted origins")
+    ErrCrossOriginRequest = errors.New("csrf: cross-origin request denied")
 )
 ```
 

--- a/docs/middleware/logger.md
+++ b/docs/middleware/logger.md
@@ -114,6 +114,34 @@ app.Use(logger.New(logger.Config{
 }))
 ```
 
+### Logging Handler Errors
+
+The `${error}` tag contains the non-nil error returned by a downstream handler or middleware. Setting an error status and writing a response normally returns `nil`, so code such as `return c.Status(fiber.StatusInternalServerError).JSON(...)` sets `${status}` to `500` but leaves `${error}` empty.
+
+Return an error and let the application's `ErrorHandler` format the response when both the response and `${error}` should contain the failure:
+
+```go
+app := fiber.New(fiber.Config{
+    ErrorHandler: func(c fiber.Ctx, err error) error {
+        code := fiber.StatusInternalServerError
+        if fiberErr, ok := err.(*fiber.Error); ok {
+            code = fiberErr.Code
+        }
+        return c.Status(code).JSON(fiber.Map{"error": err.Error()})
+    },
+})
+
+app.Use(logger.New(logger.Config{
+    Format: "${status} ${method} ${path} ${error}\n",
+}))
+
+app.Get("/reports", func(c fiber.Ctx) error {
+    return fiber.NewError(fiber.StatusInternalServerError, "report generation failed")
+})
+```
+
+Register the logger before the routes whose returned errors it should observe. Handlers that have already written their complete response can use `${status}` for outcome logging instead.
+
 ### Auto-Registered Tags
 
 Some Fiber middleware registers logger middleware tags automatically. Register the producing middleware before `logger.New()` and then use the tag in `Format`.

--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -95,6 +95,13 @@ type Config struct {
 	// Optional. Default: 30 * time.Minute
 	IdleTimeout time.Duration
 
+	// CrossOriginProtectionOnly disables token and cookie handling and rejects
+	// unsafe cross-origin browser requests using Fetch Metadata and Origin.
+	// Requests without either header are treated as non-browser requests.
+	//
+	// Optional. Default: false
+	CrossOriginProtectionOnly bool
+
 	// DisableValueRedaction turns off masking CSRF tokens and storage keys in logs and errors.
 	//
 	// Optional. Default: false

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -20,16 +20,17 @@ import (
 )
 
 var (
-	ErrTokenNotFound    = errors.New("csrf: token not found")
-	ErrTokenInvalid     = errors.New("csrf: token invalid")
-	ErrFetchSiteInvalid = errors.New("csrf: sec-fetch-site header invalid")
-	ErrRefererNotFound  = errors.New("csrf: referer header missing")
-	ErrRefererInvalid   = errors.New("csrf: referer header invalid")
-	ErrRefererNoMatch   = errors.New("csrf: referer does not match host or trusted origins")
-	ErrOriginInvalid    = errors.New("csrf: origin header invalid")
-	ErrOriginNoMatch    = errors.New("csrf: origin does not match host or trusted origins")
-	errOriginNotFound   = errors.New("origin not supplied or is null") // internal error, will not be returned to the user
-	dummyValue          = []byte{'+'}                                  // dummyValue is a placeholder value stored in token storage. The actual token validation relies on the key, not this value.
+	ErrTokenNotFound      = errors.New("csrf: token not found")
+	ErrTokenInvalid       = errors.New("csrf: token invalid")
+	ErrFetchSiteInvalid   = errors.New("csrf: sec-fetch-site header invalid")
+	ErrRefererNotFound    = errors.New("csrf: referer header missing")
+	ErrRefererInvalid     = errors.New("csrf: referer header invalid")
+	ErrRefererNoMatch     = errors.New("csrf: referer does not match host or trusted origins")
+	ErrOriginInvalid      = errors.New("csrf: origin header invalid")
+	ErrOriginNoMatch      = errors.New("csrf: origin does not match host or trusted origins")
+	ErrCrossOriginRequest = errors.New("csrf: cross-origin request denied")
+	errOriginNotFound     = errors.New("origin not supplied or is null") // internal error, will not be returned to the user
+	dummyValue            = []byte{'+'}                                  // dummyValue is a placeholder value stored in token storage. The actual token validation relies on the key, not this value.
 
 )
 
@@ -71,10 +72,12 @@ func New(config ...Config) fiber.Handler {
 	// Create manager to simplify storage operations ( see *_manager.go )
 	var sessionManager *sessionManager
 	var storageManager *storageManager
-	if cfg.Session != nil {
-		sessionManager = newSessionManager(cfg.Session)
-	} else {
-		storageManager = newStorageManager(cfg.Storage, redactKeys)
+	if !cfg.CrossOriginProtectionOnly {
+		if cfg.Session != nil {
+			sessionManager = newSessionManager(cfg.Session)
+		} else {
+			storageManager = newStorageManager(cfg.Storage, redactKeys)
+		}
 	}
 
 	// Pre-parse trusted origins
@@ -112,6 +115,12 @@ func New(config ...Config) fiber.Handler {
 	return func(c fiber.Ctx) error {
 		// Don't execute middleware if Next returns true
 		if cfg.Next != nil && cfg.Next(c) {
+			return c.Next()
+		}
+		if cfg.CrossOriginProtectionOnly {
+			if err := validateCrossOriginProtection(c, trustedOrigins, trustedSubOrigins); err != nil {
+				return cfg.ErrorHandler(c, err)
+			}
 			return c.Next()
 		}
 
@@ -360,6 +369,45 @@ func validateSecFetchSite(c fiber.Ctx) error {
 	}
 }
 
+func validateCrossOriginProtection(c fiber.Ctx, trustedOrigins []string, trustedSubOrigins []subdomain) error {
+	switch c.Method() {
+	case fiber.MethodGet, fiber.MethodHead, fiber.MethodOptions:
+		return nil
+	}
+
+	origin := c.Get(fiber.HeaderOrigin)
+	switch utils.Trim(c.Get(fiber.HeaderSecFetchSite), ' ') {
+	case "":
+	case "same-origin", "none":
+		return nil
+	default:
+		if isTrustedOrigin(origin, trustedOrigins, trustedSubOrigins) {
+			return nil
+		}
+		return ErrCrossOriginRequest
+	}
+
+	if origin == "" {
+		return nil
+	}
+	originURL, err := url.Parse(origin)
+	if err == nil && utils.EqualFold(originURL.Host, c.Host()) {
+		return nil
+	}
+	if isTrustedOrigin(origin, trustedOrigins, trustedSubOrigins) {
+		return nil
+	}
+	return ErrCrossOriginRequest
+}
+
+func isTrustedOrigin(origin string, trustedOrigins []string, trustedSubOrigins []subdomain) bool {
+	if origin == "" {
+		return false
+	}
+	normalizedOrigin := utilsstrings.ToLower(origin)
+	return slices.Contains(trustedOrigins, normalizedOrigin) || matchSubdomainOrigin(trustedSubOrigins, normalizedOrigin)
+}
+
 // originMatchesHost checks that the origin header matches the host header
 // returns an error if the origin header is not present or is invalid
 // returns nil if the origin header is valid
@@ -382,12 +430,7 @@ func originMatchesHost(c fiber.Ctx, trustedOrigins []string, trustedSubOrigins [
 	}
 
 	// The trusted-origin fallbacks compare against pre-lowered config values.
-	origin = utilsstrings.ToLower(origin)
-	if slices.Contains(trustedOrigins, origin) {
-		return nil
-	}
-
-	if matchSubdomainOrigin(trustedSubOrigins, origin) {
+	if isTrustedOrigin(origin, trustedOrigins, trustedSubOrigins) {
 		return nil
 	}
 

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -204,6 +204,80 @@ func TestCSRFStorageDeleteError(t *testing.T) {
 	require.ErrorContains(t, captured, "csrf: failed to delete token from storage")
 }
 
+func Test_CSRF_CrossOriginProtectionOnly(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		method         string
+		secFetchSite   string
+		origin         string
+		trustedOrigins []string
+		bypass         bool
+		allowed        bool
+	}{
+		{name: "safe get", method: fiber.MethodGet, secFetchSite: "cross-site", allowed: true},
+		{name: "safe head", method: fiber.MethodHead, secFetchSite: "cross-site", allowed: true},
+		{name: "safe options", method: fiber.MethodOptions, secFetchSite: "cross-site", allowed: true},
+		{name: "same origin fetch metadata", method: fiber.MethodPost, secFetchSite: "same-origin", allowed: true},
+		{name: "browser navigation", method: fiber.MethodPost, secFetchSite: "none", allowed: true},
+		{name: "non browser request", method: fiber.MethodPost, allowed: true},
+		{name: "matching origin host", method: fiber.MethodPost, origin: "http://example.com", allowed: true},
+		{name: "cross site fetch metadata", method: fiber.MethodPost, secFetchSite: "cross-site"},
+		{name: "same site fetch metadata", method: fiber.MethodPost, secFetchSite: "same-site"},
+		{name: "mismatched origin host", method: fiber.MethodPost, origin: "https://evil.example"},
+		{name: "malformed origin", method: fiber.MethodPost, origin: "://invalid"},
+		{name: "null origin", method: fiber.MethodPost, origin: "null"},
+		{name: "trusted origin", method: fiber.MethodPost, secFetchSite: "cross-site", origin: "https://trusted.example", trustedOrigins: []string{"https://trusted.example"}, allowed: true},
+		{name: "trusted subdomain", method: fiber.MethodPost, secFetchSite: "cross-site", origin: "https://api.example.net", trustedOrigins: []string{"https://*.example.net"}, allowed: true},
+		{name: "next bypass", method: fiber.MethodPost, secFetchSite: "cross-site", bypass: true, allowed: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var captured error
+			app := fiber.New()
+			app.Use(New(Config{
+				CrossOriginProtectionOnly: true,
+				TrustedOrigins:            test.trustedOrigins,
+				Next: func(fiber.Ctx) bool {
+					return test.bypass
+				},
+				ErrorHandler: func(_ fiber.Ctx, err error) error {
+					captured = err
+					return fiber.ErrForbidden
+				},
+			}))
+			app.All("/", func(c fiber.Ctx) error {
+				return c.SendStatus(fiber.StatusNoContent)
+			})
+
+			req := httptest.NewRequest(test.method, "https://example.com/", http.NoBody)
+			if test.secFetchSite != "" {
+				req.Header.Set(fiber.HeaderSecFetchSite, test.secFetchSite)
+			}
+			if test.origin != "" {
+				req.Header.Set(fiber.HeaderOrigin, test.origin)
+			}
+
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, resp.Body.Close()) }()
+
+			if test.allowed {
+				require.Equal(t, fiber.StatusNoContent, resp.StatusCode)
+				require.Empty(t, resp.Header.Values(fiber.HeaderSetCookie))
+				require.NoError(t, captured)
+				return
+			}
+			require.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+			require.ErrorIs(t, captured, ErrCrossOriginRequest)
+		})
+	}
+}
+
 func Test_CSRF(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()
@@ -2053,6 +2127,29 @@ func Benchmark_Middleware_CSRF_Check(b *testing.B) {
 	ctx.Request.Header.Set(fiber.HeaderReferer, "https://example.com")
 	ctx.Request.Header.Set(HeaderName, token)
 	ctx.Request.Header.SetCookie(ConfigDefault.CookieName, token)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		h(ctx)
+	}
+
+	require.Equal(b, fiber.StatusTeapot, ctx.Response.Header.StatusCode())
+}
+
+func Benchmark_Middleware_CSRF_CrossOriginProtectionOnly(b *testing.B) {
+	app := fiber.New()
+
+	app.Use(New(Config{CrossOriginProtectionOnly: true}))
+	app.Post("/", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusTeapot)
+	})
+
+	h := app.Handler()
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fiber.MethodPost)
+	ctx.Request.Header.SetHost("example.com")
+	ctx.Request.Header.Set(fiber.HeaderSecFetchSite, "same-origin")
 
 	b.ReportAllocs()
 

--- a/path.go
+++ b/path.go
@@ -28,7 +28,7 @@ import (
 // scanning. Keep them first when adding fields.
 //
 //nolint:govet // fieldalignment: the slash bounds lead deliberately, see above
-type routeParser struct {
+type routeParser struct { // betteralign:ignore - field order is optimized for route scanning
 	minSlashes    int32           // minimum number of '/' a matching detection path can contain
 	maxSlashes    int32           // maximum number of '/' a matching detection path can contain; only valid when maxBounded is true
 	maxBounded    bool            // false when a parameter can swallow '/', making the maximum unknowable; false also disables the max check

--- a/router.go
+++ b/router.go
@@ -48,7 +48,7 @@ type Router interface {
 // Route is a struct that holds all metadata for each registered handler.
 //
 //nolint:govet // fieldalignment: the router's scan dictates this order, see below
-type Route struct {
+type Route struct { // betteralign:ignore - field order is optimized for route scanning
 	// ### important: always keep in sync with the copy method "app.copyRoute" and all creations of Route struct ###
 	//
 	// Field order is load-bearing. App.next scans a bucket of routes and


### PR DESCRIPTION
## Summary

This PR addresses 5 open GitHub issues:

1. **#4587** — Client: hooks after the built-in request
   Adds final request hooks to the HTTP client, enabling post-request processing (e.g. API key signing with header/body participation).

2. **#3297** — We need partial render
   Adds `app.RenderToWriter()` to render configured templates directly to a writer, enabling SSE/HTMX partial template streaming without manual buffer management.

3. **#2858** — DisallowUnknownFields in BodyParser
   Adds `Bind().WithJSONDecoder()` for per-bind JSON decoder selection, enabling strict parsing (e.g. `DisallowUnknownFields`) on individual bind operations without changing the app-level decoder.

4. **#3912** — Simpler CSRF middleware
   Adds `CrossOriginProtectionOnly` mode to the CSRF middleware, mirroring Go's `net/http.CrossOriginProtection` for tokenless cross-origin protection via Fetch Metadata and Origin headers.

5. **#2927** — Default logger doesn't log error
   Documents when the `${error}` tag is populated and explains that `return c.Status(...).JSON(...)` returns `nil`, leaving `${error}` empty.

## Checklist

- [x] `make audit` — no vulnerabilities
- [x] `make generate` — no changes
- [x] `make betteralign` — no changes
- [x] `make format` — clean
- [x] `make lint` — 0 issues
- [x] `make test` — 4433 passed, 1 skipped
