### PR TITLE
ci: enable the central issue auto reply

### DIFF
--- a/.github/issue-replies/wait-for-response.md
+++ b/.github/issue-replies/wait-for-response.md
@@ -1,0 +1,9 @@
+Thanks for the report. To take this further we need a **minimal reproducible example**: the smallest program that still shows the behaviour.
+
+Please share:
+
+- a runnable `main.go`, not a fragment - imports, `app := fiber.New()`, the route, and `app.Listen`
+- the request you send (a `curl` line is ideal) and what you expected instead
+- your Fiber version (`go list -m github.com/gofiber/fiber/v3`) and `go version`
+
+If the behaviour only shows up with a middleware or a storage driver, keep that in and drop everything else.

--- a/.github/workflows/issue-auto-reply.yml
+++ b/.github/workflows/issue-auto-reply.yml
@@ -1,0 +1,13 @@
+name: issue-auto-reply
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  reply:
+    uses: gofiber/.github/.github/workflows/issue-auto-reply.yml@main

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -32,3 +32,4 @@ jobs:
           globs: |
             **/*.md
             #vendor
+            #.github/issue-replies


### PR DESCRIPTION
# Description

Adopts the `issue-auto-reply` workflow added in
gofiber/.github.

**Depends on the reusable workflow landing first**, since the caller references
`gofiber/.github@main`.

## Changes introduced

One reply template to start with, behind the existing "♻ Wait for Response"
label, asking for a minimal reproducible example. Adding another reply is one
more markdown file, there is no mapping config: the file name is the label
reduced to ascii. A hidden marker in the posted comment keeps a re-applied label
from repeating it.

The version check that comes with the same workflow needs no file at all. It
reads the `Fiber Version` field of the bug report form and asks for a retest only
when a newer release of the same major exists, so a v2 report is never answered
with a v3 release.

`.github/issue-replies/` is excluded from the markdown lint globs: those files
are comment bodies, not documents, so requiring a top level heading (MD041)
makes no sense for them.

The reusable workflow also offers a Conventional Commits title check. That one is
deliberately **not** adopted here, it can follow separately.

## Type of change

- [x] Enhancement (improvement to existing features and functionality)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.
