### PR TITLE
🔥 feat: add final request hooks to the HTTP client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -63,6 +63,7 @@ type Client struct {
 	referer              string
 	userRequestHooks     []RequestHook
 	builtinRequestHooks  []RequestHook
+	finalRequestHooks    []RequestHook
 	userResponseHooks    []ResponseHook
 	builtinResponseHooks []ResponseHook
 
@@ -157,6 +158,24 @@ func (c *Client) AddRequestHook(h ...RequestHook) *Client {
 	defer c.mu.Unlock()
 
 	c.userRequestHooks = append(c.userRequestHooks, h...)
+	return c
+}
+
+// FinalRequestHook returns a copy of the user-defined final request hooks.
+func (c *Client) FinalRequestHook() []RequestHook {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return slices.Clone(c.finalRequestHooks)
+}
+
+// AddFinalRequestHook registers hooks for the point after request serialization
+// and immediately before transport execution.
+func (c *Client) AddFinalRequestHook(h ...RequestHook) *Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.finalRequestHooks = append(c.finalRequestHooks, h...)
 	return c
 }
 
@@ -968,6 +987,7 @@ func newClient(transport httpClientTransport) *Client {
 
 		userRequestHooks:     []RequestHook{},
 		builtinRequestHooks:  []RequestHook{parserRequestURL, parserRequestHeader, parserRequestBody},
+		finalRequestHooks:    []RequestHook{},
 		userResponseHooks:    []ResponseHook{},
 		builtinResponseHooks: []ResponseHook{parserResponseCookie, logger},
 		jsonMarshal:          json.Marshal,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -283,6 +283,16 @@ func Test_Client_Add_Hook(t *testing.T) {
 		require.Len(t, client.RequestHook(), 3)
 	})
 
