### PR TITLE
test: close three coverage gaps in logger, shutdown and docs

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1535,22 +1535,24 @@ func Test_App_ShutdownWithTimeout_WaitsForStreamedBody(t *testing.T) {
 
 	// Shut down mid-stream, which is the point: the handler is long gone by now.
 	<-streaming
-	shutdownErr := make(chan error, 1)
+	// Sampled where shutdown returns, not after the read below: reading the whole
+	// body first closes finished, and the check would then hold either way.
+	streamDone := make(chan bool, 1)
 	go func() {
-		shutdownErr <- app.ShutdownWithTimeout(10 * time.Second)
+		assert.NoError(t, app.ShutdownWithTimeout(10*time.Second))
+		select {
+		case <-finished:
+			streamDone <- true
+		default:
+			streamDone <- false
+		}
 	}()
 
 	var resp fasthttp.Response
 	require.NoError(t, resp.Read(bufio.NewReader(conn)))
 	require.Equal(t, strings.Repeat("chunk", chunks), string(resp.Body()))
 
-	require.NoError(t, <-shutdownErr)
-
-	select {
-	case <-finished:
-	default:
-		t.Fatal("shutdown returned while the body was still being written")
-	}
+	require.True(t, <-streamDone, "shutdown returned while the body was still being written")
 }
 
 func Test_App_ShutdownWithContext(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -1491,6 +1491,68 @@ func Test_App_ShutdownWithTimeout(t *testing.T) {
 	}
 }
 
