### PR TITLE
perf: optimize cache middleware key generation and allocation

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"strconv"
 	"sync"
 	"time"
 
@@ -20,9 +21,23 @@ import (
 	"github.com/gofiber/fiber/v3/internal/headerlookup"
 )
 
-// buffer size for hexpool
 // hexLen is the hex-encoded length of a SHA-256 sum, shared by the auth and vary hashers.
 const hexLen = sha256.Size * 2
+
+// Sizes for the local arrays the response headers are formatted into, so the
+// values reach the header store — which copies them — without a heap
+// allocation each. Both are upper bounds; an append past one still produces the
+// same bytes, only more slowly.
+const (
+	// httpDateLen holds an IMF-fixdate, "Mon, 02 Jan 2006 15:04:05 GMT".
+	httpDateLen = 32
+	// maxUintDigits holds the decimal form of any uint64.
+	maxUintDigits = 20
+)
+
+// publicMaxAge is the Cache-Control this middleware writes on a hit when the
+// entry carries none of its own, less the delta-seconds appended after it.
+const publicMaxAge = "public, max-age="
 
 // cache status
 // unreachable: when cache is bypass, or invalid
@@ -155,15 +170,6 @@ func New(config ...Config) fiber.Handler {
 	heap := &indexedHeap{}
 	// count stored bytes (sizes of response bodies)
 	var storedBytes uint
-	// Pool for hex encoding buffers
-	hexBufPool := &sync.Pool{
-		New: func() any {
-			buf := make([]byte, hexLen)
-			return &buf
-		},
-	}
-	hashAuthorization := makeHashAuthFunc(hexBufPool)
-	buildVaryKey := makeBuildVaryKeyFunc(hexBufPool)
 
 	// Delete key from both manager and storage
 	deleteKey := func(ctx context.Context, dkey string) error {
@@ -258,9 +264,16 @@ func New(config ...Config) fiber.Handler {
 			return c.Next()
 		}
 
-		// Get key from request
-		baseKey := cacheKeyVersion + "|" + requestMethod + "|" + cfg.KeyGenerator(c)
-		manifestKey := baseKey + "|vary"
+		// Get key from request. Assembled in one pooled buffer so the whole key
+		// costs a single allocation: the pieces used to be concatenated one at a
+		// time, and every join copied the key built so far into a fresh string.
+		keyBufPtr := acquireKeyBuffer()
+		keyBuf := (*keyBufPtr)[:0]
+		keyBuf = append(keyBuf, cacheKeyVersion...)
+		keyBuf = append(keyBuf, '|')
+		keyBuf = append(keyBuf, requestMethod...)
+		keyBuf = append(keyBuf, '|')
+		keyBuf = appendGeneratedKey(keyBuf, c, &cfg)
 		if hasAuthorization {
 			// Read at the point of use: the result aliases the header's storage, and
 			// cfg.KeyGenerator is user code that may recycle the slot. Every field
@@ -270,9 +283,21 @@ func New(config ...Config) fiber.Handler {
 			// the same as two lines carrying one each, and the two are different
 			// principals, so a comma would put them in one partition.
 			authLines := fieldname.Lines(&c.Request().Header, fiber.HeaderAuthorization, canonical)
-			authHash := hashAuthorization(authLines)
-			baseKey += "|auth=" + authHash
-			manifestKey = baseKey + "|vary"
+			keyBuf = append(keyBuf, "|auth="...)
+			keyBuf = appendAuthHash(keyBuf, authLines)
+		}
+		baseLen := len(keyBuf)
+
+		// baseKey and manifestKey differ only by the suffix, so one string holds
+		// both: slicing a string off the front of another shares its bytes rather
+		// than copying them, which the separate concatenation could not do.
+		var baseKey, manifestKey string
+		if cfg.DisableVaryHeaders {
+			baseKey = string(keyBuf)
+		} else {
+			keyBuf = append(keyBuf, "|vary"...)
+			manifestKey = string(keyBuf)
+			baseKey = manifestKey[:baseLen]
 		}
 		key := baseKey
 
@@ -284,12 +309,15 @@ func New(config ...Config) fiber.Handler {
 		if !cfg.DisableVaryHeaders {
 			varyNames, hasVaryManifest, err = loadVaryManifest(reqCtx, manager, manifestKey)
 			if err != nil {
+				releaseKeyBuffer(keyBufPtr, keyBuf)
 				return err
 			}
 			if len(varyNames) > 0 {
-				key += buildVaryKey(varyNames, &c.Request().Header, canonical)
+				keyBuf = appendVaryKey(keyBuf[:baseLen], varyNames, &c.Request().Header, canonical)
+				key = string(keyBuf)
 			}
 		}
+		releaseKeyBuffer(keyBufPtr, keyBuf)
 
 		// Get entry from pool
 		e, err := manager.get(reqCtx, key)
@@ -500,7 +528,11 @@ func New(config ...Config) fiber.Handler {
 					setFieldLine(&c.Response().Header, fiber.HeaderETag, e.etag, canonical)
 				}
 				clampedDate := clampDateSeconds(e.date, ts)
-				dateValue := utils.AppendHTTPDate(nil, secondsToTime(clampedDate))
+				// Formatted into a local array rather than a fresh slice: the value
+				// is copied into the header store, so nothing outlives this line and
+				// the nil destination was an allocation on every cache hit.
+				var dateBuf [httpDateLen]byte
+				dateValue := utils.AppendHTTPDate(dateBuf[:0], secondsToTime(clampedDate))
 				setFieldLine(&c.Response().Header, fiber.HeaderDate, dateValue, canonical)
 				// One entry per field line, so Set collapsed a repeated name — a Vary
 				// sent twice came back varying only on the second. Clear every stored
@@ -531,16 +563,19 @@ func New(config ...Config) fiber.Handler {
 					if e.exp > ts {
 						remaining = e.exp - ts
 					}
-					maxAge := utils.FormatUint(remaining)
-					c.Set(fiber.HeaderCacheControl, "public, max-age="+maxAge)
+					// Built in a local array: FormatUint and the join were two
+					// allocations, and the header store copies the bytes anyway.
+					var ccBuf [len(publicMaxAge) + maxUintDigits]byte
+					cacheControlValue := strconv.AppendUint(append(ccBuf[:0], publicMaxAge...), remaining, 10)
+					setFieldLine(&c.Response().Header, fiber.HeaderCacheControl, cacheControlValue, canonical)
 				}
 
 				const maxDeltaSeconds = uint64(math.MaxInt32)
 				ageSeconds := min(entryAge, maxDeltaSeconds)
 
 				// RFC-compliant Age header (RFC 9111)
-				age := utils.FormatUint(ageSeconds)
-				setFieldLine(&c.Response().Header, fiber.HeaderAge, utils.UnsafeBytes(age), canonical)
+				var ageBuf [maxUintDigits]byte
+				setFieldLine(&c.Response().Header, fiber.HeaderAge, strconv.AppendUint(ageBuf[:0], ageSeconds, 10), canonical)
 				appendWarningHeaders(&c.Response().Header, servedStale, isHeuristicFreshness(e, &cfg, entryAge))
 
 				c.Set(cfg.CacheHeader, cacheHit)
@@ -641,7 +676,7 @@ func New(config ...Config) fiber.Handler {
 		shouldStoreVaryManifest := !cfg.DisableVaryHeaders && len(varyNames) > 0
 		if !cfg.DisableVaryHeaders && len(varyNames) > 0 {
 			if key == baseKey {
-				key += buildVaryKey(varyNames, &c.Request().Header, canonical)
+				key = varyKey(baseKey, varyNames, &c.Request().Header, canonical)
 			}
 		} else if !cfg.DisableVaryHeaders && hasVaryManifest {
 			if err := manager.del(reqCtx, manifestKey); err != nil {
@@ -817,7 +852,8 @@ func New(config ...Config) fiber.Handler {
 		// resolves to the receipt timestamp — the same answer either way.
 		parsedDate, _ := parseHTTPDate(dateHeader)
 		e.date = clampDateSeconds(parsedDate, nowUnix)
-		dateBytes := utils.AppendHTTPDate(nil, secondsToTime(e.date))
+		var dateBuf [httpDateLen]byte
+		dateBytes := utils.AppendHTTPDate(dateBuf[:0], secondsToTime(e.date))
 		setFieldLine(&c.Response().Header, fiber.HeaderDate, dateBytes, respCanonical)
 
 		// Store all response headers

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -4058,6 +4058,14 @@ func TestCacheSeparatesAuthorizationValues(t *testing.T) {
 	require.Equal(t, 2, count)
 }
 
+// Benchmark_Cache measures the hit path: the first request stores the response
+// and every one after it is served from the entry.
+//
+// The status has to be one RFC 9111 Section 15.1 lists as cacheable. This was
+// 418, which is not, so the middleware answered "unreachable" every time and
+// the benchmark measured the path that stores nothing while the handler re-read
+// the file on every iteration.
+//
 // go test -v -run=^$ -bench=Benchmark_Cache -benchmem -count=4
 func Benchmark_Cache(b *testing.B) {
 	app := fiber.New()
@@ -4066,7 +4074,7 @@ func Benchmark_Cache(b *testing.B) {
 
 	app.Get("/demo", func(c fiber.Ctx) error {
 		data, _ := os.ReadFile("../../README.md") //nolint:errcheck // We're inside a benchmark
-		return c.Status(fiber.StatusTeapot).Send(data)
+		return c.Status(fiber.StatusOK).Send(data)
 	})
 
 	h := app.Handler()
@@ -4081,7 +4089,8 @@ func Benchmark_Cache(b *testing.B) {
 		h(fctx)
 	}
 
-	require.Equal(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+	require.Equal(b, fiber.StatusOK, fctx.Response.Header.StatusCode())
+	require.Equal(b, cacheHit, string(fctx.Response.Header.Peek("X-Cache")))
 	require.Greater(b, len(fctx.Response.Body()), 30000)
 }
 
@@ -4124,7 +4133,7 @@ func Benchmark_Cache_Storage(b *testing.B) {
 
 	app.Get("/demo", func(c fiber.Ctx) error {
 		data, _ := os.ReadFile("../../README.md") //nolint:errcheck // We're inside a benchmark
-		return c.Status(fiber.StatusTeapot).Send(data)
+		return c.Status(fiber.StatusOK).Send(data)
 	})
 
 	h := app.Handler()
@@ -4139,7 +4148,8 @@ func Benchmark_Cache_Storage(b *testing.B) {
 		h(fctx)
 	}
 
-	require.Equal(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+	require.Equal(b, fiber.StatusOK, fctx.Response.Header.StatusCode())
+	require.Equal(b, cacheHit, string(fctx.Response.Header.Peek("X-Cache")))
 	require.Greater(b, len(fctx.Response.Body()), 30000)
 }
 
@@ -4151,7 +4161,7 @@ func Benchmark_Cache_AdditionalHeaders(b *testing.B) {
 
 	app.Get("/demo", func(c fiber.Ctx) error {
 		c.Response().Header.Add("X-Foobar", "foobar")
-		return c.SendStatus(418)
+		return c.SendStatus(fiber.StatusOK)
 	})
 
 	h := app.Handler()
@@ -4166,8 +4176,13 @@ func Benchmark_Cache_AdditionalHeaders(b *testing.B) {
 		h(fctx)
 	}
 
-	require.Equal(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
-	require.Equal(b, []byte("foobar"), fctx.Response.Header.Peek("X-Foobar"))
+	require.Equal(b, fiber.StatusOK, fctx.Response.Header.StatusCode())
+	require.Equal(b, cacheHit, string(fctx.Response.Header.Peek("X-Cache")))
+	// Exactly one line, not one per iteration. The handler adds it on the miss
+	// and the hit path replaces what it stored; while the response was never
+	// cached the handler ran every time and its Add piled up on the reused
+	// context, so the benchmark grew its own work as it went.
+	require.Equal(b, [][]byte{[]byte("foobar")}, fctx.Response.Header.PeekAll("X-Foobar"))
 }
 
 func Benchmark_Cache_QueryMethod(b *testing.B) {
@@ -4209,7 +4224,7 @@ func Benchmark_Cache_MaxSize(b *testing.B) {
 			app.Use(New(Config{MaxBytes: size}))
 
 			app.Get("/*", func(c fiber.Ctx) error {
-				return c.Status(fiber.StatusTeapot).SendString("1")
+				return c.Status(fiber.StatusOK).SendString("1")
 			})
 
 			h := app.Handler()
@@ -4218,14 +4233,21 @@ func Benchmark_Cache_MaxSize(b *testing.B) {
 
 			b.ReportAllocs()
 
+			// strconv, not fmt.Sprintf: the formatting is the benchmark's own
+			// setup and its allocation was landing in the middleware's numbers.
 			n := 0
+			uri := make([]byte, 0, 24)
 			for b.Loop() {
 				n++
-				fctx.Request.SetRequestURI(fmt.Sprintf("/%v", n))
+				uri = strconv.AppendInt(append(uri[:0], '/'), int64(n), 10)
+				fctx.Request.SetRequestURIBytes(uri)
 				h(fctx)
 			}
 
-			require.Equal(b, fiber.StatusTeapot, fctx.Response.Header.StatusCode())
+			// Stored, so the bounded case actually reaches the eviction loop this
+			// benchmark exists to measure.
+			require.Equal(b, fiber.StatusOK, fctx.Response.Header.StatusCode())
+			require.Equal(b, cacheMiss, string(fctx.Response.Header.Peek("X-Cache")))
 		})
 	}
 }

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -4085,6 +4085,13 @@ func Benchmark_Cache(b *testing.B) {
 	fctx.Request.Header.SetMethod(fiber.MethodGet)
 	fctx.Request.SetRequestURI("/demo")
 
+	// One untimed request to populate the entry, so every measured iteration is
+	// a hit rather than the first being the miss that fills the cache. b.Loop
+	// resets the timer when it first returns, so this stays out of the numbers.
+	// Without it the benchmark also fails outright at -benchtime=1x, where the
+	// single iteration is that miss.
+	h(fctx)
+
 	b.ReportAllocs()
 
 	for b.Loop() {
@@ -4144,6 +4151,13 @@ func Benchmark_Cache_Storage(b *testing.B) {
 	fctx.Request.Header.SetMethod(fiber.MethodGet)
 	fctx.Request.SetRequestURI("/demo")
 
+	// One untimed request to populate the entry, so every measured iteration is
+	// a hit rather than the first being the miss that fills the cache. b.Loop
+	// resets the timer when it first returns, so this stays out of the numbers.
+	// Without it the benchmark also fails outright at -benchtime=1x, where the
+	// single iteration is that miss.
+	h(fctx)
+
 	b.ReportAllocs()
 
 	for b.Loop() {
@@ -4171,6 +4185,13 @@ func Benchmark_Cache_AdditionalHeaders(b *testing.B) {
 	fctx := &fasthttp.RequestCtx{}
 	fctx.Request.Header.SetMethod(fiber.MethodGet)
 	fctx.Request.SetRequestURI("/demo")
+
+	// One untimed request to populate the entry, so every measured iteration is
+	// a hit rather than the first being the miss that fills the cache. b.Loop
+	// resets the timer when it first returns, so this stays out of the numbers.
+	// Without it the benchmark also fails outright at -benchtime=1x, where the
+	// single iteration is that miss.
+	h(fctx)
 
 	b.ReportAllocs()
 
@@ -4204,6 +4225,13 @@ func Benchmark_Cache_QueryMethod(b *testing.B) {
 	fctx.Request.SetRequestURI("/demo")
 	fctx.Request.SetBody([]byte(`{"filter":"active","page":1}`))
 
+	// One untimed request to populate the entry, so every measured iteration is
+	// a hit rather than the first being the miss that fills the cache. b.Loop
+	// resets the timer when it first returns, so this stays out of the numbers.
+	// Without it the benchmark also fails outright at -benchtime=1x, where the
+	// single iteration is that miss.
+	h(fctx)
+
 	b.ReportAllocs()
 
 	for b.Loop() {
@@ -4211,6 +4239,7 @@ func Benchmark_Cache_QueryMethod(b *testing.B) {
 	}
 
 	require.Equal(b, fiber.StatusOK, fctx.Response.Header.StatusCode())
+	require.Equal(b, cacheHit, string(fctx.Response.Header.Peek("X-Cache")))
 }
 
 func Benchmark_Cache_MaxSize(b *testing.B) {

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -4061,10 +4061,12 @@ func TestCacheSeparatesAuthorizationValues(t *testing.T) {
 // Benchmark_Cache measures the hit path: the first request stores the response
 // and every one after it is served from the entry.
 //
-// The status has to be one RFC 9111 Section 15.1 lists as cacheable. This was
-// 418, which is not, so the middleware answered "unreachable" every time and
-// the benchmark measured the path that stores nothing while the handler re-read
-// the file on every iteration.
+// The status has to be one this middleware treats as cacheable, which is the
+// set RFC 9110 Section 15.1 marks heuristically cacheable — RFC 9111 defines
+// caching but has no Section 15, and defers the status codes to that one. This
+// was 418, which is not in the set, so the middleware answered "unreachable"
+// every time and the benchmark measured the path that stores nothing while the
+// handler re-read the file on every iteration.
 //
 // go test -v -run=^$ -bench=Benchmark_Cache -benchmem -count=4
 func Benchmark_Cache(b *testing.B) {

--- a/middleware/cache/config.go
+++ b/middleware/cache/config.go
@@ -117,6 +117,12 @@ type Config struct {
 	//
 	// Default: false
 	StoreResponseHeaders bool
+
+	// usesDefaultKeyGenerator records that KeyGenerator above is the one this
+	// package installed, which lets the handler build that key straight into the
+	// buffer holding the rest of the cache key. Set only by configDefault, so a
+	// KeyGenerator the user supplied is always called through the field.
+	usesDefaultKeyGenerator bool
 }
 
 // ConfigDefault is the default config
@@ -147,6 +153,7 @@ func configDefault(config ...Config) Config {
 		cfg.KeyHeaders = normalizeHeaderDimensions(cfg.KeyHeaders, ConfigDefault.KeyHeaders)
 		cfg.KeyCookies = normalizeCookieDimensions(cfg.KeyCookies, nil)
 		if cfg.KeyGenerator == nil {
+			cfg.usesDefaultKeyGenerator = true
 			cfg.KeyGenerator = func(c fiber.Ctx) string {
 				return defaultKeyGenerator(c, &cfg)
 			}
@@ -183,9 +190,14 @@ func configDefault(config ...Config) Config {
 		cfg.Methods = normalized
 	}
 	if cfg.KeyGenerator == nil {
+		cfg.usesDefaultKeyGenerator = true
 		cfg.KeyGenerator = func(c fiber.Ctx) string {
 			return defaultKeyGenerator(c, &cfg)
 		}
+	} else {
+		// A Config the caller built may carry the flag from a copy of one this
+		// package filled in, while naming a generator of its own.
+		cfg.usesDefaultKeyGenerator = false
 	}
 	return cfg
 }

--- a/middleware/cache/coverage_test.go
+++ b/middleware/cache/coverage_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"math"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -368,15 +367,20 @@ func Test_secondsConversions_Overflow(t *testing.T) {
 	require.Equal(t, 5*time.Second, secondsToDuration(5))
 }
 
-func Test_makeHashAuthFunc(t *testing.T) {
+func Test_appendAuthHash(t *testing.T) {
 	t.Parallel()
 
-	pool := &sync.Pool{}
-	fn := makeHashAuthFunc(pool)
+	fn := func(lines [][]byte) string {
+		return string(appendAuthHash(nil, lines))
+	}
 	got := fn([][]byte{[]byte("Bearer token")})
 	require.Len(t, got, hexLen)
-	// Stable for the same input, and uses the pool on the second call.
+	// Stable for the same input, and reuses the pooled framing buffer on the
+	// second call.
 	require.Equal(t, got, fn([][]byte{[]byte("Bearer token")}))
+
+	// Appended to whatever the caller is already building, not returned alone.
+	require.Equal(t, "key|auth="+got, string(appendAuthHash([]byte("key|auth="), [][]byte{[]byte("Bearer token")})))
 
 	// Length-prefixed, so a split that concatenates to the same bytes does not
 	// land on the same digest.
@@ -519,10 +523,12 @@ func Test_varyManifest_StoreLoad(t *testing.T) {
 	require.ErrorContains(t, err, "boom")
 }
 
-func Test_makeBuildVaryKeyFunc(t *testing.T) {
+func Test_appendVaryKey(t *testing.T) {
 	t.Parallel()
 
-	fn := makeBuildVaryKeyFunc(&sync.Pool{})
+	fn := func(names []string, hdr *fasthttp.RequestHeader, normalized bool) string {
+		return string(appendVaryKey(nil, names, hdr, normalized))
+	}
 
 	var hdr fasthttp.RequestHeader
 	hdr.Set("Accept", "application/json")
@@ -530,11 +536,13 @@ func Test_makeBuildVaryKeyFunc(t *testing.T) {
 
 	key := fn([]string{"accept", "accept-encoding"}, &hdr, true)
 	require.Contains(t, key, "|vary|")
-	// Deterministic for the same inputs (also exercises the pooled buffer path).
+	// Deterministic for the same inputs.
 	require.Equal(t, key, fn([]string{"accept", "accept-encoding"}, &hdr, true))
+	// varyKey is the same suffix appended to a base key, in one allocation.
+	require.Equal(t, "base"+key, varyKey("base", []string{"accept", "accept-encoding"}, &hdr, true))
 }
 
-// Test_makeBuildVaryKeyFunc_RepeatedFieldLines pins that every field line of a
+// Test_appendVaryKey_RepeatedFieldLines pins that every field line of a
 // Vary'd header reaches the key.
 //
 // A name may arrive on more than one line, and the split is equivalent to the
@@ -542,10 +550,12 @@ func Test_makeBuildVaryKeyFunc(t *testing.T) {
 // only the first line, so a request carrying two X-Tenant lines and one
 // carrying just the first shared an entry — the exact cross-request mixing
 // Vary exists to prevent.
-func Test_makeBuildVaryKeyFunc_RepeatedFieldLines(t *testing.T) {
+func Test_appendVaryKey_RepeatedFieldLines(t *testing.T) {
 	t.Parallel()
 
-	fn := makeBuildVaryKeyFunc(&sync.Pool{})
+	fn := func(names []string, hdr *fasthttp.RequestHeader, normalized bool) string {
+		return string(appendVaryKey(nil, names, hdr, normalized))
+	}
 
 	key := func(values ...string) string {
 		var hdr fasthttp.RequestHeader

--- a/middleware/cache/keygen.go
+++ b/middleware/cache/keygen.go
@@ -34,6 +34,16 @@ var keyBufferPool = sync.Pool{
 	},
 }
 
+// acquireKeyBuffer takes a scratch buffer from the pool. The type assertion is
+// guarded because a Pool may hand back whatever was Put into it.
+func acquireKeyBuffer() *[]byte {
+	if bufPtr, ok := keyBufferPool.Get().(*[]byte); ok && bufPtr != nil {
+		return bufPtr
+	}
+	b := make([]byte, 0, defaultKeyBufferCap)
+	return &b
+}
+
 // releaseKeyBuffer returns buf to the pool unless it grew too large to retain.
 func releaseKeyBuffer(bufPtr *[]byte, buf []byte) {
 	if cap(buf) <= defaultKeyBufferCap*4 {
@@ -42,43 +52,56 @@ func releaseKeyBuffer(bufPtr *[]byte, buf []byte) {
 	}
 }
 
-func defaultKeyGenerator(c fiber.Ctx, cfg *Config) string {
-	v := keyBufferPool.Get()
-	bufPtr, ok := v.(*[]byte)
-	if !ok || bufPtr == nil {
-		b := make([]byte, 0, defaultKeyBufferCap)
-		bufPtr = &b
+// appendGeneratedKey appends the request's generated key to dst.
+//
+// The configured generator hands back a string, which the caller then copies
+// into the key it is assembling. Where that generator is this package's own, the
+// segments go straight into dst instead and the intermediate string is never
+// built — one allocation saved on every cacheable request. A generator the user
+// supplied still returns a string, and is called exactly once either way.
+func appendGeneratedKey(dst []byte, c fiber.Ctx, cfg *Config) []byte {
+	if cfg.usesDefaultKeyGenerator {
+		return appendDefaultKey(dst, c, cfg)
 	}
-	buf := (*bufPtr)[:0]
+	return append(dst, cfg.KeyGenerator(c)...)
+}
 
+func defaultKeyGenerator(c fiber.Ctx, cfg *Config) string {
+	bufPtr := acquireKeyBuffer()
+	buf := appendDefaultKey((*bufPtr)[:0], c, cfg)
+	result := string(buf)
+	releaseKeyBuffer(bufPtr, buf)
+	return result
+}
+
+// appendDefaultKey appends the default generator's key to dst.
+func appendDefaultKey(dst []byte, c fiber.Ctx, cfg *Config) []byte {
 	// Escape delimiters in path to prevent crafted paths from injecting key structure
-	buf = append(buf, boundKeySegment(escapeKeyDelimiters(c.Path()))...)
+	dst = appendEscapedBoundKeySegment(dst, c.Path())
 
 	if !cfg.DisableQueryKeys {
-		buf = append(buf, '|', 'q', '=')
-		buf = appendCanonicalQueryString(buf, c.Request().URI())
+		dst = append(dst, '|', 'q', '=')
+		dst = appendCanonicalQueryString(dst, c.Request().URI())
 	}
 
 	if len(cfg.KeyHeaders) > 0 {
-		buf = append(buf, '|', 'h', '=')
-		buf = appendCanonicalHeaderSubset(buf, &c.Request().Header, cfg.KeyHeaders, headerlookup.Canonical(c))
+		dst = append(dst, '|', 'h', '=')
+		dst = appendCanonicalHeaderSubset(dst, &c.Request().Header, cfg.KeyHeaders, headerlookup.Canonical(c))
 	}
 
 	if len(cfg.KeyCookies) > 0 {
-		buf = append(buf, '|', 'c', '=')
-		buf = appendCanonicalCookieSubset(buf, c, cfg.KeyCookies)
+		dst = append(dst, '|', 'c', '=')
+		dst = appendCanonicalCookieSubset(dst, c, cfg.KeyCookies)
 	}
 
 	if c.Method() == fiber.MethodQuery {
 		// RFC 10008: incorporate the request body so different QUERY bodies on the
 		// same URL get distinct keys.
-		buf = append(buf, '|', 'b', '=')
-		buf = appendQueryBodySegment(buf, c.Request().Body())
+		dst = append(dst, '|', 'b', '=')
+		dst = appendQueryBodySegment(dst, c.Request().Body())
 	}
 
-	result := string(buf)
-	releaseKeyBuffer(bufPtr, buf)
-	return result
+	return dst
 }
 
 // appendCanonicalQueryString appends the canonicalized query segment to dst.
@@ -97,12 +120,12 @@ func appendCanonicalQueryString(dst []byte, uri *fasthttp.URI) []byte {
 	// Pre-scan query string to detect excessive parameters before expensive parsing.
 	// This prevents DoS via url.ParseQuery allocating large maps/slices.
 	if len(query) > maxQueryBufferSize {
-		return appendBoundKeySegment(dst, escapeKeyDelimiters(query))
+		return appendEscapedBoundKeySegment(dst, query)
 	}
 
 	// Fast path: single key=value pair needs no parsing or sorting
 	if strings.IndexByte(query, '&') < 0 {
-		return appendBoundKeySegment(dst, escapeKeyDelimiters(query))
+		return appendEscapedBoundKeySegment(dst, query)
 	}
 
 	// Quick count of potential parameters (ampersands + 1)
@@ -112,14 +135,14 @@ func appendCanonicalQueryString(dst []byte, uri *fasthttp.URI) []byte {
 			paramCount++
 			if paramCount > maxQueryParams {
 				// Too many parameters detected, hash without parsing
-				return appendBoundKeySegment(dst, escapeKeyDelimiters(query))
+				return appendEscapedBoundKeySegment(dst, query)
 			}
 		}
 	}
 
 	parsed, err := url.ParseQuery(query)
 	if err != nil {
-		return appendBoundKeySegment(dst, escapeKeyDelimiters(query))
+		return appendEscapedBoundKeySegment(dst, query)
 	}
 
 	// Double-check actual parameter count after parsing
@@ -127,7 +150,7 @@ func appendCanonicalQueryString(dst []byte, uri *fasthttp.URI) []byte {
 	for _, values := range parsed {
 		actualCount += len(values)
 		if actualCount > maxQueryParams {
-			return appendBoundKeySegment(dst, escapeKeyDelimiters(query))
+			return appendEscapedBoundKeySegment(dst, query)
 		}
 	}
 
@@ -139,12 +162,7 @@ func appendCanonicalQueryString(dst []byte, uri *fasthttp.URI) []byte {
 
 	// Use pooled buffer to prevent excessive memory allocation during URL escaping.
 	// URL escaping can expand strings up to 3x (each byte -> %XX).
-	v := keyBufferPool.Get()
-	bufPtr, ok := v.(*[]byte)
-	if !ok || bufPtr == nil {
-		b := make([]byte, 0, defaultKeyBufferCap)
-		bufPtr = &b
-	}
+	bufPtr := acquireKeyBuffer()
 	buf := (*bufPtr)[:0]
 
 	for _, key := range keys {
@@ -166,7 +184,7 @@ func appendCanonicalQueryString(dst []byte, uri *fasthttp.URI) []byte {
 			// plus '=' is already appended, leaving only the +1 slack.
 			if len(buf)+1 > maxQueryBufferSize {
 				releaseKeyBuffer(bufPtr, buf)
-				return appendBoundKeySegment(dst, escapeKeyDelimiters(query))
+				return appendEscapedBoundKeySegment(dst, query)
 			}
 		}
 	}
@@ -182,7 +200,7 @@ func appendCanonicalHeaderSubset(dst []byte, header *fasthttp.RequestHeader, nam
 			dst = append(dst, '|')
 		}
 		// Escape name (though names are normalized and trusted)
-		dst = append(dst, escapeKeyDelimiters(name)...)
+		dst = appendEscapedKeyDelimiters(dst, name)
 		dst = append(dst, ':')
 
 		// Every field line, not just the first: the split and comma-joined forms are
@@ -210,7 +228,7 @@ func appendCanonicalHeaderSubset(dst []byte, header *fasthttp.RequestHeader, nam
 		for _, value := range values {
 			dst = append(dst, '|')
 			// Escape value to prevent delimiter injection
-			dst = appendBoundKeySegment(dst, escapeKeyDelimiters(utils.UnsafeString(value)))
+			dst = appendEscapedBoundKeySegment(dst, utils.UnsafeString(value))
 		}
 	}
 
@@ -239,39 +257,79 @@ func appendCanonicalCookieSubset(dst []byte, c fiber.Ctx, names []string) []byte
 			dst = append(dst, '|')
 		}
 		// Escape name (though names are normalized and trusted)
-		dst = append(dst, escapeKeyDelimiters(name)...)
+		dst = appendEscapedKeyDelimiters(dst, name)
 		dst = append(dst, ':')
-		cookieValue := c.Cookies(name)
 		// Escape value to prevent delimiter injection
-		escapedValue := escapeKeyDelimiters(cookieValue)
-		dst = appendBoundKeySegment(dst, escapedValue)
+		dst = appendEscapedBoundKeySegment(dst, c.Cookies(name))
 	}
 
 	return dst
 }
 
-// keyDelimiterEscaper escapes the delimiters in one pass: \ as \\, | as \p, : as \c.
-var keyDelimiterEscaper = strings.NewReplacer(`\`, `\\`, `|`, `\p`, `:`, `\c`)
-
-// escapeKeyDelimiters escapes pipe, colon, and backslash characters used as delimiters in cache keys
-// to prevent injection attacks where crafted values could collide with different inputs
-func escapeKeyDelimiters(s string) string {
-	// Fast path: no characters to escape
-	if utils.IndexAny3(s, '|', ':', '\\') == -1 {
-		return s
+// countKeyDelimiters returns how many bytes escaping s would add, which is one
+// per delimiter since each is replaced by a two-byte sequence. Asking this first
+// lets the append forms below bound a segment without building the escaped
+// string a strings.Replacer used to allocate for every request whose path,
+// query, or body carries one of these bytes — a colon in a JSON body is
+// enough.
+func countKeyDelimiters(s string) int {
+	n := 0
+	for i := utils.IndexAny3(s, '|', ':', '\\'); i >= 0; i = utils.IndexAny3(s, '|', ':', '\\') {
+		n++
+		s = s[i+1:]
 	}
-	return keyDelimiterEscaper.Replace(s)
+	return n
 }
 
-func boundKeySegment(segment string) string {
-	// Hash oversized segments, and also any segment that already starts with the
-	// reserved hashPrefix, so a literal "sha256:..." value cannot collide with a
-	// genuinely-hashed long segment (defense-in-depth alongside escapeKeyDelimiters).
-	if len(segment) <= maxKeyDimensionSegmentLength && !strings.HasPrefix(segment, hashPrefix) {
-		return segment
+// appendEscapedKeyDelimiters appends s to dst with the cache-key delimiters
+// escaped: \ as \\, | as \p, : as \c. Escaping them stops a crafted path,
+// query, header, or cookie value from injecting key structure of its own.
+func appendEscapedKeyDelimiters(dst []byte, s string) []byte {
+	for {
+		i := utils.IndexAny3(s, '|', ':', '\\')
+		if i < 0 {
+			return append(dst, s...)
+		}
+		dst = append(dst, s[:i]...)
+		switch s[i] {
+		case '\\':
+			dst = append(dst, '\\', '\\')
+		case '|':
+			dst = append(dst, '\\', 'p')
+		default: // ':'
+			dst = append(dst, '\\', 'c')
+		}
+		s = s[i+1:]
 	}
-	hash := sha256.Sum256(utils.UnsafeBytes(segment))
-	return hashPrefix + hex.EncodeToString(hash[:])
+}
+
+// appendEscapedBoundKeySegment escapes segment and appends it under the same
+// bound appendBoundKeySegment applies.
+//
+// The reserved-prefix check appendBoundKeySegment makes is kept only on the
+// path where nothing needed escaping. A segment that did cannot need it: the
+// escaping emits no ':' at all, so its result never starts with hashPrefix.
+func appendEscapedBoundKeySegment(dst []byte, segment string) []byte {
+	extra := countKeyDelimiters(segment)
+	if extra == 0 {
+		// Escaping would leave the segment as it is, so this is
+		// appendBoundKeySegment's own path, reserved-prefix check included.
+		return appendBoundKeySegment(dst, segment)
+	}
+
+	if len(segment)+extra <= maxKeyDimensionSegmentLength {
+		return appendEscapedKeyDelimiters(dst, segment)
+	}
+
+	// Oversized, so the digest is what lands in the key, and it covers the
+	// escaped bytes — the same preimage as when the caller escaped first and
+	// handed the result to appendBoundKeySegment. Escaped in a pooled buffer so
+	// that stays true without a fresh string.
+	bufPtr := acquireKeyBuffer()
+	buf := appendEscapedKeyDelimiters((*bufPtr)[:0], segment)
+	dst = appendHashedKeySegment(dst, buf)
+	releaseKeyBuffer(bufPtr, buf)
+	return dst
 }
 
 // appendBoundKeySegment appends segment to dst, hashing it first when it exceeds
@@ -301,8 +359,9 @@ func appendHashedKeySegment(dst, segment []byte) []byte {
 // still stops a body containing |/:/\ from injecting key-suffix structure.
 func appendQueryBodySegment(dst, body []byte) []byte {
 	if len(body) <= maxKeyDimensionSegmentLength {
-		if escaped := escapeKeyDelimiters(utils.UnsafeString(body)); len(escaped) <= maxKeyDimensionSegmentLength {
-			return append(dst, escaped...)
+		s := utils.UnsafeString(body)
+		if len(s)+countKeyDelimiters(s) <= maxKeyDimensionSegmentLength {
+			return appendEscapedKeyDelimiters(dst, s)
 		}
 	}
 	return appendHashedKeySegment(dst, body)

--- a/middleware/cache/keygen_test.go
+++ b/middleware/cache/keygen_test.go
@@ -1,10 +1,19 @@
 package cache
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/utils/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 )
@@ -114,4 +123,207 @@ func Test_defaultKeyGenerator_stableKeys(t *testing.T) {
 			require.Equal(t, tc.want, defaultKeyGenerator(c, cfg))
 		})
 	}
+}
+
+// Test_EscapeKeyDelimiters_AppendFormsMatch pins the append-based escapers
+// against the Replacer they replaced.
+//
+// They exist to keep the escaped form out of the heap, not to change it: a
+// segment that escapes differently is a different cache key, so an entry a
+// previous build stored would stop being found. Every assertion here is byte
+// equality with escapeKeyDelimiters.
+func Test_EscapeKeyDelimiters_AppendFormsMatch(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("a", maxKeyDimensionSegmentLength+1)
+	corpus := []string{
+		"", "a", "|", ":", `\`, `\\`, "::", "||", `a|b:c\d`,
+		"no-delimiters-here", "sha256:deadbeef", hashPrefix,
+		`{"filter":"active","page":1}`,
+		// Bounded verbatim before escaping, over the bound after it: the
+		// expansion is what decides, so both forms have to agree on which.
+		strings.Repeat(":", maxKeyDimensionSegmentLength/2),
+		strings.Repeat(":", maxKeyDimensionSegmentLength),
+		long, long + ":", strings.Repeat("|", 500),
+	}
+	// Every length either side of the bound, in both plain and delimiter-heavy
+	// form, since the two paths part at that boundary.
+	for n := maxKeyDimensionSegmentLength - 3; n <= maxKeyDimensionSegmentLength+3; n++ {
+		corpus = append(corpus, strings.Repeat("x", n), strings.Repeat("x:", n/2), strings.Repeat("x", n-1)+"|")
+	}
+
+	for _, s := range corpus {
+		escaped := escapeKeyDelimiters(s)
+
+		require.Equal(t, len(escaped)-len(s), countKeyDelimiters(s), "delimiter count for %q", s)
+		require.Equal(t, "seg="+escaped, string(appendEscapedKeyDelimiters([]byte("seg="), s)), "escape of %q", s)
+		require.Equal(t,
+			string(appendBoundKeySegment([]byte("seg="), escaped)),
+			string(appendEscapedBoundKeySegment([]byte("seg="), s)),
+			"bounded escape of %q", s)
+	}
+}
+
+// Test_Cache_KeyFormatIsStable pins the bytes of an assembled cache key.
+//
+// The pieces are joined in one buffer now rather than concatenated one at a
+// time. That is a change to how the key is built and must not be one to what
+// the key is: a different format silently empties every cache that survived the
+// deploy, and no other test in this suite would notice. The keys are read back
+// off a storage that records what it was asked for, so this asserts on what the
+// middleware actually used.
+func Test_Cache_KeyFormatIsStable(t *testing.T) {
+	t.Parallel()
+
+	authHash := string(appendAuthHash(nil, [][]byte{[]byte("Bearer token")}))
+
+	tests := []struct {
+		name        string
+		auth        string
+		want        []string
+		disableVary bool
+	}{
+		{
+			name: "anonymous",
+			want: []string{"v2|GET|/demo|vary", "v2|GET|/demo"},
+		},
+		{
+			name: "authenticated",
+			auth: "Bearer token",
+			want: []string{"v2|GET|/demo|auth=" + authHash + "|vary", "v2|GET|/demo|auth=" + authHash},
+		},
+		{
+			name:        "vary disabled",
+			disableVary: true,
+			want:        []string{"v2|GET|/demo"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newKeyRecordingStorage()
+			app := fiber.New()
+			app.Use(New(Config{
+				Storage:            store,
+				DisableVaryHeaders: tc.disableVary,
+				// A generator of the caller's own, to pin that its result lands
+				// verbatim between the version and method partitions and the
+				// suffixes this middleware adds.
+				KeyGenerator: func(c fiber.Ctx) string { return c.Path() },
+			}))
+			app.Get("/demo", func(c fiber.Ctx) error { return c.SendString("ok") })
+
+			req := httptest.NewRequest(fiber.MethodGet, "/demo", http.NoBody)
+			if tc.auth != "" {
+				req.Header.Set(fiber.HeaderAuthorization, tc.auth)
+			}
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			require.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+			// The body is stored under its own key, which is the entry key plus
+			// the suffix the manager appends.
+			require.Equal(t, tc.want, store.lookedUp())
+		})
+	}
+}
+
+// keyRecordingStorage reports every key it was asked to read, in order and
+// without duplicates, so a test can assert on the keys the middleware built.
+type keyRecordingStorage struct {
+	data map[string][]byte
+	seen []string
+	mu   sync.Mutex
+}
+
+func newKeyRecordingStorage() *keyRecordingStorage {
+	return &keyRecordingStorage{data: make(map[string][]byte)}
+}
+
+func (s *keyRecordingStorage) GetWithContext(_ context.Context, key string) ([]byte, error) {
+	return s.Get(key)
+}
+
+func (s *keyRecordingStorage) Get(key string) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !slices.Contains(s.seen, key) {
+		s.seen = append(s.seen, key)
+	}
+	return s.data[key], nil
+}
+
+func (s *keyRecordingStorage) SetWithContext(_ context.Context, key string, val []byte, exp time.Duration) error {
+	return s.Set(key, val, exp)
+}
+
+func (s *keyRecordingStorage) Set(key string, val []byte, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = val
+	return nil
+}
+
+func (s *keyRecordingStorage) DeleteWithContext(_ context.Context, key string) error {
+	return s.Delete(key)
+}
+
+func (s *keyRecordingStorage) Delete(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, key)
+	return nil
+}
+
+func (s *keyRecordingStorage) ResetWithContext(context.Context) error { return s.Reset() }
+
+func (s *keyRecordingStorage) Reset() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data = make(map[string][]byte)
+	return nil
+}
+
+func (s *keyRecordingStorage) Close() error { return nil }
+
+func (s *keyRecordingStorage) lookedUp() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.seen)
+}
+
+// The escaping and bounding below are the reference implementations the key
+// segments were built with before they were rewritten to append into the key
+// buffer. Production no longer calls them — the append forms produce the same
+// bytes without the intermediate string — so they live here, as the oracle the
+// tests check those forms against.
+//
+// Test_EscapeKeyDelimiters_AppendFormsMatch is what ties the two together, and
+// the security tests that pin what escaping and bounding must do read against
+// these. Change one side and that test fails, which is the point.
+
+// keyDelimiterEscaper escapes the delimiters in one pass: \ as \\, | as \p, : as \c.
+var keyDelimiterEscaper = strings.NewReplacer(`\`, `\\`, `|`, `\p`, `:`, `\c`)
+
+// escapeKeyDelimiters escapes pipe, colon, and backslash characters used as delimiters in cache keys
+// to prevent injection attacks where crafted values could collide with different inputs
+func escapeKeyDelimiters(s string) string {
+	// Fast path: no characters to escape
+	if utils.IndexAny3(s, '|', ':', '\\') == -1 {
+		return s
+	}
+	return keyDelimiterEscaper.Replace(s)
+}
+
+func boundKeySegment(segment string) string {
+	// Hash oversized segments, and also any segment that already starts with the
+	// reserved hashPrefix, so a literal "sha256:..." value cannot collide with a
+	// genuinely-hashed long segment (defense-in-depth alongside escapeKeyDelimiters).
+	if len(segment) <= maxKeyDimensionSegmentLength && !strings.HasPrefix(segment, hashPrefix) {
+		return segment
+	}
+	hash := sha256.Sum256(utils.UnsafeBytes(segment))
+	return hashPrefix + hex.EncodeToString(hash[:])
 }

--- a/middleware/cache/keygen_test.go
+++ b/middleware/cache/keygen_test.go
@@ -286,7 +286,7 @@ func (s *keyRecordingStorage) Reset() error {
 	return nil
 }
 
-func (s *keyRecordingStorage) Close() error { return nil }
+func (*keyRecordingStorage) Close() error { return nil }
 
 func (s *keyRecordingStorage) lookedUp() []string {
 	s.mu.Lock()

--- a/middleware/cache/manager.go
+++ b/middleware/cache/manager.go
@@ -77,6 +77,12 @@ func newManager(storage fiber.Storage, shouldRedactKeys bool) *manager {
 
 // acquire returns an *entry from the sync.Pool
 func (m *manager) acquire() *item {
+	// The in-memory store keeps the entry itself, so release never hands one
+	// back and the pool is empty every time. Going through it only pays for the
+	// lookup before landing on the same allocation.
+	if m.storage == nil {
+		return new(item)
+	}
 	return m.pool.Get().(*item) //nolint:forcetypeassert,errcheck // We store nothing else in the pool
 }
 

--- a/middleware/cache/utils.go
+++ b/middleware/cache/utils.go
@@ -287,45 +287,28 @@ var authScratchPool = sync.Pool{
 	},
 }
 
-// makeHashAuthFunc returns the digest of a request's Authorization field lines,
-// each length-prefixed so that ["ab"] and ["a","b"] do not collide.
-func makeHashAuthFunc(hexBufPool *sync.Pool) func([][]byte) string {
-	return func(lines [][]byte) string {
-		scratchPtr, ok := authScratchPool.Get().(*[]byte)
-		if !ok || scratchPtr == nil {
-			b := make([]byte, 0, 256)
-			scratchPtr = &b
-		}
-		framed := (*scratchPtr)[:0]
-		for _, v := range lines {
-			framed = binary.AppendUvarint(framed, uint64(len(v)))
-			framed = append(framed, v...)
-		}
-		sum := sha256.Sum256(framed)
-		if cap(framed) <= maxAuthScratch {
-			*scratchPtr = framed
-			authScratchPool.Put(scratchPtr)
-		}
-
-		v := hexBufPool.Get()
-		bufPtr, ok := v.(*[]byte)
-		if !ok || bufPtr == nil {
-			b := make([]byte, hexLen)
-			bufPtr = &b
-		}
-
-		buf := *bufPtr
-		if cap(buf) < hexLen {
-			buf = make([]byte, hexLen)
-		} else {
-			buf = buf[:hexLen]
-		}
-		*bufPtr = buf
-
-		hex.Encode(buf, sum[:])
-		result := string(buf)
-
-		hexBufPool.Put(bufPtr)
-		return result
+// appendAuthHash appends the hex digest of a request's Authorization field
+// lines, each length-prefixed so that ["ab"] and ["a","b"] do not collide.
+//
+// Written into the caller's buffer rather than returned as a string: the digest
+// only ever becomes part of a cache key, and handing one back cost an
+// allocation per authenticated request on top of the key's own.
+func appendAuthHash(dst []byte, lines [][]byte) []byte {
+	scratchPtr, ok := authScratchPool.Get().(*[]byte)
+	if !ok || scratchPtr == nil {
+		b := make([]byte, 0, 256)
+		scratchPtr = &b
 	}
+	framed := (*scratchPtr)[:0]
+	for _, v := range lines {
+		framed = binary.AppendUvarint(framed, uint64(len(v)))
+		framed = append(framed, v...)
+	}
+	sum := sha256.Sum256(framed)
+	if cap(framed) <= maxAuthScratch {
+		*scratchPtr = framed
+		authScratchPool.Put(scratchPtr)
+	}
+
+	return hex.AppendEncode(dst, sum[:])
 }

--- a/middleware/cache/vary.go
+++ b/middleware/cache/vary.go
@@ -25,7 +25,13 @@ func parseVary(vary string) ([]string, bool) {
 		return nil, false
 	}
 
-	var names []string
+	// Sized to the separators the field actually carries. Appending into a nil
+	// slice grows the backing array as it goes — three allocations for a
+	// three-name manifest — and this runs per lookup for every entry that
+	// varies. The cap the loop enforces bounds it, and a comma-separated list
+	// never holds more names than it has commas plus one, so the slice is
+	// allocated once and never grown.
+	names := make([]string, 0, min(strings.Count(vary, ",")+1, maxVaryHeaders))
 	count := 0
 	for part := range strings.SplitSeq(vary, ",") {
 		name := utils.TrimSpace(utilsstrings.ToLower(part))

--- a/middleware/cache/vary.go
+++ b/middleware/cache/vary.go
@@ -18,6 +18,10 @@ import (
 // maxVaryHeaders caps the number of Vary headers processed to prevent DoS.
 const maxVaryHeaders = 32
 
+// defaultVaryNames is the capacity parseVary starts its name slice at, sized to
+// hold what a real Vary field carries without regrowing.
+const defaultVaryNames = 8
+
 func parseVary(vary string) ([]string, bool) {
 	// Asked of every response, and almost none carry the field. The scan below
 	// would answer the same, after allocating the slice it never fills.
@@ -25,13 +29,16 @@ func parseVary(vary string) ([]string, bool) {
 		return nil, false
 	}
 
-	// Sized to the separators the field actually carries. Appending into a nil
-	// slice grows the backing array as it goes — three allocations for a
-	// three-name manifest — and this runs per lookup for every entry that
-	// varies. The cap the loop enforces bounds it, and a comma-separated list
-	// never holds more names than it has commas plus one, so the slice is
-	// allocated once and never grown.
-	names := make([]string, 0, min(strings.Count(vary, ",")+1, maxVaryHeaders))
+	// Given a capacity up front, because appending into a nil slice regrows the
+	// backing array as it goes — three allocations for a three-name manifest —
+	// and this runs per lookup for every entry that varies.
+	//
+	// A fixed size rather than one counted off the separators: counting them
+	// reads the whole field, while the walk below stops at the cap. That gave a
+	// long list one full pass it is about to be rejected for, which is the work
+	// maxVaryHeaders exists to refuse. Real fields carry a name or three, so the
+	// exact size bought one allocation over this in a case that does not arise.
+	names := make([]string, 0, defaultVaryNames)
 	count := 0
 	for part := range strings.SplitSeq(vary, ",") {
 		name := utils.TrimSpace(utilsstrings.ToLower(part))

--- a/middleware/cache/vary.go
+++ b/middleware/cache/vary.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gofiber/utils/v2"
@@ -20,7 +19,13 @@ import (
 const maxVaryHeaders = 32
 
 func parseVary(vary string) ([]string, bool) {
-	names := make([]string, 0, 8)
+	// Asked of every response, and almost none carry the field. The scan below
+	// would answer the same, after allocating the slice it never fills.
+	if utils.TrimSpace(vary) == "" {
+		return nil, false
+	}
+
+	var names []string
 	count := 0
 	for part := range strings.SplitSeq(vary, ",") {
 		name := utils.TrimSpace(utilsstrings.ToLower(part))
@@ -49,55 +54,53 @@ func parseVary(vary string) ([]string, bool) {
 	return names, false
 }
 
-func makeBuildVaryKeyFunc(hexBufPool *sync.Pool) func([]string, *fasthttp.RequestHeader, bool) string {
-	return func(names []string, hdr *fasthttp.RequestHeader, normalized bool) string {
-		sum := sha256.New()
-		// Written inline rather than through a closure: capturing lenBuf would
-		// force the array to the heap, adding two allocations to every request
-		// that has a Vary manifest.
-		var lenBuf [binary.MaxVarintLen64]byte
-		for _, name := range names {
-			_, _ = sum.Write(binary.AppendUvarint(lenBuf[:0], uint64(len(name)))) //nolint:errcheck // hash.Hash.Write for std hashes never errors
-			_, _ = sum.Write(utils.UnsafeBytes(name))                             //nolint:errcheck // hash.Hash.Write for std hashes never errors
+// appendVaryKey appends the variant suffix — "|vary|" and the digest of the
+// Vary'd request headers — to dst.
+//
+// Appended rather than returned as a string so the whole cache key is built in
+// one buffer: returning the suffix cost an allocation for it and another for the
+// concatenation, on every request whose entry varies.
+func appendVaryKey(dst []byte, names []string, hdr *fasthttp.RequestHeader, normalized bool) []byte { //nolint:revive // flag-parameter: normalized is a property of the header store
+	sum := sha256.New()
+	// Written inline rather than through a closure: capturing lenBuf would
+	// force the array to the heap, adding two allocations to every request
+	// that has a Vary manifest.
+	var lenBuf [binary.MaxVarintLen64]byte
+	for _, name := range names {
+		_, _ = sum.Write(binary.AppendUvarint(lenBuf[:0], uint64(len(name)))) //nolint:errcheck // hash.Hash.Write for std hashes never errors
+		_, _ = sum.Write(utils.UnsafeBytes(name))                             //nolint:errcheck // hash.Hash.Write for std hashes never errors
 
-			// Every field line, not just the first: the split and comma-joined forms
-			// are equivalent (RFC 9110 §5.2), so a request sending X-Tenant twice
-			// hashed like one sending just the first value.
-			values := keyFieldLines(hdr, name, normalized)
-			_, _ = sum.Write(binary.AppendUvarint(lenBuf[:0], uint64(len(values)))) //nolint:errcheck // hash.Hash.Write for std hashes never errors
-			for _, v := range values {
-				// Length-prefixed so the framing stays injective: without it
-				// two lines "a" and "b" would hash like a single line "a\x00b".
-				_, _ = sum.Write(binary.AppendUvarint(lenBuf[:0], uint64(len(v)))) //nolint:errcheck // hash.Hash.Write for std hashes never errors
-				_, _ = sum.Write(v)                                                //nolint:errcheck // hash.Hash.Write for std hashes never errors
-			}
+		// Every field line, not just the first: the split and comma-joined forms
+		// are equivalent (RFC 9110 §5.2), so a request sending X-Tenant twice
+		// hashed like one sending just the first value.
+		values := keyFieldLines(hdr, name, normalized)
+		_, _ = sum.Write(binary.AppendUvarint(lenBuf[:0], uint64(len(values)))) //nolint:errcheck // hash.Hash.Write for std hashes never errors
+		for _, v := range values {
+			// Length-prefixed so the framing stays injective: without it
+			// two lines "a" and "b" would hash like a single line "a\x00b".
+			_, _ = sum.Write(binary.AppendUvarint(lenBuf[:0], uint64(len(v)))) //nolint:errcheck // hash.Hash.Write for std hashes never errors
+			_, _ = sum.Write(v)                                                //nolint:errcheck // hash.Hash.Write for std hashes never errors
 		}
-
-		var hashBytes [sha256.Size]byte
-		sum.Sum(hashBytes[:0])
-
-		v := hexBufPool.Get()
-		bufPtr, ok := v.(*[]byte)
-		if !ok || bufPtr == nil {
-			b := make([]byte, hexLen)
-			bufPtr = &b
-		}
-
-		buf := *bufPtr
-		// Defensive in case someone changed Pool.New or Put a different sized buffer.
-		if cap(buf) < hexLen {
-			buf = make([]byte, hexLen)
-		} else {
-			buf = buf[:hexLen]
-		}
-		*bufPtr = buf
-
-		hex.Encode(buf, hashBytes[:])
-		result := "|vary|" + string(buf)
-
-		hexBufPool.Put(bufPtr)
-		return result
 	}
+
+	var hashBytes [sha256.Size]byte
+	sum.Sum(hashBytes[:0])
+
+	dst = append(dst, "|vary|"...)
+	return hex.AppendEncode(dst, hashBytes[:])
+}
+
+// varyKey returns base with the variant suffix appended, assembled in a pooled
+// buffer so the result costs one allocation rather than one for the suffix and
+// another for the join.
+func varyKey(base string, names []string, hdr *fasthttp.RequestHeader, normalized bool) string { //nolint:revive // flag-parameter: normalized is a property of the header store
+	bufPtr := acquireKeyBuffer()
+	buf := (*bufPtr)[:0]
+	buf = append(buf, base...)
+	buf = appendVaryKey(buf, names, hdr, normalized)
+	key := string(buf)
+	releaseKeyBuffer(bufPtr, buf)
+	return key
 }
 
 func storeVaryManifest(ctx context.Context, manager *manager, manifestKey string, names []string, exp time.Duration) error {


### PR DESCRIPTION
# Description

This PR optimizes the cache middleware to reduce memory allocations and improve performance by refactoring key generation and buffer management. The changes consolidate key building into single pooled buffers, eliminate intermediate string allocations, and optimize delimiter escaping to avoid heap allocations on every request.

## Changes introduced

### Performance Improvements
- **Buffer consolidation**: Cache keys are now assembled in a single pooled buffer instead of being concatenated multiple times, eliminating intermediate string allocations
- **Optimized escaping**: Replaced `strings.Replacer`-based delimiter escaping with append-based implementations that avoid allocating intermediate strings
- **Vary key optimization**: The vary suffix is now appended directly to the key buffer instead of being returned as a separate string and concatenated
- **Auth hash optimization**: Authorization hash is appended directly to the key buffer instead of being returned as a string
- **Header formatting**: Response headers (Date, Cache-Control, Age) are now formatted into local arrays instead of allocating fresh slices
- **Early exit optimization**: Added early return in `parseVary()` when the Vary header is empty to avoid unnecessary allocations

### Code Quality
- Added comprehensive tests (`Test_EscapeKeyDelimiters_AppendFormsMatch`, `Test_Cache_KeyFormatIsStable`) to ensure cache key format stability across refactoring
- Introduced `keyRecordingStorage` test helper to verify the exact keys used by the middleware
- Refactored key generation to support both default and custom generators efficiently
- Added detailed comments explaining allocation optimization strategies

### Benchmarks
The changes reduce allocations on the cache hit path by consolidating multiple string concatenations and intermediate allocations into single buffer operations. Specific improvements:
- Eliminated 2-3 allocations per cache key generation (one per string concatenation)
- Eliminated 1 allocation per delimiter escaping operation
- Eliminated 1 allocation per vary key generation
- Eliminated 1 allocation per auth hash generation
- Eliminated 1 allocation per response header formatting

## Type of change

- [x] Performance improvement (non-breaking change which improves efficiency)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts
- [x] Added unit tests to validate the effectiveness of the changes (`Test_EscapeKeyDelimiters_AppendFormsMatch`, `Test_Cache_KeyFormatIsStable`, updated `Test_appendAuthHash`, `Test_appendVaryKey`)
- [x] Ensured that new and existing unit tests pass locally with the changes
- [x] Aimed for optimal performance with minimal allocations in the new code
- [x] Verified cache key format stability through pinning tests

## Test Plan

The changes are covered by:
- New test `Test_EscapeKeyDelimiters_AppendFormsMatch` verifies that append-based escaping produces identical bytes to the reference implementation
- New test `Test_Cache_KeyFormatIsStable` pins the exact cache keys generated for various request scenarios
- Updated tests for `appendAuthHash` and `appendVaryKey` verify the new append-based APIs
- Existing cache tests continue to pass, ensuring backward compatibility
- Benchmark tests updated to use cacheable status codes and verify cache hits

https://claude.ai/code/session_01DsGg5ckK1hkruPKChMEj2U