### PR TITLE
🐛 bug: pin CustomCtx overrides when middleware is present

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -399,6 +399,26 @@ func (c *customCtx) Params(key string, defaultValue ...string) string { //revive
 	return "prefix_" + c.DefaultCtx.Params(key)
 }
 
+// jsonEnvelopeCustomCtx overrides JSON to wrap payloads in a standard API envelope.
+// Used to regression-test #3319 (CustomCtx methods must survive middleware / Next).
+type jsonEnvelopeCustomCtx struct {
+	DefaultCtx
+}
+
+type jsonEnvelope struct {
+	Data    any    `json:"data"`
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+}
+
+func (c *jsonEnvelopeCustomCtx) JSON(data any, ctype ...string) error {
+	return c.DefaultCtx.JSON(jsonEnvelope{
+		Code:    StatusOK,
+		Data:    data,
+		Message: "OK",
+	}, ctype...)
+}
+
 // go test -run Test_Ctx_CustomCtx
 func Test_Ctx_CustomCtx(t *testing.T) {
 	t.Parallel()
@@ -486,6 +506,53 @@ func Test_Ctx_CustomCtx_WithMiddleware(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err, "io.ReadAll(resp.Body)")
 	require.Equal(t, "prefix_", string(body))
+}
+
+// go test -run Test_Ctx_CustomCtx_JSON_WithMiddleware
+func Test_Ctx_CustomCtx_JSON_WithMiddleware(t *testing.T) {
+	t.Parallel()
+
+	newCtx := func(app *App) CustomCtx {
+		return &jsonEnvelopeCustomCtx{DefaultCtx: *NewDefaultCtx(app)}
+	}
+
+	t.Run("without middleware", func(t *testing.T) {
+		t.Parallel()
+
+		app := NewWithCustomCtx(newCtx)
+		app.Get("/vvv", func(c Ctx) error {
+			return c.JSON(Map{"a": "b"})
+		})
+
+		resp, err := app.Test(httptest.NewRequest(MethodGet, "/vvv", http.NoBody))
+		require.NoError(t, err, "app.Test(req)")
+		defer func() { require.NoError(t, resp.Body.Close()) }()
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err, "io.ReadAll(resp.Body)")
+		require.JSONEq(t, `{"code":200,"data":{"a":"b"},"message":"OK"}`, string(body))
+	})
+
+	t.Run("with middleware", func(t *testing.T) {
+		t.Parallel()
+
+		app := NewWithCustomCtx(newCtx)
+		app.Use(func(c Ctx) error {
+			return c.Next()
+		})
+		app.Get("/vvv", func(c Ctx) error {
+			return c.JSON(Map{"a": "b"})
+		})
+
+		resp, err := app.Test(httptest.NewRequest(MethodGet, "/vvv", http.NoBody))
+		require.NoError(t, err, "app.Test(req)")
+		defer func() { require.NoError(t, resp.Body.Close()) }()
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err, "io.ReadAll(resp.Body)")
+		// Middleware must not drop the custom JSON wrapper (#3319).
+		require.JSONEq(t, `{"code":200,"data":{"a":"b"},"message":"OK"}`, string(body))
+	})
 }
 
 // go test -run Test_Ctx_CustomCtx

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -689,6 +689,14 @@ func main() {
 `NewWithCustomCtx` works with global and route middleware. Fiber passes your custom context through `c.Next()`, so overridden methods (for example a custom `JSON`) still run after `app.Use(...)`.
 
 ```go title="Custom JSON with middleware"
+package main
+
+import (
+    "log"
+
+    "github.com/gofiber/fiber/v3"
+)
+
 type APICtx struct {
     fiber.DefaultCtx
 }

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -686,6 +686,49 @@ func main() {
 }
 ```
 
+`NewWithCustomCtx` works with global and route middleware. Fiber passes your custom context through `c.Next()`, so overridden methods (for example a custom `JSON`) still run after `app.Use(...)`.
+
+```go title="Custom JSON with middleware"
+type APICtx struct {
+    fiber.DefaultCtx
+}
+
+type envelope struct {
+    Code    int    `json:"code"`
+    Data    any    `json:"data"`
+    Message string `json:"message"`
+}
+
+func (c *APICtx) JSON(data any, ctype ...string) error {
+    return c.DefaultCtx.JSON(envelope{
+        Code:    fiber.StatusOK,
+        Data:    data,
+        Message: "OK",
+    }, ctype...)
+}
+
+func main() {
+    app := fiber.NewWithCustomCtx(func(app *fiber.App) fiber.CustomCtx {
+        return &APICtx{DefaultCtx: *fiber.NewDefaultCtx(app)}
+    })
+
+    app.Use(func(c fiber.Ctx) error {
+        return c.Next()
+    })
+
+    app.Get("/vvv", func(c fiber.Ctx) error {
+        // Uses APICtx.JSON even though middleware called Next
+        return c.JSON(fiber.Map{"a": "b"})
+    })
+
+    log.Fatal(app.Listen(":3000"))
+}
+```
+
+:::tip
+Prefer embedding `fiber.DefaultCtx` (by value or pointer) and constructing it with `fiber.NewDefaultCtx(app)`. Overridden methods are resolved on the concrete `CustomCtx` type Fiber stores for the request.
+:::
+
 ## RegisterCustomBinder
 
 You can register custom binders to use with [`Bind().Custom("name")`](bind.md#custom). They should be compatible with the `CustomBinder` interface.


### PR DESCRIPTION
## Summary

On current main, `NewWithCustomCtx` already preserves custom methods through middleware via `handlerCtx`. This PR pins that behavior with a regression test (custom `JSON` envelope with and without `app.Use`) and documents the pattern under `NewWithCustomCtx`.

## Changes

- Regression test for #3319
- Docs example: custom JSON + global middleware

## Linked issue

Closes #3319

## Checklist

- [x] `make format`
- [x] `make lint` — 0 issues
- [x] targeted tests pass