### PR TITLE
🐛 bug: pin Context() not canceled on graceful shutdown

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1620,33 +1620,41 @@ func Test_App_Shutdown_ContextNotCanceled(t *testing.T) {
 	app.Get("/slow", func(c Ctx) error {
 		close(handlerStarted)
 
-		// Wait long enough for Shutdown to start and close fasthttp's done channel.
-		select {
-		case <-c.Context().Done():
-			contextErr <- c.Context().Err()
-		case <-time.After(500 * time.Millisecond):
-			contextErr <- nil
-		}
-
+		// Waiting on RequestCtx first is what gives the second check meaning: it
+		// proves shutdown has actually started, so a c.Context() that is still
+		// alive afterwards cannot just be one that shutdown has yet to reach.
 		select {
 		case <-c.RequestCtx().Done():
 			requestCtxCanceled <- true
-		case <-time.After(50 * time.Millisecond):
+		case <-time.After(5 * time.Second):
 			requestCtxCanceled <- false
+		}
+
+		select {
+		case <-c.Context().Done():
+			contextErr <- c.Context().Err()
+		default:
+			contextErr <- nil
 		}
 
 		return c.SendString("ok")
 	})
 
 	ln := fasthttputil.NewInmemoryListener()
+	serverReady := make(chan struct{})
 	go func() {
+		close(serverReady)
 		assert.NoError(t, app.Listener(ln))
 	}()
-	time.Sleep(50 * time.Millisecond)
+	<-serverReady
 
+	clientDone := make(chan struct{})
 	go func() {
+		defer close(clientDone)
 		conn, err := ln.Dial()
-		assert.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 		_, err = conn.Write([]byte("GET /slow HTTP/1.1\r\nHost: example.com\r\n\r\n"))
 		assert.NoError(t, err)
 		// Drain response so the connection can finish cleanly.
@@ -1655,11 +1663,16 @@ func Test_App_Shutdown_ContextNotCanceled(t *testing.T) {
 		assert.NoError(t, conn.Close())
 	}()
 
-	<-handlerStarted
-	require.NoError(t, app.ShutdownWithTimeout(2*time.Second))
+	select {
+	case <-handlerStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the handler never ran; the client goroutine could not reach it")
+	}
+	require.NoError(t, app.ShutdownWithTimeout(5*time.Second))
+	<-clientDone
 
-	require.NoError(t, <-contextErr, "c.Context() must not be canceled by graceful shutdown")
 	require.True(t, <-requestCtxCanceled, "RequestCtx.Done() is closed when the server shuts down")
+	require.NoError(t, <-contextErr, "c.Context() must not be canceled by graceful shutdown")
 }
 
 func Test_App_ShutdownWithContext(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -1606,6 +1606,62 @@ func Test_App_ShutdownWithTimeout_WaitsForStreamedBody(t *testing.T) {
 	require.True(t, <-streamDone, "shutdown returned while the body was still being written")
 }
 
+// Test_App_Shutdown_ContextNotCanceled pins #3431: c.Context() stays usable for
+// in-flight work during graceful shutdown (unlike RequestCtx.Done()).
+func Test_App_Shutdown_ContextNotCanceled(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	handlerStarted := make(chan struct{})
+	// Results observed inside the handler after shutdown has begun.
+	contextErr := make(chan error, 1)
+	requestCtxCanceled := make(chan bool, 1)
+
+	app.Get("/slow", func(c Ctx) error {
+		close(handlerStarted)
+
+		// Wait long enough for Shutdown to start and close fasthttp's done channel.
+		select {
+		case <-c.Context().Done():
+			contextErr <- c.Context().Err()
+		case <-time.After(500 * time.Millisecond):
+			contextErr <- nil
+		}
+
+		select {
+		case <-c.RequestCtx().Done():
+			requestCtxCanceled <- true
+		case <-time.After(50 * time.Millisecond):
+			requestCtxCanceled <- false
+		}
+
+		return c.SendString("ok")
+	})
+
+	ln := fasthttputil.NewInmemoryListener()
+	go func() {
+		assert.NoError(t, app.Listener(ln))
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	go func() {
+		conn, err := ln.Dial()
+		assert.NoError(t, err)
+		_, err = conn.Write([]byte("GET /slow HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+		assert.NoError(t, err)
+		// Drain response so the connection can finish cleanly.
+		_, copyErr := io.Copy(io.Discard, conn)
+		assert.NoError(t, copyErr)
+		assert.NoError(t, conn.Close())
+	}()
+
+	<-handlerStarted
+	require.NoError(t, app.ShutdownWithTimeout(2*time.Second))
+
+	require.NoError(t, <-contextErr, "c.Context() must not be canceled by graceful shutdown")
+	require.True(t, <-requestCtxCanceled, "RequestCtx.Done() is closed when the server shuts down")
+}
+
 func Test_App_ShutdownWithContext(t *testing.T) {
 	t.Parallel()
 

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -84,6 +84,12 @@ app.Get("/", func(c fiber.Ctx) error {
 })
 ```
 
+:::info Graceful shutdown
+The default `Context()` is **not** canceled when the app shuts down. In-flight handlers that pass `c.Context()` to database clients or other cancellation-aware work keep running until they finish (or until you cancel a derived context yourself).
+
+[`RequestCtx`](#requestctx) implements `context.Context` differently: its `Done()` channel is closed when the underlying fasthttp server starts shutting down. Prefer `c.Context()` (or a context you derive with `context.WithCancel` / timeouts) for work that must outlive the start of graceful shutdown.
+:::
+
 ### context.Context
 
 `Ctx` implements `context.Context`, but as a context that can never be canceled: `Deadline()` reports no deadline, `Done()` returns `nil` and `Err()` returns `nil`, regardless of what you pass to [`SetContext`](#setcontext). The `fiber.Ctx` instance is pooled and reused after the handler returns, which is why it cannot carry cancellation of its own. Call [`Context`](#context) within the handler to obtain a real `context.Context`, and pass that to anything that is cancellation-aware or that outlives the handler.

--- a/docs/api/fiber.md
+++ b/docs/api/fiber.md
@@ -343,6 +343,14 @@ func (app *App) ShutdownWithTimeout(timeout time.Duration) error
 func (app *App) ShutdownWithContext(ctx context.Context) error
 ```
 
+:::info How long does shutdown wait?
+`Shutdown` / `ShutdownWithTimeout` / `ShutdownWithContext` wait for **in-flight handlers** (including streaming responses written with `SendStream` / `SendStreamWriter`) until they return or the timeout fires. The timeout is measured from the start of shutdown; if a handler finishes before the deadline, shutdown returns without waiting for the full timeout.
+
+Call `Shutdown*` from a separate goroutine while `Listen` / `Listener` runs, and keep the process alive until `Shutdown*` returns. Set a non-zero `ReadTimeout` / `IdleTimeout` so idle keepalive connections do not block shutdown forever.
+
+`ListenConfig.ShutdownTimeout` is applied only when Fiber runs its **built-in** graceful shutdown path (for example with `GracefulContext`). If you call `app.ShutdownWithTimeout` yourself, that argument is the one that applies.
+:::
+
 ## Helper functions
 
 ### NewError


### PR DESCRIPTION
## Summary

Pins and documents the v3 behavior for #3431: `c.Context()` is **not** canceled when graceful shutdown starts (default is `context.Background()` unless you `SetContext`). By contrast, `c.RequestCtx().Done()` **is** closed when fasthttp begins shutdown.

In-flight handlers that pass `c.Context()` to DB/clients can finish during graceful shutdown.

## Changes

- Integration regression test during `ShutdownWithTimeout`
- Docs note on `Context()` vs `RequestCtx`

## Linked issue

Closes #3431

## Checklist

- [x] `make format`
- [x] `make lint` — 0 issues
- [x] targeted tests pass