### PR TITLE
🐛 fix(domain): expand nested mounts when cloning a sub-app

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -431,13 +431,7 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	subApp.mutex.Lock()
 	defer subApp.mutex.Unlock()
 	for m := range subApp.stack {
-		for _, route := range subApp.stack[m] {
-			clonedRoute := subApp.copyRoute(route)
-			if len(clonedRoute.Handlers) > 0 {
-				clonedRoute.Handlers = d.wrapHandlers(clonedRoute.Handlers)
-			}
-			wrapperApp.stack[m] = append(wrapperApp.stack[m], clonedRoute)
-		}
+		wrapperApp.stack[m] = append(wrapperApp.stack[m], d.cloneRoutes(subApp, m)...)
 	}
 
 	d.app.mutex.Lock()
@@ -471,6 +465,34 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	}
 
 	return d
+}
+
+// cloneRoutes returns the routes app has registered for a single HTTP method,
+// cloned with domain-filtered handlers. Apps mounted on app are expanded in
+// place rather than cloned as mount placeholders: copyRoute does not carry over
+// the unexported group field, so a placeholder surviving into the clone would
+// leave processSubAppsRoutes dereferencing a nil group at startup.
+func (d *domainRouter) cloneRoutes(app *App, m int) []*Route {
+	routes := make([]*Route, 0, len(app.stack[m]))
+
+	for _, route := range app.stack[m] {
+		if route.mount {
+			mountedApp := route.group.app
+			for _, mountedRoute := range d.cloneRoutes(mountedApp, m) {
+				routes = append(routes, app.addPrefixToRoute(route.path, mountedRoute, mountedApp.config.RegexHandler, mountedApp.customConstraints...))
+			}
+
+			continue
+		}
+
+		clonedRoute := app.copyRoute(route)
+		if len(clonedRoute.Handlers) > 0 {
+			clonedRoute.Handlers = d.wrapHandlers(clonedRoute.Handlers)
+		}
+		routes = append(routes, clonedRoute)
+	}
+
+	return routes
 }
 
 // Get registers a route for GET methods.

--- a/domain_test.go
+++ b/domain_test.go
@@ -1898,6 +1898,62 @@ func Test_Domain_UseMountRoutesAfterMount(t *testing.T) {
 	require.Equal(t, StatusNotFound, resp.StatusCode)
 }
 
+// Test_Domain_UseMountNested verifies that a sub-app which itself mounts
+// another app can be mounted on a domain router: the nested routes are
+// registered and stay domain-filtered.
+func Test_Domain_UseMountNested(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	subApp := New()
+	childApp := New()
+	grandChildApp := New()
+
+	grandChildApp.Get("/deep", func(c Ctx) error {
+		return c.SendString("deep response")
+	})
+	childApp.Get("/data", func(c Ctx) error {
+		return c.SendString("data response")
+	})
+	childApp.Use("/nested", grandChildApp)
+	subApp.Use("/v1", childApp)
+
+	// Mount the sub-app, which carries its own mounts, on the domain router
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	// Routes of the nested apps work on the correct domain
+	req := httptest.NewRequest(MethodGet, "/api/v1/data", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "data response", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/api/v1/nested/deep", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "deep response", string(body))
+
+	// The same routes are rejected on a wrong domain
+	req = httptest.NewRequest(MethodGet, "/api/v1/data", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+
+	req = httptest.NewRequest(MethodGet, "/api/v1/nested/deep", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
+
 // Test_Domain_Security_PatternLengthLimits verifies RFC 1035 length limits
 // are enforced for domain patterns (253 total, 63 per label).
 func Test_Domain_Security_PatternLengthLimits(t *testing.T) {


### PR DESCRIPTION
# Description

`domainRouter.mount` clones the sub-app's routes into a wrapper app so the original is left alone. The clone comes from `App.copyRoute`, which does not carry over the unexported `group` field. That is fine for a normal route, but a mount placeholder keeps the app it points at in `route.group.app`, so if the sub-app has mounts of its own the clone reaches startup with `mount == true` and `group == nil`, and `processSubAppsRoutes` dereferences it.

The plain (non-domain) case does not hit this because every mounted app expands its own placeholders before the parent copies its stack. The wrapper app is never in `mountFields.appList`, so nothing expands its placeholders and one survives into the parent stack.

Instead of cloning placeholders, the wrapper is now built by expanding the sub-app's mounts in place, recursively, applying the placeholder prefix the same way `processSubAppsRoutes` does. The handlers of the nested apps go through `wrapHandlers` too, so they keep the host filter rather than being served on every host.

Fixes #4618

## Changes introduced

- Added `domainRouter.cloneRoutes`, which returns a sub-app's routes for one method with domain-filtered handlers and mounted apps expanded in place.
- `domainRouter.mount` builds the wrapper app through it.

## Type of change

- [x] Bug fix (non-breaking change which corrects existing functionality)

## Checklist

- [x] Conducted a self-review of the code.
- [x] Added a unit test, `Test_Domain_UseMountNested`, which panics on `main` and passes here. It covers two levels of nesting and checks that the nested routes still 404 on a non-matching host.
- [x] Ensured that new and existing unit tests pass locally, `go test -race ./...` and `make lint` are clean.
- [x] No new dependencies.
- [x] The expansion happens once at mount time, so request-time routing is unchanged.
