### PR TITLE
docs(bind): document the nested and array field notations

### DIFF
--- a/binder/notation_test.go
+++ b/binder/notation_test.go
@@ -1,6 +1,8 @@
 package binder
 
 import (
+	"bytes"
+	"mime/multipart"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,9 +25,31 @@ type notationTarget struct {
 	Items  []notationInner `form:"items" query:"items"`
 }
 
+// multipartRequest re-encodes a urlencoded input as a multipart body, so the
+// same table can be sent through bindMultipart without being written out twice.
+func multipartRequest(t *testing.T, input string) *fasthttp.Request {
+	t.Helper()
+
+	var args fasthttp.Args
+	args.Parse(input)
+
+	body := new(bytes.Buffer)
+	writer := multipart.NewWriter(body)
+	for key, value := range args.All() {
+		require.NoError(t, writer.WriteField(string(key), string(value)))
+	}
+	require.NoError(t, writer.Close())
+
+	req := fasthttp.AcquireRequest()
+	req.SetBody(body.Bytes())
+	req.Header.SetContentType(writer.FormDataContentType())
+
+	return req
+}
+
 // Test_Notation_FormAndQuery pins the key notations the binding docs promise.
-// Form and query share one schema decoder, so both run against the same table:
-// a divergence between them is a bug in either.
+// Form, multipart and query share one schema decoder, so all three run against
+// the same table: a divergence between them is a bug in one of them.
 func Test_Notation_FormAndQuery(t *testing.T) {
 	t.Parallel()
 
@@ -105,6 +129,15 @@ func Test_Notation_FormAndQuery(t *testing.T) {
 			var form notationTarget
 			require.NoError(t, (&FormBinding{}).Bind(formReq, &form))
 			require.Equal(t, tc.want, form)
+
+			// Multipart takes its own branch through bindMultipart before it
+			// reaches the shared decoder, so the docs only get to claim both.
+			multipartReq := multipartRequest(t, tc.input)
+			defer fasthttp.ReleaseRequest(multipartReq)
+
+			var multipartOut notationTarget
+			require.NoError(t, (&FormBinding{}).Bind(multipartReq, &multipartOut))
+			require.Equal(t, tc.want, multipartOut)
 
 			queryReq := fasthttp.AcquireRequest()
 			defer fasthttp.ReleaseRequest(queryReq)

--- a/binder/notation_test.go
+++ b/binder/notation_test.go
@@ -1,0 +1,118 @@
+package binder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+type notationInner struct {
+	Name string `form:"name" query:"name"`
+	Age  int    `form:"age" query:"age"`
+}
+
+type notationDeep struct {
+	Sub notationInner `form:"sub" query:"sub"`
+}
+
+type notationTarget struct {
+	Inner  notationInner   `form:"inner" query:"inner"`
+	Deep   notationDeep    `form:"deep" query:"deep"`
+	Colors []string        `form:"colors" query:"colors"`
+	Items  []notationInner `form:"items" query:"items"`
+}
+
+// Test_Notation_FormAndQuery pins the key notations the binding docs promise.
+// Form and query share one schema decoder, so both run against the same table:
+// a divergence between them is a bug in either.
+func Test_Notation_FormAndQuery(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  notationTarget
+	}{
+		{
+			name:  "repeated key",
+			input: "colors=red&colors=blue",
+			want:  notationTarget{Colors: []string{"red", "blue"}},
+		},
+		{
+			name:  "empty brackets",
+			input: "colors[]=red&colors[]=blue",
+			want:  notationTarget{Colors: []string{"red", "blue"}},
+		},
+		{
+			// An index addresses a struct field, so it never reaches a []string
+			// element. The value is dropped, and without an error.
+			name:  "index on a scalar slice is dropped",
+			input: "colors[0]=red&colors[1]=blue",
+			want:  notationTarget{},
+		},
+		{
+			name:  "dot index on a scalar slice is dropped",
+			input: "colors.0=red&colors.1=blue",
+			want:  notationTarget{},
+		},
+		{
+			name:  "bracket struct field",
+			input: "inner[name]=bob&inner[age]=7",
+			want:  notationTarget{Inner: notationInner{Name: "bob", Age: 7}},
+		},
+		{
+			name:  "dot struct field",
+			input: "inner.name=bob&inner.age=7",
+			want:  notationTarget{Inner: notationInner{Name: "bob", Age: 7}},
+		},
+		{
+			name:  "indexed brackets on a struct slice",
+			input: "items[0][name]=a&items[1][name]=b",
+			want:  notationTarget{Items: []notationInner{{Name: "a"}, {Name: "b"}}},
+		},
+		{
+			name:  "dot index on a struct slice",
+			input: "items.0.name=a&items.1.name=b",
+			want:  notationTarget{Items: []notationInner{{Name: "a"}, {Name: "b"}}},
+		},
+		{
+			name:  "bracket index mixed with a dot field",
+			input: "items[0].name=a&items[1].name=b",
+			want:  notationTarget{Items: []notationInner{{Name: "a"}, {Name: "b"}}},
+		},
+		{
+			name:  "brackets two levels deep",
+			input: "deep[sub][name]=x&deep[sub][age]=3",
+			want:  notationTarget{Deep: notationDeep{Sub: notationInner{Name: "x", Age: 3}}},
+		},
+		{
+			name:  "dots two levels deep",
+			input: "deep.sub.name=x&deep.sub.age=3",
+			want:  notationTarget{Deep: notationDeep{Sub: notationInner{Name: "x", Age: 3}}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			formReq := fasthttp.AcquireRequest()
+			defer fasthttp.ReleaseRequest(formReq)
+			formReq.SetBodyString(tc.input)
+			formReq.Header.SetContentType("application/x-www-form-urlencoded")
+
+			var form notationTarget
+			require.NoError(t, (&FormBinding{}).Bind(formReq, &form))
+			require.Equal(t, tc.want, form)
+
+			queryReq := fasthttp.AcquireRequest()
+			defer fasthttp.ReleaseRequest(queryReq)
+			queryReq.URI().SetQueryString(tc.input)
+
+			var query notationTarget
+			require.NoError(t, (&QueryBinding{}).Bind(queryReq, &query))
+			require.Equal(t, tc.want, query)
+		})
+	}
+}

--- a/docs/api/bind.md
+++ b/docs/api/bind.md
@@ -272,6 +272,63 @@ Run tests with the following `curl` command:
 curl -X POST -H "Content-Type: multipart/form-data" -F "name=john" -F "pass=doe" -F 'avatar=@filename' localhost:3000
 ```
 
+#### Nested and Array Form Fields
+
+A form body is a flat list of key/value pairs, so structure lives in the field name. The notations below work for both `application/x-www-form-urlencoded` and `multipart/form-data`, and identically for [query parameters](#query).
+
+| Notation           | Example field name           | Binds to                             |
+| ------------------ | ---------------------------- | ------------------------------------ |
+| Repeated key       | `colors=red&colors=blue`     | slice of scalars                     |
+| Empty brackets     | `colors[]=red&colors[]=blue` | slice of scalars                     |
+| Bracket field      | `address[city]=Berlin`       | field of a nested struct             |
+| Dot field          | `address.city=Berlin`        | field of a nested struct             |
+| Indexed brackets   | `items[0][sku]=A1`           | field of a struct slice element      |
+| Dot index          | `items.0.sku=A1`             | field of a struct slice element      |
+| Mixed index/field  | `items[0].sku=A1`            | field of a struct slice element      |
+
+Bracket and dot notation are interchangeable and can be nested to any depth:
+
+```go title="Struct"
+type Address struct {
+    City string `form:"city"`
+    Zip  string `form:"zip"`
+}
+
+type Item struct {
+    SKU string `form:"sku"`
+    Qty int    `form:"qty"`
+}
+
+type Order struct {
+    Colors  []string `form:"colors"`
+    Address Address  `form:"address"`
+    Items   []Item   `form:"items"`
+}
+```
+
+```bash title="curl"
+curl -X POST http://localhost:3000/orders \
+  --data "colors[]=red&colors[]=blue" \
+  --data "address[city]=Berlin&address.zip=10115" \
+  --data "items[0][sku]=A1&items[0].qty=2&items.1.sku=B2&items.1.qty=5"
+```
+
+```go title="Result"
+Order{
+    Colors:  []string{"red", "blue"},
+    Address: Address{City: "Berlin", Zip: "10115"},
+    Items:   []Item{{SKU: "A1", Qty: 2}, {SKU: "B2", Qty: 5}},
+}
+```
+
+:::caution
+An index only ever addresses a struct field. `colors[0]=red` and `colors.0=red` do **not** fill a `[]string`; the value is dropped and no error is returned. Use a repeated key or `colors[]` for slices of scalars.
+:::
+
+:::note
+The struct field tag never contains the brackets or the index. `colors[]`, `colors[0]` and `colors.0` all resolve against `form:"colors"`.
+:::
+
 ### JSON
 
 Binds the request JSON body to a struct.
@@ -512,6 +569,7 @@ Fiber supports several formats for passing array values via query parameters. Th
 | Comma-separated          | `?colors=red,blue`                             | **Yes**                             |
 | Indexed bracket notation | `?posts[0][title]=Hello&posts[1][title]=World` | No                                  |
 | Nested bracket notation  | `?preferences[tags]=golang,api`                | No (comma splitting: **Yes**)       |
+| Dot notation             | `?user.name=Alice&posts.0.title=Hello`         | No                                  |
 
 ##### Repeated Key
 
@@ -653,6 +711,32 @@ curl "http://localhost:3000/api?preferences[tags]=golang,api"
 :::note
 Pointer fields (`*[]string`, `*Preferences`) let you distinguish between a missing parameter (`nil`) and an empty one. When the parameter is present, Fiber allocates the pointer automatically.
 :::
+
+##### Dot Notation
+
+Every bracket form has a dot equivalent, and the two can be mixed within one request:
+
+```text
+GET /api?user.name=Alice&posts.0.title=Hello&posts[1].title=World
+```
+
+```go title="Struct"
+type Post struct {
+    Title string `query:"title"`
+}
+
+type User struct {
+    Name string `query:"name"`
+}
+
+type Request struct {
+    User  User   `query:"user"`
+    Posts []Post `query:"posts"`
+}
+// Result: User = {Name: "Alice"}, Posts = [{Title: "Hello"}, {Title: "World"}]
+```
+
+Query and form binding share the same decoder, so the full notation reference in [Nested and Array Form Fields](#nested-and-array-form-fields) applies here too — including the caveat that an index never fills a slice of scalars.
 
 ### RespHeader
 

--- a/docs/api/bind.md
+++ b/docs/api/bind.md
@@ -276,7 +276,7 @@ curl -X POST -H "Content-Type: multipart/form-data" -F "name=john" -F "pass=doe"
 
 A form body is a flat list of key/value pairs, so structure lives in the field name. The notations below work for both `application/x-www-form-urlencoded` and `multipart/form-data`, and identically for [query parameters](#query).
 
-| Notation           | Example field name           | Binds to                             |
+| Notation           | Example                      | Binds to                             |
 | ------------------ | ---------------------------- | ------------------------------------ |
 | Repeated key       | `colors=red&colors=blue`     | slice of scalars                     |
 | Empty brackets     | `colors[]=red&colors[]=blue` | slice of scalars                     |
@@ -322,7 +322,7 @@ Order{
 ```
 
 :::caution
-An index only ever addresses a struct field. `colors[0]=red` and `colors.0=red` do **not** fill a `[]string`; the value is dropped and no error is returned. Use a repeated key or `colors[]` for slices of scalars.
+An index only ever addresses a struct field. `colors[0]=red` and `colors.0=red` do **not** fill a `[]string`. With the default decoder the value is dropped and no error is returned; after `SetParserDecoder(ParserConfig{IgnoreUnknownKeys: false})` the same input fails with `schema: invalid path "colors.0"`. Use a repeated key or `colors[]` for slices of scalars.
 :::
 
 :::note
@@ -714,7 +714,7 @@ Pointer fields (`*[]string`, `*Preferences`) let you distinguish between a missi
 
 ##### Dot Notation
 
-Every bracket form has a dot equivalent, and the two can be mixed within one request:
+Nested fields and indexes have a dot equivalent, and the two can be mixed within one request. Empty brackets are the exception, `colors[]` has no dot form:
 
 ```text
 GET /api?user.name=Alice&posts.0.title=Hello&posts[1].title=World
@@ -736,7 +736,7 @@ type Request struct {
 // Result: User = {Name: "Alice"}, Posts = [{Title: "Hello"}, {Title: "World"}]
 ```
 
-Query and form binding share the same decoder, so the full notation reference in [Nested and Array Form Fields](#nested-and-array-form-fields) applies here too — including the caveat that an index never fills a slice of scalars.
+Query and form binding share the same decoder, so the full notation reference in [Nested and Array Form Fields](#nested-and-array-form-fields) applies here too, including the caveat that an index never fills a slice of scalars.
 
 ### RespHeader
 


### PR DESCRIPTION
# Description

The binding docs describe array notations for query parameters and say nothing
about them for a form body, even though both go through the same schema decoder
and behave identically. Dot notation is not documented anywhere, although it has
always worked. And nothing warns about the one shape that fails silently.

## Changes introduced

A "Nested and Array Form Fields" reference under `### Form`, with the full
notation table, a worked example and a curl line, plus a "Dot Notation"
subsection under the query array parameters that cross-references it.

| Notation | Example | Binds to |
| --- | --- | --- |
| Repeated key | `colors=red&colors=blue` | slice of scalars |
| Empty brackets | `colors[]=red&colors[]=blue` | slice of scalars |
| Bracket field | `address[city]=Berlin` | field of a nested struct |
| Dot field | `address.city=Berlin` | field of a nested struct |
| Indexed brackets | `items[0][sku]=A1` | field of a struct slice element |
| Dot index | `items.0.sku=A1` | field of a struct slice element |
| Mixed | `items[0].sku=A1` | field of a struct slice element |

The trap, now a `:::caution`: an index only ever addresses a struct field, so
`colors[0]=red` and `colors.0=red` do **not** fill a `[]string`. The value is
dropped and no error is returned.

`binder/notation_test.go` pins all of it. Form and query run against the same
table, so a divergence between the two binders is a test failure.

- [x] Documentation Update: `docs/api/bind.md`
- [x] Examples: the notation table and one worked example per section

## Verification

Every row of the table was measured against the binder before it was written,
and both worked examples in the docs were run against it as well. Not written
from memory.

## Type of change

- [x] Documentation update (changes to documentation)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
