### PR TITLE
🔥 feat: add Endpoint() for middleware look-ahead

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -60,6 +60,7 @@ type DefaultCtx struct {
 	DefaultRes                                  // Default response api
 	app                    *App                 // Reference to *App
 	route                  *Route               // Reference to *Route
+	matchedRoute           *Route               // Cached next non-middleware route match (MatchedRoute)
 	fasthttp               *fasthttp.RequestCtx // Reference to *fasthttp.RequestCtx
 	bind                   *Bind                // Default bind reference
 	redirect               *Redirect            // Default redirect reference
@@ -314,6 +315,8 @@ func (c *DefaultCtx) Path(override ...string) string {
 		c.configDependentPaths()
 		// The detection path/tree hash changed; invalidate the lookahead index.
 		c.firstMatchIndex = -1
+		// Path rewrite invalidates any cached MatchedRoute look-ahead.
+		c.matchedRoute = nil
 	}
 	return c.app.toString(c.path)
 }
@@ -385,6 +388,61 @@ func (c *DefaultCtx) routeFallback() *Route {
 		Handlers: emptyRouteHandlers[:],
 		Params:   emptyRouteParams[:],
 	}
+}
+
+// MatchedRoute returns the next non-middleware route that matches the current
+// request without advancing the handler chain. It is useful inside global
+// middleware when you need to inspect the target route (path or name) before
+// calling Next. Returns nil when no endpoint matches.
+//
+// Unlike Route, which reflects the route currently being executed (often the
+// middleware itself before Next), MatchedRoute looks ahead in the route stack.
+func (c *DefaultCtx) MatchedRoute() *Route {
+	// Already on a non-middleware endpoint.
+	if c.route != nil && !c.route.use && !c.route.mount {
+		return c.route
+	}
+	if c.matchedRoute != nil {
+		return c.matchedRoute
+	}
+	if c.methodInt == -1 || c.app == nil {
+		return nil
+	}
+
+	// SkipUnmatchedRoutes already resolved the endpoint index.
+	if c.firstMatchIndex >= 0 {
+		tree := c.app.treeIndex[c.methodInt].lookup(c.treePathHash)
+		if c.firstMatchIndex < len(tree) {
+			route := tree[c.firstMatchIndex]
+			if route != nil && !route.use && !route.mount {
+				c.matchedRoute = route
+				return route
+			}
+		}
+	}
+
+	tree := c.app.treeIndex[c.methodInt].lookup(c.treePathHash)
+	detectionPath := utils.UnsafeString(c.detectionPath)
+	path := utils.UnsafeString(c.path)
+	pathSlashes := c.pathSlashCount(c.app)
+	// Use a scratch params buffer so look-ahead does not clobber c.values.
+	var scratch [maxParams]string
+
+	for i := c.indexRoute + 1; i < len(tree); i++ {
+		route := tree[i]
+		if route.mount || route.use {
+			continue
+		}
+		if route.prefixRejects(pathHeadWord(detectionPath)) {
+			continue
+		}
+		if route.match(detectionPath, path, &scratch, pathSlashes) {
+			c.matchedRoute = route
+			return route
+		}
+	}
+
+	return nil
 }
 
 // FullPath returns the matched route path, including any group prefixes.
