### PR TITLE
🩹 fix: Honor only-if-cached for non-shareable entries

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -419,6 +419,9 @@ func New(config ...Config) fiber.Handler {
 					}
 					unlock()
 					c.Set(cfg.CacheHeader, cacheUnreachable)
+					if reqDirectives.onlyIfCached {
+						return c.SendStatus(fiber.StatusGatewayTimeout)
+					}
 					return c.Next()
 				}
 

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -411,6 +411,13 @@ func New(config ...Config) fiber.Handler {
 					return c.SendStatus(fiber.StatusGatewayTimeout)
 				}
 				return c.Next()
+			case entryHasExpiration && hasAuthorization && !e.shareable && reqDirectives.onlyIfCached:
+				if cfg.Storage != nil {
+					manager.release(e)
+				}
+				unlock()
+				c.Set(cfg.CacheHeader, cacheUnreachable)
+				return c.SendStatus(fiber.StatusGatewayTimeout)
 			case entryHasExpiration && !requestNoCache:
 				servedStale = entryExpired
 				if hasAuthorization && !e.shareable {
@@ -419,9 +426,6 @@ func New(config ...Config) fiber.Handler {
 					}
 					unlock()
 					c.Set(cfg.CacheHeader, cacheUnreachable)
-					if reqDirectives.onlyIfCached {
-						return c.SendStatus(fiber.StatusGatewayTimeout)
-					}
 					return c.Next()
 				}
 

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -3650,6 +3650,79 @@ func TestCacheBypassesExistingEntryForAuthorization(t *testing.T) {
 	require.Equal(t, "1", string(body))
 }
 
+func TestCacheOnlyIfCachedRejectsNonShareableAuthorizationEntry(t *testing.T) {
+	t.Parallel()
+
+	const cacheHeader = "X-Test-Cache"
+
+	storage := newMutatingStorage(nil)
+	app := fiber.New()
+	app.Use(New(Config{
+		CacheHeader: cacheHeader,
+		Expiration:  time.Hour,
+		Storage:     storage,
+	}))
+
+	var originCalls atomic.Int32
+	app.Get("/", func(c fiber.Ctx) error {
+		call := originCalls.Add(1)
+		if call == 1 {
+			c.Set(fiber.HeaderCacheControl, "public, max-age=3600")
+		}
+		return c.SendString(fmt.Sprintf("origin-%d", call))
+	})
+
+	newAuthorizationRequest := func(cacheControl string) *http.Request {
+		req := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+		req.Header.Set(fiber.HeaderAuthorization, "Bearer token")
+		if cacheControl != "" {
+			req.Header.Set(fiber.HeaderCacheControl, cacheControl)
+		}
+		return req
+	}
+
+	resp, err := app.Test(newAuthorizationRequest(""))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, cacheMiss, resp.Header.Get(cacheHeader))
+	require.Equal(t, int32(1), originCalls.Load())
+
+	metadataKey := ""
+	for key, value := range storage.data {
+		if strings.HasSuffix(key, "_body") {
+			continue
+		}
+
+		var cached item
+		_, err = cached.UnmarshalMsg(value)
+		require.NoError(t, err)
+		cached.shareable = false
+		storage.data[key], err = cached.MarshalMsg(nil)
+		require.NoError(t, err)
+		metadataKey = key
+	}
+	require.NotEmpty(t, metadataKey)
+
+	resp, err = app.Test(newAuthorizationRequest("only-if-cached"))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusGatewayTimeout, resp.StatusCode)
+	require.Equal(t, cacheUnreachable, resp.Header.Get(cacheHeader))
+	require.Equal(t, int32(1), originCalls.Load())
+	require.Contains(t, storage.data, metadataKey)
+	require.Contains(t, storage.data, metadataKey+"_body")
+
+	resp, err = app.Test(newAuthorizationRequest(""))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	require.Equal(t, cacheUnreachable, resp.Header.Get(cacheHeader))
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "origin-2", string(body))
+	require.Equal(t, int32(2), originCalls.Load())
+	require.Contains(t, storage.data, metadataKey)
+	require.Contains(t, storage.data, metadataKey+"_body")
+}
+
 func TestCacheAllowsSharedCacheWithAuthorization(t *testing.T) {
 	t.Parallel()
 

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -3672,16 +3672,19 @@ func TestCacheOnlyIfCachedRejectsNonShareableAuthorizationEntry(t *testing.T) {
 		return c.SendString(fmt.Sprintf("origin-%d", call))
 	})
 