+// A streamed body is written after the handler has already returned, so the
+// shutdown tests above, which block inside the handler, say nothing about it.
+// Reported as #3370 against v3.0.0-beta.4: a download was cut off instead of
+// being allowed to finish within the timeout.
+func Test_App_ShutdownWithTimeout_WaitsForStreamedBody(t *testing.T) {
+	t.Parallel()
+
+	const chunks = 5
+
+	streaming := make(chan struct{})
+	finished := make(chan struct{})
+
+	app := New()
+	app.Get("/stream", func(c Ctx) error {
+		c.Response().SetBodyStreamWriter(func(w *bufio.Writer) {
+			defer close(finished)
+			for i := range chunks {
+				_, err := w.WriteString("chunk")
+				assert.NoError(t, err)
+				assert.NoError(t, w.Flush())
+				if i == 0 {
+					close(streaming)
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+		})
+		return nil
+	})
+
+	ln := fasthttputil.NewInmemoryListener()
+	serverReady := make(chan struct{})
+	go func() {
+		close(serverReady)
+		assert.NoError(t, app.Listener(ln))
+	}()
+	<-serverReady
+
+	conn, err := ln.Dial()
+	require.NoError(t, err)
+	_, err = conn.Write([]byte("GET /stream HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+	require.NoError(t, err)
+
+	// Shut down mid-stream, which is the point: the handler is long gone by now.
+	<-streaming
+	shutdownErr := make(chan error, 1)
+	go func() {
+		shutdownErr <- app.ShutdownWithTimeout(10 * time.Second)
+	}()
+
+	var resp fasthttp.Response
+	require.NoError(t, resp.Read(bufio.NewReader(conn)))
+	require.Equal(t, strings.Repeat("chunk", chunks), string(resp.Body()))
+
+	require.NoError(t, <-shutdownErr)
+
+	select {
+	case <-finished:
+	default:
+		t.Fatal("shutdown returned while the body was still being written")
+	}
+}
+
 func Test_App_ShutdownWithContext(t *testing.T) {
 	t.Parallel()
 

--- a/docs/middleware/adaptor.md
+++ b/docs/middleware/adaptor.md
@@ -50,7 +50,7 @@ or `FiberApp`, the adaptor enforces the app's configured `BodyLimit`. The app's 
 
 ---
 
-## Usage Examples
+## Examples
 
 ### 1. Using `net/http` handlers in Fiber (`HTTPHandler`, `HTTPHandlerFunc`)
 

--- a/docs/middleware/rewrite.md
+++ b/docs/middleware/rewrite.md
@@ -23,7 +23,7 @@ func New(config ...Config) fiber.Handler
 Rules are stored in a map, so iteration order is undefined. Avoid overlapping patterns if precedence matters.
 :::
 
-### Examples
+## Examples
 
 ```go
 package main

--- a/docs_structure_test.go
+++ b/docs_structure_test.go
@@ -1,0 +1,110 @@
+package fiber
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// middlewareDocsDir holds one page per built-in middleware.
+const middlewareDocsDir = "docs/middleware"
+
+// Sections every middleware page carries, so a reader can jump to the
+// signature or the config of any middleware without first reading the page.
+var middlewareDocSections = []string{
+	"## Signatures",
+	"## Config",
+	"## Examples",
+}
+
+type middlewareDocException struct {
+	file   string
+	reason string
+	skip   []string
+}
+
+// Pages that are not shaped like a middleware page. Listing them here rather
+// than loosening the check keeps the deviation visible and reviewable.
+var middlewareDocExceptions = []middlewareDocException{
+	{
+		file:   "adaptor.md",
+		skip:   []string{"## Signatures", "## Config"},
+		reason: "a converter between net/http and Fiber, documented one function at a time and with no config",
+	},
+	{
+		file:   "csrf.md",
+		skip:   []string{"## Signatures", "## Config", "## Examples"},
+		reason: "guide-shaped page, config lives under Advanced Configuration and the examples under Recipes",
+	},
+	{
+		file:   "session.md",
+		skip:   []string{"## Signatures", "## Config"},
+		reason: "guide-shaped page, the config is reached through Configuration",
+	},
+	{
+		file:   "skip.md",
+		skip:   []string{"## Config"},
+		reason: "wraps a handler behind a predicate, there is no config struct",
+	},
+}
+
+// Test_Docs_MiddlewarePageSections keeps the middleware pages to one layout.
+// The docs are synced to gofiber.io as they are, so a page that invents its
+// own section names is only noticed once it is published.
+func Test_Docs_MiddlewarePageSections(t *testing.T) {
+	t.Parallel()
+
+	skips := make(map[string]map[string]bool, len(middlewareDocExceptions))
+	for _, exception := range middlewareDocExceptions {
+		set := make(map[string]bool, len(exception.skip))
+		for _, section := range exception.skip {
+			set[section] = true
+		}
+		skips[exception.file] = set
+	}
+
+	entries, err := os.ReadDir(middlewareDocsDir)
+	require.NoError(t, err)
+
+	pages := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		pages[name] = true
+
+		body, readErr := os.ReadFile(filepath.Join(middlewareDocsDir, name))
+		require.NoError(t, readErr)
+
+		headings := make(map[string]bool)
+		for line := range strings.SplitSeq(string(body), "\n") {
+			line = strings.TrimRight(line, " \r")
+			if strings.HasPrefix(line, "## ") {
+				headings[line] = true
+			}
+		}
+
+		for _, section := range middlewareDocSections {
+			if skips[name][section] {
+				continue
+			}
+			require.True(t, headings[section],
+				"%s/%s is missing %q - add the section, or add the page to middlewareDocExceptions with a reason",
+				middlewareDocsDir, name, section)
+		}
+	}
+
+	require.NotEmpty(t, pages, "no middleware pages found under %s", middlewareDocsDir)
+
+	// An exception for a page that no longer exists would silently excuse that
+	// page the day someone adds it back.
+	for _, exception := range middlewareDocExceptions {
+		require.True(t, pages[exception.file],
+			"middlewareDocExceptions covers %s (%s) but that page does not exist",
+			exception.file, exception.reason)
+	}
+}

--- a/docs_structure_test.go
+++ b/docs_structure_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gofiber/utils/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -108,7 +109,7 @@ func Test_Docs_MiddlewarePageSections(t *testing.T) {
 	// An exception for a page that no longer exists would silently excuse that
 	// page the day someone adds it back.
 	for _, exception := range middlewareDocExceptions {
-		require.NotEmpty(t, strings.TrimSpace(exception.reason),
+		require.NotEmpty(t, utils.TrimSpace(exception.reason),
 			"middlewareDocExceptions covers %s without a reason", exception.file)
 		require.True(t, pages[exception.file],
 			"middlewareDocExceptions covers %s (%s) but that page does not exist",

--- a/docs_structure_test.go
+++ b/docs_structure_test.go
@@ -90,6 +90,11 @@ func Test_Docs_MiddlewarePageSections(t *testing.T) {
 
 		for _, section := range middlewareDocSections {
 			if skips[name][section] {
+				// A page that has grown the section back keeps its exception alive
+				// and with it a hole in the check, so the skip has to go.
+				require.False(t, headings[section],
+					"%s/%s carries %q again - drop that section from its middlewareDocExceptions entry",
+					middlewareDocsDir, name, section)
 				continue
 			}
 			require.True(t, headings[section],
@@ -103,6 +108,8 @@ func Test_Docs_MiddlewarePageSections(t *testing.T) {
 	// An exception for a page that no longer exists would silently excuse that
 	// page the day someone adds it back.
 	for _, exception := range middlewareDocExceptions {
+		require.NotEmpty(t, strings.TrimSpace(exception.reason),
+			"middlewareDocExceptions covers %s without a reason", exception.file)
 		require.True(t, pages[exception.file],
 			"middlewareDocExceptions covers %s (%s) but that page does not exist",
 			exception.file, exception.reason)

--- a/middleware/logger/color_test.go
+++ b/middleware/logger/color_test.go
@@ -118,6 +118,9 @@ func Test_Logger_DefaultFormat_ColoredError(t *testing.T) {
 // beforeHandlerFunc decides whether stdout keeps its escape sequences. Nothing
 // pinned that choice so far, and the env overrides are what users reach for in
 // CI logs.
+//
+// No t.Parallel() here or in the subtests: t.Setenv rejects both, and the env
+// is what is under test. Same as prefork_test.go and middleware/envvar.
 func Test_beforeHandlerFunc_StdoutColorSelection(t *testing.T) {
 	stdoutCfg := func() *Config {
 		return &Config{Stream: os.Stdout, areColorsEnabled: true}

--- a/middleware/logger/color_test.go
+++ b/middleware/logger/color_test.go
@@ -1,0 +1,177 @@
+package logger
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/mattn/go-colorable"
+	"github.com/stretchr/testify/require"
+)
+
+// The colored default format needs ForceColors to be reachable from a test:
+// writing to anything but os.Stdout switches colors off. Without it the whole
+// fmt.Fprintf branch of defaultLoggerInstance is only touched by benchmarks.
+func Test_Logger_DefaultFormat_StatusColors(t *testing.T) {
+	t.Parallel()
+
+	colors := fiber.DefaultColors
+
+	cases := []struct {
+		want   string
+		status int
+	}{
+		{colors.Green, fiber.StatusOK},
+		{colors.Blue, fiber.StatusMovedPermanently},
+		{colors.Yellow, fiber.StatusNotFound},
+		{colors.Red, fiber.StatusInternalServerError},
+	}
+
+	for _, tc := range cases {
+		t.Run(strconv.Itoa(tc.status), func(t *testing.T) {
+			t.Parallel()
+
+			buf := bytes.NewBuffer(nil)
+			app := fiber.New()
+			app.Use(New(Config{Stream: buf, ForceColors: true}))
+			app.Get("/", func(c fiber.Ctx) error {
+				return c.SendStatus(tc.status)
+			})
+
+			resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+			require.NoError(t, err)
+			require.Equal(t, tc.status, resp.StatusCode)
+			require.Contains(t, buf.String(), "|"+tc.want+fmt.Sprintf(" %3d ", tc.status)+colors.Reset+"|")
+		})
+	}
+}
+
+func Test_Logger_DefaultFormat_MethodColors(t *testing.T) {
+	t.Parallel()
+
+	colors := fiber.DefaultColors
+
+	cases := []struct {
+		method string
+		want   string
+	}{
+		{fiber.MethodGet, colors.Cyan},
+		{fiber.MethodPost, colors.Green},
+		{fiber.MethodPut, colors.Yellow},
+		{fiber.MethodDelete, colors.Red},
+		{fiber.MethodPatch, colors.White},
+		{fiber.MethodHead, colors.Magenta},
+		{fiber.MethodOptions, colors.Blue},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.method, func(t *testing.T) {
+			t.Parallel()
+
+			buf := bytes.NewBuffer(nil)
+			app := fiber.New()
+			app.Use(New(Config{Stream: buf, ForceColors: true}))
+			app.All("/", func(c fiber.Ctx) error {
+				return c.SendString("ok")
+			})
+
+			resp, err := app.Test(httptest.NewRequest(tc.method, "/", http.NoBody))
+			require.NoError(t, err)
+			require.Equal(t, fiber.StatusOK, resp.StatusCode)
+			require.Contains(t, buf.String(), "|"+tc.want+fmt.Sprintf(" %-7s ", tc.method)+colors.Reset+"|")
+		})
+	}
+}
+
+// The colored branch assembles the error suffix itself instead of going
+// through the ${error} tag, so it needs its own scrubbing check: a raw CR/LF
+// in the error would otherwise forge a second access-log line (#4341).
+func Test_Logger_DefaultFormat_ColoredError(t *testing.T) {
+	t.Parallel()
+
+	colors := fiber.DefaultColors
+	buf := bytes.NewBuffer(nil)
+
+	app := fiber.New()
+	app.Use(New(Config{Stream: buf, ForceColors: true}))
+	app.Get("/", func(fiber.Ctx) error {
+		return errors.New("boom\r\n200 | forged")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+
+	out := buf.String()
+	require.Contains(t, out, colors.Red+" | boom  200 | forged"+colors.Reset)
+	require.Equal(t, 1, strings.Count(out, "\n"), "scrubbed error must stay on one line")
+}
+
+// beforeHandlerFunc decides whether stdout keeps its escape sequences. Nothing
+// pinned that choice so far, and the env overrides are what users reach for in
+// CI logs.
+func Test_beforeHandlerFunc_StdoutColorSelection(t *testing.T) {
+	stdoutCfg := func() *Config {
+		return &Config{Stream: os.Stdout, areColorsEnabled: true}
+	}
+	isPlain := func(w io.Writer) bool {
+		_, ok := w.(*colorable.NonColorable)
+		return ok
+	}
+
+	t.Run("NO_COLOR strips colors", func(t *testing.T) {
+		t.Setenv("TERM", "xterm")
+		t.Setenv("NO_COLOR", "1")
+
+		cfg := stdoutCfg()
+		beforeHandlerFunc(cfg)
+		require.True(t, isPlain(cfg.Stream))
+	})
+
+	t.Run("dumb terminal strips colors", func(t *testing.T) {
+		t.Setenv("TERM", "dumb")
+		t.Setenv("NO_COLOR", "")
+
+		cfg := stdoutCfg()
+		beforeHandlerFunc(cfg)
+		require.True(t, isPlain(cfg.Stream))
+	})
+
+	t.Run("ForceColors overrides both", func(t *testing.T) {
+		t.Setenv("TERM", "dumb")
+		t.Setenv("NO_COLOR", "1")
+
+		cfg := stdoutCfg()
+		cfg.ForceColors = true
+		beforeHandlerFunc(cfg)
+		require.False(t, isPlain(cfg.Stream))
+	})
+
+	t.Run("custom stream is left alone", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "1")
+
+		buf := bytes.NewBuffer(nil)
+		cfg := &Config{Stream: buf, areColorsEnabled: true}
+		beforeHandlerFunc(cfg)
+		require.Same(t, buf, cfg.Stream)
+	})
+
+	t.Run("colors disabled is left alone", func(t *testing.T) {
+		cfg := stdoutCfg()
+		cfg.areColorsEnabled = false
+		beforeHandlerFunc(cfg)
+		require.Same(t, os.Stdout, cfg.Stream)
+	})
+
+	t.Run("nil config", func(t *testing.T) {
+		require.NotPanics(t, func() { beforeHandlerFunc(nil) })
+	})
+}


### PR DESCRIPTION
# Description

Three independent coverage gaps, one commit each. No production code changes,
apart from two headings in the middleware docs.

Relates to #3370.

## Changes introduced

**Colored logger output.** The colored branch of the default access log format
is only reachable with `ForceColors` when the stream is not `os.Stdout`, so it
ran in benchmarks alone. Nothing pinned the colored status and method segments,
the red error suffix, or the control byte scrubbing that suffix applies (it is
assembled directly instead of going through the `${error}` tag, see #4341).
`beforeHandlerFunc`, which decides whether stdout keeps its escape sequences for
`NO_COLOR`, `TERM=dumb` and `ForceColors`, had no test at all.

**Shutdown with a streamed body.** The existing shutdown tests all block inside
the handler. A streamed body is written after the handler has returned, which is
the case reported in #3370 against v3.0.0-beta.4. Current behaviour is correct
(fasthttp closes only idle connections and counts open ones), so this pins it.
Checked the other way round as well: with a 10ms timeout the same test fails
with `context deadline exceeded`.

**Middleware doc structure.** Every page under `docs/middleware/` is expected to
carry `## Signatures`, `## Config` and `## Examples`, so a reader can jump
straight to either. Four pages deviate for a reason and now say so in the test
rather than being tolerated silently. Two did not have a reason: `adaptor.md`
used "Usage Examples" and `rewrite.md` nested Examples under Config at level 3.
Neither anchor was linked anywhere, so both were renamed. This runs with
`go test ./...` and needs no CI wiring.

- [x] Documentation Update: `docs/middleware/adaptor.md` and
      `docs/middleware/rewrite.md`, heading names only

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
