### PR TITLE
🔥 feat: support per-bind JSON decoders

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -39,6 +39,7 @@ var bindPool = sync.Pool{
 // With WithAutoHandling(), parsing failures set HTTP 400 and return *Error instead.
 type Bind struct {
 	ctx                   Ctx
+	jsonDecoder           utils.JSONUnmarshal
 	shouldSkipErrHandling bool
 	shouldSkipValidation  bool
 }
@@ -128,8 +129,17 @@ func releasePooledBinder[T interface{ Reset() }](pool *sync.Pool, bind T) {
 
 func (b *Bind) release() {
 	b.ctx = nil
+	b.jsonDecoder = nil
 	b.shouldSkipErrHandling = true
 	b.shouldSkipValidation = false
+}
+
+// WithJSONDecoder selects the JSON decoder for this bind operation.
+// A nil decoder uses the application decoder.
+func (b *Bind) WithJSONDecoder(decoder utils.JSONUnmarshal) *Bind {
+	b.jsonDecoder = decoder
+
+	return b
 }
 
 // WithoutAutoHandling If you want to handle binder errors manually, you can use `WithoutAutoHandling`.
@@ -300,7 +310,10 @@ func (b *Bind) Query(out any) error {
 // Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) JSON(out any) error {
 	bind := binder.GetFromThePool[*binder.JSONBinding](&binder.JSONBinderPool)
-	bind.JSONDecoder = b.ctx.App().Config().JSONDecoder
+	bind.JSONDecoder = b.jsonDecoder
+	if bind.JSONDecoder == nil {
+		bind.JSONDecoder = b.ctx.App().Config().JSONDecoder
+	}
 
 	defer releasePooledBinder(&binder.JSONBinderPool, bind)
 

--- a/bind.go
+++ b/bind.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofiber/fiber/v3/binder"
 	"github.com/gofiber/fiber/v3/internal/nilerror"
 	"github.com/gofiber/schema"
+	"github.com/gofiber/utils/v2"
 )
 
 // CustomBinder An interface to register custom binders.

--- a/bind.go
+++ b/bind.go
@@ -134,7 +134,7 @@ func (b *Bind) release() {
 	b.shouldSkipValidation = false
 }
 
-// WithJSONDecoder selects the JSON decoder for this bind operation.
+// WithJSONDecoder selects the JSON decoder for the current bind chain.
 // A nil decoder uses the application decoder.
 func (b *Bind) WithJSONDecoder(decoder utils.JSONUnmarshal) *Bind {
 	b.jsonDecoder = decoder

--- a/bind_test.go
+++ b/bind_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -79,17 +80,153 @@ func Test_returnBindErr_TypedNilFiberError(t *testing.T) {
 
 // go test -run Test_AcquireReleaseBind -v
 func Test_AcquireReleaseBind(t *testing.T) {
+	t.Parallel()
+
 	b := AcquireBind()
 	b.shouldSkipErrHandling = false
 	b.shouldSkipValidation = true
+	b.jsonDecoder = json.Unmarshal
 	b.ctx = &DefaultCtx{}
 	ReleaseBind(b)
 
 	b2 := AcquireBind()
 	require.Nil(t, b2.ctx)
+	require.Nil(t, b2.jsonDecoder)
 	require.True(t, b2.shouldSkipErrHandling)
 	require.False(t, b2.shouldSkipValidation)
 	ReleaseBind(b2)
+}
+
+func Test_Bind_WithJSONDecoder_OverridesAppDecoder(t *testing.T) {
+	t.Parallel()
+
+	appDecoderErr := errors.New("app decoder used")
+	for _, bindJSON := range []struct {
+		bind func(*Bind, any) error
+		name string
+	}{
+		{name: "json", bind: func(b *Bind, out any) error { return b.JSON(out) }},
+		{name: "body", bind: func(b *Bind, out any) error { return b.Body(out) }},
+		{name: "all", bind: func(b *Bind, out any) error { return b.All(out) }},
+	} {
+		t.Run(bindJSON.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := New(Config{
+				JSONDecoder: func([]byte, any) error { return appDecoderErr },
+			})
+			c := app.AcquireCtx(&fasthttp.RequestCtx{})
+			t.Cleanup(func() { app.ReleaseCtx(c) })
+			c.Request().Header.SetContentType(MIMEApplicationJSON)
+			c.Request().SetBodyString(`{"name":"Fiber"}`)
+
+			var result struct {
+				Name string `json:"name"`
+			}
+			err := bindJSON.bind(c.Bind().WithJSONDecoder(json.Unmarshal), &result)
+
+			require.NoError(t, err)
+			require.Equal(t, "Fiber", result.Name)
+		})
+	}
+}
+
+func Test_Bind_WithJSONDecoder_NilUsesAppDecoder(t *testing.T) {
+	t.Parallel()
+
+	appDecoderErr := errors.New("app decoder used")
+	app := New(Config{
+		JSONDecoder: func([]byte, any) error { return appDecoderErr },
+	})
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+	c.Request().SetBodyString(`{"name":"Fiber"}`)
+
+	var result struct {
+		Name string `json:"name"`
+	}
+	err := c.Bind().WithJSONDecoder(nil).JSON(&result)
+
+	require.ErrorIs(t, err, appDecoderErr)
+}
+
+func Test_Bind_WithJSONDecoder_NilUsesDefaultAppDecoder(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+	c.Request().SetBodyString(`{"name":"Fiber"}`)
+
+	var result struct {
+		Name string `json:"name"`
+	}
+	err := c.Bind().WithJSONDecoder(nil).JSON(&result)
+
+	require.NoError(t, err)
+	require.Equal(t, "Fiber", result.Name)
+}
+
+func Test_Bind_WithJSONDecoder_RejectsStrictJSONErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, bindJSON := range []struct {
+		bind func(*Bind, any) error
+		name string
+	}{
+		{name: "json", bind: func(b *Bind, out any) error { return b.JSON(out) }},
+		{name: "body", bind: func(b *Bind, out any) error { return b.Body(out) }},
+		{name: "all", bind: func(b *Bind, out any) error { return b.All(out) }},
+	} {
+		t.Run(bindJSON.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, testCase := range []struct {
+				body    string
+				name    string
+				wantErr string
+			}{
+				{body: `{"name":"Fiber","unknown":true}`, name: "unknown field", wantErr: `unknown field "unknown"`},
+				{body: `{"name":"Fiber"} {}`, name: "trailing JSON", wantErr: "json: multiple values"},
+			} {
+				t.Run(testCase.name, func(t *testing.T) {
+					t.Parallel()
+
+					app := New()
+					c := app.AcquireCtx(&fasthttp.RequestCtx{})
+					t.Cleanup(func() { app.ReleaseCtx(c) })
+					c.Request().Header.SetContentType(MIMEApplicationJSON)
+					c.Request().SetBodyString(testCase.body)
+
+					var result struct {
+						Name string `json:"name"`
+					}
+					err := bindJSON.bind(c.Bind().WithJSONDecoder(strictJSONUnmarshal), &result)
+
+					require.ErrorContains(t, err, testCase.wantErr)
+				})
+			}
+		})
+	}
+}
+
+func strictJSONUnmarshal(data []byte, out any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(out); err != nil {
+		return err
+	}
+
+	var trailing any
+	err := decoder.Decode(&trailing)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err == nil {
+		return errors.New("json: multiple values")
+	}
+
+	return err
 }
 
 // go test -run Test_BindError -v

--- a/bind_test.go
+++ b/bind_test.go
@@ -87,14 +87,12 @@ func Test_AcquireReleaseBind(t *testing.T) {
 	b.shouldSkipValidation = true
 	b.jsonDecoder = json.Unmarshal
 	b.ctx = &DefaultCtx{}
+	b.release()
+	require.Nil(t, b.ctx)
+	require.Nil(t, b.jsonDecoder)
+	require.True(t, b.shouldSkipErrHandling)
+	require.False(t, b.shouldSkipValidation)
 	ReleaseBind(b)
-
-	b2 := AcquireBind()
-	require.Nil(t, b2.ctx)
-	require.Nil(t, b2.jsonDecoder)
-	require.True(t, b2.shouldSkipErrHandling)
-	require.False(t, b2.shouldSkipValidation)
-	ReleaseBind(b2)
 }
 
 func Test_Bind_WithJSONDecoder_OverridesAppDecoder(t *testing.T) {

--- a/docs/api/bind.md
+++ b/docs/api/bind.md
@@ -892,6 +892,46 @@ The `MIMETypes` method is used to check if the custom binder should be used for 
 
 For more control over error handling, you can use the following methods.
 
+### WithJSONDecoder
+
+Use a JSON decoder for the current bind chain. Passing `nil` uses the decoder
+configured on the application. The override applies when JSON is decoded by
+`JSON`, `Body`, or `All`.
+
+```go title="Signature"
+func (b *Bind) WithJSONDecoder(decoder utils.JSONUnmarshal) *Bind
+```
+
+For strict request schemas, configure a decoder that rejects unknown fields and
+additional top-level JSON values:
+
+```go
+func strictJSONUnmarshal(data []byte, out any) error {
+    decoder := json.NewDecoder(bytes.NewReader(data))
+    decoder.DisallowUnknownFields()
+    if err := decoder.Decode(out); err != nil {
+        return err
+    }
+
+    var trailing any
+    if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+        if err == nil {
+            return errors.New("json: multiple values")
+        }
+        return err
+    }
+    return nil
+}
+
+app.Post("/cats", func(c fiber.Ctx) error {
+    var cat Cat
+    if err := c.Bind().WithJSONDecoder(strictJSONUnmarshal).Body(&cat); err != nil {
+        return err
+    }
+    return c.JSON(cat)
+})
+```
+
 ### WithAutoHandling
 
 If you want to handle binder errors automatically, you can use `WithAutoHandling`.


### PR DESCRIPTION
## Summary

Adds `Bind().WithJSONDecoder(...)` so callers can select a JSON decoder for a single bind operation without changing the app-level decoder.

This enables strict parsing patterns such as `DisallowUnknownFields` on individual binds (issue #2858), while leaving the global decoder untouched.

## Changes

- `WithJSONDecoder` on the bind API
- Tests for per-bind decoder selection / strict unknown-field behavior
- Docs in `docs/api/bind.md`

## Linked issue

Closes #2858

## Checklist

- [x] `make audit`
- [x] `make generate`
- [x] `make format`
- [x] `make lint` — 0 issues
- [x] `make test` — passed
- Note: `make betteralign` reports pre-existing alignment suggestions on `main` (`path.go` / `router.go`); not part of this change