@@ -677,6 +735,8 @@ func (c *DefaultCtx) XHR() bool {
 // configDependentPaths set paths for route recognition and prepared paths for the user,
 // here the features for caseSensitive, decoded paths, strict paths are evaluated
 func (c *DefaultCtx) configDependentPaths() {
+	// Path normalization may change detectionPath / tree hash; drop look-ahead cache.
+	c.matchedRoute = nil
 	c.path = append(c.path[:0], c.pathOriginal...)
 	// If UnescapePath enabled, we decode the path and save it for the framework user
 	if c.app.config.UnescapePath {
@@ -720,6 +780,8 @@ func (c *DefaultCtx) Reset(fctx *fasthttp.RequestCtx) {
 	c.isMatched = false
 	c.shouldSkipNonUseRoutes = false
 	c.firstMatchIndex = -1
+	c.route = nil
+	c.matchedRoute = nil
 	// Set paths
 	c.pathOriginal = c.app.toString(fctx.URI().PathOriginal())
 	// Set method
@@ -744,6 +806,7 @@ func (c *DefaultCtx) release() {
 		c.isUserContextSet = false
 	}
 	c.route = nil
+	c.matchedRoute = nil
 	c.fasthttp = nil
 	if c.bind != nil {
 		ReleaseBind(c.bind)

--- a/ctx.go
+++ b/ctx.go
@@ -60,7 +60,6 @@ type DefaultCtx struct {
 	DefaultRes                                  // Default response api
 	app                    *App                 // Reference to *App
 	route                  *Route               // Reference to *Route
-	matchedRoute           *Route               // Cached next non-middleware route match (MatchedRoute)
 	fasthttp               *fasthttp.RequestCtx // Reference to *fasthttp.RequestCtx
 	bind                   *Bind                // Default bind reference
 	redirect               *Redirect            // Default redirect reference
@@ -315,8 +314,6 @@ func (c *DefaultCtx) Path(override ...string) string {
 		c.configDependentPaths()
 		// The detection path/tree hash changed; invalidate the lookahead index.
 		c.firstMatchIndex = -1
-		// Path rewrite invalidates any cached MatchedRoute look-ahead.
-		c.matchedRoute = nil
 	}
 	return c.app.toString(c.path)
 }
@@ -402,42 +399,45 @@ func (c *DefaultCtx) MatchedRoute() *Route {
 	if c.route != nil && !c.route.use && !c.route.mount {
 		return c.route
 	}
-	if c.matchedRoute != nil {
-		return c.matchedRoute
-	}
 	if c.methodInt == -1 || c.app == nil {
 		return nil
 	}
-
-	// SkipUnmatchedRoutes already resolved the endpoint index.
-	if c.firstMatchIndex >= 0 {
-		tree := c.app.treeIndex[c.methodInt].lookup(c.treePathHash)
-		if c.firstMatchIndex < len(tree) {
-			route := tree[c.firstMatchIndex]
-			if route != nil && !route.use && !route.mount {
-				c.matchedRoute = route
-				return route
-			}
-		}
+	// serverErrorHandler replays the chain with this set, and next() then lets no
+	// endpoint run, so naming one here would promise a handler that cannot run.
+	if c.shouldSkipNonUseRoutes {
+		return nil
 	}
 
 	tree := c.app.treeIndex[c.methodInt].lookup(c.treePathHash)
 	detectionPath := utils.UnsafeString(c.detectionPath)
 	path := utils.UnsafeString(c.path)
+	head := pathHeadWord(detectionPath)
 	pathSlashes := c.pathSlashCount(c.app)
+
+	// SkipUnmatchedRoutes already resolved the endpoint, but the index only answers
+	// while routing has not walked past it, and a route registered mid-request can
+	// shift the bucket under it, so it still has to clear the prefix filter.
+	if c.firstMatchIndex > c.indexRoute && c.firstMatchIndex < len(tree) {
+		if route := tree[c.firstMatchIndex]; route != nil && !route.use && !route.mount &&
+			!route.prefixRejects(head) {
+			return route
+		}
+	}
+
 	// Use a scratch params buffer so look-ahead does not clobber c.values.
 	var scratch [maxParams]string
 
+	// Starting past indexRoute follows the chain, which is why the result needs no
+	// cache: every mutation that would invalidate one already moves a field read here.
 	for i := c.indexRoute + 1; i < len(tree); i++ {
 		route := tree[i]
 		if route.mount || route.use {
 			continue
 		}
-		if route.prefixRejects(pathHeadWord(detectionPath)) {
+		if route.prefixRejects(head) {
 			continue
 		}
 		if route.match(detectionPath, path, &scratch, pathSlashes) {
-			c.matchedRoute = route
 			return route
 		}
 	}
@@ -735,8 +735,6 @@ func (c *DefaultCtx) XHR() bool {
 // configDependentPaths set paths for route recognition and prepared paths for the user,
 // here the features for caseSensitive, decoded paths, strict paths are evaluated
 func (c *DefaultCtx) configDependentPaths() {
-	// Path normalization may change detectionPath / tree hash; drop look-ahead cache.
-	c.matchedRoute = nil
 	c.path = append(c.path[:0], c.pathOriginal...)
 	// If UnescapePath enabled, we decode the path and save it for the framework user
 	if c.app.config.UnescapePath {
@@ -781,7 +779,6 @@ func (c *DefaultCtx) Reset(fctx *fasthttp.RequestCtx) {
 	c.shouldSkipNonUseRoutes = false
 	c.firstMatchIndex = -1
 	c.route = nil
-	c.matchedRoute = nil
 	// Set paths
 	c.pathOriginal = c.app.toString(fctx.URI().PathOriginal())
 	// Set method
@@ -806,7 +803,6 @@ func (c *DefaultCtx) release() {
 		c.isUserContextSet = false
 	}
 	c.route = nil
-	c.matchedRoute = nil
 	c.fasthttp = nil
 	if c.bind != nil {
 		ReleaseBind(c.bind)

--- a/ctx.go
+++ b/ctx.go
@@ -387,14 +387,18 @@ func (c *DefaultCtx) routeFallback() *Route {
 	}
 }
 
-// MatchedRoute returns the next non-middleware route that matches the current
-// request without advancing the handler chain. It is useful inside global
-// middleware when you need to inspect the target route (path or name) before
-// calling Next. Returns nil when no endpoint matches.
+// Endpoint returns the route that will handle this request, without advancing the
+// handler chain, so global middleware can read its Path or Name before calling
+// Next. Returns nil when no endpoint will run: 404, 405, and while the error
+// handler replays the chain for a request rejected at the protocol level.
 //
-// Unlike Route, which reflects the route currently being executed (often the
-// middleware itself before Next), MatchedRoute looks ahead in the route stack.
-func (c *DefaultCtx) MatchedRoute() *Route {
+// It looks ahead, where the neighboring accessors look back: Route reports the
+// route currently executing, which inside middleware is the middleware itself,
+// and Matched reports whether an endpoint has been selected yet.
+//
+// It scans the remaining routes in the request's tree bucket, so calling it from
+// global middleware costs a second router scan per request.
+func (c *DefaultCtx) Endpoint() *Route {
 	// Already on a non-middleware endpoint.
 	if c.route != nil && !c.route.use && !c.route.mount {
 		return c.route

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -114,14 +114,18 @@ type Ctx interface {
 	// fallback for unregistered methods) so Route and Method always agree.
 	// Never inlined: inlining it would push Route over the inlining budget.
 	routeFallback() *Route
-	// MatchedRoute returns the next non-middleware route that matches the current
-	// request without advancing the handler chain. It is useful inside global
-	// middleware when you need to inspect the target route (path or name) before
-	// calling Next. Returns nil when no endpoint matches.
+	// Endpoint returns the route that will handle this request, without advancing the
+	// handler chain, so global middleware can read its Path or Name before calling
+	// Next. Returns nil when no endpoint will run: 404, 405, and while the error
+	// handler replays the chain for a request rejected at the protocol level.
 	//
-	// Unlike Route, which reflects the route currently being executed (often the
-	// middleware itself before Next), MatchedRoute looks ahead in the route stack.
-	MatchedRoute() *Route
+	// It looks ahead, where the neighboring accessors look back: Route reports the
+	// route currently executing, which inside middleware is the middleware itself,
+	// and Matched reports whether an endpoint has been selected yet.
+	//
+	// It scans the remaining routes in the request's tree bucket, so calling it from
+	// global middleware costs a second router scan per request.
+	Endpoint() *Route
 	// FullPath returns the matched route path, including any group prefixes.
 	FullPath() string
 	// Matched returns true if the current request path was matched by the router.

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -114,6 +114,14 @@ type Ctx interface {
 	// fallback for unregistered methods) so Route and Method always agree.
 	// Never inlined: inlining it would push Route over the inlining budget.
 	routeFallback() *Route
+	// MatchedRoute returns the next non-middleware route that matches the current
+	// request without advancing the handler chain. It is useful inside global
+	// middleware when you need to inspect the target route (path or name) before
+	// calling Next. Returns nil when no endpoint matches.
+	//
+	// Unlike Route, which reflects the route currently being executed (often the
+	// middleware itself before Next), MatchedRoute looks ahead in the route stack.
+	MatchedRoute() *Route
 	// FullPath returns the matched route path, including any group prefixes.
 	FullPath() string
 	// Matched returns true if the current request path was matched by the router.

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -6138,6 +6138,39 @@ func Test_Ctx_Endpoint_FollowsMethodOverride(t *testing.T) {
 	require.Equal(t, "x.post", after, "Endpoint must follow a method override, not report the route the old method would have hit")
 }
 
+// go test -run Test_Ctx_Endpoint_LooksPastTheCurrentRoute
+// A middleware placed behind an endpoint that already ran must be told the next
+// endpoint, not the one the chain has passed. Both endpoints are parametric so
+// that SkipUnmatchedRoutes resolves a firstMatchIndex at all: a static hit
+// short-circuits resolveSkip before it records one.
+func Test_Ctx_Endpoint_LooksPastTheCurrentRoute(t *testing.T) {
+	t.Parallel()
+
+	for _, skipUnmatched := range []bool{false, true} {
+		t.Run(fmt.Sprintf("SkipUnmatchedRoutes=%v", skipUnmatched), func(t *testing.T) {
+			t.Parallel()
+
+			app := New(Config{SkipUnmatchedRoutes: skipUnmatched})
+
+			var seen *Route
+			app.Get("/:first", func(c Ctx) error { return c.Next() })
+			app.Use(func(c Ctx) error {
+				seen = c.Endpoint()
+				return c.Next()
+			})
+			app.Get("/:second", func(c Ctx) error { return c.SendStatus(StatusOK) })
+
+			resp, err := app.Test(httptest.NewRequest(MethodGet, "/x", http.NoBody))
+			require.NoError(t, err, "app.Test(req)")
+			defer func() { require.NoError(t, resp.Body.Close()) }()
+
+			require.Equal(t, StatusOK, resp.StatusCode)
+			require.NotNil(t, seen, "an endpoint is still ahead")
+			require.Equal(t, "/:second", seen.Path, "the /:first endpoint already ran")
+		})
+	}
+}
+
 // go test -run Test_Ctx_Endpoint_SkipUnmatchedRoutes
 func Test_Ctx_Endpoint_SkipUnmatchedRoutes(t *testing.T) {
 	t.Parallel()

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5971,6 +5971,36 @@ func Test_Ctx_MatchedRoute_NotFound(t *testing.T) {
 	require.Equal(t, StatusNotFound, resp.StatusCode)
 }
 
+// go test -run Test_Ctx_MatchedRoute_CachedAndSkipped
+func Test_Ctx_MatchedRoute_CachedAndSkipped(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+
+	var calls int
+	app.Use(func(c Ctx) error {
+		first := c.MatchedRoute()  // computes and caches the look-ahead
+		second := c.MatchedRoute() // hits the cached value
+		require.Same(t, first, second)
+		calls++
+		return c.Next()
+	})
+	// A route with a non-matching prefix exercises prefixRejects skip.
+	app.Get("/other/:id", func(c Ctx) error { return c.SendStatus(StatusOK) })
+	// A middleware route registered ahead of the target exercises the use/mount skip.
+	app.Use("/users", func(c Ctx) error { return c.Next() })
+	app.Get("/users/:id", func(c Ctx) error {
+		return c.SendStatus(StatusOK)
+	}).Name("user.show")
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/users/42", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	require.Equal(t, StatusOK, resp.StatusCode)
+	require.Equal(t, 1, calls)
+}
+
 // go test -run Test_Ctx_MatchedRoute_SkipUnmatchedRoutes
 func Test_Ctx_MatchedRoute_SkipUnmatchedRoutes(t *testing.T) {
 	t.Parallel()

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -6003,6 +6003,28 @@ func Test_Ctx_Endpoint_RepeatedAndSkipped(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
+// go test -bench=Benchmark_Ctx_Endpoint -benchmem -count=4
+func Benchmark_Ctx_Endpoint(b *testing.B) {
+	app := New()
+	app.Use(func(c Ctx) error { return c.Next() })
+	registerDummyRoutes(app)
+	app.startupProcess()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.SetMethod(MethodDelete)
+	fctx.Request.SetRequestURI("/user/keys/1337")
+	c := app.AcquireCtx(fctx).(*DefaultCtx) //nolint:errcheck,forcetypeassert // matches the other ctx benchmarks
+	defer app.ReleaseCtx(c)
+	c.Reset(fctx)
+
+	var route *Route
+	b.ReportAllocs()
+	for b.Loop() {
+		route = c.Endpoint()
+	}
+	require.NotNil(b, route)
+}
+
 // go test -run Test_Ctx_Endpoint_NilWhenNoEndpointCanRun
 // serverErrorHandler replays the chain for protocol-level errors with
 // shouldSkipNonUseRoutes set, and next() then runs no endpoint at all.

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5924,8 +5924,8 @@ func Test_Ctx_FullPath_Middleware(t *testing.T) {
 	require.Equal(t, []string{"/", "/test"}, recorded)
 }
 
-// go test -run Test_Ctx_MatchedRoute_Middleware
-func Test_Ctx_MatchedRoute_Middleware(t *testing.T) {
+// go test -run Test_Ctx_Endpoint_Middleware
+func Test_Ctx_Endpoint_Middleware(t *testing.T) {
 	t.Parallel()
 
 	app := New()
@@ -5933,15 +5933,15 @@ func Test_Ctx_MatchedRoute_Middleware(t *testing.T) {
 	var recorded []string
 
 	app.Use(func(c Ctx) error {
-		if route := c.MatchedRoute(); route != nil {
+		if route := c.Endpoint(); route != nil {
 			recorded = append(recorded, route.Path, route.Name)
 		}
 		return c.Next()
 	})
 
 	app.Get("/users/:id", func(c Ctx) error {
-		require.Equal(t, "/users/:id", c.MatchedRoute().Path)
-		require.Equal(t, "user.show", c.MatchedRoute().Name)
+		require.Equal(t, "/users/:id", c.Endpoint().Path)
+		require.Equal(t, "user.show", c.Endpoint().Name)
 		return c.SendStatus(StatusOK)
 	}).Name("user.show")
 
@@ -5953,14 +5953,14 @@ func Test_Ctx_MatchedRoute_Middleware(t *testing.T) {
 	require.Equal(t, []string{"/users/:id", "user.show"}, recorded)
 }
 
-// go test -run Test_Ctx_MatchedRoute_NotFound
-func Test_Ctx_MatchedRoute_NotFound(t *testing.T) {
+// go test -run Test_Ctx_Endpoint_NotFound
+func Test_Ctx_Endpoint_NotFound(t *testing.T) {
 	t.Parallel()
 
 	app := New()
 
 	app.Use(func(c Ctx) error {
-		require.Nil(t, c.MatchedRoute())
+		require.Nil(t, c.Endpoint())
 		return c.Next()
 	})
 
@@ -5971,8 +5971,8 @@ func Test_Ctx_MatchedRoute_NotFound(t *testing.T) {
 	require.Equal(t, StatusNotFound, resp.StatusCode)
 }
 
-// go test -run Test_Ctx_MatchedRoute_CachedAndSkipped
-func Test_Ctx_MatchedRoute_RepeatedAndSkipped(t *testing.T) {
+// go test -run Test_Ctx_Endpoint_CachedAndSkipped
+func Test_Ctx_Endpoint_RepeatedAndSkipped(t *testing.T) {
 	t.Parallel()
 
 	app := New()
@@ -5981,8 +5981,8 @@ func Test_Ctx_MatchedRoute_RepeatedAndSkipped(t *testing.T) {
 	app.Use(func(c Ctx) error {
 		// Repeated calls resolve to the same *Route out of the tree, without a
 		// cached copy in between.
-		first := c.MatchedRoute()
-		second := c.MatchedRoute()
+		first := c.Endpoint()
+		second := c.Endpoint()
 		require.Same(t, first, second)
 		calls++
 		return c.Next()
@@ -6003,10 +6003,10 @@ func Test_Ctx_MatchedRoute_RepeatedAndSkipped(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
-// go test -run Test_Ctx_MatchedRoute_NilWhenNoEndpointCanRun
+// go test -run Test_Ctx_Endpoint_NilWhenNoEndpointCanRun
 // serverErrorHandler replays the chain for protocol-level errors with
 // shouldSkipNonUseRoutes set, and next() then runs no endpoint at all.
-func Test_Ctx_MatchedRoute_NilWhenNoEndpointCanRun(t *testing.T) {
+func Test_Ctx_Endpoint_NilWhenNoEndpointCanRun(t *testing.T) {
 	t.Parallel()
 
 	app := New(Config{BodyLimit: 8})
@@ -6014,7 +6014,7 @@ func Test_Ctx_MatchedRoute_NilWhenNoEndpointCanRun(t *testing.T) {
 	var reported []*Route
 	endpointRan := false
 	app.Use(func(c Ctx) error {
-		reported = append(reported, c.MatchedRoute())
+		reported = append(reported, c.Endpoint())
 		return c.Next()
 	})
 	app.Post("/big", func(c Ctx) error {
@@ -6033,18 +6033,18 @@ func Test_Ctx_MatchedRoute_NilWhenNoEndpointCanRun(t *testing.T) {
 	}
 }
 
-// go test -run Test_Ctx_MatchedRoute_MatchesTheRouteThatRuns
+// go test -run Test_Ctx_Endpoint_MatchesTheRouteThatRuns
 // Sweeps the whole route fixture: whatever the look-ahead names in middleware
 // must be the endpoint next() then executes, or nil when none does. prefixRejects
 // warns that hand-written scan copies drift unnoticed; this is that guard.
-func Test_Ctx_MatchedRoute_MatchesTheRouteThatRuns(t *testing.T) {
+func Test_Ctx_Endpoint_MatchesTheRouteThatRuns(t *testing.T) {
 	t.Parallel()
 
 	app := New()
 
 	var predicted, actual *Route
 	app.Use(func(c Ctx) error {
-		predicted = c.MatchedRoute()
+		predicted = c.Endpoint()
 		return c.Next()
 	})
 	// A middleware between the observer and the endpoints: the scan has to skip it,
@@ -6087,20 +6087,20 @@ func routeName(r *Route) any {
 	return r.Method + " " + r.Path
 }
 
-// go test -run Test_Ctx_MatchedRoute_FollowsMethodOverride
-func Test_Ctx_MatchedRoute_FollowsMethodOverride(t *testing.T) {
+// go test -run Test_Ctx_Endpoint_FollowsMethodOverride
+func Test_Ctx_Endpoint_FollowsMethodOverride(t *testing.T) {
 	t.Parallel()
 
 	app := New()
 
 	var before, after string
 	app.Use(func(c Ctx) error {
-		if r := c.MatchedRoute(); r != nil {
+		if r := c.Endpoint(); r != nil {
 			before = r.Name
 		}
 		c.Request().Header.SetMethod(MethodPost)
 		c.Req().Method(MethodPost)
-		if r := c.MatchedRoute(); r != nil {
+		if r := c.Endpoint(); r != nil {
 			after = r.Name
 		}
 		return c.Next()
@@ -6113,18 +6113,18 @@ func Test_Ctx_MatchedRoute_FollowsMethodOverride(t *testing.T) {
 	defer func() { require.NoError(t, resp.Body.Close()) }()
 
 	require.Equal(t, "x.get", before)
-	require.Equal(t, "x.post", after, "MatchedRoute must follow a method override, not report the route the old method would have hit")
+	require.Equal(t, "x.post", after, "Endpoint must follow a method override, not report the route the old method would have hit")
 }
 
-// go test -run Test_Ctx_MatchedRoute_SkipUnmatchedRoutes
-func Test_Ctx_MatchedRoute_SkipUnmatchedRoutes(t *testing.T) {
+// go test -run Test_Ctx_Endpoint_SkipUnmatchedRoutes
+func Test_Ctx_Endpoint_SkipUnmatchedRoutes(t *testing.T) {
 	t.Parallel()
 
 	app := New(Config{SkipUnmatchedRoutes: true})
 
 	var path string
 	app.Use(func(c Ctx) error {
-		if route := c.MatchedRoute(); route != nil {
+		if route := c.Endpoint(); route != nil {
 			path = route.Path
 		}
 		return c.Next()

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5972,15 +5972,17 @@ func Test_Ctx_MatchedRoute_NotFound(t *testing.T) {
 }
 
 // go test -run Test_Ctx_MatchedRoute_CachedAndSkipped
-func Test_Ctx_MatchedRoute_CachedAndSkipped(t *testing.T) {
+func Test_Ctx_MatchedRoute_RepeatedAndSkipped(t *testing.T) {
 	t.Parallel()
 
 	app := New()
 
 	var calls int
 	app.Use(func(c Ctx) error {
-		first := c.MatchedRoute()  // computes and caches the look-ahead
-		second := c.MatchedRoute() // hits the cached value
+		// Repeated calls resolve to the same *Route out of the tree, without a
+		// cached copy in between.
+		first := c.MatchedRoute()
+		second := c.MatchedRoute()
 		require.Same(t, first, second)
 		calls++
 		return c.Next()
@@ -5999,6 +6001,86 @@ func Test_Ctx_MatchedRoute_CachedAndSkipped(t *testing.T) {
 
 	require.Equal(t, StatusOK, resp.StatusCode)
 	require.Equal(t, 1, calls)
+}
+
+// go test -run Test_Ctx_MatchedRoute_MatchesTheRouteThatRuns
+// Sweeps the whole route fixture: whatever the look-ahead names in middleware
+// must be the endpoint next() then executes, or nil when none does. prefixRejects
+// warns that hand-written scan copies drift unnoticed; this is that guard.
+func Test_Ctx_MatchedRoute_MatchesTheRouteThatRuns(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+
+	var predicted, actual *Route
+	app.Use(func(c Ctx) error {
+		predicted = c.MatchedRoute()
+		return c.Next()
+	})
+	registerDummyRoutes(app)
+	// Record what really ran, from inside the endpoint's own chain position.
+	for _, r := range app.stack {
+		for _, route := range r {
+			if route.use || route.mount || len(route.Handlers) == 0 {
+				continue
+			}
+			handler := route.Handlers[len(route.Handlers)-1]
+			route.Handlers[len(route.Handlers)-1] = func(c Ctx) error {
+				actual = c.Route()
+				return handler(c)
+			}
+		}
+	}
+
+	for i := range routesFixture.TestRoutes {
+		tr := routesFixture.TestRoutes[i]
+		predicted, actual = nil, nil
+
+		req := httptest.NewRequest(tr.Method, tr.Path, http.NoBody)
+		resp, err := app.Test(req)
+		require.NoError(t, err, "%s %s", tr.Method, tr.Path)
+		require.NoError(t, resp.Body.Close())
+
+		require.Same(t, actual, predicted,
+			"%s %s: look-ahead named %v but %v ran", tr.Method, tr.Path,
+			routeName(predicted), routeName(actual))
+	}
+}
+
+func routeName(r *Route) any {
+	if r == nil {
+		return nil
+	}
+	return r.Method + " " + r.Path
+}
+
+// go test -run Test_Ctx_MatchedRoute_FollowsMethodOverride
+func Test_Ctx_MatchedRoute_FollowsMethodOverride(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+
+	var before, after string
+	app.Use(func(c Ctx) error {
+		if r := c.MatchedRoute(); r != nil {
+			before = r.Name
+		}
+		c.Request().Header.SetMethod(MethodPost)
+		c.Req().Method(MethodPost)
+		if r := c.MatchedRoute(); r != nil {
+			after = r.Name
+		}
+		return c.Next()
+	})
+	app.Get("/x", func(c Ctx) error { return c.SendStatus(StatusOK) }).Name("x.get")
+	app.Post("/x", func(c Ctx) error { return c.SendStatus(StatusOK) }).Name("x.post")
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/x", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	require.Equal(t, "x.get", before)
+	require.Equal(t, "x.post", after, "MatchedRoute must follow a method override, not report the route the old method would have hit")
 }
 
 // go test -run Test_Ctx_MatchedRoute_SkipUnmatchedRoutes

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -6003,6 +6003,36 @@ func Test_Ctx_MatchedRoute_RepeatedAndSkipped(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
+// go test -run Test_Ctx_MatchedRoute_NilWhenNoEndpointCanRun
+// serverErrorHandler replays the chain for protocol-level errors with
+// shouldSkipNonUseRoutes set, and next() then runs no endpoint at all.
+func Test_Ctx_MatchedRoute_NilWhenNoEndpointCanRun(t *testing.T) {
+	t.Parallel()
+
+	app := New(Config{BodyLimit: 8})
+
+	var reported []*Route
+	endpointRan := false
+	app.Use(func(c Ctx) error {
+		reported = append(reported, c.MatchedRoute())
+		return c.Next()
+	})
+	app.Post("/big", func(c Ctx) error {
+		endpointRan = true
+		return c.SendString("endpoint")
+	}).Name("big.post")
+
+	req := httptest.NewRequest(MethodPost, "/big", bytes.NewReader(bytes.Repeat([]byte("x"), 4096)))
+	_, err := app.Test(req)
+	require.Error(t, err, "the body limit should reject this request")
+
+	require.False(t, endpointRan)
+	require.NotEmpty(t, reported, "the middleware chain should still have run")
+	for _, r := range reported {
+		require.Nil(t, r, "no endpoint can run in this pass, so none may be named")
+	}
+}
+
 // go test -run Test_Ctx_MatchedRoute_MatchesTheRouteThatRuns
 // Sweeps the whole route fixture: whatever the look-ahead names in middleware
 // must be the endpoint next() then executes, or nil when none does. prefixRejects
@@ -6017,6 +6047,9 @@ func Test_Ctx_MatchedRoute_MatchesTheRouteThatRuns(t *testing.T) {
 		predicted = c.MatchedRoute()
 		return c.Next()
 	})
+	// A middleware between the observer and the endpoints: the scan has to skip it,
+	// and the sweep has to notice if it ever stops doing so.
+	app.Use("/repos", func(c Ctx) error { return c.Next() })
 	registerDummyRoutes(app)
 	// Record what really ran, from inside the endpoint's own chain position.
 	for _, r := range app.stack {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5971,7 +5971,7 @@ func Test_Ctx_Endpoint_NotFound(t *testing.T) {
 	require.Equal(t, StatusNotFound, resp.StatusCode)
 }
 
-// go test -run Test_Ctx_Endpoint_CachedAndSkipped
+// go test -run Test_Ctx_Endpoint_RepeatedAndSkipped
 func Test_Ctx_Endpoint_RepeatedAndSkipped(t *testing.T) {
 	t.Parallel()
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -5924,6 +5924,78 @@ func Test_Ctx_FullPath_Middleware(t *testing.T) {
 	require.Equal(t, []string{"/", "/test"}, recorded)
 }
 
+// go test -run Test_Ctx_MatchedRoute_Middleware
+func Test_Ctx_MatchedRoute_Middleware(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+
+	var recorded []string
+
+	app.Use(func(c Ctx) error {
+		if route := c.MatchedRoute(); route != nil {
+			recorded = append(recorded, route.Path, route.Name)
+		}
+		return c.Next()
+	})
+
+	app.Get("/users/:id", func(c Ctx) error {
+		require.Equal(t, "/users/:id", c.MatchedRoute().Path)
+		require.Equal(t, "user.show", c.MatchedRoute().Name)
+		return c.SendStatus(StatusOK)
+	}).Name("user.show")
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/users/42", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	require.Equal(t, StatusOK, resp.StatusCode)
+	require.Equal(t, []string{"/users/:id", "user.show"}, recorded)
+}
+
+// go test -run Test_Ctx_MatchedRoute_NotFound
+func Test_Ctx_MatchedRoute_NotFound(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+
+	app.Use(func(c Ctx) error {
+		require.Nil(t, c.MatchedRoute())
+		return c.Next()
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/not-found", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
+
+// go test -run Test_Ctx_MatchedRoute_SkipUnmatchedRoutes
+func Test_Ctx_MatchedRoute_SkipUnmatchedRoutes(t *testing.T) {
+	t.Parallel()
+
+	app := New(Config{SkipUnmatchedRoutes: true})
+
+	var path string
+	app.Use(func(c Ctx) error {
+		if route := c.MatchedRoute(); route != nil {
+			path = route.Path
+		}
+		return c.Next()
+	})
+	app.Get("/items/:id", func(c Ctx) error {
+		return c.SendStatus(StatusOK)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/items/7", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	require.Equal(t, StatusOK, resp.StatusCode)
+	require.Equal(t, "/items/:id", path)
+}
+
 // go test -run Test_Ctx_RouteNormalized
 func Test_Ctx_RouteNormalized(t *testing.T) {
 	t.Parallel()

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -604,7 +604,7 @@ app.Get("/hello/:name", func(c fiber.Ctx) error {
 ```
 
 :::caution
-Do not rely on `c.Route()` in middlewares **before** calling `c.Next()` - `c.Route()` returns the **last executed route**.
+`c.Route()` returns the **last executed route**. Inside middleware that runs before your handler it reflects the middleware route itself. Use [`c.MatchedRoute()`](#matchedroute) to look up the downstream handler without advancing the chain.
 :::
 
 ```go title="Example"
@@ -616,6 +616,27 @@ func MyMiddleware() fiber.Handler {
     return err
   }
 }
+```
+
+### MatchedRoute
+
+Returns the next non-middleware route that matches the current request without advancing the handler chain. Useful inside global middleware for access control or logging when you need the target route's `Path` or `Name` before calling `Next`. Returns `nil` when no endpoint matches.
+
+```go title="Signature"
+func (c fiber.Ctx) MatchedRoute() *Route
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  route := c.MatchedRoute() // e.g. "/api/users/:id" named "user.show"
+  if route == nil {
+    return c.Next()
+  }
+  // enforce access control using route.Path or route.Name
+  return c.Next()
+})
+
+app.Get("/api/users/:id", handler).Name("user.show")
 ```
 
 ### SetContext

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -161,6 +161,37 @@ app.Get("/", func(c fiber.Ctx) error {
 })
 ```
 
+### Endpoint
+
+Returns the route that will handle this request, without advancing the handler chain. Useful inside global middleware for access control or logging when you need the target route's `Path` or `Name` before calling `Next`.
+
+Returns `nil` when no endpoint will run: on `404` and `405`, and while the error handler replays the chain for a request rejected at the protocol level, such as one over `BodyLimit`.
+
+```go title="Signature"
+func (c fiber.Ctx) Endpoint() *Route
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  route := c.Endpoint() // e.g. "/api/users/:id" named "user.show"
+  if route == nil {
+    return c.Next()
+  }
+  // enforce access control using route.Path or route.Name
+  return c.Next()
+})
+
+app.Get("/api/users/:id", handler).Name("user.show")
+```
+
+:::info
+`Endpoint` looks ahead, while its neighbors look back: [`Route`](#route) is the route currently executing, which inside middleware is the middleware itself, and [`Matched`](#matched) reports whether an endpoint has been selected yet.
+
+Mounted sub-apps report the flattened, prefixed route. The result is the route the router *would* reach, not a promise that it runs: an earlier middleware can still end the request first.
+
+It scans the remaining routes in the request's tree bucket, so calling it from global middleware costs a second router scan per request. That is cheap for routes spread over many prefixes and noticeable when a hundred or more share one, as with everything under `/api/v1`.
+:::
+
 ### FullPath
 
 Returns the full path of the matched route. This includes any prefixes that were added by [groups](../guide/routing.md#grouping) or mounts.
@@ -604,7 +635,7 @@ app.Get("/hello/:name", func(c fiber.Ctx) error {
 ```
 
 :::caution
-`c.Route()` returns the **last executed route**. Inside middleware that runs before your handler it reflects the middleware route itself. Use [`c.MatchedRoute()`](#matchedroute) to look up the downstream handler without advancing the chain.
+`c.Route()` returns the **last executed route**. Inside middleware that runs before your handler it reflects the middleware route itself. Use [`c.Endpoint()`](#endpoint) to look up the downstream handler without advancing the chain.
 :::
 
 ```go title="Example"
@@ -616,27 +647,6 @@ func MyMiddleware() fiber.Handler {
     return err
   }
 }
-```
-
-### MatchedRoute
-
-Returns the next non-middleware route that matches the current request without advancing the handler chain. Useful inside global middleware for access control or logging when you need the target route's `Path` or `Name` before calling `Next`. Returns `nil` when no endpoint matches.
-
-```go title="Signature"
-func (c fiber.Ctx) MatchedRoute() *Route
-```
-
-```go title="Example"
-app.Use(func(c fiber.Ctx) error {
-  route := c.MatchedRoute() // e.g. "/api/users/:id" named "user.show"
-  if route == nil {
-    return c.Next()
-  }
-  // enforce access control using route.Path or route.Name
-  return c.Next()
-})
-
-app.Get("/api/users/:id", handler).Name("user.show")
 ```
 
 ### SetContext

--- a/req.go
+++ b/req.go
@@ -1290,6 +1290,11 @@ func (r *DefaultReq) Range(size int64) (Range, error) {
 	return rangeData, nil
 }
 
+// Endpoint returns the route that will handle this request. See Ctx.Endpoint.
+func (r *DefaultReq) Endpoint() *Route {
+	return r.c.Endpoint()
+}
+
 // Route returns the matched Route struct.
 func (r *DefaultReq) Route() *Route {
 	return r.c.Route()

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -183,6 +183,8 @@ type Req interface {
 	Queries() map[string]string
 	// Range returns a struct containing the type and a slice of ranges.
 	Range(size int64) (Range, error)
+	// Endpoint returns the route that will handle this request. See Ctx.Endpoint.
+	Endpoint() *Route
 	// Route returns the matched Route struct.
 	Route() *Route
 	// Subdomains returns a slice of subdomains from the host, excluding the last `offset` components.


### PR DESCRIPTION
## Summary

Adds `c.Endpoint()` so middleware can inspect the route that will actually handle the request **before** calling `c.Next()`, without advancing the handler chain.

This unblocks RBAC, audit logging and similar patterns that today see an empty `c.Route().Name` while middleware runs (#2195). The look-ahead walks the same `treeIndex` bucket the router walks and applies the same filters, so it cannot name a route the router would not run.

## Changes

- `Endpoint()` on `Ctx` / `DefaultCtx`, mirrored on `Req` next to `Route()`
- Skips `use` and `mount` routes, respects `shouldSkipNonUseRoutes`, and starts the scan past `indexRoute`, so it never names a route that cannot run
- Fast path when `SkipUnmatchedRoutes` has already resolved the endpoint, guarded against a stale index
- Scratch params buffer, so the look-ahead does not clobber `c.values`
- Tests: middleware, 404, method override, `SkipUnmatchedRoutes`, repeated calls, routes the chain has already passed, plus a differential sweep asserting the prediction against the route that actually runs
- Benchmark for the look-ahead
- Docs for `Route` and `Endpoint`

## Notes

Renamed from `MatchedRoute()` during review. Nothing has matched yet at the point middleware asks, and `Ctx` already has `Matched() bool` with a different meaning, so `Matched() == false` next to `MatchedRoute() == /hit` read as a contradiction. No released tag contains the old name.

The result is not cached. A repeated call costs 32.2 ns/op against 1.9 ns/op cached, and the cache needed four invalidation sites, one of which was missing. Every mutation that would invalidate a cached answer already moves a field the scan reads, so the uncached version is correct by construction.

## Linked issue

Closes #2195

## Checklist

- [x] `make generate`
- [x] `make format`
- [x] `make lint`, 0 issues
- [x] targeted tests pass