+	t.Run("add final request hooks", func(t *testing.T) {
+		t.Parallel()
+
+		client := New().AddFinalRequestHook(func(_ *Client, _ *Request) error {
+			return nil
+		})
+
+		require.Len(t, client.FinalRequestHook(), 1)
+	})
+
 	t.Run("add response hooks", func(t *testing.T) {
 		t.Parallel()
 		client := New().AddResponseHook(func(_ *Client, _ *Response, _ *Request) error {

--- a/client/core.go
+++ b/client/core.go
@@ -150,16 +150,31 @@ func (c *core) preHooks() error {
 		}
 	}
 
-	c.client.mu.Lock()
-	defer c.client.mu.Unlock()
+	finalHooks, err := c.runBuiltinRequestHooks()
+	if err != nil {
+		return err
+	}
 
-	for _, f := range c.client.builtinRequestHooks {
+	for _, f := range finalHooks {
 		if err := f(c.client, c.req); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (c *core) runBuiltinRequestHooks() ([]RequestHook, error) {
+	c.client.mu.Lock()
+	defer c.client.mu.Unlock()
+
+	for _, f := range c.client.builtinRequestHooks {
+		if err := f(c.client, c.req); err != nil {
+			return nil, err
+		}
+	}
+
+	return slices.Clone(c.client.finalRequestHooks), nil
 }
 
 // afterHooks runs all response hooks after receiving the response.

--- a/client/core.go
+++ b/client/core.go
@@ -142,6 +142,7 @@ func (c *core) execFunc() (*Response, error) {
 func (c *core) preHooks() error {
 	c.client.mu.RLock()
 	userHooks := slices.Clone(c.client.userRequestHooks)
+	finalHooks := slices.Clone(c.client.finalRequestHooks)
 	c.client.mu.RUnlock()
 
 	for _, f := range userHooks {
@@ -150,8 +151,7 @@ func (c *core) preHooks() error {
 		}
 	}
 
-	finalHooks, err := c.runBuiltinRequestHooks()
-	if err != nil {
+	if err := c.runBuiltinRequestHooks(); err != nil {
 		return err
 	}
 
@@ -164,17 +164,19 @@ func (c *core) preHooks() error {
 	return nil
 }
 
-func (c *core) runBuiltinRequestHooks() ([]RequestHook, error) {
+// runBuiltinRequestHooks serializes the request under the client lock, as the
+// built-in hooks read client-level state while they fill in RawRequest.
+func (c *core) runBuiltinRequestHooks() error {
 	c.client.mu.Lock()
 	defer c.client.mu.Unlock()
 
 	for _, f := range c.client.builtinRequestHooks {
 		if err := f(c.client, c.req); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return slices.Clone(c.client.finalRequestHooks), nil
+	return nil
 }
 
 // afterHooks runs all response hooks after receiving the response.

--- a/client/core_test.go
+++ b/client/core_test.go
@@ -448,6 +448,95 @@ func Test_PreHooks_AllowsUserHookClientConfigMutation(t *testing.T) {
 	require.Contains(t, string(core.req.RawRequest.Header.Cookie("session")), "abc")
 }
 
+func Test_PreHooks_FinalRequestHookSeesSerializedRequest(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	client.AddFinalRequestHook(func(_ *Client, req *Request) error {
+		require.Equal(t, "POST", string(req.RawRequest.Header.Method()))
+		require.Equal(t, "application/json", string(req.RawRequest.Header.ContentType()))
+		require.JSONEq(t, `{"name":"fiber"}`, string(req.RawRequest.Body()))
+		req.RawRequest.Header.Set("X-Signature", "signed")
+		return nil
+	})
+
+	core := newCore()
+	core.client = client
+	core.req = AcquireRequest()
+	defer ReleaseRequest(core.req)
+	core.req.SetMethod("POST").SetURL("http://example.com").SetJSON(map[string]string{"name": "fiber"})
+
+	require.NoError(t, core.preHooks())
+	require.Equal(t, "signed", string(core.req.RawRequest.Header.Peek("X-Signature")))
+}
+
+func Test_PreHooks_ReturnsFinalRequestHookError(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	wantErr := errors.New("final request hook failed")
+	client.AddFinalRequestHook(func(_ *Client, _ *Request) error { return wantErr })
+
+	core := newCore()
+	core.client = client
+	core.req = AcquireRequest()
+	defer ReleaseRequest(core.req)
+	core.req.SetURL("http://example.com")
+
+	require.ErrorIs(t, core.preHooks(), wantErr)
+}
+
+func Test_PreHooks_ReleasesClientLockWhenBuiltinHookPanics(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	callCount := 0
+	client.builtinRequestHooks = []RequestHook{func(_ *Client, _ *Request) error {
+		callCount++
+		if callCount == 1 {
+			panic("built-in request hook panic")
+		}
+		return nil
+	}}
+
+	firstCore := newCore()
+	firstCore.client = client
+	firstCore.req = AcquireRequest()
+	defer ReleaseRequest(firstCore.req)
+
+	require.PanicsWithValue(t, "built-in request hook panic", func() {
+		require.NoError(t, firstCore.preHooks())
+	})
+
+	secondCore := newCore()
+	secondCore.client = client
+	secondCore.req = AcquireRequest()
+	defer ReleaseRequest(secondCore.req)
+
+	require.NoError(t, secondCore.preHooks())
+	require.Equal(t, 2, callCount)
+}
+
+func Test_PreHooks_RunsFinalRequestHooksOutsideClientLock(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+	hookCount := 0
+	client.AddFinalRequestHook(func(c *Client, _ *Request) error {
+		hookCount = len(c.FinalRequestHook())
+		return nil
+	})
+
+	core := newCore()
+	core.client = client
+	core.req = AcquireRequest()
+	defer ReleaseRequest(core.req)
+	core.req.SetURL("http://example.com")
+
+	require.NoError(t, core.preHooks())
+	require.Equal(t, 1, hookCount)
+}
+
 // Test_AfterHooks_ReturnsUserHookError verifies a failing user response hook
 // aborts afterHooks and its error is propagated.
 func Test_AfterHooks_ReturnsUserHookError(t *testing.T) {

--- a/docs/client/hooks.md
+++ b/docs/client/hooks.md
@@ -105,17 +105,29 @@ If a request hook returns an error, Fiber stops the request and returns the erro
 Hooks added with `AddRequestHook` run before Fiber's built-in hooks, so they can
 configure high-level request fields such as URL parameters, headers, and body.
 Hooks added with `AddFinalRequestHook` run after the built-in hooks and
-immediately before the request is sent. At that point `RawRequest` contains the
-final serialized URL, headers, cookies, and body, which is useful for request
-signing:
+immediately before the request is sent, when `RawRequest` holds the resolved
+URL, the merged headers and cookies, and the serialized body. This is the place
+for request signing:
 
 ```go
 cc.AddFinalRequestHook(func(_ *client.Client, req *client.Request) error {
-    signature := sign(req.RawRequest.Header.Header(), req.RawRequest.Body())
-    req.RawRequest.Header.Set("X-Signature", signature)
+    raw := req.RawRequest
+    signature := sign(raw.URI().RequestURI(), raw.URI().Host(), raw.Body())
+    raw.Header.Set("X-Signature", signature)
     return nil
 })
 ```
+
+:::caution
+fasthttp writes the request line, `Host` and `Content-Length` when it sends the
+request, which is after this hook. Take the target and the host from
+`RawRequest.URI()`: `Header.Header()` still carries the absolute URL without its
+query string, and `Header.Host()` is empty.
+
+Redirects are followed below the hook, so it runs once per call rather than once
+per request. A signature bound to one URL stays on the request when fasthttp
+follows a `Location` to another.
+:::
 
 **Example with Multiple Hooks:**
 

--- a/docs/client/hooks.md
+++ b/docs/client/hooks.md
@@ -150,6 +150,10 @@ for request signing:
 ```go
 cc.AddFinalRequestHook(func(_ *client.Client, req *client.Request) error {
     raw := req.RawRequest
+    if raw.IsBodyStream() {
+        return errors.New("cannot sign a streamed body")
+    }
+
     signature := sign(raw.URI().RequestURI(), raw.URI().Host(), raw.Body())
     raw.Header.Set("X-Signature", signature)
     return nil
@@ -166,8 +170,10 @@ The hook runs once per call, not once per attempt: retries resend the request it
 signed, and a redirect is followed below it, carrying a signature bound to the
 previous URL. Sign with a nonce or a timestamp only when retries are off.
 
-On a streamed body, `RawRequest.Body()` drains the stream into memory. The
-signature then covers what is sent, but the request is no longer streamed.
+Hence the `IsBodyStream` guard above. Reading `RawRequest.Body()` drains a body
+stream into memory, and a stream that fails mid-read leaves fasthttp's error
+text in the body: that text is then sent as the payload, signed as if it were
+genuine, while `Send` reports no error. Buffer such a body before attaching it.
 :::
 
 ## Response Hooks

--- a/docs/client/hooks.md
+++ b/docs/client/hooks.md
@@ -100,35 +100,6 @@ Fiber includes built-in request hooks:
 If a request hook returns an error, Fiber stops the request and returns the error immediately.
 :::
 
-### Final Request Hooks
-
-Hooks added with `AddRequestHook` run before Fiber's built-in hooks, so they can
-configure high-level request fields such as URL parameters, headers, and body.
-Hooks added with `AddFinalRequestHook` run after the built-in hooks and
-immediately before the request is sent, when `RawRequest` holds the resolved
-URL, the merged headers and cookies, and the serialized body. This is the place
-for request signing:
-
-```go
-cc.AddFinalRequestHook(func(_ *client.Client, req *client.Request) error {
-    raw := req.RawRequest
-    signature := sign(raw.URI().RequestURI(), raw.URI().Host(), raw.Body())
-    raw.Header.Set("X-Signature", signature)
-    return nil
-})
-```
-
-:::caution
-fasthttp writes the request line, `Host` and `Content-Length` when it sends the
-request, which is after this hook. Take the target and the host from
-`RawRequest.URI()`: `Header.Header()` still carries the absolute URL without its
-query string, and `Header.Host()` is empty.
-
-Redirects are followed below the hook, so it runs once per call rather than once
-per request. A signature bound to one URL stays on the request when fasthttp
-follows a `Location` to another.
-:::
-
 **Example with Multiple Hooks:**
 
 ```go
@@ -166,6 +137,38 @@ exit status 2
 ```
 
 </details>
+
+### Final Request Hooks
+
+Hooks added with `AddRequestHook` run before Fiber's built-in hooks, so they can
+configure high-level request fields such as URL parameters, headers, and body.
+Hooks added with `AddFinalRequestHook` run after the built-in hooks and
+immediately before the request is sent, when `RawRequest` holds the resolved
+URL, the merged headers and cookies, and the serialized body. This is the place
+for request signing:
+
+```go
+cc.AddFinalRequestHook(func(_ *client.Client, req *client.Request) error {
+    raw := req.RawRequest
+    signature := sign(raw.URI().RequestURI(), raw.URI().Host(), raw.Body())
+    raw.Header.Set("X-Signature", signature)
+    return nil
+})
+```
+
+:::caution
+fasthttp writes the request line, `Host` and `Content-Length` when it sends the
+request, which is after this hook. Take the target and the host from
+`RawRequest.URI()`: `Header.Header()` still carries the absolute URL without its
+query string, and `Header.Host()` is empty.
+
+The hook runs once per call, not once per attempt: retries resend the request it
+signed, and a redirect is followed below it, carrying a signature bound to the
+previous URL. Sign with a nonce or a timestamp only when retries are off.
+
+On a streamed body, `RawRequest.Body()` drains the stream into memory. The
+signature then covers what is sent, but the request is no longer streamed.
+:::
 
 ## Response Hooks
 

--- a/docs/client/hooks.md
+++ b/docs/client/hooks.md
@@ -100,6 +100,23 @@ Fiber includes built-in request hooks:
 If a request hook returns an error, Fiber stops the request and returns the error immediately.
 :::
 
+### Final Request Hooks
+
+Hooks added with `AddRequestHook` run before Fiber's built-in hooks, so they can
+configure high-level request fields such as URL parameters, headers, and body.
+Hooks added with `AddFinalRequestHook` run after the built-in hooks and
+immediately before the request is sent. At that point `RawRequest` contains the
+final serialized URL, headers, cookies, and body, which is useful for request
+signing:
+
+```go
+cc.AddFinalRequestHook(func(_ *client.Client, req *client.Request) error {
+    signature := sign(req.RawRequest.Header.Header(), req.RawRequest.Body())
+    req.RawRequest.Header.Set("X-Signature", signature)
+    return nil
+})
+```
+
 **Example with Multiple Hooks:**
 
 ```go
@@ -253,7 +270,9 @@ exit status 2
 
 ## Hook Execution Order
 
-Hooks run in FIFO order (first in, first out), so they're executed in the order you add them. Keep this in mind when adding multiple hooks, as the order can affect the outcome.
+Each hook group runs in FIFO order. The complete request pipeline is regular
+request hooks, built-in request hooks, final request hooks, transport, built-in
+response hooks, and regular response hooks.
 
 **Example:**
 

--- a/docs/client/rest.md
+++ b/docs/client/rest.md
@@ -257,7 +257,7 @@ func (c *Client) FinalRequestHook() []RequestHook
 Adds final request hooks. Use these when request signing or authentication must
 inspect the serialized request body together with the merged headers. See
 [Final Request Hooks](./hooks.md#final-request-hooks) for what is already set at
-that point and what fasthttp adds afterwards.
+that point and what fasthttp adds afterward.
 
 ```go title="Signature"
 func (c *Client) AddFinalRequestHook(h ...RequestHook) *Client

--- a/docs/client/rest.md
+++ b/docs/client/rest.md
@@ -255,7 +255,9 @@ func (c *Client) FinalRequestHook() []RequestHook
 ### AddFinalRequestHook
 
 Adds final request hooks. Use these when request signing or authentication must
-inspect the serialized request body and automatically generated headers.
+inspect the serialized request body together with the merged headers. See
+[Final Request Hooks](./hooks.md#final-request-hooks) for what is already set at
+that point and what fasthttp adds afterwards.
 
 ```go title="Signature"
 func (c *Client) AddFinalRequestHook(h ...RequestHook) *Client

--- a/docs/client/rest.md
+++ b/docs/client/rest.md
@@ -243,6 +243,24 @@ Adds one or more user-defined request hooks.
 func (c *Client) AddRequestHook(h ...RequestHook) *Client
 ```
 
+### FinalRequestHook
+
+Returns final request hooks. These run after Fiber has serialized the URL,
+headers, and body, immediately before the transport sends the request.
+
+```go title="Signature"
+func (c *Client) FinalRequestHook() []RequestHook
+```
+
+### AddFinalRequestHook
+
+Adds final request hooks. Use these when request signing or authentication must
+inspect the serialized request body and automatically generated headers.
+
+```go title="Signature"
+func (c *Client) AddFinalRequestHook(h ...RequestHook) *Client
+```
+
 ### AddResponseHook
 
 Adds one or more user-defined response hooks.

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -2806,6 +2806,7 @@ jar.Set(uri, c)
 | Feature | v3 API |
 |---------|--------|
 | Request Hooks | `c.AddRequestHook(fn)` |
+| Final Request Hooks | `c.AddFinalRequestHook(fn)` |
 | Response Hooks | `c.AddResponseHook(fn)` |
 | Proxy | `c.SetProxyURL(url)` |
 | Context | `req.SetContext(ctx)` |


### PR DESCRIPTION
## Summary

Adds final request hooks that run after Fiber's built-in request preparation, so callers can inspect/modify headers and body together (e.g. API-key signing that needs both).

Addresses #4587.

## Changes

- Final request hook registration on the client
- Core execution path + tests
- Docs in `docs/client/hooks.md` and `docs/client/rest.md`

## Linked issue

Closes #4587

## Checklist

- [x] `make audit`
- [x] `make generate`
- [x] `make format`
- [x] `make lint` — 0 issues
- [x] `make test` — passed
- Note: `make betteralign` reports pre-existing alignment suggestions on `main` (`path.go` / `router.go`); not part of this change