### PR TITLE
🐛 bug: preserve Connection tokens through adaptor middleware

### DIFF
--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -466,10 +466,10 @@ func HTTPMiddleware(mw func(http.Handler) http.Handler) fiber.Handler {
 				joined := strings.Join(connection, ", ")
 				fhdr.Set(fiber.HeaderConnection, joined)
 				if hasCloseToken(joined) {
-					// Setting fasthttp's close flag hides every other Connection
-					// token from downstream middleware. Defer it until c.Next has
-					// consumed the complete list (RFC 9110 §7.6.1), while still
-					// preserving the transport-level close instruction.
+					// The close instruction is carried separately rather than
+					// written back here: fasthttp's request flag makes Peek answer
+					// "close" and hides the rest of the list (RFC 9110 §7.6.1),
+					// which is how a proxy downstream learns what to strip.
 					connectionClose = true
 				}
 			}
@@ -481,15 +481,18 @@ func HTTPMiddleware(mw func(http.Handler) http.Handler) fiber.Handler {
 		// error result is always nil.
 		fasthttpadaptor.NewFastHTTPHandler(mw(nextHandler))(c.RequestCtx())
 
-		if next {
-			err := c.Next()
-			if connectionClose {
-				c.Request().Header.SetConnectionClose()
-			}
-			return err
-		}
 		if connectionClose {
-			c.Request().Header.SetConnectionClose()
+			// The close instruction rides on the response so the request keeps the
+			// complete field for every observer — downstream handlers, middleware
+			// resuming after Next, and the app's ErrorHandler alike. It also has to
+			// go here to have any effect: fasthttp stores the request flag before
+			// calling the handler and never reads it again, whereas the response
+			// flag is what the server consults once the handler returns.
+			c.Response().Header.SetConnectionClose()
+		}
+
+		if next {
+			return c.Next()
 		}
 		return nil
 	}

--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -481,20 +481,26 @@ func HTTPMiddleware(mw func(http.Handler) http.Handler) fiber.Handler {
 		// error result is always nil.
 		fasthttpadaptor.NewFastHTTPHandler(mw(nextHandler))(c.RequestCtx())
 
+		var err error
+		if next {
+			err = c.Next()
+		}
+
 		if connectionClose {
 			// The close instruction rides on the response so the request keeps the
 			// complete field for every observer — downstream handlers, middleware
 			// resuming after Next, and the app's ErrorHandler alike. It also has to
-			// go here to have any effect: fasthttp stores the request flag before
-			// calling the handler and never reads it again, whereas the response
-			// flag is what the server consults once the handler returns.
+			// go on the response to have any effect: fasthttp stores the request
+			// flag before calling the handler and never reads it again, whereas the
+			// response flag is what the server consults once the handler returns.
+			//
+			// Applied on the way out, because a single flag stands for the whole
+			// response and the downstream chain can clear it: a handler resetting
+			// the response, or setting a Connection value of its own, left the
+			// connection reused despite the rewrite that asked for it to close.
 			c.Response().Header.SetConnectionClose()
 		}
-
-		if next {
-			return c.Next()
-		}
-		return nil
+		return err
 	}
 }
 

