### PR TITLE
🐛 bug: prevent pooled binder decoder cache retention

### DIFF
--- a/binder/mapping.go
+++ b/binder/mapping.go
@@ -113,10 +113,13 @@ func parseToStruct(aliasTag string, out any, data map[string][]string, files ...
 	// Get decoder from pool
 	pool := getDecoderPool(aliasTag)
 	schemaDecoder := pool.Get().(*schema.Decoder) //nolint:errcheck,forcetypeassert // not needed
-	defer pool.Put(schemaDecoder)
+	defer func() {
+		// Decode caches parsed paths, which originate from untrusted request keys.
+		// Clear them before pooling the decoder so they cannot accumulate across requests.
+		schemaDecoder.SetAliasTag(aliasTag)
+		pool.Put(schemaDecoder)
+	}()
 
-	// Alias tag is baked in at build time (see decoderBuilder); setting it here
-	// would reset the decoder's type cache on every request.
 	if err := schemaDecoder.Decode(out, data, files...); err != nil {
 		return fmt.Errorf("%w", err)
 	}


### PR DESCRIPTION
## Description

Prevent pooled binder schema decoders from retaining request-derived path cache entries across requests.

Previously, attacker-controlled query, form, header, cookie, and URI keys could populate the `gofiber/schema` parsed-path cache and survive decoder reuse, causing unbounded memory growth across requests and potential denial of service.

The decoder cache is now reset with its binding alias tag immediately before returning the decoder to `sync.Pool`. This preserves decoder pooling while preventing attacker-controlled paths from accumulating across requests.

## Changes introduced

- Reset pooled schema decoder caches before reuse.
- No public API or dependency changes.
- No documentation or migration changes required.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [x] Conducted a self-review of the code.
- [ ] Updated documentation — not applicable; no public API change.
- [ ] Added or updated unit tests.
- [x] Ensured that existing tests pass locally.
- [x] No new dependencies were added.
- [x] Kept the change limited to the binder decoder cache path.

## Verification

- `make audit`
- `make generate`
- `make format`
- `make lint`
- `make test` — 4404 tests passed