-	newAuthorizationRequest := func(cacheControl string) *http.Request {
+	newAuthorizationRequest := func(cacheControl, pragma string) *http.Request {
 		req := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
 		req.Header.Set(fiber.HeaderAuthorization, "Bearer token")
 		if cacheControl != "" {
 			req.Header.Set(fiber.HeaderCacheControl, cacheControl)
 		}
+		if pragma != "" {
+			req.Header.Set(fiber.HeaderPragma, pragma)
+		}
 		return req
 	}
 
-	resp, err := app.Test(newAuthorizationRequest(""))
+	resp, err := app.Test(newAuthorizationRequest("", ""))
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusOK, resp.StatusCode)
 	require.Equal(t, cacheMiss, resp.Header.Get(cacheHeader))
@@ -3703,7 +3706,7 @@ func TestCacheOnlyIfCachedRejectsNonShareableAuthorizationEntry(t *testing.T) {
 	}
 	require.NotEmpty(t, metadataKey)
 
-	resp, err = app.Test(newAuthorizationRequest("only-if-cached"))
+	resp, err = app.Test(newAuthorizationRequest("only-if-cached", ""))
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusGatewayTimeout, resp.StatusCode)
 	require.Equal(t, cacheUnreachable, resp.Header.Get(cacheHeader))
@@ -3711,7 +3714,23 @@ func TestCacheOnlyIfCachedRejectsNonShareableAuthorizationEntry(t *testing.T) {
 	require.Contains(t, storage.data, metadataKey)
 	require.Contains(t, storage.data, metadataKey+"_body")
 
-	resp, err = app.Test(newAuthorizationRequest(""))
+	resp, err = app.Test(newAuthorizationRequest("no-cache, only-if-cached", ""))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusGatewayTimeout, resp.StatusCode)
+	require.Equal(t, cacheUnreachable, resp.Header.Get(cacheHeader))
+	require.Equal(t, int32(1), originCalls.Load())
+	require.Contains(t, storage.data, metadataKey)
+	require.Contains(t, storage.data, metadataKey+"_body")
+
+	resp, err = app.Test(newAuthorizationRequest("only-if-cached", "no-cache"))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusGatewayTimeout, resp.StatusCode)
+	require.Equal(t, cacheUnreachable, resp.Header.Get(cacheHeader))
+	require.Equal(t, int32(1), originCalls.Load())
+	require.Contains(t, storage.data, metadataKey)
+	require.Contains(t, storage.data, metadataKey+"_body")
+
+	resp, err = app.Test(newAuthorizationRequest("no-cache", ""))
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusOK, resp.StatusCode)
 	require.Equal(t, cacheUnreachable, resp.Header.Get(cacheHeader))


### PR DESCRIPTION
# Description

Authorized requests must not reuse cached responses unless those responses are explicitly shareable. When an authorized `only-if-cached` request encountered a cached entry that was not marked shareable, the cache middleware bypassed the entry and forwarded the request to the origin.

That behavior conflicts with RFC 9111: `only-if-cached` prevents forwarding when the cache cannot satisfy the request. The middleware now returns `504 Gateway Timeout` and marks the cache result as `unreachable` instead of contacting the origin.

The same rule now applies when `only-if-cached` is combined with `Cache-Control: no-cache` or `Pragma: no-cache`. In those cases, `no-cache` prevents using the stored response without validation while `only-if-cached` prevents contacting the origin to perform that validation, so the request must receive a 504 response.

Requests without `only-if-cached`, including requests containing only `no-cache`, retain the existing behavior and continue to the origin. The non-shareable cached entry is left untouched.

Follow-up to #4492.

## Changes introduced

- Return `504 Gateway Timeout` when an authorized `only-if-cached` request encounters a non-shareable cached entry.
- Apply the `only-if-cached` restriction independently of request `no-cache` handling.
- Handle both `Cache-Control: no-cache, only-if-cached` and `Cache-Control: only-if-cached` combined with `Pragma: no-cache` without forwarding to the origin.
- Set the configured cache status header to `unreachable` for these responses.
- Preserve normal origin forwarding for authorized requests without `only-if-cached`, including plain `no-cache` requests.
- Preserve the existing non-shareable cache entry and its separately stored body.
- Add external-storage regression coverage for each directive combination, origin-call behavior, cache-entry retention, and custom cache status headers.

## Type of change

- [x] Bug fix (non-breaking change which corrects existing functionality)
- [x] Code consistency (non-breaking change which improves protocol compliance and reliability)

## Checklist

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage. Not applicable; this adds no new functionality or API.
- [x] Conducted a self-review of the code and the request-control flow.
- [x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/). Not applicable; there is no public API or configuration change.
- [x] Added or updated unit tests to validate the corrected behavior.
- [x] Ensured that the focused tests and full race-enabled test suite pass locally.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community. No dependencies were added.
- [x] Aimed for optimal performance with minimal allocations; the change introduces no allocations or additional storage calls.
- [x] Provided benchmarks for the new code to analyze and improve upon. Not applicable because the change affects an exceptional bypass path; focused regression tests and the full suite passed.