--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -427,6 +427,7 @@ func isFramingHeader(name string) bool {
 func HTTPMiddleware(mw func(http.Handler) http.Handler) fiber.Handler {
 	return func(c fiber.Ctx) error {
 		var next bool
+		var connectionClose bool
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			next = true
 
@@ -465,15 +466,11 @@ func HTTPMiddleware(mw func(http.Handler) http.Handler) fiber.Handler {
 				joined := strings.Join(connection, ", ")
 				fhdr.Set(fiber.HeaderConnection, joined)
 				if hasCloseToken(joined) {
-					// fasthttp holds either the close flag or an arbitrary value,
-					// never both: setting the flag makes Peek answer "close" and
-					// hides the rest, while Set of anything but a bare "close"
-					// clears the flag. Where the two conflict the flag has to win —
-					// Set alone left a connection the client asked to close being
-					// kept open, since the server reads the flag and nothing else.
-					// The cost is that a field named beside "close" stops being
-					// visible as hop-by-hop for this request.
-					fhdr.SetConnectionClose()
+					// Setting fasthttp's close flag hides every other Connection
+					// token from downstream middleware. Defer it until c.Next has
+					// consumed the complete list (RFC 9110 §7.6.1), while still
+					// preserving the transport-level close instruction.
+					connectionClose = true
 				}
 			}
 			CopyContextToFiberContext(r.Context(), c.RequestCtx())
@@ -485,7 +482,14 @@ func HTTPMiddleware(mw func(http.Handler) http.Handler) fiber.Handler {
 		fasthttpadaptor.NewFastHTTPHandler(mw(nextHandler))(c.RequestCtx())
 
 		if next {
-			return c.Next()
+			err := c.Next()
+			if connectionClose {
+				c.Request().Header.SetConnectionClose()
+			}
+			return err
+		}
+		if connectionClose {
+			c.Request().Header.SetConnectionClose()
 		}
 		return nil
 	}

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -2444,10 +2444,10 @@ func Test_HTTPMiddleware_JoinsRepeatedConnectionValues(t *testing.T) {
 		wantClose bool
 	}{
 		{name: "token list", write: []string{"keep-alive", "X-Internal"}, want: "keep-alive, X-Internal"},
-		// Downstream middleware must see the complete token list so a proxy can
-		// remove every named hop-by-hop field. The transport close flag is set
-		// only after the downstream chain returns, because fasthttp otherwise
-		// hides all tokens beside "close".
+		// Every observer must see the complete token list so a proxy can remove
+		// each named hop-by-hop field. Setting fasthttp's request flag would hide
+		// all tokens beside "close", so the close instruction is carried on the
+		// response instead.
 		{name: "close first", write: []string{"close", "X-Internal"}, want: "close, X-Internal", wantClose: true},
 		{name: "close last", write: []string{"X-Internal", "close"}, want: "X-Internal, close", wantClose: true},
 		{name: "close cased", write: []string{"X-Internal", "CLOSE"}, want: "X-Internal, CLOSE", wantClose: true},
@@ -2457,14 +2457,17 @@ func Test_HTTPMiddleware_JoinsRepeatedConnectionValues(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			var got string
-			var gotClose bool
-			var finalClose bool
+			var got, afterNext string
+			var gotClose, finalClose bool
 
 			app := fiber.New()
 			app.Use(func(c fiber.Ctx) error {
 				err := c.Next()
-				finalClose = c.Request().Header.ConnectionClose()
+				// A middleware resuming here — or the app's ErrorHandler, which
+				// runs once this returns — reads the same field a downstream
+				// proxy would, so it has to survive the whole chain intact.
+				afterNext = c.Get(fiber.HeaderConnection)
+				finalClose = c.Response().Header.ConnectionClose()
 				return err
 			})
 			app.Use(HTTPMiddleware(func(next http.Handler) http.Handler {
@@ -2483,12 +2486,10 @@ func Test_HTTPMiddleware_JoinsRepeatedConnectionValues(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, fiber.StatusOK, resp.StatusCode)
 			require.Equal(t, tc.want, got)
-			if len(tc.write) > 1 && tc.wantClose {
-				require.False(t, gotClose, "downstream must see the complete Connection field")
-			} else {
-				require.Equal(t, tc.wantClose, gotClose)
-			}
-			require.Equal(t, tc.wantClose, finalClose, "the transport close flag must survive downstream processing")
+			require.Equal(t, tc.wantClose, resp.Close, "close has to reach the wire, not just the fiber context")
+			require.Equal(t, tc.want, afterNext, "the complete Connection field must outlive the downstream chain")
+			require.Equal(t, tc.want == "close", gotClose, "the request flag stands in only for a bare close")
+			require.Equal(t, tc.wantClose, finalClose, "the transport close instruction rides on the response")
 		})
 	}
 }

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -2428,6 +2428,70 @@ func Test_HTTPMiddleware_PropagatesConnectionRewrite(t *testing.T) {
 	}
 }
 
+// Test_HTTPMiddleware_ConnectionCloseSurvivesDownstream covers the close
+// instruction against a downstream chain that writes the response field itself.
+//
+// fasthttp holds one flag for the whole response, so a handler that resets the
+// response or sets a Connection value of its own clears it. Setting the flag
+// before c.Next left the connection reused despite the rewrite that asked for
+// it to close, so it is applied on the way out instead.
+func Test_HTTPMiddleware_ConnectionCloseSurvivesDownstream(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		handler func(fiber.Ctx) error
+		name    string
+		status  int
+	}{
+		{
+			name:    "plain handler",
+			handler: func(c fiber.Ctx) error { return c.SendString("ok") },
+			status:  fiber.StatusOK,
+		},
+		{
+			name: "handler resetting the response",
+			handler: func(c fiber.Ctx) error {
+				c.Response().Reset()
+				return c.SendString("ok")
+			},
+			status: fiber.StatusOK,
+		},
+		{
+			name: "handler asking to keep the connection",
+			handler: func(c fiber.Ctx) error {
+				c.Response().Header.Set(fiber.HeaderConnection, "keep-alive")
+				return c.SendString("ok")
+			},
+			status: fiber.StatusOK,
+		},
+		{
+			// The ErrorHandler writes the response after this middleware has
+			// returned, so the flag has to outlive that too.
+			name:    "handler returning an error",
+			handler: func(_ fiber.Ctx) error { return errors.New("boom") },
+			status:  fiber.StatusInternalServerError,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := fiber.New()
+			app.Use(HTTPMiddleware(func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					r.Header[http.CanonicalHeaderKey(fiber.HeaderConnection)] = []string{"close", "X-Internal"}
+					next.ServeHTTP(w, r)
+				})
+			}))
+			app.Get("/", tc.handler)
+
+			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+			require.NoError(t, err)
+			require.Equal(t, tc.status, resp.StatusCode)
+			require.True(t, resp.Close, "the connection the middleware asked to close has to close")
+		})
+	}
+}
+
 // Test_HTTPMiddleware_JoinsRepeatedConnectionValues covers middleware that
 // writes Connection as several slice entries, which is how net/http represents a
 // combined value. fasthttp keeps the field in a slot of its own, so a second Add

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -2444,13 +2444,13 @@ func Test_HTTPMiddleware_JoinsRepeatedConnectionValues(t *testing.T) {
 		wantClose bool
 	}{
 		{name: "token list", write: []string{"keep-alive", "X-Internal"}, want: "keep-alive, X-Internal"},
-		// Where "close" is among the tokens the flag wins, since fasthttp holds
-		// one or the other and the server reads only the flag. Peek answers
-		// "close" once it is set, so the other tokens go — the alternative was a
-		// connection the client asked to close being kept open.
-		{name: "close first", write: []string{"close", "X-Internal"}, want: "close", wantClose: true},
-		{name: "close last", write: []string{"X-Internal", "close"}, want: "close", wantClose: true},
-		{name: "close cased", write: []string{"X-Internal", "CLOSE"}, want: "close", wantClose: true},
+		// Downstream middleware must see the complete token list so a proxy can
+		// remove every named hop-by-hop field. The transport close flag is set
+		// only after the downstream chain returns, because fasthttp otherwise
+		// hides all tokens beside "close".
+		{name: "close first", write: []string{"close", "X-Internal"}, want: "close, X-Internal", wantClose: true},
+		{name: "close last", write: []string{"X-Internal", "close"}, want: "X-Internal, close", wantClose: true},
+		{name: "close cased", write: []string{"X-Internal", "CLOSE"}, want: "X-Internal, CLOSE", wantClose: true},
 		{name: "close alone still closes", write: []string{"close"}, want: "close", wantClose: true},
 		{name: "single entry is unchanged", write: []string{"keep-alive"}, want: "keep-alive"},
 	} {
@@ -2459,8 +2459,14 @@ func Test_HTTPMiddleware_JoinsRepeatedConnectionValues(t *testing.T) {
 
 			var got string
 			var gotClose bool
+			var finalClose bool
 
 			app := fiber.New()
+			app.Use(func(c fiber.Ctx) error {
+				err := c.Next()
+				finalClose = c.Request().Header.ConnectionClose()
+				return err
+			})
 			app.Use(HTTPMiddleware(func(next http.Handler) http.Handler {
 				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					r.Header[http.CanonicalHeaderKey(fiber.HeaderConnection)] = tc.write
@@ -2477,7 +2483,12 @@ func Test_HTTPMiddleware_JoinsRepeatedConnectionValues(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, fiber.StatusOK, resp.StatusCode)
 			require.Equal(t, tc.want, got)
-			require.Equal(t, tc.wantClose, gotClose)
+			if len(tc.write) > 1 && tc.wantClose {
+				require.False(t, gotClose, "downstream must see the complete Connection field")
+			} else {
+				require.Equal(t, tc.wantClose, gotClose)
+			}
+			require.Equal(t, tc.wantClose, finalClose, "the transport close flag must survive downstream processing")
 		})
 	}
 }


### PR DESCRIPTION
### Motivation

- A `net/http` middleware that rewrites the request's `Connection` field had its edit hidden from everything downstream. fasthttp holds either the close flag or an arbitrary value, never both, so setting the flag made `Peek` answer `"close"` and dropped the remaining tokens — the ones naming which fields are hop-by-hop, which a proxy downstream is meant to strip.

### Description

- Record whether the joined `Connection` value lists `close`, leave the request field itself intact, and carry the close instruction on the response instead — `c.Response().Header.SetConnectionClose()`.
- The response is where it has to go to have any effect at all: fasthttp stores `ctx.Request.Header.ConnectionClose()` *before* invoking the handler and never reads it again (`server.go`, "store req.ConnectionClose so even if it was changed inside of handler"). Only the response flag is consulted once the handler returns, so writing the request flag back from a handler cost every observer the complete field and closed nothing.
- Applied after `c.Next()` rather than before, because one flag stands for the whole response and the downstream chain can clear it: a handler calling `c.Response().Reset()`, or setting a `Connection` value of its own, otherwise left the connection reused despite the rewrite that asked for it to close.
- The request field now survives the whole chain — downstream handlers, middleware resuming after `Next`, and the app's `ErrorHandler`, which writes the response without touching this field.

Files changed: `middleware/adaptor/adaptor.go`, `middleware/adaptor/adaptor_test.go`.

### Testing

- `go test ./middleware/adaptor -count=1` passes; `go vet ./middleware/adaptor` and `gofmt -l` are clean.
- End-to-end through `app.Test`, with middleware writing `["close", "X-Internal"]`: the response now comes back `resp.Close=true` with `Connection: close` on the wire. It was `false` before this change — the connection was being reused.
- `Test_HTTPMiddleware_JoinsRepeatedConnectionValues` asserts the complete token list is visible both downstream and after `c.Next()`, that close reaches the wire, and that the request flag stands in only for a bare `close`.
- `Test_HTTPMiddleware_ConnectionCloseSurvivesDownstream` covers a plain handler, `Response().Reset()`, a handler writing `Connection: keep-alive`, and the error path through `ErrorHandler`. The reset and keep-alive cases fail without the fix.
- CI is green on this head, including lint, unit across Go 1.25/1.26 on ubuntu/windows/macos, the repeated runs, CodeQL, and govulncheck. Codecov reports the patch fully covered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b1943ab1c8333a6a4fc880199b9e0)