### PR TITLE
🐛 fix: nil pointer dereference when a domain-mounted sub-app contains a nested mount

### DIFF
--- a/app.go
+++ b/app.go
@@ -20,6 +20,7 @@ import (
 	"net/http/httputil"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1589,6 +1590,7 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 
 	var (
 		mountedErrHandler  ErrorHandler
+		mountedErrApp      *App
 		mountedPrefixParts int
 	)
 
@@ -1601,6 +1603,7 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 			if mountedPrefixParts <= parts {
 				if subApp.configured.ErrorHandler != nil {
 					mountedErrHandler = subApp.config.ErrorHandler
+					mountedErrApp = subApp
 				}
 
 				mountedPrefixParts = parts
@@ -1618,7 +1621,11 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 		// above them both still encloses the owner, and an owner configuring
 		// no handler of its own inherits it, as a nested mount inherits the
 		// handler of the mount it sits in.
-		if owner.ties(mountedPrefixParts) {
+		//
+		// Unless the mount is one of the apps the owner sits in: a domain
+		// mount at the root of a plain one covers exactly the paths that mount
+		// does, and is as deep as it without being beside it.
+		if owner.ties(mountedPrefixParts) && !slices.Contains(owner.ancestors, mountedErrApp) {
 			mountedErrHandler = nil
 		}
 

--- a/app.go
+++ b/app.go
@@ -1599,7 +1599,7 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 
 		if app.mountCoversPath(prefix, ctx.Path()) {
 			// Count slashes instead of splitting - more efficient
-			parts := strings.Count(prefix, "/") + 1
+			parts := mountDepth(prefix)
 			if mountedPrefixParts <= parts {
 				if subApp.configured.ErrorHandler != nil {
 					mountedErrHandler = subApp.config.ErrorHandler
@@ -1611,27 +1611,16 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 	}
 
 	// Sub-apps mounted on a domain answer only for a matching host, so their
-	// error handler cannot be picked by path alone. They are considered after
-	// the plain mounts, which lets a domain mount win a tie on path depth: it
-	// matched the host too, so it is the more specific of the two.
-	//
-	// Between two domain mounts at the same depth the first one registered
-	// wins, matching the order their routes are matched in — a pattern that
-	// only overlaps a later one still keeps its own handler.
-	domainPrefixParts := -1
-
-	for i := range app.mountFields.domainAppList {
-		mount := &app.mountFields.domainAppList[i]
-
-		if app.mountCoversPath(mount.path, ctx.Path()) && mount.matchesHost(ctx.Hostname()) {
-			if parts := mount.prefixParts(); mountedPrefixParts <= parts && domainPrefixParts < parts {
-				if mount.app.configured.ErrorHandler != nil {
-					mountedErrHandler = mount.app.config.ErrorHandler
-				}
-
-				mountedPrefixParts = parts
-				domainPrefixParts = parts
-			}
+	// error handler cannot be picked by path alone. The owner is considered
+	// after the plain mounts, which lets a domain mount win a tie on path
+	// depth: it matched the host too, so it is the more specific of the two.
+	if owner, depth := app.domainMountOwner(ctx); owner != nil && mountedPrefixParts <= depth {
+		// The owner decides, as it does among the plain mounts: one without a
+		// handler of its own falls through to this app's, rather than to the
+		// handler of a shallower mount that did not serve the request.
+		mountedErrHandler = nil
+		if owner.configured.ErrorHandler != nil {
+			mountedErrHandler = owner.config.ErrorHandler
 		}
 	}
 

--- a/app.go
+++ b/app.go
@@ -1606,13 +1606,10 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 		mountedPrefixParts int
 	)
 
-	normalizedPath := utils.AddTrailingSlashString(ctx.Path())
-
 	for _, prefix := range app.mountFields.appListKeys {
 		subApp := app.mountFields.appList[prefix]
-		normalizedPrefix := utils.AddTrailingSlashString(prefix)
 
-		if prefix != "" && strings.HasPrefix(normalizedPath, normalizedPrefix) {
+		if app.mountCoversPath(prefix, ctx.Path()) {
 			// Count slashes instead of splitting - more efficient
 			parts := strings.Count(prefix, "/") + 1
 			if mountedPrefixParts <= parts {
@@ -1637,9 +1634,8 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 
 	for i := range app.mountFields.domainAppList {
 		mount := &app.mountFields.domainAppList[i]
-		normalizedPrefix := utils.AddTrailingSlashString(mount.path)
 
-		if mount.path != "" && strings.HasPrefix(normalizedPath, normalizedPrefix) && mount.matchesHost(ctx.Hostname()) {
+		if app.mountCoversPath(mount.path, ctx.Path()) && mount.matchesHost(ctx.Hostname()) {
 			if parts := mount.prefixParts(); mountedPrefixParts <= parts && domainPrefixParts < parts {
 				if mount.app.configured.ErrorHandler != nil {
 					mountedErrHandler = mount.app.config.ErrorHandler

--- a/app.go
+++ b/app.go
@@ -1613,10 +1613,15 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 	// after the plain mounts, which lets a domain mount win a tie on path
 	// depth: it matched the host too, so it is the more specific of the two.
 	if owner := app.domainMountOwner(ctx); owner.outranks(mountedPrefixParts) {
-		// The owner decides, as it does among the plain mounts: one without a
-		// handler of its own falls through to this app's, rather than to the
-		// handler of a shallower mount that did not serve the request.
-		mountedErrHandler = nil
+		// A plain mount as deep as the owner is a sibling that did not serve
+		// the request, so its handler is dropped rather than inherited. One
+		// above them both still encloses the owner, and an owner configuring
+		// no handler of its own inherits it, as a nested mount inherits the
+		// handler of the mount it sits in.
+		if owner.ties(mountedPrefixParts) {
+			mountedErrHandler = nil
+		}
+
 		if owner.app.configured.ErrorHandler != nil {
 			mountedErrHandler = owner.app.config.ErrorHandler
 		}

--- a/app.go
+++ b/app.go
@@ -1629,17 +1629,24 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 	// error handler cannot be picked by path alone. They are considered after
 	// the plain mounts, which lets a domain mount win a tie on path depth: it
 	// matched the host too, so it is the more specific of the two.
+	//
+	// Between two domain mounts at the same depth the first one registered
+	// wins, matching the order their routes are matched in — a pattern that
+	// only overlaps a later one still keeps its own handler.
+	domainPrefixParts := -1
+
 	for i := range app.mountFields.domainAppList {
 		mount := &app.mountFields.domainAppList[i]
 		normalizedPrefix := utils.AddTrailingSlashString(mount.path)
 
 		if mount.path != "" && strings.HasPrefix(normalizedPath, normalizedPrefix) && mount.matchesHost(ctx.Hostname()) {
-			if parts := mount.prefixParts(); mountedPrefixParts <= parts {
+			if parts := mount.prefixParts(); mountedPrefixParts <= parts && domainPrefixParts < parts {
 				if mount.app.configured.ErrorHandler != nil {
 					mountedErrHandler = mount.app.config.ErrorHandler
 				}
 
 				mountedPrefixParts = parts
+				domainPrefixParts = parts
 			}
 		}
 	}

--- a/app.go
+++ b/app.go
@@ -20,7 +20,6 @@ import (
 	"net/http/httputil"
 	"os"
 	"reflect"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1616,16 +1615,15 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 	// after the plain mounts, which lets a domain mount win a tie on path
 	// depth: it matched the host too, so it is the more specific of the two.
 	if owner := app.domainMountOwner(ctx); owner.outranks(mountedPrefixParts) {
-		// A plain mount as deep as the owner is a sibling that did not serve
-		// the request, so its handler is dropped rather than inherited. One
-		// above them both still encloses the owner, and an owner configuring
-		// no handler of its own inherits it, as a nested mount inherits the
-		// handler of the mount it sits in.
+		// A plain mount the owner supersedes did not serve the request, so its
+		// handler is dropped rather than inherited. One enclosing the owner
+		// still does, and an owner configuring no handler of its own inherits
+		// it, as a nested mount inherits the handler of the mount it sits in.
 		//
 		// Unless the mount is one of the apps the owner sits in: a domain
 		// mount at the root of a plain one covers exactly the paths that mount
 		// does, and is as deep as it without being beside it.
-		if owner.ties(mountedPrefixParts) && !slices.Contains(owner.ancestors, mountedErrApp) {
+		if owner.supersedes(mountedPrefixParts, mountedErrApp) {
 			mountedErrHandler = nil
 		}
 

--- a/app.go
+++ b/app.go
@@ -20,6 +20,7 @@ import (
 	"net/http/httputil"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -901,9 +902,19 @@ func (app *App) ReloadViews() error {
 	app.mutex.Lock()
 	defer app.mutex.Unlock()
 
-	apps := map[string]*App{"": app}
+	apps := []*App{app}
 	if app.mountFields != nil {
-		apps = app.mountFields.appList
+		apps = apps[:0]
+		for _, subApp := range app.mountFields.appList {
+			apps = append(apps, subApp)
+		}
+		// Domain mounts are kept out of appList, but their view engines still
+		// have to be reloaded.
+		for i := range app.mountFields.domainAppList {
+			if mount := &app.mountFields.domainAppList[i]; !slices.Contains(apps, mount.app) {
+				apps = append(apps, mount.app)
+			}
+		}
 	}
 
 	var reloaded bool
@@ -1585,7 +1596,7 @@ func (app *App) init() *App {
 // the app, which if not set is the DefaultErrorHandler.
 func (app *App) ErrorHandler(ctx Ctx, err error) error {
 	// Fast path: no mounted sub-apps, so no prefix lookup is needed
-	if len(app.mountFields.appListKeys) == 0 {
+	if len(app.mountFields.appListKeys) == 0 && len(app.mountFields.domainAppList) == 0 {
 		return app.config.ErrorHandler(ctx, err)
 	}
 
@@ -1606,6 +1617,25 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 			if mountedPrefixParts <= parts {
 				if subApp.configured.ErrorHandler != nil {
 					mountedErrHandler = subApp.config.ErrorHandler
+				}
+
+				mountedPrefixParts = parts
+			}
+		}
+	}
+
+	// Sub-apps mounted on a domain answer only for a matching host, so their
+	// error handler cannot be picked by path alone. They are considered after
+	// the plain mounts, which lets a domain mount win a tie on path depth: it
+	// matched the host too, so it is the more specific of the two.
+	for i := range app.mountFields.domainAppList {
+		mount := &app.mountFields.domainAppList[i]
+		normalizedPrefix := utils.AddTrailingSlashString(mount.path)
+
+		if mount.path != "" && strings.HasPrefix(normalizedPath, normalizedPrefix) && mount.matchesHost(ctx.Hostname()) {
+			if parts := mount.prefixParts(); mountedPrefixParts <= parts {
+				if mount.app.configured.ErrorHandler != nil {
+					mountedErrHandler = mount.app.config.ErrorHandler
 				}
 
 				mountedPrefixParts = parts

--- a/app.go
+++ b/app.go
@@ -20,7 +20,6 @@ import (
 	"net/http/httputil"
 	"os"
 	"reflect"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -902,21 +901,10 @@ func (app *App) ReloadViews() error {
 	app.mutex.Lock()
 	defer app.mutex.Unlock()
 
-	apps := []*App{app}
-	if app.mountFields != nil {
-		for _, subApp := range app.mountFields.appList {
-			if !slices.Contains(apps, subApp) {
-				apps = append(apps, subApp)
-			}
-		}
-		// Domain mounts are kept out of appList, but their view engines still
-		// have to be reloaded.
-		for i := range app.mountFields.domainAppList {
-			if mount := &app.mountFields.domainAppList[i]; !slices.Contains(apps, mount.app) {
-				apps = append(apps, mount.app)
-			}
-		}
-	}
+	// Walks the mount metadata rather than the flattened app list: a domain
+	// mount nested inside a plain one only reaches the root's list once the
+	// app has started, and ReloadViews may be called before that.
+	apps := app.mountedApps()
 
 	var reloaded bool
 	for _, targetApp := range apps {

--- a/app.go
+++ b/app.go
@@ -1622,7 +1622,7 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 			mountedErrHandler = nil
 		}
 
-		if handler := app.domainMountConfig(ctx, owner, appHasErrorHandler); handler != nil {
+		if handler := domainMountConfig(owner, appHasErrorHandler); handler != nil {
 			mountedErrHandler = handler.config.ErrorHandler
 		}
 	}

--- a/app.go
+++ b/app.go
@@ -1612,13 +1612,13 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 	// error handler cannot be picked by path alone. The owner is considered
 	// after the plain mounts, which lets a domain mount win a tie on path
 	// depth: it matched the host too, so it is the more specific of the two.
-	if owner, depth := app.domainMountOwner(ctx); owner != nil && mountedPrefixParts <= depth {
+	if owner := app.domainMountOwner(ctx); owner.outranks(mountedPrefixParts) {
 		// The owner decides, as it does among the plain mounts: one without a
 		// handler of its own falls through to this app's, rather than to the
 		// handler of a shallower mount that did not serve the request.
 		mountedErrHandler = nil
-		if owner.configured.ErrorHandler != nil {
-			mountedErrHandler = owner.config.ErrorHandler
+		if owner.app.configured.ErrorHandler != nil {
+			mountedErrHandler = owner.app.config.ErrorHandler
 		}
 	}
 

--- a/app.go
+++ b/app.go
@@ -1622,8 +1622,8 @@ func (app *App) ErrorHandler(ctx Ctx, err error) error {
 			mountedErrHandler = nil
 		}
 
-		if owner.app.configured.ErrorHandler != nil {
-			mountedErrHandler = owner.app.config.ErrorHandler
+		if handler := app.domainMountConfig(ctx, owner, appHasErrorHandler); handler != nil {
+			mountedErrHandler = handler.config.ErrorHandler
 		}
 	}
 

--- a/app.go
+++ b/app.go
@@ -898,12 +898,10 @@ func (app *App) RegisterCustomBinder(customBinder CustomBinder) {
 // ReloadViews reloads the configured view engine by invoking its Load method.
 // It returns an error if no view engine is configured or if reloading fails.
 func (app *App) ReloadViews() error {
-	app.mutex.Lock()
-	defer app.mutex.Unlock()
-
 	// Walks the mount metadata rather than the flattened app list: a domain
 	// mount nested inside a plain one only reaches the root's list once the
-	// app has started, and ReloadViews may be called before that.
+	// app has started, and ReloadViews may be called before that. The walk
+	// takes each app's own lock in turn, so this must not hold one itself.
 	apps := app.mountedApps()
 
 	var reloaded bool

--- a/app.go
+++ b/app.go
@@ -904,9 +904,10 @@ func (app *App) ReloadViews() error {
 
 	apps := []*App{app}
 	if app.mountFields != nil {
-		apps = apps[:0]
 		for _, subApp := range app.mountFields.appList {
-			apps = append(apps, subApp)
+			if !slices.Contains(apps, subApp) {
+				apps = append(apps, subApp)
+			}
 		}
 		// Domain mounts are kept out of appList, but their view engines still
 		// have to be reloaded.

--- a/app_test.go
+++ b/app_test.go
@@ -2479,6 +2479,42 @@ func Test_App_ReloadViews_MountedViews_MultipleApps(t *testing.T) {
 	require.Equal(t, initialLoadsB+1, viewB.loads)
 }
 
+func Test_App_ReloadViews_MountedViews_ConcurrentMount(t *testing.T) {
+	t.Parallel()
+	view := &countingView{}
+	subApp := New()
+	app := New(Config{Views: view})
+	app.Use("/sub", subApp)
+
+	// The walk down the mount tree reads every app's mount metadata, so it has
+	// to take each app's own lock rather than only the one it started from.
+	initialLoads := view.loads
+
+	var (
+		wg        sync.WaitGroup
+		reloadErr error
+	)
+
+	wg.Go(func() {
+		for range 200 {
+			if err := app.ReloadViews(); err != nil {
+				reloadErr = err
+				return
+			}
+		}
+	})
+
+	wg.Go(func() {
+		for range 200 {
+			subApp.Use("/nested", New())
+		}
+	})
+
+	wg.Wait()
+	require.NoError(t, reloadErr)
+	require.Equal(t, initialLoads+200, view.loads)
+}
+
 func Test_App_ReloadViews_MountedViews_SharedEngineBlocksSiblingRender(t *testing.T) {
 	t.Parallel()
 

--- a/constraint.go
+++ b/constraint.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -171,6 +172,27 @@ func findConstraintHandler(name string, regexHandler any, customs []CustomConstr
 		}
 	}
 	return nil
+}
+
+// mergeCustomConstraints adds the constraints of a mounted app to the app its
+// routes are being expanded into.
+//
+// Expanding a mount re-parses the sub-app's routes against the expanding app,
+// so without this a constraint the sub-app registered stops resolving the
+// moment its routes move up a level — findConstraintHandler returns nil and
+// analyseParameterPart drops the constraint, leaving a route that silently
+// validates nothing. A name the expanding app already defines keeps its own
+// constraint, which is what its own routes were parsed with.
+func mergeCustomConstraints(dst, src []CustomConstraint) []CustomConstraint {
+	for _, constraint := range src {
+		if slices.ContainsFunc(dst, func(existing CustomConstraint) bool { return existing.Name() == constraint.Name() }) {
+			continue
+		}
+
+		dst = append(dst, constraint)
+	}
+
+	return dst
 }
 
 // newConstraint creates a Constraint with the given handler and data,

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -249,6 +249,8 @@ Because domain filtering is applied at handler-execution time (not during route 
 
 :::note
 When mounting sub-applications via `Domain(...).Use(*fiber.App)`, routes are cloned from the sub-app at mount time. This means the same sub-app can safely be mounted on multiple domains without double-wrapping, but routes registered on the sub-app **after** mounting will not inherit domain filtering. Register all sub-app routes before mounting.
+
+Apps that the sub-app has mounted itself are cloned along with it, so nested routes are domain-filtered as well. The same "register before mounting" rule applies to them.
 :::
 
 ```go title="Signature"

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -251,6 +251,8 @@ Because domain filtering is applied at handler-execution time (not during route 
 When mounting sub-applications via `Domain(...).Use(*fiber.App)`, routes are cloned from the sub-app at mount time. This means the same sub-app can safely be mounted on multiple domains without double-wrapping, but routes registered on the sub-app **after** mounting will not inherit domain filtering. Register all sub-app routes before mounting.
 
 Apps that the sub-app has mounted itself are cloned along with it, so nested routes are domain-filtered as well. The same "register before mounting" rule applies to them.
+
+A domain-mounted sub-app's `ErrorHandler` and `Views` are host-scoped like its routes: they apply to requests whose hostname matches the pattern, and requests on other hosts fall back to the parent's. Two sub-apps mounted at the same path on different domains therefore keep their own configuration.
 :::
 
 ```go title="Signature"

--- a/domain.go
+++ b/domain.go
@@ -478,23 +478,22 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 		path := getGroupPath(mountPath, mountedPrefixes)
 
 		subAppInstance.mountFields.mountPath = path
-		d.app.mountFields.domainAppList = addDomainMount(d.app.mountFields.domainAppList, domainMountedApp{
-			app:      subAppInstance,
-			path:     path,
-			matchers: []domainMatcher{d.matcher},
-		})
+		d.app.mountFields.domainAppList = addDomainMount(
+			d.app.mountFields.domainAppList,
+			d.app.newDomainMount(subAppInstance, path, []domainMatcher{d.matcher}),
+		)
 	}
 	// Apps the sub-app itself domain-mounted keep their own patterns as well:
 	// a request has to satisfy both to reach them.
-	for _, mount := range domainMounts {
+	for i := range domainMounts {
+		mount := &domainMounts[i]
 		path := getGroupPath(mountPath, mount.path)
 
 		mount.app.mountFields.mountPath = path
-		d.app.mountFields.domainAppList = addDomainMount(d.app.mountFields.domainAppList, domainMountedApp{
-			app:      mount.app,
-			path:     path,
-			matchers: append(slices.Clone(mount.matchers), d.matcher),
-		})
+		d.app.mountFields.domainAppList = addDomainMount(
+			d.app.mountFields.domainAppList,
+			d.app.newDomainMount(mount.app, path, append(slices.Clone(mount.matchers), d.matcher)),
+		)
 	}
 	d.app.mutex.Unlock()
 

--- a/domain.go
+++ b/domain.go
@@ -6,6 +6,7 @@ package fiber
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -448,12 +449,19 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	// sub-apps mounted at the same path on different domains do not displace
 	// each other.
 	//
-	// Hold the sub-app while its lists are read: App.mount writes them under
-	// the same lock, so a concurrent mount on the sub-app would race.
+	// Snapshot the sub-app's lists under its own lock and let go of it before
+	// taking the parent's. App.mount writes them under that lock, so reading
+	// them unguarded would race — but holding both at once would hang outright
+	// when an app is mounted on itself, and could deadlock two goroutines
+	// mounting each other's apps.
 	subApp.mutex.Lock()
+	pathMounts := maps.Clone(subApp.mountFields.appList)
+	domainMounts := slices.Clone(subApp.mountFields.domainAppList)
+	subApp.mutex.Unlock()
+
 	d.app.mutex.Lock()
 	// Support for configs of mounted-apps and sub-mounted-apps
-	for mountedPrefixes, subAppInstance := range subApp.mountFields.appList {
+	for mountedPrefixes, subAppInstance := range pathMounts {
 		path := getGroupPath(mountPath, mountedPrefixes)
 
 		subAppInstance.mountFields.mountPath = path
@@ -465,7 +473,7 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	}
 	// Apps the sub-app itself domain-mounted keep their own patterns as well:
 	// a request has to satisfy both to reach them.
-	for _, mount := range subApp.mountFields.domainAppList {
+	for _, mount := range domainMounts {
 		path := getGroupPath(mountPath, mount.path)
 
 		mount.app.mountFields.mountPath = path
@@ -476,7 +484,6 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 		})
 	}
 	d.app.mutex.Unlock()
-	subApp.mutex.Unlock()
 
 	// Create a mount group referencing the wrapper app (not the original).
 	// During route expansion (processSubAppsRoutes), Fiber reads routes from
@@ -555,12 +562,9 @@ func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*A
 	for m := range routes {
 		for _, route := range stack[m] {
 			if route.mount {
-				// A placeholder registered by mount() always has both, but a
-				// sub-app assembled by other means may not.
-				if route.group == nil || route.group.app == nil {
-					continue
-				}
-
+				// register only sets mount for a route whose group carries the
+				// mounted app, so group and group.app are both set here — the
+				// same invariant processSubAppsRoutes relies on.
 				if mounted[route.group] == nil {
 					if mounted == nil {
 						mounted = make(map[*Group][][]*Route)

--- a/domain.go
+++ b/domain.go
@@ -6,7 +6,6 @@ package fiber
 
 import (
 	"fmt"
-	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -462,37 +461,50 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	// sub-apps mounted at the same path on different domains do not displace
 	// each other.
 	//
-	// Snapshot the sub-app's lists under its own lock and let go of it before
-	// taking the parent's. App.mount writes them under that lock, so reading
-	// them unguarded would race — but holding both at once would hang outright
-	// when an app is mounted on itself, and could deadlock two goroutines
-	// mounting each other's apps.
-	subApp.mutex.Lock()
-	pathMounts := maps.Clone(subApp.mountFields.appList)
-	domainMounts := slices.Clone(subApp.mountFields.domainAppList)
-	subApp.mutex.Unlock()
+	// Collect the mounts before taking the parent's lock, and hold only one
+	// app's lock at a time while doing it. App.mount writes these lists under
+	// the lock of the app they belong to, so reading them unguarded would race
+	// — but holding two at once would hang outright when an app is mounted on
+	// itself, and could deadlock two goroutines mounting each other's apps.
+	//
+	// The sub-app's list carries its ordinary descendants, and each of them
+	// carries the apps it domain-mounted itself: those records live only on the
+	// app they were registered on, and ordinary mounting does not propagate
+	// them. Walking the descendants here is what puts an app domain-mounted
+	// behind one of them on the map, since the routes reach this app either way.
+	pathMounts := subApp.plainMountsSnapshot()
+
+	type pendingMount struct {
+		app      *App
+		path     string
+		matchers []domainMatcher
+	}
+
+	pending := make([]pendingMount, 0, len(pathMounts))
+	for mountedPrefixes, mounted := range pathMounts {
+		prefixed := getGroupPath(mountPath, mountedPrefixes)
+		pending = append(pending, pendingMount{app: mounted, path: prefixed})
+
+		// Apps mounted on a domain keep their own patterns as well: a request
+		// has to satisfy every one of them to reach the app.
+		for _, mount := range mounted.domainMountsSnapshot() {
+			pending = append(pending, pendingMount{
+				app:      mount.app,
+				path:     getGroupPath(prefixed, mount.path),
+				matchers: mount.matchers,
+			})
+		}
+	}
 
 	d.app.mutex.Lock()
 	// Support for configs of mounted-apps and sub-mounted-apps
-	for mountedPrefixes, subAppInstance := range pathMounts {
-		path := getGroupPath(mountPath, mountedPrefixes)
+	for i := range pending {
+		mount := &pending[i]
 
-		subAppInstance.mountFields.mountPath = path
+		mount.app.mountFields.mountPath = mount.path
 		d.app.mountFields.domainAppList = addDomainMount(
 			d.app.mountFields.domainAppList,
-			d.app.newDomainMount(subAppInstance, path, []domainMatcher{d.matcher}),
-		)
-	}
-	// Apps the sub-app itself domain-mounted keep their own patterns as well:
-	// a request has to satisfy both to reach them.
-	for i := range domainMounts {
-		mount := &domainMounts[i]
-		path := getGroupPath(mountPath, mount.path)
-
-		mount.app.mountFields.mountPath = path
-		d.app.mountFields.domainAppList = addDomainMount(
-			d.app.mountFields.domainAppList,
-			d.app.newDomainMount(mount.app, path, append(slices.Clone(mount.matchers), d.matcher)),
+			d.app.newDomainMount(mount.app, mount.path, append(slices.Clone(mount.matchers), d.matcher)),
 		)
 	}
 	d.app.mutex.Unlock()

--- a/domain.go
+++ b/domain.go
@@ -467,39 +467,18 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	// — but holding two at once would hang outright when an app is mounted on
 	// itself, and could deadlock two goroutines mounting each other's apps.
 	//
-	// The sub-app's list carries its ordinary descendants, and each of them
-	// carries the apps it domain-mounted itself: those records live only on the
-	// app they were registered on, and ordinary mounting does not propagate
-	// them. Walking the descendants here is what puts an app domain-mounted
-	// behind one of them on the map, since the routes reach this app either way.
-	pathMounts := subApp.plainMountsSnapshot()
-
-	type pendingMount struct {
-		app      *App
-		path     string
-		matchers []domainMatcher
-	}
-
-	pending := make([]pendingMount, 0, len(pathMounts))
-	for mountedPrefixes, mounted := range pathMounts {
-		prefixed := getGroupPath(mountPath, mountedPrefixes)
-		pending = append(pending, pendingMount{app: mounted, path: prefixed})
-
-		// Apps mounted on a domain keep their own patterns as well: a request
-		// has to satisfy every one of them to reach the app.
-		for _, mount := range mounted.domainMountsSnapshot() {
-			pending = append(pending, pendingMount{
-				app:      mount.app,
-				path:     getGroupPath(prefixed, mount.path),
-				matchers: mount.matchers,
-			})
-		}
-	}
+	// The walk goes through the sub-app's own mount metadata rather than its
+	// flattened list, which is filled in as apps are mounted and so misses one
+	// mounted on a descendant afterwards; it also picks up the apps each
+	// descendant domain-mounted itself, since those records live only on the
+	// app they were registered on. The routes reach all of them either way.
+	pending := subApp.mountTree()
 
 	d.app.mutex.Lock()
 	// Support for configs of mounted-apps and sub-mounted-apps
 	for i := range pending {
 		mount := &pending[i]
+		mount.path = getGroupPath(mountPath, mount.path)
 
 		mount.app.mountFields.mountPath = mount.path
 		d.app.mountFields.domainAppList = addDomainMount(

--- a/domain.go
+++ b/domain.go
@@ -434,14 +434,22 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	})
 	// Clone routes from the sub-app with domain-wrapped handlers. The clone
 	// also collects the constraints of every app it walks, since the wrapper is
-	// what the routes are re-parsed against when the mount is expanded.
-	d.cloneRoutesForDomain(wrapperApp, subApp)
+	// what the routes are re-parsed against when the mount is expanded, and
+	// reports whether they all register automatic HEAD routes.
+	autoHead := d.cloneRoutesForDomain(wrapperApp, subApp)
 
 	// Give the clones their automatic HEAD routes. A mounted app normally gets
 	// them from startupProcess, which walks the parent's app list — and the
 	// wrapper is deliberately not in it, so without this a domain-mounted GET
 	// route answers HEAD with 405 where a plain mount answers 200.
-	wrapperApp.ensureAutoHeadRoutes()
+	//
+	// Only when every app behind the mount registers them itself. The wrapper
+	// synthesizes a HEAD route from a GET one, and its middleware comes from
+	// the clone: an app that does not serve HEAD contributed none, so the
+	// synthesized route would run its handler with nothing in front of it.
+	if autoHead {
+		wrapperApp.ensureAutoHeadRoutes()
+	}
 
 	// Register the sub-app, and every app it has mounted, as domain mounts of
 	// the parent. They are kept out of appList so that their ErrorHandler and
@@ -518,10 +526,15 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 // processSubAppsRoutes. Flattening the descendants here also runs their
 // handlers through wrapHandlers, so they stay bound to the domain instead of
 // being served on every host.
-func (d *domainRouter) cloneRoutesForDomain(dst, src *App) {
-	for m, routes := range d.domainRoutes(dst, src, "", nil) {
+// It reports whether every app it walked registers automatic HEAD routes, so
+// the caller can tell when synthesizing them on the clone would be safe.
+func (d *domainRouter) cloneRoutesForDomain(dst, src *App) bool {
+	autoHead := true
+	for m, routes := range d.domainRoutes(dst, src, "", nil, &autoHead) {
 		dst.stack[m] = routes
 	}
+
+	return autoHead
 }
 
 // domainRoutes returns src's routes, cloned with domain-filtered handlers and
@@ -533,10 +546,16 @@ func (d *domainRouter) cloneRoutesForDomain(dst, src *App) {
 // terminates. It is a slice rather than a set because it is only ever a few
 // entries deep and each branch needs its own: an app mounted twice on sibling
 // branches is cloned for both.
-func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*App) [][]*Route {
+func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*App, autoHead *bool) [][]*Route {
 	routes := make([][]*Route, len(dst.stack))
 	if slices.Contains(chain, src) {
 		return routes
+	}
+
+	// An app that does not serve HEAD, or that turned the automatic routes off,
+	// contributes neither HEAD routes nor HEAD middleware to the clone.
+	if src.config.DisableHeadAutoRegister || src.methodInt(MethodHead) < 0 {
+		*autoHead = false
 	}
 
 	// Take a snapshot rather than holding the lock for the whole walk: it
@@ -569,7 +588,7 @@ func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*A
 					if mounted == nil {
 						mounted = make(map[*Group][][]*Route)
 					}
-					mounted[route.group] = d.domainRoutes(dst, route.group.app, getGroupPath(pathPrefix, route.path), append(chain, src))
+					mounted[route.group] = d.domainRoutes(dst, route.group.app, getGroupPath(pathPrefix, route.path), append(chain, src), autoHead)
 				}
 
 				routes[m] = append(routes[m], mounted[route.group][m]...)

--- a/domain.go
+++ b/domain.go
@@ -442,8 +442,14 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	// route answers HEAD with 405 where a plain mount answers 200.
 	wrapperApp.ensureAutoHeadRoutes()
 
-	// Hold the sub-app while its app list is read: App.mount writes that map
-	// under the same lock, so a concurrent mount on the sub-app would race.
+	// Register the sub-app, and every app it has mounted, as domain mounts of
+	// the parent. They are kept out of appList so that their ErrorHandler and
+	// view engine only answer for hosts this domain matches, and so that two
+	// sub-apps mounted at the same path on different domains do not displace
+	// each other.
+	//
+	// Hold the sub-app while its lists are read: App.mount writes them under
+	// the same lock, so a concurrent mount on the sub-app would race.
 	subApp.mutex.Lock()
 	d.app.mutex.Lock()
 	// Support for configs of mounted-apps and sub-mounted-apps
@@ -451,7 +457,23 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 		path := getGroupPath(mountPath, mountedPrefixes)
 
 		subAppInstance.mountFields.mountPath = path
-		d.app.mountFields.appList[path] = subAppInstance
+		d.app.mountFields.domainAppList = append(d.app.mountFields.domainAppList, domainMountedApp{
+			app:      subAppInstance,
+			path:     path,
+			matchers: []domainMatcher{d.matcher},
+		})
+	}
+	// Apps the sub-app itself domain-mounted keep their own patterns as well:
+	// a request has to satisfy both to reach them.
+	for _, mount := range subApp.mountFields.domainAppList {
+		path := getGroupPath(mountPath, mount.path)
+
+		mount.app.mountFields.mountPath = path
+		d.app.mountFields.domainAppList = append(d.app.mountFields.domainAppList, domainMountedApp{
+			app:      mount.app,
+			path:     path,
+			matchers: append(slices.Clone(mount.matchers), d.matcher),
+		})
 	}
 	d.app.mutex.Unlock()
 	subApp.mutex.Unlock()

--- a/domain.go
+++ b/domain.go
@@ -431,6 +431,11 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 		RequestMethods:          d.app.config.RequestMethods,
 		DisableHeadAutoRegister: subApp.config.DisableHeadAutoRegister,
 	})
+	// Every route the wrapper carries is filtered by the pattern of the mount
+	// it came from, which is what the automatic HEAD routes have to respect:
+	// the apps behind one wrapper do not all answer for the same hostnames.
+	wrapperApp.mountFields.hostScopedRoutes = true
+
 	// Clone routes from the sub-app with domain-wrapped handlers. The clone
 	// also collects the constraints of every app it walks, since the wrapper is
 	// what the routes are re-parsed against when the mount is expanded, and

--- a/domain.go
+++ b/domain.go
@@ -581,8 +581,9 @@ func (d *domainRouter) domainRoutes(dst, src *App, walk domainClone) [][]*Route 
 	// configure its own RequestMethods, and the two tables then neither line up
 	// nor have to be the same length.
 	type sourceRoute struct {
-		route *Route
-		owner *App
+		route       *Route
+		owner       *App
+		constraints []CustomConstraint
 	}
 
 	src.mutex.Lock()
@@ -604,7 +605,11 @@ func (d *domainRouter) domainRoutes(dst, src *App, walk domainClone) [][]*Route 
 				owner = src
 			}
 
-			stack[m][i] = sourceRoute{route: src.copyRoute(route), owner: owner}
+			stack[m][i] = sourceRoute{
+				route:       src.copyRoute(route),
+				owner:       owner,
+				constraints: src.routeConstraintsFor(route),
+			}
 		}
 	}
 	dst.customConstraints = mergeCustomConstraints(dst.customConstraints, src.customConstraints)
@@ -640,8 +645,15 @@ func (d *domainRouter) domainRoutes(dst, src *App, walk domainClone) [][]*Route 
 			clonedRoute := source.route
 			// An empty prefix cannot change the path, and re-parsing the route
 			// to reach the same result is the most expensive thing here.
+			// The route brings the constraints of the apps that composed its
+			// path, and those win over the ones collected from the rest of the
+			// tree: two apps mounted side by side can name one constraint
+			// differently, and neither binds the other.
+			constraints := mergeCustomConstraints(slices.Clone(source.constraints), dst.customConstraints)
+			dst.markRouteConstraints(clonedRoute, constraints)
+
 			if walk.prefix != "" {
-				dst.addPrefixToRoute(walk.prefix, clonedRoute, src.config.RegexHandler, src.customConstraints...)
+				dst.addPrefixToRoute(walk.prefix, clonedRoute, src.config.RegexHandler, constraints...)
 			}
 			clonedRoute.Handlers = d.wrapHandlers(clonedRoute.Handlers)
 

--- a/domain.go
+++ b/domain.go
@@ -439,26 +439,17 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	// Clone routes from the sub-app with domain-wrapped handlers. The clone
 	// also collects the constraints of every app it walks, since the wrapper is
 	// what the routes are re-parsed against when the mount is expanded, and
-	// reports whether they all register automatic HEAD routes.
-	autoHead := d.cloneRoutesForDomain(wrapperApp, subApp)
+	// marks the routes of the apps that register no automatic HEAD routes.
+	d.cloneRoutesForDomain(wrapperApp, subApp)
 
 	// Give the clones their automatic HEAD routes. A mounted app normally gets
 	// them from startupProcess, which walks the parent's app list — and the
 	// wrapper is deliberately not in it, so without this a domain-mounted GET
 	// route answers HEAD with 405 where a plain mount answers 200.
 	//
-	// Only when every app behind the mount registers them itself. The wrapper
-	// synthesizes a HEAD route from a GET one, and its middleware comes from
-	// the clone: an app that does not serve HEAD contributed none, so the
-	// synthesized route would run its handler with nothing in front of it.
-	//
-	// The wrapper carries that answer for the whole tree, so the app it is
-	// mounted on withholds automatic HEAD routes from these routes too when
-	// it expands them.
-	wrapperApp.config.DisableHeadAutoRegister = !autoHead
-	if autoHead {
-		wrapperApp.ensureAutoHeadRoutes()
-	}
+	// The routes marked while cloning are passed over, and the marks travel on
+	// to the app this one is mounted on, so it withholds them there as well.
+	wrapperApp.ensureAutoHeadRoutes()
 
 	// Register the sub-app, and every app it has mounted, as domain mounts of
 	// the parent. They are kept out of appList so that their ErrorHandler and
@@ -534,37 +525,48 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 // processSubAppsRoutes. Flattening the descendants here also runs their
 // handlers through wrapHandlers, so they stay bound to the domain instead of
 // being served on every host.
-// It reports whether every app it walked registers automatic HEAD routes, so
-// the caller can tell when synthesizing them on the clone would be safe.
-func (d *domainRouter) cloneRoutesForDomain(dst, src *App) bool {
-	autoHead := true
-	for m, routes := range d.domainRoutes(dst, src, "", nil, &autoHead) {
+// Routes cloned from an app that registers no automatic HEAD routes are marked
+// as such on the wrapper, so synthesizing them stays off for those and stays on
+// for the rest.
+func (d *domainRouter) cloneRoutesForDomain(dst, src *App) {
+	for m, routes := range d.domainRoutes(dst, src, domainClone{}) {
 		dst.stack[m] = routes
 	}
+}
 
-	return autoHead
+// domainClone is what a walk down a mounted app's tree carries with it.
+type domainClone struct {
+	// prefix is the path the app being walked is mounted at, relative to the
+	// app the domain mount was registered with
+	prefix string
+	// chain holds the apps between the mounted sub-app and this one, so a mount
+	// cycle terminates. It is a slice rather than a set because it is only ever
+	// a few entries deep and each branch needs its own: an app mounted twice on
+	// sibling branches is cloned for both.
+	chain []*App
+	// skipAutoHead marks that an app above this one registers no automatic HEAD
+	// routes, and stands in front of these
+	skipAutoHead bool
 }
 
 // domainRoutes returns src's routes, cloned with domain-filtered handlers and
-// with pathPrefix applied, as one slice per method index of dst. Routes of an
-// app src has mounted take the placeholder's position, so the order the
+// with the walk's prefix applied, as one slice per method index of dst. Routes
+// of an app src has mounted take the placeholder's position, so the order the
 // sub-app registered its routes in is preserved.
-//
-// chain holds the apps between the mounted sub-app and src, so a mount cycle
-// terminates. It is a slice rather than a set because it is only ever a few
-// entries deep and each branch needs its own: an app mounted twice on sibling
-// branches is cloned for both.
-func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*App, autoHead *bool) [][]*Route {
+func (d *domainRouter) domainRoutes(dst, src *App, walk domainClone) [][]*Route {
 	routes := make([][]*Route, len(dst.stack))
-	if slices.Contains(chain, src) {
+	if slices.Contains(walk.chain, src) {
 		return routes
 	}
 
 	// An app that does not serve HEAD, or that turned the automatic routes off,
-	// contributes neither HEAD routes nor HEAD middleware to the clone.
-	if src.config.DisableHeadAutoRegister || src.methodInt(MethodHead) < 0 {
-		*autoHead = false
-	}
+	// contributes neither HEAD routes nor HEAD middleware to the clone — so a
+	// HEAD route synthesized from one of its GET routes would run the handler
+	// with nothing in front of it. That holds for the apps it has mounted too,
+	// whose routes it stands in front of, and for no one else: the mount is a
+	// tree, and an app opting out says nothing about its siblings or the apps
+	// it is mounted inside.
+	skipAutoHead := walk.skipAutoHead || src.config.DisableHeadAutoRegister || src.methodInt(MethodHead) < 0
 
 	// Take a snapshot rather than holding the lock for the whole walk: it keeps
 	// this from ever holding two apps' locks at once. The routes are copied by
@@ -624,7 +626,11 @@ func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*A
 					if mounted == nil {
 						mounted = make(map[*Group][][]*Route)
 					}
-					mounted[group] = d.domainRoutes(dst, group.app, getGroupPath(pathPrefix, source.route.path), append(chain, src), autoHead)
+					mounted[group] = d.domainRoutes(dst, group.app, domainClone{
+						prefix:       getGroupPath(walk.prefix, source.route.path),
+						chain:        append(walk.chain, src),
+						skipAutoHead: skipAutoHead,
+					})
 				}
 
 				routes[m] = append(routes[m], mounted[group][m]...)
@@ -634,8 +640,8 @@ func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*A
 			clonedRoute := source.route
 			// An empty prefix cannot change the path, and re-parsing the route
 			// to reach the same result is the most expensive thing here.
-			if pathPrefix != "" {
-				dst.addPrefixToRoute(pathPrefix, clonedRoute, src.config.RegexHandler, src.customConstraints...)
+			if walk.prefix != "" {
+				dst.addPrefixToRoute(walk.prefix, clonedRoute, src.config.RegexHandler, src.customConstraints...)
 			}
 			clonedRoute.Handlers = d.wrapHandlers(clonedRoute.Handlers)
 
@@ -643,6 +649,10 @@ func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*A
 			// resolves that app's config rather than one inferred from the host
 			// and the path.
 			dst.markRouteOwner(clonedRoute, source.owner)
+
+			if skipAutoHead {
+				dst.markSkipAutoHead(clonedRoute)
+			}
 
 			routes[m] = append(routes[m], clonedRoute)
 		}

--- a/domain.go
+++ b/domain.go
@@ -431,9 +431,9 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 		RequestMethods:          d.app.config.RequestMethods,
 		DisableHeadAutoRegister: subApp.config.DisableHeadAutoRegister,
 	})
-	wrapperApp.customConstraints = subApp.customConstraints
-
-	// Clone routes from the sub-app with domain-wrapped handlers.
+	// Clone routes from the sub-app with domain-wrapped handlers. The clone
+	// also collects the constraints of every app it walks, since the wrapper is
+	// what the routes are re-parsed against when the mount is expanded.
 	d.cloneRoutesForDomain(wrapperApp, subApp)
 
 	// Give the clones their automatic HEAD routes. A mounted app normally gets
@@ -522,6 +522,7 @@ func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*A
 	for m := range stack {
 		stack[m] = slices.Clone(src.routesForMethod(dst.method(m)))
 	}
+	dst.customConstraints = mergeCustomConstraints(dst.customConstraints, src.customConstraints)
 	src.mutex.Unlock()
 
 	// Mounted apps are flattened once and reused across the method indexes:

--- a/domain.go
+++ b/domain.go
@@ -425,15 +425,22 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	// method indexes, so a wrapper with a shorter stack would put that read out
 	// of range.
 	wrapperApp := New(Config{
-		CaseSensitive:  subApp.config.CaseSensitive,
-		StrictRouting:  subApp.config.StrictRouting,
-		RegexHandler:   subApp.config.RegexHandler,
-		RequestMethods: d.app.config.RequestMethods,
+		CaseSensitive:           subApp.config.CaseSensitive,
+		StrictRouting:           subApp.config.StrictRouting,
+		RegexHandler:            subApp.config.RegexHandler,
+		RequestMethods:          d.app.config.RequestMethods,
+		DisableHeadAutoRegister: subApp.config.DisableHeadAutoRegister,
 	})
 	wrapperApp.customConstraints = subApp.customConstraints
 
 	// Clone routes from the sub-app with domain-wrapped handlers.
 	d.cloneRoutesForDomain(wrapperApp, subApp)
+
+	// Give the clones their automatic HEAD routes. A mounted app normally gets
+	// them from startupProcess, which walks the parent's app list — and the
+	// wrapper is deliberately not in it, so without this a domain-mounted GET
+	// route answers HEAD with 405 where a plain mount answers 200.
+	wrapperApp.ensureAutoHeadRoutes()
 
 	// Hold the sub-app while its app list is read: App.mount writes that map
 	// under the same lock, so a concurrent mount on the sub-app would race.

--- a/domain.go
+++ b/domain.go
@@ -506,10 +506,14 @@ func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*A
 	// Take a snapshot rather than holding the lock for the whole walk: it
 	// keeps concurrent route registration on src from racing the read, and it
 	// keeps this from ever holding two apps' locks at once.
+	//
+	// It is indexed by dst's methods, not src's: an app is free to configure
+	// its own RequestMethods, and the two tables then neither line up nor have
+	// to be the same length.
 	src.mutex.Lock()
-	stack := make([][]*Route, len(src.stack))
-	for m := range src.stack {
-		stack[m] = slices.Clone(src.stack[m])
+	stack := make([][]*Route, len(routes))
+	for m := range stack {
+		stack[m] = slices.Clone(src.routesForMethod(dst.method(m)))
 	}
 	src.mutex.Unlock()
 
@@ -519,13 +523,6 @@ func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*A
 	var mounted map[*Group][][]*Route
 
 	for m := range routes {
-		// An app configured with fewer request methods than the app it is
-		// mounted on has a shorter stack, and simply holds no routes for the
-		// remaining methods.
-		if m >= len(stack) {
-			continue
-		}
-
 		for _, route := range stack[m] {
 			if route.mount {
 				// A placeholder registered by mount() always has both, but a

--- a/domain.go
+++ b/domain.go
@@ -495,7 +495,7 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	// Support for configs of mounted-apps and sub-mounted-apps
 	for i := range pending {
 		mount := &pending[i]
-		recorded := d.app.newDomainMount(mount.app, mount.path, append(slices.Clone(mount.matchers), d.matcher), mount.ancestors)
+		recorded := d.app.newDomainMount(mount.app, mount.path, append(slices.Clone(mount.matchers), d.matcher), mount.ancestors, mount.declared)
 
 		d.app.mountFields.domainAppList = addDomainMount(d.app.mountFields.domainAppList, &recorded)
 	}

--- a/domain.go
+++ b/domain.go
@@ -7,6 +7,7 @@ package fiber
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/gofiber/utils/v2"
@@ -418,28 +419,25 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	// Create a wrapper app so that the original sub-app is not mutated.
 	// This allows the same sub-app to be reused (e.g., mounted on multiple
 	// domains) without double-wrapping handlers.
+	//
+	// The method table comes from the app being mounted on, not from the
+	// sub-app: processSubAppsRoutes reads the wrapper's stack at the parent's
+	// method indexes, so a wrapper with a shorter stack would put that read out
+	// of range.
 	wrapperApp := New(Config{
-		CaseSensitive: subApp.config.CaseSensitive,
-		StrictRouting: subApp.config.StrictRouting,
-		RegexHandler:  subApp.config.RegexHandler,
+		CaseSensitive:  subApp.config.CaseSensitive,
+		StrictRouting:  subApp.config.StrictRouting,
+		RegexHandler:   subApp.config.RegexHandler,
+		RequestMethods: d.app.config.RequestMethods,
 	})
 	wrapperApp.customConstraints = subApp.customConstraints
 
 	// Clone routes from the sub-app with domain-wrapped handlers.
-	// Lock the sub-app while reading to prevent data races with concurrent
-	// route registration.
-	subApp.mutex.Lock()
-	defer subApp.mutex.Unlock()
-	for m := range subApp.stack {
-		for _, route := range subApp.stack[m] {
-			clonedRoute := subApp.copyRoute(route)
-			if len(clonedRoute.Handlers) > 0 {
-				clonedRoute.Handlers = d.wrapHandlers(clonedRoute.Handlers)
-			}
-			wrapperApp.stack[m] = append(wrapperApp.stack[m], clonedRoute)
-		}
-	}
+	d.cloneRoutesForDomain(wrapperApp, subApp)
 
+	// Hold the sub-app while its app list is read: App.mount writes that map
+	// under the same lock, so a concurrent mount on the sub-app would race.
+	subApp.mutex.Lock()
 	d.app.mutex.Lock()
 	// Support for configs of mounted-apps and sub-mounted-apps
 	for mountedPrefixes, subAppInstance := range subApp.mountFields.appList {
@@ -449,6 +447,7 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 		d.app.mountFields.appList[path] = subAppInstance
 	}
 	d.app.mutex.Unlock()
+	subApp.mutex.Unlock()
 
 	// Create a mount group referencing the wrapper app (not the original).
 	// During route expansion (processSubAppsRoutes), Fiber reads routes from
@@ -471,6 +470,93 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	}
 
 	return d
+}
+
+// cloneRoutesForDomain fills dst with domain-filtered clones of src's routes,
+// expanding any app src itself has mounted.
+//
+// The expansion is what keeps a nested mount working. A mount is registered as
+// a placeholder route that carries its target app in the unexported group
+// field, and copyRoute does not carry that field over, so a cloned placeholder
+// would reach startup with mount set and group nil and crash the expansion in
+// processSubAppsRoutes. Flattening the descendants here also runs their
+// handlers through wrapHandlers, so they stay bound to the domain instead of
+// being served on every host.
+func (d *domainRouter) cloneRoutesForDomain(dst, src *App) {
+	for m, routes := range d.domainRoutes(dst, src, "", nil) {
+		dst.stack[m] = routes
+	}
+}
+
+// domainRoutes returns src's routes, cloned with domain-filtered handlers and
+// with pathPrefix applied, as one slice per method index of dst. Routes of an
+// app src has mounted take the placeholder's position, so the order the
+// sub-app registered its routes in is preserved.
+//
+// chain holds the apps between the mounted sub-app and src, so a mount cycle
+// terminates. It is a slice rather than a set because it is only ever a few
+// entries deep and each branch needs its own: an app mounted twice on sibling
+// branches is cloned for both.
+func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*App) [][]*Route {
+	routes := make([][]*Route, len(dst.stack))
+	if slices.Contains(chain, src) {
+		return routes
+	}
+
+	// Take a snapshot rather than holding the lock for the whole walk: it
+	// keeps concurrent route registration on src from racing the read, and it
+	// keeps this from ever holding two apps' locks at once.
+	src.mutex.Lock()
+	stack := make([][]*Route, len(src.stack))
+	for m := range src.stack {
+		stack[m] = slices.Clone(src.stack[m])
+	}
+	src.mutex.Unlock()
+
+	// Mounted apps are flattened once and reused across the method indexes:
+	// register files a copy of the placeholder in every method's stack, and
+	// all of them share the one group it was registered with.
+	var mounted map[*Group][][]*Route
+
+	for m := range routes {
+		// An app configured with fewer request methods than the app it is
+		// mounted on has a shorter stack, and simply holds no routes for the
+		// remaining methods.
+		if m >= len(stack) {
+			continue
+		}
+
+		for _, route := range stack[m] {
+			if route.mount {
+				// A placeholder registered by mount() always has both, but a
+				// sub-app assembled by other means may not.
+				if route.group == nil || route.group.app == nil {
+					continue
+				}
+
+				if mounted[route.group] == nil {
+					if mounted == nil {
+						mounted = make(map[*Group][][]*Route)
+					}
+					mounted[route.group] = d.domainRoutes(dst, route.group.app, getGroupPath(pathPrefix, route.path), append(chain, src))
+				}
+
+				routes[m] = append(routes[m], mounted[route.group][m]...)
+				continue
+			}
+
+			clonedRoute := src.copyRoute(route)
+			// An empty prefix cannot change the path, and re-parsing the route
+			// to reach the same result is the most expensive thing here.
+			if pathPrefix != "" {
+				dst.addPrefixToRoute(pathPrefix, clonedRoute, src.config.RegexHandler, src.customConstraints...)
+			}
+			clonedRoute.Handlers = d.wrapHandlers(clonedRoute.Handlers)
+			routes[m] = append(routes[m], clonedRoute)
+		}
+	}
+
+	return routes
 }
 
 // Get registers a route for GET methods.

--- a/domain.go
+++ b/domain.go
@@ -606,6 +606,18 @@ func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*A
 				dst.addPrefixToRoute(pathPrefix, clonedRoute, src.config.RegexHandler, src.customConstraints...)
 			}
 			clonedRoute.Handlers = d.wrapHandlers(clonedRoute.Handlers)
+
+			// Record the app the route came from, so a request that runs it
+			// resolves that app's config rather than one inferred from the host
+			// and the path. src is itself a wrapper when the sub-app had domain
+			// mounts of its own, and already knows the real app behind each of
+			// its routes.
+			owner := src.routeOwner(route)
+			if owner == nil {
+				owner = src
+			}
+			dst.markRouteOwner(clonedRoute, owner)
+
 			routes[m] = append(routes[m], clonedRoute)
 		}
 	}

--- a/domain.go
+++ b/domain.go
@@ -479,17 +479,25 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	// app they were registered on. The routes reach all of them either way.
 	pending := subApp.mountTree()
 
-	d.app.mutex.Lock()
-	// Support for configs of mounted-apps and sub-mounted-apps
+	// Each app's mount path is written under its own lock, and before the
+	// parent's is taken: an app registering a route reads it there, and it may
+	// be the parent itself when an app is mounted on itself.
 	for i := range pending {
 		mount := &pending[i]
 		mount.path = getGroupPath(mountPath, mount.path)
 
+		mount.app.mutex.Lock()
 		mount.app.mountFields.mountPath = mount.path
-		d.app.mountFields.domainAppList = addDomainMount(
-			d.app.mountFields.domainAppList,
-			d.app.newDomainMount(mount.app, mount.path, append(slices.Clone(mount.matchers), d.matcher)),
-		)
+		mount.app.mutex.Unlock()
+	}
+
+	d.app.mutex.Lock()
+	// Support for configs of mounted-apps and sub-mounted-apps
+	for i := range pending {
+		mount := &pending[i]
+		recorded := d.app.newDomainMount(mount.app, mount.path, append(slices.Clone(mount.matchers), d.matcher), mount.ancestors)
+
+		d.app.mountFields.domainAppList = addDomainMount(d.app.mountFields.domainAppList, &recorded)
 	}
 	d.app.mutex.Unlock()
 
@@ -558,17 +566,44 @@ func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*A
 		*autoHead = false
 	}
 
-	// Take a snapshot rather than holding the lock for the whole walk: it
-	// keeps concurrent route registration on src from racing the read, and it
-	// keeps this from ever holding two apps' locks at once.
+	// Take a snapshot rather than holding the lock for the whole walk: it keeps
+	// this from ever holding two apps' locks at once. The routes are copied by
+	// value, not by pointer, because registering a route on a path src already
+	// serves appends to that route's handlers in place, and renaming one writes
+	// its name — a clone taken after the lock was released would race both.
 	//
-	// It is indexed by dst's methods, not src's: an app is free to configure
-	// its own RequestMethods, and the two tables then neither line up nor have
-	// to be the same length.
+	// A mount placeholder is kept as it is: its target app is read from the
+	// group it carries, and the walk into it has to happen unlocked.
+	//
+	// The snapshot is indexed by dst's methods, not src's: an app is free to
+	// configure its own RequestMethods, and the two tables then neither line up
+	// nor have to be the same length.
+	type sourceRoute struct {
+		route *Route
+		owner *App
+	}
+
 	src.mutex.Lock()
-	stack := make([][]*Route, len(routes))
+	stack := make([][]sourceRoute, len(routes))
 	for m := range stack {
-		stack[m] = slices.Clone(src.routesForMethod(dst.method(m)))
+		srcRoutes := src.routesForMethod(dst.method(m))
+		stack[m] = make([]sourceRoute, len(srcRoutes))
+
+		for i, route := range srcRoutes {
+			if route.mount {
+				stack[m][i] = sourceRoute{route: route}
+				continue
+			}
+
+			// src is itself a wrapper when the sub-app had domain mounts of its
+			// own, and already knows the real app behind each of its routes.
+			owner := src.routeOwner(route)
+			if owner == nil {
+				owner = src
+			}
+
+			stack[m][i] = sourceRoute{route: src.copyRoute(route), owner: owner}
+		}
 	}
 	dst.customConstraints = mergeCustomConstraints(dst.customConstraints, src.customConstraints)
 	src.mutex.Unlock()
@@ -579,23 +614,24 @@ func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*A
 	var mounted map[*Group][][]*Route
 
 	for m := range routes {
-		for _, route := range stack[m] {
-			if route.mount {
+		for _, source := range stack[m] {
+			if source.route.mount {
 				// register only sets mount for a route whose group carries the
 				// mounted app, so group and group.app are both set here — the
 				// same invariant processSubAppsRoutes relies on.
-				if mounted[route.group] == nil {
+				group := source.route.group
+				if mounted[group] == nil {
 					if mounted == nil {
 						mounted = make(map[*Group][][]*Route)
 					}
-					mounted[route.group] = d.domainRoutes(dst, route.group.app, getGroupPath(pathPrefix, route.path), append(chain, src), autoHead)
+					mounted[group] = d.domainRoutes(dst, group.app, getGroupPath(pathPrefix, source.route.path), append(chain, src), autoHead)
 				}
 
-				routes[m] = append(routes[m], mounted[route.group][m]...)
+				routes[m] = append(routes[m], mounted[group][m]...)
 				continue
 			}
 
-			clonedRoute := src.copyRoute(route)
+			clonedRoute := source.route
 			// An empty prefix cannot change the path, and re-parsing the route
 			// to reach the same result is the most expensive thing here.
 			if pathPrefix != "" {
@@ -605,14 +641,8 @@ func (d *domainRouter) domainRoutes(dst, src *App, pathPrefix string, chain []*A
 
 			// Record the app the route came from, so a request that runs it
 			// resolves that app's config rather than one inferred from the host
-			// and the path. src is itself a wrapper when the sub-app had domain
-			// mounts of its own, and already knows the real app behind each of
-			// its routes.
-			owner := src.routeOwner(route)
-			if owner == nil {
-				owner = src
-			}
-			dst.markRouteOwner(clonedRoute, owner)
+			// and the path.
+			dst.markRouteOwner(clonedRoute, source.owner)
 
 			routes[m] = append(routes[m], clonedRoute)
 		}

--- a/domain.go
+++ b/domain.go
@@ -447,6 +447,11 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 	// synthesizes a HEAD route from a GET one, and its middleware comes from
 	// the clone: an app that does not serve HEAD contributed none, so the
 	// synthesized route would run its handler with nothing in front of it.
+	//
+	// The wrapper carries that answer for the whole tree, so the app it is
+	// mounted on withholds automatic HEAD routes from these routes too when
+	// it expands them.
+	wrapperApp.config.DisableHeadAutoRegister = !autoHead
 	if autoHead {
 		wrapperApp.ensureAutoHeadRoutes()
 	}
@@ -473,7 +478,7 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 		path := getGroupPath(mountPath, mountedPrefixes)
 
 		subAppInstance.mountFields.mountPath = path
-		d.app.mountFields.domainAppList = append(d.app.mountFields.domainAppList, domainMountedApp{
+		d.app.mountFields.domainAppList = addDomainMount(d.app.mountFields.domainAppList, domainMountedApp{
 			app:      subAppInstance,
 			path:     path,
 			matchers: []domainMatcher{d.matcher},
@@ -485,7 +490,7 @@ func (d *domainRouter) mount(prefix string, subApp *App) Router {
 		path := getGroupPath(mountPath, mount.path)
 
 		mount.app.mountFields.mountPath = path
-		d.app.mountFields.domainAppList = append(d.app.mountFields.domainAppList, domainMountedApp{
+		d.app.mountFields.domainAppList = addDomainMount(d.app.mountFields.domainAppList, domainMountedApp{
 			app:      mount.app,
 			path:     path,
 			matchers: append(slices.Clone(mount.matchers), d.matcher),

--- a/domain_test.go
+++ b/domain_test.go
@@ -3379,6 +3379,158 @@ func Test_Domain_UseMountStartedSubApp(t *testing.T) {
 	require.Equal(t, 587, resp.StatusCode)
 }
 
+// Test_Domain_UseMountLateOrdinaryDescendant verifies that an app mounted on a
+// descendant after that descendant was itself mounted is still found: the
+// flattened list is filled in as apps are mounted, so only the mount metadata
+// of each app in turn is current.
+func Test_Domain_UseMountLateOrdinaryDescendant(t *testing.T) {
+	t.Parallel()
+
+	child := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(589).SendString("child")
+	}})
+	child.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	mid := New()
+	outer := New()
+	outer.Use("/mid", mid)
+	mid.Use("/child", child) // mounted after mid itself was
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", outer)
+
+	req := httptest.NewRequest(MethodGet, "/api/mid/child/boom", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 589, resp.StatusCode)
+}
+
+// Test_Domain_UseMountViewsSkipsPlainSibling verifies that a domain mount
+// without an engine of its own renders through the engine enclosing it rather
+// than through a plain mount at its own path, which did not serve the request.
+func Test_Domain_UseMountViewsSkipsPlainSibling(t *testing.T) {
+	t.Parallel()
+
+	rootEngine := &testTemplateEngine{}
+	require.NoError(t, rootEngine.Load())
+
+	// Registered at the same path, and holds no template the domain mount asks
+	// for: borrowing it would fail rather than render the wrong page.
+	plainEngine := &testTemplateEngine{path: "testdata2"}
+	require.NoError(t, plainEngine.Load())
+
+	plain := New(Config{Views: plainEngine})
+	plain.Get("/other", func(c Ctx) error {
+		return c.Render("bruh.tmpl", Map{})
+	})
+
+	subApp := New()
+	subApp.Get("/view", func(c Ctx) error {
+		return c.Render("index.tmpl", Map{"Title": "domain"})
+	})
+
+	app := New(Config{Views: rootEngine})
+	app.Use("/api", plain)
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/view", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>domain</h1>", string(body))
+}
+
+// Test_Domain_UseMountInheritsEnclosingErrorHandler verifies that a domain
+// mount configuring no error handler inherits the one of the app it is mounted
+// inside, as an ordinarily nested mount does.
+func Test_Domain_UseMountInheritsEnclosingErrorHandler(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	mid := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(590).SendString("mid")
+	}})
+	mid.Domain("api.example.com").Use("/child", child)
+
+	app := New()
+	app.Use("/mid", mid)
+
+	req := httptest.NewRequest(MethodGet, "/mid/child/boom", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 590, resp.StatusCode)
+}
+
+// Test_Domain_UseMountDropsPlainSiblingErrorHandler verifies that a domain
+// mount configuring no error handler falls through to the app enclosing it
+// rather than to a plain mount at its own path, which did not serve the
+// request.
+func Test_Domain_UseMountDropsPlainSiblingErrorHandler(t *testing.T) {
+	t.Parallel()
+
+	plain := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(592).SendString("plain")
+	}})
+	plain.Get("/other", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	subApp := New()
+	subApp.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	app := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(593).SendString("root")
+	}})
+	app.Use("/api", plain)
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/boom", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 593, resp.StatusCode)
+}
+
+// Test_Domain_UseMountCyclicOrdinaryMounts verifies that domain-mounting an app
+// whose ordinary mounts form a cycle terminates and still serves its routes.
+func Test_Domain_UseMountCyclicOrdinaryMounts(t *testing.T) {
+	t.Parallel()
+
+	first := New()
+	second := New()
+	second.Get("/ping", func(c Ctx) error {
+		return c.SendString("pong")
+	})
+
+	first.Use("/second", second)
+	second.Use("/first", first)
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", first)
+
+	req := httptest.NewRequest(MethodGet, "/api/second/ping", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "pong", string(body))
+}
+
 // Test_Domain_UseMountKeepsParentAutoHead verifies that a domain mount which
 // registers no automatic HEAD routes only withholds them from its own routes,
 // leaving a route the parent registered at the same path with its own.

--- a/domain_test.go
+++ b/domain_test.go
@@ -1898,6 +1898,484 @@ func Test_Domain_UseMountRoutesAfterMount(t *testing.T) {
 	require.Equal(t, StatusNotFound, resp.StatusCode)
 }
 
+// Test_Domain_UseMountNested verifies that a sub-app that itself mounts another
+// app can be mounted on a domain router: the nested routes are served under the
+// domain and are filtered by host like any other domain-mounted route.
+func Test_Domain_UseMountNested(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.Get("/x", func(c Ctx) error {
+		return c.SendString("nested x")
+	})
+
+	subApp := New()
+	subApp.Use("/v1", child)
+	subApp.Get("/flat", func(c Ctx) error {
+		return c.SendString("flat")
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	// The nested route is reachable on the matching host
+	req := httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "nested x", string(body))
+
+	// The sub-app's own routes still work alongside the nested ones
+	req = httptest.NewRequest(MethodGet, "/api/flat", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "flat", string(body))
+
+	// Both are rejected on a non-matching host
+	for _, path := range []string{"/api/v1/x", "/api/flat"} {
+		req = httptest.NewRequest(MethodGet, path, http.NoBody)
+		req.Host = "www.example.com"
+		resp, err = app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, StatusNotFound, resp.StatusCode, path)
+	}
+}
+
+// Test_Domain_UseMountNestedDeep verifies that mounts nested more than one
+// level deep are expanded, and that domain parameters resolve inside them.
+func Test_Domain_UseMountNestedDeep(t *testing.T) {
+	t.Parallel()
+
+	grandChild := New()
+	grandChild.Get("/deep", func(c Ctx) error {
+		return c.SendString("tenant=" + DomainParam(c, "tenant"))
+	})
+
+	child := New()
+	child.Use("/v2", grandChild)
+
+	subApp := New()
+	subApp.Use("/v1", child)
+
+	app := New()
+	app.Domain(":tenant.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/v1/v2/deep", http.NoBody)
+	req.Host = "acme.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "tenant=acme", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/api/v1/v2/deep", http.NoBody)
+	req.Host = "acme.example.org"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
+
+// Test_Domain_UseMountNestedMiddleware verifies that middleware of a nested
+// sub-app is domain-filtered too, instead of running on every host.
+func Test_Domain_UseMountNestedMiddleware(t *testing.T) {
+	t.Parallel()
+
+	var hits int
+	child := New()
+	child.Use(func(c Ctx) error {
+		hits++
+		return c.Next()
+	})
+	child.Get("/x", func(c Ctx) error {
+		return c.SendString("nested x")
+	})
+
+	subApp := New()
+	subApp.Use("/v1", child)
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+	// Same path outside the domain, so the request is served instead of 404ing
+	// and any nested middleware that leaked would run.
+	app.Get("/api/v1/x", func(c Ctx) error {
+		return c.SendString("fallback")
+	})
+
+	req := httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "fallback", string(body))
+	require.Equal(t, 0, hits, "nested middleware must not run on a non-matching host")
+
+	req = httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "nested x", string(body))
+	require.Equal(t, 1, hits)
+}
+
+// Test_Domain_UseMountNestedAtRoot verifies the nested mount also works when
+// both the domain mount and the nested mount sit at the root path.
+func Test_Domain_UseMountNestedAtRoot(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.Get("/x", func(c Ctx) error {
+		return c.SendString("nested x")
+	})
+
+	subApp := New()
+	subApp.Use(child)
+
+	app := New()
+	app.Domain("api.example.com").Use(subApp)
+
+	req := httptest.NewRequest(MethodGet, "/x", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "nested x", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/x", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
+
+// Test_Domain_UseMountNestedFromGroup verifies a nested mount registered
+// through a group's domain router picks up the group prefix.
+func Test_Domain_UseMountNestedFromGroup(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.Get("/data", func(c Ctx) error {
+		return c.SendString("data response")
+	})
+
+	subApp := New()
+	subApp.Use("/v1", child)
+
+	app := New()
+	api := app.Group("/api")
+	api.Domain("api.example.com").Use("/mnt", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/mnt/v1/data", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "data response", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/api/mnt/v1/data", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
+
+// Test_Domain_UseMountNestedReusable verifies that a sub-app with a nested
+// mount can be mounted on several domains and still be usable unfiltered
+// elsewhere, i.e. the original sub-app's handlers are never domain-wrapped.
+func Test_Domain_UseMountNestedReusable(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.Get("/x", func(c Ctx) error {
+		return c.SendString("nested x")
+	})
+
+	subApp := New()
+	subApp.Use("/v1", child)
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+	app.Domain("admin.example.com").Use("/api", subApp)
+
+	for _, host := range []string{"api.example.com", "admin.example.com"} {
+		req := httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+		req.Host = host
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, StatusOK, resp.StatusCode, host)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, "nested x", string(body), host)
+	}
+
+	req := httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+
+	// The original sub-app's handlers were never wrapped, so a plain mount of
+	// it still serves on any host.
+	plain := New()
+	plain.Use("/api", subApp)
+
+	req = httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+	req.Host = "anything.example.net"
+	resp, err = plain.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "nested x", string(body))
+}
+
+// Test_Domain_UseMountNestedOrder verifies the nested app's routes are expanded
+// in the position its mount was registered at, so registration order still
+// decides which route wins.
+func Test_Domain_UseMountNestedOrder(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.Get("/x", func(c Ctx) error {
+		return c.SendString("child")
+	})
+
+	subApp := New()
+	subApp.Get("/v1/x", func(c Ctx) error {
+		return c.SendString("before mount")
+	})
+	subApp.Use("/v1", child)
+	subApp.Get("/v1/y", func(c Ctx) error {
+		return c.SendString("after mount")
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	// Registered before the mount, so it takes precedence over the nested /x
+	req := httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "before mount", string(body))
+
+	// Routes registered after the mount are kept as well
+	req = httptest.NewRequest(MethodGet, "/api/v1/y", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "after mount", string(body))
+}
+
+// Test_Domain_UseMountNestedParams verifies parameters and wildcards of a
+// nested sub-app survive the prefixing done while expanding the mount.
+func Test_Domain_UseMountNestedParams(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.Get("/user/:id", func(c Ctx) error {
+		return c.SendString("id=" + c.Params("id"))
+	})
+	child.Get("/files/*", func(c Ctx) error {
+		return c.SendString("file=" + c.Params("*"))
+	})
+
+	subApp := New()
+	subApp.Use("/v1", child)
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/v1/user/42", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "id=42", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/api/v1/files/a/b.txt", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "file=a/b.txt", string(body))
+}
+
+// Test_Domain_UseMountNestedDomainMount verifies that a sub-app whose own
+// nested mount was registered on a domain router can itself be mounted, both
+// on a domain router and plainly.
+func Test_Domain_UseMountNestedDomainMount(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.Get("/x", func(c Ctx) error {
+		return c.SendString("nested x")
+	})
+
+	subApp := New()
+	subApp.Domain("api.example.com").Use("/v1", child)
+
+	// Mounted on a matching domain: the host check applies twice, which is
+	// satisfied by the same host.
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "nested x", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+
+	// Mounted plainly: the sub-app's own domain filter still applies.
+	plain := New()
+	plain.Use("/api", subApp)
+
+	req = httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err = plain.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "nested x", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err = plain.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
+
+// Test_Domain_UseMountNestedRestrictedMethods verifies that a sub-app which
+// declares fewer request methods than the app it is mounted on can still be
+// domain-mounted: the wrapper's stack has to stay indexable at the parent's
+// method indexes.
+func Test_Domain_UseMountNestedRestrictedMethods(t *testing.T) {
+	t.Parallel()
+
+	subApp := New(Config{RequestMethods: []string{MethodGet}})
+	subApp.Get("/x", func(c Ctx) error {
+		return c.SendString("restricted x")
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/x", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "restricted x", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/api/x", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
+
+// Test_Domain_UseMountNestedExtraMethods verifies that a sub-app can be
+// domain-mounted on an app whose request methods go beyond the defaults: the
+// parent reads the wrapper's stack at its own method indexes, so the wrapper
+// has to be as long as the parent's method table.
+func Test_Domain_UseMountNestedExtraMethods(t *testing.T) {
+	t.Parallel()
+
+	methods := append(append([]string{}, DefaultMethods...), "PURGE")
+	app := New(Config{RequestMethods: methods})
+
+	child := New()
+	child.Get("/x", func(c Ctx) error {
+		return c.SendString("nested x")
+	})
+	subApp := New()
+	subApp.Use("/v1", child)
+
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "nested x", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
+
+// Test_Domain_UseMountNestedCycle verifies that cloning a sub-app whose mount
+// graph contains a cycle terminates, and stops at the point the cycle closes.
+// It drives the clone directly: such an app cannot be served, because the
+// parent's startup loops in appendSubAppLists, independently of domain routing.
+func Test_Domain_UseMountNestedCycle(t *testing.T) {
+	t.Parallel()
+
+	first := New()
+	second := New()
+	second.Get("/x", func(c Ctx) error {
+		return c.SendString("nested x")
+	})
+	first.Use("/second", second)
+	second.Use("/first", first)
+
+	app := New()
+	d := &domainRouter{app: app, matcher: parseDomainPattern("api.example.com")}
+	wrapper := New()
+	d.cloneRoutesForDomain(wrapper, first)
+
+	// second's route is cloned once, under the prefix it was mounted at, and
+	// the mount that closes the cycle back onto first contributes nothing.
+	var paths []string
+	for _, route := range wrapper.stack[app.methodInt(MethodGet)] {
+		paths = append(paths, route.path)
+	}
+	require.Equal(t, []string{"/second/x"}, paths)
+}
+
 // Test_Domain_Security_PatternLengthLimits verifies RFC 1035 length limits
 // are enforced for domain patterns (253 total, 63 per label).
 func Test_Domain_Security_PatternLengthLimits(t *testing.T) {

--- a/domain_test.go
+++ b/domain_test.go
@@ -3062,6 +3062,120 @@ func Test_Domain_UseMountCaseInsensitivePath(t *testing.T) {
 	require.Equal(t, StatusNotFound, resp.StatusCode)
 }
 
+// Test_Domain_UseMountRecordedOnce verifies that a domain mount reached through
+// several layers of ordinary mounts is recorded once. Each app list already
+// holds the descendants of the apps it lists, so the startup walk arrives at
+// the same mount by every path that leads to it.
+func Test_Domain_UseMountRecordedOnce(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.Get("/x", func(c Ctx) error {
+		return c.SendString("nested x")
+	})
+
+	inner := New()
+	inner.Domain("api.example.com").Use("/child", child)
+
+	app := inner
+	for range 6 {
+		outer := New()
+		outer.Use("/layer", app)
+		app = outer
+	}
+
+	req := httptest.NewRequest(MethodGet, "/unrouted", http.NoBody)
+	req.Host = "api.example.com"
+	_, err := app.Test(req)
+	require.NoError(t, err)
+
+	require.Len(t, app.mountFields.domainAppList, 1)
+}
+
+// Test_Domain_UseMountReloadViewsBeforeStart verifies that ReloadViews reaches
+// a domain-mounted app nested inside an ordinary mount before the app has been
+// through its startup process.
+func Test_Domain_UseMountReloadViewsBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	engine := &testTemplateEngine{path: "testdata2"}
+	require.NoError(t, engine.Load())
+
+	child := New(Config{Views: engine})
+	child.Get("/view", func(c Ctx) error {
+		return c.Render("bruh.tmpl", Map{})
+	})
+
+	mid := New()
+	mid.Domain("api.example.com").Use("/child", child)
+
+	app := New()
+	app.Use("/mid", mid)
+
+	require.NoError(t, app.ReloadViews())
+}
+
+// Test_Domain_UseMountOverlappingViews verifies that when two domain mounts at
+// one path both match, the one that owns the route decides which views apply —
+// a later overlapping mount's engine is not borrowed for it.
+func Test_Domain_UseMountOverlappingViews(t *testing.T) {
+	t.Parallel()
+
+	rootEngine := &testTemplateEngine{}
+	require.NoError(t, rootEngine.Load())
+
+	wildcardEngine := &testTemplateEngine{path: "testdata2"}
+	require.NoError(t, wildcardEngine.Load())
+
+	// Registered first, owns the route, and configures no views of its own.
+	exact := New()
+	exact.Get("/view", func(c Ctx) error {
+		return c.Render("index.tmpl", Map{"Title": "exact"})
+	})
+
+	wildcard := New(Config{Views: wildcardEngine})
+	wildcard.Get("/other", func(c Ctx) error {
+		return c.Render("bruh.tmpl", Map{})
+	})
+
+	app := New(Config{Views: rootEngine})
+	app.Domain("admin.example.com").Use("/api", exact)
+	app.Domain(":tenant.example.com").Use("/api", wildcard)
+
+	req := httptest.NewRequest(MethodGet, "/api/view", http.NoBody)
+	req.Host = "admin.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>exact</h1>", string(body))
+}
+
+// Test_Domain_UseMountKeepsParentAutoHead verifies that a domain mount which
+// registers no automatic HEAD routes only withholds them from its own routes,
+// leaving a route the parent registered at the same path with its own.
+func Test_Domain_UseMountKeepsParentAutoHead(t *testing.T) {
+	t.Parallel()
+
+	subApp := New(Config{DisableHeadAutoRegister: true})
+	subApp.Get("/x", func(c Ctx) error {
+		return c.SendString("sub x")
+	})
+
+	app := New()
+	app.Get("/api/x", func(c Ctx) error {
+		return c.SendString("parent x")
+	})
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodHead, "/api/x", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode, "the parent's own route keeps its HEAD route")
+}
+
 // Test_Domain_UseMountNestedCycle verifies that cloning a sub-app whose mount
 // graph contains a cycle terminates, and stops at the point the cycle closes.
 // It drives the clone directly: such an app cannot be served, because the

--- a/domain_test.go
+++ b/domain_test.go
@@ -3830,6 +3830,37 @@ func Test_Domain_UseMountLayoutStopsAtEngine(t *testing.T) {
 	require.Equal(t, "<h1>child</h1>", string(body))
 }
 
+// Test_Domain_UseMountAutoHeadPerSubtree verifies that one app opting out of
+// automatic HEAD routes withholds them from itself and the apps it is mounted
+// in front of, and from nothing else — the routes of the app it sits inside
+// keep theirs, as they do under an ordinary mount.
+func Test_Domain_UseMountAutoHeadPerSubtree(t *testing.T) {
+	t.Parallel()
+
+	handler := func(c Ctx) error { return c.SendString("x") }
+
+	child := New(Config{DisableHeadAutoRegister: true})
+	child.Get("/deep", handler)
+
+	subApp := New()
+	subApp.Get("/top", handler)
+	subApp.Use("/v1", child)
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	for path, want := range map[string]int{
+		"/api/top":     StatusOK,
+		"/api/v1/deep": StatusMethodNotAllowed,
+	} {
+		req := httptest.NewRequest(MethodHead, path, http.NoBody)
+		req.Host = "api.example.com"
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, want, resp.StatusCode, path)
+	}
+}
+
 // Test_Domain_UseMountInheritsDomainViews verifies the same inheritance for the
 // view engine: a child of a domain-mounted app renders through that app's
 // engine rather than the root's.

--- a/domain_test.go
+++ b/domain_test.go
@@ -2447,6 +2447,42 @@ func Test_Domain_UseMountAutoHeadDisabled(t *testing.T) {
 	require.Equal(t, StatusMethodNotAllowed, resp.StatusCode)
 }
 
+// Test_Domain_UseMountCustomConstraint verifies that custom constraints of a
+// domain-mounted app, and of an app it has mounted in turn, still validate once
+// the routes are expanded into the parent.
+func Test_Domain_UseMountCustomConstraint(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.RegisterCustomConstraint(&onlyFooConstraint{})
+	child.Get("/nested/:name<onlyfoo>", func(c Ctx) error {
+		return c.SendString(c.Params("name"))
+	})
+
+	subApp := New()
+	subApp.RegisterCustomConstraint(&onlyBarConstraint{})
+	subApp.Use("/v1", child)
+	subApp.Get("/flat/:name<onlybar>", func(c Ctx) error {
+		return c.SendString(c.Params("name"))
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	for path, want := range map[string]int{
+		"/api/v1/nested/foo": StatusOK,
+		"/api/v1/nested/bar": StatusNotFound,
+		"/api/flat/bar":      StatusOK,
+		"/api/flat/foo":      StatusNotFound,
+	} {
+		req := httptest.NewRequest(MethodGet, path, http.NoBody)
+		req.Host = "api.example.com"
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, want, resp.StatusCode, path)
+	}
+}
+
 // Test_Domain_UseMountNestedCycle verifies that cloning a sub-app whose mount
 // graph contains a cycle terminates, and stops at the point the cycle closes.
 // It drives the clone directly: such an app cannot be served, because the

--- a/domain_test.go
+++ b/domain_test.go
@@ -3531,6 +3531,138 @@ func Test_Domain_UseMountCyclicOrdinaryMounts(t *testing.T) {
 	require.Equal(t, "pong", string(body))
 }
 
+// Test_Domain_UseMountAutoHeadPerMount verifies that a HEAD route one mounted
+// app registers does not stand in for another's GET route at the same path:
+// on a hostname the first app's pattern rejects, its route declines and the GET
+// route needs an automatic companion of its own.
+func Test_Domain_UseMountAutoHeadPerMount(t *testing.T) {
+	t.Parallel()
+
+	inner := New()
+	inner.Head("/x", func(c Ctx) error {
+		c.Set("X-Handler", "inner")
+		return nil
+	})
+
+	outer := New()
+	outer.Get("/x", func(c Ctx) error {
+		c.Set("X-Handler", "outer")
+		return nil
+	})
+	outer.Domain("admin.example.com").Use("/", inner)
+
+	app := New()
+	app.Domain(":tenant.example.com").Use("/api", outer)
+
+	for host, want := range map[string]string{
+		"admin.example.com": "inner", // matches both patterns
+		"other.example.com": "outer", // only the outer one
+	} {
+		req := httptest.NewRequest(MethodHead, "/api/x", http.NoBody)
+		req.Host = host
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, StatusOK, resp.StatusCode, host)
+		require.Equal(t, want, resp.Header.Get("X-Handler"), host)
+	}
+}
+
+// Test_Domain_UseMountInheritsDomainErrorHandler verifies that an app mounted
+// inside a domain-mounted one inherits its error handler when it configures
+// none, as an ordinarily nested mount does.
+func Test_Domain_UseMountInheritsDomainErrorHandler(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	subApp := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(594).SendString("sub")
+	}})
+	subApp.Use("/child", child)
+
+	app := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(595).SendString("root")
+	}})
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/child/boom", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 594, resp.StatusCode)
+}
+
+// Test_Domain_UseMountInheritsOnlyFromCoveringMounts verifies that inheritance
+// reaches the mounts a request passed through, not every shallower one: a
+// domain mount on another path encloses nothing here.
+func Test_Domain_UseMountInheritsOnlyFromCoveringMounts(t *testing.T) {
+	t.Parallel()
+
+	other := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(596).SendString("other")
+	}})
+	other.Get("/thing", func(c Ctx) error {
+		return c.SendString("thing")
+	})
+
+	child := New()
+	child.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	subApp := New()
+	subApp.Use("/child", child)
+
+	app := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(597).SendString("root")
+	}})
+	app.Domain("api.example.com").Use("/other", other)
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/child/boom", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 597, resp.StatusCode)
+}
+
+// Test_Domain_UseMountInheritsDomainViews verifies the same inheritance for the
+// view engine: a child of a domain-mounted app renders through that app's
+// engine rather than the root's.
+func Test_Domain_UseMountInheritsDomainViews(t *testing.T) {
+	t.Parallel()
+
+	// Holds no template the child asks for, so borrowing it would fail.
+	rootEngine := &testTemplateEngine{path: "testdata2"}
+	require.NoError(t, rootEngine.Load())
+
+	subEngine := &testTemplateEngine{}
+	require.NoError(t, subEngine.Load())
+
+	child := New()
+	child.Get("/view", func(c Ctx) error {
+		return c.Render("index.tmpl", Map{"Title": "child"})
+	})
+
+	subApp := New(Config{Views: subEngine})
+	subApp.Use("/child", child)
+
+	app := New(Config{Views: rootEngine})
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/child/view", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>child</h1>", string(body))
+}
+
 // Test_Domain_UseMountKeepsParentAutoHead verifies that a domain mount which
 // registers no automatic HEAD routes only withholds them from its own routes,
 // leaving a route the parent registered at the same path with its own.

--- a/domain_test.go
+++ b/domain_test.go
@@ -3727,6 +3727,75 @@ func Test_Domain_UseMountConcurrentRegistration(t *testing.T) {
 	wg.Wait()
 }
 
+// Test_Domain_UseMountNestedPrefixConstraint verifies that a constraint named in
+// a nested mount prefix is still applied when the mount is recorded on the app
+// above: the constraint is registered on the app that wrote the prefix, not on
+// the one recording it.
+func Test_Domain_UseMountNestedPrefixConstraint(t *testing.T) {
+	t.Parallel()
+
+	child := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(603).SendString("child")
+	}})
+	child.Get("/x", func(c Ctx) error {
+		return c.SendString("x")
+	})
+
+	mid := New()
+	mid.RegisterCustomConstraint(&onlyFooConstraint{})
+	mid.Use("/:name<onlyfoo>", child)
+
+	outer := New()
+	outer.Use("/mid", mid)
+
+	app := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(604).SendString("root")
+	}})
+	app.Domain("api.example.com").Use("/api", outer)
+
+	// The mount covers the path the constraint accepts, and nothing else.
+	for path, want := range map[string]int{"/api/mid/foo/nope": 603, "/api/mid/bar/nope": 604} {
+		req := httptest.NewRequest(MethodGet, path, http.NoBody)
+		req.Host = "api.example.com"
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, want, resp.StatusCode, path)
+	}
+}
+
+// Test_Domain_UseMountAncestryIsStable verifies that a mount reached both
+// through its own parent and as an entry of the app above it keeps the ancestry
+// of the former, whichever the unordered walk happens to record first.
+func Test_Domain_UseMountAncestryIsStable(t *testing.T) {
+	t.Parallel()
+
+	for range 40 {
+		child := New()
+		child.Get("/boom", func(_ Ctx) error {
+			return errors.New("boom")
+		})
+
+		mid := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(605).SendString("mid")
+		}})
+		mid.Use("/child", child)
+
+		outer := New()
+		outer.Use("/mid", mid)
+
+		app := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(606).SendString("root")
+		}})
+		app.Domain("api.example.com").Use("/api", outer)
+
+		req := httptest.NewRequest(MethodGet, "/api/mid/child/boom", http.NoBody)
+		req.Host = "api.example.com"
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, 605, resp.StatusCode)
+	}
+}
+
 // Test_Domain_UseMountInheritsDomainViews verifies the same inheritance for the
 // view engine: a child of a domain-mounted app renders through that app's
 // engine rather than the root's.

--- a/domain_test.go
+++ b/domain_test.go
@@ -2390,6 +2390,63 @@ func Test_Domain_UseMountNestedRequestMethods(t *testing.T) {
 	}
 }
 
+// Test_Domain_UseMountAutoHead verifies that domain-mounted routes get their
+// automatic HEAD companion, for the sub-app's own routes and for the routes of
+// an app it has mounted, and that the HEAD route is domain-filtered too.
+func Test_Domain_UseMountAutoHead(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.Get("/nested", func(c Ctx) error {
+		return c.SendString("nested")
+	})
+
+	subApp := New()
+	subApp.Use("/v1", child)
+	subApp.Get("/flat", func(c Ctx) error {
+		return c.SendString("flat")
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	// HEAD is the first request, so the route has to exist after the single
+	// startup pass a served app performs.
+	for _, path := range []string{"/api/v1/nested", "/api/flat"} {
+		req := httptest.NewRequest(MethodHead, path, http.NoBody)
+		req.Host = "api.example.com"
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, StatusOK, resp.StatusCode, path)
+
+		req = httptest.NewRequest(MethodHead, path, http.NoBody)
+		req.Host = "www.example.com"
+		resp, err = app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, StatusNotFound, resp.StatusCode, path)
+	}
+}
+
+// Test_Domain_UseMountAutoHeadDisabled verifies that a sub-app which turned
+// automatic HEAD registration off does not get HEAD routes from the mount.
+func Test_Domain_UseMountAutoHeadDisabled(t *testing.T) {
+	t.Parallel()
+
+	subApp := New(Config{DisableHeadAutoRegister: true})
+	subApp.Get("/flat", func(c Ctx) error {
+		return c.SendString("flat")
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodHead, "/api/flat", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusMethodNotAllowed, resp.StatusCode)
+}
+
 // Test_Domain_UseMountNestedCycle verifies that cloning a sub-app whose mount
 // graph contains a cycle terminates, and stops at the point the cycle closes.
 // It drives the clone directly: such an app cannot be served, because the

--- a/domain_test.go
+++ b/domain_test.go
@@ -2982,6 +2982,86 @@ func Test_Domain_UseMountOverlappingPatterns(t *testing.T) {
 	require.Equal(t, 598, resp.StatusCode)
 }
 
+// Test_Domain_UseMountParametricPrefix verifies that a parametric mount prefix
+// inside a domain-mounted sub-app still matches as a pattern once the routes
+// have been prefixed twice.
+func Test_Domain_UseMountParametricPrefix(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.Get("/x", func(c Ctx) error {
+		return c.SendString("version=" + c.Params("version"))
+	})
+
+	subApp := New()
+	subApp.Use("/v1/:version", child)
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/v1/42/x", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "version=42", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/api/v1/42/x", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
+
+// Test_Domain_UseMountCaseInsensitivePath verifies that a domain mount
+// registered with a differently-cased path still owns its config on a
+// case-insensitive app, the way its routes do.
+func Test_Domain_UseMountCaseInsensitivePath(t *testing.T) {
+	t.Parallel()
+
+	engine := &testTemplateEngine{path: "testdata2"}
+	require.NoError(t, engine.Load())
+
+	subApp := New(Config{
+		Views: engine,
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(599).SendString("sub error")
+		},
+	})
+	subApp.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+	subApp.Get("/view", func(c Ctx) error {
+		return c.Render("bruh.tmpl", Map{})
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/API", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/boom", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 599, resp.StatusCode)
+
+	req = httptest.NewRequest(MethodGet, "/api/view", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>I'm Bruh</h1>", string(body))
+
+	// Still host-scoped: another host gets neither the route nor the config.
+	req = httptest.NewRequest(MethodGet, "/api/boom", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
+
 // Test_Domain_UseMountNestedCycle verifies that cloning a sub-app whose mount
 // graph contains a cycle terminates, and stops at the point the cycle closes.
 // It drives the clone directly: such an app cannot be served, because the

--- a/domain_test.go
+++ b/domain_test.go
@@ -3176,6 +3176,113 @@ func Test_Domain_UseMountKeepsParentAutoHead(t *testing.T) {
 	require.Equal(t, StatusOK, resp.StatusCode, "the parent's own route keeps its HEAD route")
 }
 
+// Test_Domain_UseMountParametricMountPath verifies that a domain mount
+// registered at a parametric path owns the requests its routes serve, so its
+// error handler and views apply to them.
+func Test_Domain_UseMountParametricMountPath(t *testing.T) {
+	t.Parallel()
+
+	subApp := New(Config{
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(571).SendString("sub error")
+		},
+	})
+	subApp.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/:tenant", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/acme/boom", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 571, resp.StatusCode)
+}
+
+// Test_Domain_UseMountRootIsShallowest verifies that a mount at the root is
+// the least specific of the mounts covering a request, so a named mount
+// registered after it still owns its own routes.
+func Test_Domain_UseMountRootIsShallowest(t *testing.T) {
+	t.Parallel()
+
+	rootApp := New(Config{
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(572).SendString("root mount")
+		},
+	})
+	rootApp.Get("/other", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	apiApp := New(Config{
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(573).SendString("api mount")
+		},
+	})
+	apiApp.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/", rootApp)
+	app.Domain("api.example.com").Use("/api", apiApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/boom", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 573, resp.StatusCode)
+}
+
+// Test_Domain_UseMountViewsRankedAgainstPlain verifies that a domain mount and
+// an ordinary one are ranked against each other by mount depth, so the deeper
+// of the two renders with its own engine.
+func Test_Domain_UseMountViewsRankedAgainstPlain(t *testing.T) {
+	t.Parallel()
+
+	domainEngine := &testTemplateEngine{path: "testdata2"}
+	require.NoError(t, domainEngine.Load())
+
+	plainEngine := &testTemplateEngine{path: "testdata3"}
+	require.NoError(t, plainEngine.Load())
+
+	domainApp := New(Config{Views: domainEngine})
+	domainApp.Get("/x", func(c Ctx) error {
+		return c.Render("bruh.tmpl", Map{})
+	})
+
+	plainApp := New(Config{Views: plainEngine})
+	plainApp.Get("/view", func(c Ctx) error {
+		return c.Render("hello_world.tmpl", Map{"Name": "deep"})
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", domainApp)
+	app.Use("/api/admin", plainApp)
+
+	// The deeper plain mount owns this one.
+	req := httptest.NewRequest(MethodGet, "/api/admin/view", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>Hello deep!</h1>", string(body))
+
+	// And the domain mount still owns its own.
+	req = httptest.NewRequest(MethodGet, "/api/x", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>I'm Bruh</h1>", string(body))
+}
+
 // Test_Domain_UseMountNestedCycle verifies that cloning a sub-app whose mount
 // graph contains a cycle terminates, and stops at the point the cycle closes.
 // It drives the clone directly: such an app cannot be served, because the

--- a/domain_test.go
+++ b/domain_test.go
@@ -2673,6 +2673,161 @@ func Test_Domain_UseMountLeavesSubAppIntact(t *testing.T) {
 	require.Equal(t, "nested x", string(body))
 }
 
+// Test_Domain_UseMountViewsLayout verifies that a domain-mounted sub-app's
+// ViewsLayout is applied when the caller passes no layout of its own.
+func Test_Domain_UseMountViewsLayout(t *testing.T) {
+	t.Parallel()
+
+	engine := &testTemplateEngine{}
+	require.NoError(t, engine.Load())
+
+	subApp := New(Config{Views: engine, ViewsLayout: "main.tmpl"})
+	subApp.Get("/view", func(c Ctx) error {
+		return c.Render("index.tmpl", Map{"Title": "Hello, World!"})
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/view", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>Hello, World!</h1><h1>I'm main</h1>", string(body))
+}
+
+// Test_Domain_UseMountViewsError verifies that a render failure in a
+// domain-mounted sub-app's engine is reported rather than falling through to
+// the parent's views.
+func Test_Domain_UseMountViewsError(t *testing.T) {
+	t.Parallel()
+
+	parentEngine := &testTemplateEngine{}
+	require.NoError(t, parentEngine.Load())
+
+	subApp := New(Config{Views: errorTemplateEngine{}})
+	subApp.Get("/view", func(c Ctx) error {
+		return c.Render("index.tmpl", Map{"Title": "Hello, World!"})
+	})
+
+	app := New(Config{Views: parentEngine})
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/view", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusInternalServerError, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), "errorTemplateEngine")
+}
+
+// Test_Domain_UseMountWithoutViews verifies that a domain-mounted sub-app with
+// no view engine of its own leaves rendering to the parent.
+func Test_Domain_UseMountWithoutViews(t *testing.T) {
+	t.Parallel()
+
+	engine := &testTemplateEngine{}
+	require.NoError(t, engine.Load())
+
+	subApp := New()
+	subApp.Get("/view", func(c Ctx) error {
+		return c.Render("index.tmpl", Map{"Title": "from parent"})
+	})
+
+	app := New(Config{Views: engine})
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/view", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>from parent</h1>", string(body))
+}
+
+// Test_Domain_UseMountReloadViews verifies that ReloadViews reaches the view
+// engine of a domain-mounted sub-app, which appList no longer holds.
+func Test_Domain_UseMountReloadViews(t *testing.T) {
+	t.Parallel()
+
+	engine := &testTemplateEngine{path: "testdata2"}
+	require.NoError(t, engine.Load())
+
+	subApp := New(Config{Views: engine})
+	subApp.Get("/view", func(c Ctx) error {
+		return c.Render("bruh.tmpl", Map{})
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	require.NoError(t, app.ReloadViews())
+
+	req := httptest.NewRequest(MethodGet, "/api/view", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>I'm Bruh</h1>", string(body))
+}
+
+// Test_Domain_UseMountSelf verifies that mounting an app on its own domain
+// router returns instead of deadlocking on the app's mutex.
+func Test_Domain_UseMountSelf(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	app.Get("/x", func(c Ctx) error {
+		return c.SendString("x")
+	})
+
+	require.NotPanics(t, func() {
+		app.Domain("api.example.com").Use("/self", app)
+	})
+}
+
+// Test_Domain_UseMountViewsPathOnly verifies that a domain-mounted sub-app's
+// views are chosen by the request path, not by the mount path appearing
+// anywhere in the URL — a query string carrying it must not select them.
+func Test_Domain_UseMountViewsPathOnly(t *testing.T) {
+	t.Parallel()
+
+	subEngine := &testTemplateEngine{path: "testdata2"}
+	require.NoError(t, subEngine.Load())
+
+	parentEngine := &testTemplateEngine{}
+	require.NoError(t, parentEngine.Load())
+
+	subApp := New(Config{Views: subEngine})
+	subApp.Get("/view", func(c Ctx) error {
+		return c.Render("bruh.tmpl", Map{})
+	})
+
+	app := New(Config{Views: parentEngine})
+	app.Domain("api.example.com").Use("/api", subApp)
+	app.Get("/elsewhere", func(c Ctx) error {
+		return c.Render("index.tmpl", Map{"Title": "parent"})
+	})
+
+	req := httptest.NewRequest(MethodGet, "/elsewhere?next=/api/view", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>parent</h1>", string(body))
+}
+
 // Test_Domain_UseMountNestedCycle verifies that cloning a sub-app whose mount
 // graph contains a cycle terminates, and stops at the point the cycle closes.
 // It drives the clone directly: such an app cannot be served, because the

--- a/domain_test.go
+++ b/domain_test.go
@@ -3796,6 +3796,40 @@ func Test_Domain_UseMountAncestryIsStable(t *testing.T) {
 	}
 }
 
+// Test_Domain_UseMountLayoutStopsAtEngine verifies that a mount rendering
+// through an engine of its own takes no layout from the mount enclosing it, as
+// an ordinary mount does not: the scan stops at the first engine covering the
+// request either way.
+func Test_Domain_UseMountLayoutStopsAtEngine(t *testing.T) {
+	t.Parallel()
+
+	childEngine := &testTemplateEngine{}
+	require.NoError(t, childEngine.Load())
+
+	subEngine := &testTemplateEngine{}
+	require.NoError(t, subEngine.Load())
+
+	child := New(Config{Views: childEngine}) // an engine, and no layout
+	child.Get("/view", func(c Ctx) error {
+		return c.Render("index.tmpl", Map{"Title": "child"})
+	})
+
+	subApp := New(Config{Views: subEngine, ViewsLayout: "main.tmpl"})
+	subApp.Use("/child", child)
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/child/view", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>child</h1>", string(body))
+}
+
 // Test_Domain_UseMountInheritsDomainViews verifies the same inheritance for the
 // view engine: a child of a domain-mounted app renders through that app's
 // engine rather than the root's.

--- a/domain_test.go
+++ b/domain_test.go
@@ -5,6 +5,7 @@
 package fiber
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -2481,6 +2482,195 @@ func Test_Domain_UseMountCustomConstraint(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, want, resp.StatusCode, path)
 	}
+}
+
+// Test_Domain_UseMountPerHostConfig verifies that two sub-apps mounted at the
+// same path on different domains each keep their own error handler and view
+// engine. Keyed by path alone they would displace each other.
+func Test_Domain_UseMountPerHostConfig(t *testing.T) {
+	t.Parallel()
+
+	engineA := &testTemplateEngine{path: "testdata2"}
+	require.NoError(t, engineA.Load())
+
+	engineB := &testTemplateEngine{path: "testdata3"}
+	require.NoError(t, engineB.Load())
+
+	subA := New(Config{
+		Views: engineA,
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(591).SendString("a error")
+		},
+	})
+	subA.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+	subA.Get("/view", func(c Ctx) error {
+		return c.Render("bruh.tmpl", Map{})
+	})
+
+	subB := New(Config{
+		Views: engineB,
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(592).SendString("b error")
+		},
+	})
+	subB.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+	subB.Get("/view", func(c Ctx) error {
+		return c.Render("hello_world.tmpl", Map{"Name": "b"})
+	})
+
+	app := New()
+	app.Domain("a.example.com").Use("/api", subA)
+	app.Domain("b.example.com").Use("/api", subB)
+
+	req := httptest.NewRequest(MethodGet, "/api/boom", http.NoBody)
+	req.Host = "a.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 591, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "a error", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/api/boom", http.NoBody)
+	req.Host = "b.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 592, resp.StatusCode)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "b error", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/api/view", http.NoBody)
+	req.Host = "a.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>I'm Bruh</h1>", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/api/view", http.NoBody)
+	req.Host = "b.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>Hello b!</h1>", string(body))
+}
+
+// Test_Domain_UseMountConfigIgnoredOnOtherHost verifies that a domain-mounted
+// sub-app's error handler does not answer for a host its pattern rejects.
+func Test_Domain_UseMountConfigIgnoredOnOtherHost(t *testing.T) {
+	t.Parallel()
+
+	subApp := New(Config{
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(593).SendString("sub error")
+		},
+	})
+	subApp.Get("/mounted", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+	// A route of the parent, under the same prefix, on every host.
+	app.Get("/api/own", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	req := httptest.NewRequest(MethodGet, "/api/own", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusInternalServerError, resp.StatusCode)
+
+	// On a matching host the sub-app still governs its own prefix.
+	req = httptest.NewRequest(MethodGet, "/api/mounted", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 593, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "sub error", string(body))
+}
+
+// Test_Domain_UseMountNestedErrorHandler verifies that the deepest mount
+// covering the request wins, nested apps included.
+func Test_Domain_UseMountNestedErrorHandler(t *testing.T) {
+	t.Parallel()
+
+	child := New(Config{
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(594).SendString("child error")
+		},
+	})
+	child.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	subApp := New(Config{
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(595).SendString("sub error")
+		},
+	})
+	subApp.Use("/v1", child)
+	subApp.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	for path, want := range map[string]int{"/api/v1/boom": 594, "/api/boom": 595} {
+		req := httptest.NewRequest(MethodGet, path, http.NoBody)
+		req.Host = "api.example.com"
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, want, resp.StatusCode, path)
+	}
+}
+
+// Test_Domain_UseMountLeavesSubAppIntact verifies that mounting a sub-app on a
+// domain does not flatten the sub-app's own mounts, so it stays usable on its
+// own afterwards.
+func Test_Domain_UseMountLeavesSubAppIntact(t *testing.T) {
+	t.Parallel()
+
+	child := New()
+	child.Get("/x", func(c Ctx) error {
+		return c.SendString("nested x")
+	})
+
+	subApp := New()
+	subApp.Use("/v1", child)
+
+	getIndex := subApp.methodInt(MethodGet)
+	routesBefore := len(subApp.stack[getIndex])
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/v1/x", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+
+	require.Len(t, subApp.stack[getIndex], routesBefore, "the sub-app's own stack was rewritten")
+	require.True(t, subApp.stack[getIndex][0].mount, "the sub-app's mount was expanded in place")
+
+	// The sub-app still resolves its own mount when served on its own.
+	resp, err = subApp.Test(httptest.NewRequest(MethodGet, "/v1/x", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "nested x", string(body))
 }
 
 // Test_Domain_UseMountNestedCycle verifies that cloning a sub-app whose mount

--- a/domain_test.go
+++ b/domain_test.go
@@ -3282,6 +3282,103 @@ func Test_Domain_UseMountDeclinedHostKeepsRootErrorHandler(t *testing.T) {
 	require.Equal(t, StatusNotFound, resp.StatusCode)
 }
 
+// Test_Domain_UseMountViewsLayoutWithoutViews verifies that a domain mount
+// configuring only a layout renders through the engine above it and keeps its
+// layout, as an ordinary mount without an engine of its own does.
+func Test_Domain_UseMountViewsLayoutWithoutViews(t *testing.T) {
+	t.Parallel()
+
+	engine := &testTemplateEngine{}
+	require.NoError(t, engine.Load())
+
+	subApp := New(Config{ViewsLayout: "main.tmpl"})
+	subApp.Get("/view", func(c Ctx) error {
+		return c.Render("index.tmpl", Map{"Title": "Hello"})
+	})
+
+	app := New(Config{Views: engine})
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/view", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>Hello</h1><h1>I'm main</h1>", string(body))
+}
+
+// Test_Domain_UseMountBehindPlainDescendant verifies that an app domain-mounted
+// on an ordinary descendant of a domain-mounted app is found: those records live
+// only on the app they were registered on, and ordinary mounting does not carry
+// them upward.
+func Test_Domain_UseMountBehindPlainDescendant(t *testing.T) {
+	t.Parallel()
+
+	inner := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(586).SendString("inner")
+	}})
+	inner.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	mid := New()
+	outer := New()
+	outer.Use("/mid", mid)
+	mid.Domain("admin.example.com").Use("/child", inner)
+
+	app := New()
+	app.Domain(":tenant.example.com").Use("/api", outer)
+
+	req := httptest.NewRequest(MethodGet, "/api/mid/child/boom", http.NoBody)
+	req.Host = "admin.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 586, resp.StatusCode)
+
+	// Both patterns have to match: the inner app is behind its own domain
+	// router as well as the one it was reached through.
+	req = httptest.NewRequest(MethodGet, "/api/mid/child/boom", http.NoBody)
+	req.Host = "other.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
+
+// Test_Domain_UseMountStartedSubApp verifies that a sub-app which has already
+// expanded its own mounts keeps its children as the owners of their routes when
+// it is domain-mounted afterwards, rather than being credited with all of them.
+func Test_Domain_UseMountStartedSubApp(t *testing.T) {
+	t.Parallel()
+
+	child := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(587).SendString("child")
+	}})
+	child.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	subApp := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(588).SendString("sub")
+	}})
+	subApp.Use("/mid", child)
+
+	// Run the sub-app on its own first, which replaces its mount placeholders
+	// with the child's routes.
+	_, err := subApp.Test(httptest.NewRequest(MethodGet, "/mid/boom", http.NoBody))
+	require.NoError(t, err)
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/mid/boom", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 587, resp.StatusCode)
+}
+
 // Test_Domain_UseMountKeepsParentAutoHead verifies that a domain mount which
 // registers no automatic HEAD routes only withholds them from its own routes,
 // leaving a route the parent registered at the same path with its own.

--- a/domain_test.go
+++ b/domain_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -3627,6 +3628,103 @@ func Test_Domain_UseMountInheritsOnlyFromCoveringMounts(t *testing.T) {
 	resp, err := app.Test(req)
 	require.NoError(t, err)
 	require.Equal(t, 597, resp.StatusCode)
+}
+
+// Test_Domain_UseMountIgnoresOverlappingSibling verifies that inheritance
+// follows the mounts an app is registered inside, not every shallower one that
+// happens to reach the same request: a separately registered mount overlapping
+// by host and path encloses nothing.
+func Test_Domain_UseMountIgnoresOverlappingSibling(t *testing.T) {
+	t.Parallel()
+
+	wildcard := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(598).SendString("wildcard")
+	}})
+	wildcard.Get("/thing", func(c Ctx) error {
+		return c.SendString("thing")
+	})
+
+	exact := New() // no handler of its own
+	exact.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	app := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(599).SendString("root")
+	}})
+	app.Domain(":tenant.example.com").Use("/api", wildcard)
+	app.Domain("admin.example.com").Use("/api/child", exact)
+
+	req := httptest.NewRequest(MethodGet, "/api/child/boom", http.NoBody)
+	req.Host = "admin.example.com" // matches both patterns
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 599, resp.StatusCode)
+}
+
+// Test_Domain_UseMountPlainRouteKeepsItsOwnConfig verifies that a domain mount
+// does not answer for a route an ordinary mount served, even where it covers
+// the same prefix on a matching host.
+func Test_Domain_UseMountPlainRouteKeepsItsOwnConfig(t *testing.T) {
+	t.Parallel()
+
+	plain := New() // no handler of its own
+	plain.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	subApp := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(601).SendString("domain")
+	}})
+	subApp.Get("/other", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	app := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(602).SendString("root")
+	}})
+	app.Use("/api", plain)
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/boom", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 602, resp.StatusCode)
+
+	// The domain mount still answers for the routes it did serve.
+	req = httptest.NewRequest(MethodGet, "/api/other", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 601, resp.StatusCode)
+}
+
+// Test_Domain_UseMountConcurrentRegistration verifies that cloning a sub-app's
+// routes does not race registration on that sub-app: a route registered on a
+// path it already serves has its handlers appended in place.
+func Test_Domain_UseMountConcurrentRegistration(t *testing.T) {
+	t.Parallel()
+
+	handler := func(c Ctx) error { return c.SendString("x") }
+	subApp := New()
+	subApp.Get("/x", handler)
+
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		for range 200 {
+			subApp.Get("/x", handler)
+		}
+	})
+
+	wg.Go(func() {
+		for range 200 {
+			New().Domain("api.example.com").Use("/api", subApp)
+		}
+	})
+
+	wg.Wait()
 }
 
 // Test_Domain_UseMountInheritsDomainViews verifies the same inheritance for the

--- a/domain_test.go
+++ b/domain_test.go
@@ -3911,6 +3911,74 @@ func Test_Domain_UseMountTreeVisitsEachMountOnce(t *testing.T) {
 	require.Less(t, len(apps[0].mountTree()), (depth+1)*(depth+1))
 }
 
+// Test_Domain_UseMountSharedAppOnTwoPatterns verifies that one app mounted at a
+// path for two hostnames is recorded for both: the mounts differ only in the
+// patterns that reach them.
+func Test_Domain_UseMountSharedAppOnTwoPatterns(t *testing.T) {
+	t.Parallel()
+
+	shared := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(608).SendString("shared")
+	}})
+	shared.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	subApp := New()
+	subApp.Domain("a.example.com").Use("/", shared)
+	subApp.Domain("b.example.com").Use("/", shared)
+
+	app := New()
+	app.Domain(":sub.example.com").Use("/api", subApp)
+
+	for _, host := range []string{"a.example.com", "b.example.com"} {
+		req := httptest.NewRequest(MethodGet, "/api/boom", http.NoBody)
+		req.Host = host
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, 608, resp.StatusCode, host)
+	}
+}
+
+// Test_Domain_UseMountOutranksDeeperUnrelatedMount verifies that the app a route
+// was mounted from answers for it even where an unrelated plain mount reaches
+// deeper: that mount serves none of these routes, and depth only stands in for
+// ownership where nothing better is known.
+func Test_Domain_UseMountOutranksDeeperUnrelatedMount(t *testing.T) {
+	t.Parallel()
+
+	subApp := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(609).SendString("domain")
+	}})
+	subApp.Get("/admin/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	plain := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(610).SendString("plain")
+	}})
+	plain.Get("/other", func(c Ctx) error {
+		return c.SendString("other")
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+	app.Use("/api/admin", plain)
+
+	req := httptest.NewRequest(MethodGet, "/api/admin/boom", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 609, resp.StatusCode)
+
+	// The deeper mount still answers for the routes it does serve.
+	req = httptest.NewRequest(MethodGet, "/api/admin/missing", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 610, resp.StatusCode)
+}
+
 // Test_Domain_UseMountInheritsDomainViews verifies the same inheritance for the
 // view engine: a child of a domain-mounted app renders through that app's
 // engine rather than the root's.

--- a/domain_test.go
+++ b/domain_test.go
@@ -2347,6 +2347,49 @@ func Test_Domain_UseMountNestedExtraMethods(t *testing.T) {
 	require.Equal(t, StatusNotFound, resp.StatusCode)
 }
 
+// Test_Domain_UseMountNestedRequestMethods verifies that a nested sub-app
+// listing its own request methods keeps each route under the method it was
+// registered with, and that a shorter table does not cut the clone short.
+func Test_Domain_UseMountNestedRequestMethods(t *testing.T) {
+	t.Parallel()
+
+	// Swap GET and POST, so the two apps' stack indexes disagree.
+	methods := append([]string{}, DefaultMethods...)
+	for i, method := range methods {
+		switch method {
+		case MethodGet:
+			methods[i] = MethodPost
+		case MethodPost:
+			methods[i] = MethodGet
+		}
+	}
+
+	child := New(Config{RequestMethods: methods})
+	child.Get("/x", func(c Ctx) error {
+		return c.SendString("get x")
+	})
+	child.Post("/x", func(c Ctx) error {
+		return c.SendString("post x")
+	})
+
+	subApp := New()
+	subApp.Use("/v1", child)
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	for method, want := range map[string]string{MethodGet: "get x", MethodPost: "post x"} {
+		req := httptest.NewRequest(method, "/api/v1/x", http.NoBody)
+		req.Host = "api.example.com"
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, StatusOK, resp.StatusCode, method)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, want, string(body), method)
+	}
+}
+
 // Test_Domain_UseMountNestedCycle verifies that cloning a sub-app whose mount
 // graph contains a cycle terminates, and stops at the point the cycle closes.
 // It drives the clone directly: such an app cannot be served, because the

--- a/domain_test.go
+++ b/domain_test.go
@@ -2792,13 +2792,18 @@ func Test_Domain_UseMountSelf(t *testing.T) {
 	})
 
 	done := make(chan struct{})
+
+	var mountPanic any
 	go func() {
 		defer close(done)
+		defer func() { mountPanic = recover() }()
+
 		app.Domain("api.example.com").Use("/self", app)
 	}()
 
 	select {
 	case <-done:
+		require.Nil(t, mountPanic, "mounting an app on its own domain router panicked")
 	case <-time.After(10 * time.Second):
 		require.FailNow(t, "mounting an app on its own domain router did not return")
 	}

--- a/domain_test.go
+++ b/domain_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
@@ -2790,9 +2791,17 @@ func Test_Domain_UseMountSelf(t *testing.T) {
 		return c.SendString("x")
 	})
 
-	require.NotPanics(t, func() {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
 		app.Domain("api.example.com").Use("/self", app)
-	})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "mounting an app on its own domain router did not return")
+	}
 }
 
 // Test_Domain_UseMountViewsPathOnly verifies that a domain-mounted sub-app's
@@ -2826,6 +2835,146 @@ func Test_Domain_UseMountViewsPathOnly(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "<h1>parent</h1>", string(body))
+}
+
+// Test_Domain_UseMountAutoHeadKeepsMiddleware verifies that a sub-app which
+// does not serve HEAD gets no synthesized HEAD routes. Its middleware is
+// registered for its own methods only, so a HEAD route built from the GET one
+// would reach the handler with nothing in front of it.
+func Test_Domain_UseMountAutoHeadKeepsMiddleware(t *testing.T) {
+	t.Parallel()
+
+	subApp := New(Config{RequestMethods: []string{MethodGet, MethodPost}})
+	subApp.Use(func(c Ctx) error {
+		return c.SendStatus(StatusUnauthorized)
+	})
+	subApp.Get("/secret", func(c Ctx) error {
+		c.Set("X-Secret", "leaked")
+		return c.SendString("secret")
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/secret", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusUnauthorized, resp.StatusCode)
+
+	// Twice: app.Test runs the startup process on every call, and the second
+	// pass sees the mount already expanded into the parent's stack.
+	for range 2 {
+		req = httptest.NewRequest(MethodHead, "/api/secret", http.NoBody)
+		req.Host = "api.example.com"
+		resp, err = app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, StatusMethodNotAllowed, resp.StatusCode)
+		require.Empty(t, resp.Header.Get("X-Secret"))
+	}
+}
+
+// Test_Domain_UseMountNestedAutoHeadDisabled verifies that a nested app which
+// turned automatic HEAD routes off does not get them from the mount either.
+func Test_Domain_UseMountNestedAutoHeadDisabled(t *testing.T) {
+	t.Parallel()
+
+	child := New(Config{DisableHeadAutoRegister: true})
+	child.Get("/x", func(c Ctx) error {
+		return c.SendString("nested x")
+	})
+
+	subApp := New()
+	subApp.Use("/v1", child)
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodHead, "/api/v1/x", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusMethodNotAllowed, resp.StatusCode)
+}
+
+// Test_Domain_UseMountAfterOuterMount verifies that a domain mount registered
+// on a sub-app after that sub-app was itself mounted is still found: the
+// parent picks the metadata up when it discovers sub-apps at startup.
+func Test_Domain_UseMountAfterOuterMount(t *testing.T) {
+	t.Parallel()
+
+	child := New(Config{
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(596).SendString("child error")
+		},
+	})
+	child.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	mid := New()
+
+	app := New()
+	app.Use("/mid", mid)
+	// Registered after the outer mount, but before the app is served.
+	mid.Domain("api.example.com").Use("/child", child)
+
+	req := httptest.NewRequest(MethodGet, "/mid/child/boom", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 596, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "child error", string(body))
+
+	req = httptest.NewRequest(MethodGet, "/mid/child/boom", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
+
+// Test_Domain_UseMountOverlappingPatterns verifies that when two domain mounts
+// at one path have patterns that both match, each sub-app still handles the
+// errors of its own routes.
+func Test_Domain_UseMountOverlappingPatterns(t *testing.T) {
+	t.Parallel()
+
+	exact := New(Config{
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(597).SendString("exact error")
+		},
+	})
+	exact.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	wildcard := New(Config{
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(598).SendString("wildcard error")
+		},
+	})
+	wildcard.Get("/other", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	app := New()
+	app.Domain("admin.example.com").Use("/api", exact)
+	app.Domain(":tenant.example.com").Use("/api", wildcard)
+
+	// admin.example.com matches both patterns; the route belongs to the first.
+	req := httptest.NewRequest(MethodGet, "/api/boom", http.NoBody)
+	req.Host = "admin.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 597, resp.StatusCode)
+
+	req = httptest.NewRequest(MethodGet, "/api/other", http.NoBody)
+	req.Host = "acme.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 598, resp.StatusCode)
 }
 
 // Test_Domain_UseMountNestedCycle verifies that cloning a sub-app whose mount

--- a/domain_test.go
+++ b/domain_test.go
@@ -3152,6 +3152,136 @@ func Test_Domain_UseMountOverlappingViews(t *testing.T) {
 	require.Equal(t, "<h1>exact</h1>", string(body))
 }
 
+// Test_Domain_UseMountOverlappingViewsLaterMount verifies that the second of two
+// mounts at one path renders through its own engine when it owns the route: the
+// mounts are equally deep and both match the host, so only the route that ran
+// tells them apart.
+func Test_Domain_UseMountOverlappingViewsLaterMount(t *testing.T) {
+	t.Parallel()
+
+	rootEngine := &testTemplateEngine{}
+	require.NoError(t, rootEngine.Load())
+
+	exactEngine := &testTemplateEngine{}
+	require.NoError(t, exactEngine.Load())
+
+	wildcardEngine := &testTemplateEngine{path: "testdata2"}
+	require.NoError(t, wildcardEngine.Load())
+
+	exact := New(Config{Views: exactEngine})
+	exact.Get("/view", func(c Ctx) error {
+		return c.Render("index.tmpl", Map{"Title": "exact"})
+	})
+
+	// Registered second, and owns the route this request runs.
+	wildcard := New(Config{Views: wildcardEngine})
+	wildcard.Get("/other", func(c Ctx) error {
+		return c.Render("bruh.tmpl", Map{})
+	})
+
+	app := New(Config{Views: rootEngine})
+	app.Domain("admin.example.com").Use("/api", exact)
+	app.Domain(":tenant.example.com").Use("/api", wildcard)
+
+	// bruh.tmpl only exists in the wildcard mount's engine, so rendering it at
+	// all is what proves the engine of the mount that owns the route was used.
+	req := httptest.NewRequest(MethodGet, "/api/other", http.NoBody)
+	req.Host = "admin.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>I'm Bruh</h1>", string(body))
+}
+
+// Test_Domain_UseMountOverlappingErrorHandler verifies that two mounts at one
+// path each answer for their own routes. They are equally deep and both match
+// the host, so the request is only attributable through the route that ran.
+func Test_Domain_UseMountOverlappingErrorHandler(t *testing.T) {
+	t.Parallel()
+
+	first := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(581).SendString("first")
+	}})
+	first.Get("/first", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	second := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(582).SendString("second")
+	}})
+	second.Get("/second", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	app := New()
+	app.Domain("admin.example.com").Use("/api", first)
+	app.Domain(":tenant.example.com").Use("/api", second)
+
+	for path, want := range map[string]int{"/api/first": 581, "/api/second": 582} {
+		req := httptest.NewRequest(MethodGet, path, http.NoBody)
+		req.Host = "admin.example.com" // matches both patterns
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, want, resp.StatusCode, path)
+	}
+}
+
+// Test_Domain_UseMountOverlappingErrorHandlerAutoHead verifies that an automatic
+// HEAD route resolves the same owner its GET route does, rather than falling
+// back to the first mount that covers the path.
+func Test_Domain_UseMountOverlappingErrorHandlerAutoHead(t *testing.T) {
+	t.Parallel()
+
+	first := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(583).SendString("first")
+	}})
+	first.Get("/first", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	second := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(584).SendString("second")
+	}})
+	second.Get("/second", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	app := New()
+	app.Domain("admin.example.com").Use("/api", first)
+	app.Domain(":tenant.example.com").Use("/api", second)
+
+	req := httptest.NewRequest(MethodHead, "/api/second", http.NoBody)
+	req.Host = "admin.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 584, resp.StatusCode)
+}
+
+// Test_Domain_UseMountDeclinedHostKeepsRootErrorHandler verifies that a mount
+// whose handlers declined the host does not answer for the request they passed
+// on: the route it registered is the one that ran, but it served nothing.
+func Test_Domain_UseMountDeclinedHostKeepsRootErrorHandler(t *testing.T) {
+	t.Parallel()
+
+	subApp := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(585).SendString("sub")
+	}})
+	subApp.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	app := New()
+	app.Domain("api.example.com").Use("/api", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/api/boom", http.NoBody)
+	req.Host = "other.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, StatusNotFound, resp.StatusCode)
+}
+
 // Test_Domain_UseMountKeepsParentAutoHead verifies that a domain mount which
 // registers no automatic HEAD routes only withholds them from its own routes,
 // leaving a route the parent registered at the same path with its own.

--- a/domain_test.go
+++ b/domain_test.go
@@ -3861,6 +3861,56 @@ func Test_Domain_UseMountAutoHeadPerSubtree(t *testing.T) {
 	}
 }
 
+// Test_Domain_UseMountInheritsEqualDepthAncestor verifies that a mount as deep
+// as the owner is only passed over when it is beside it. A domain mount at the
+// root of an ordinary one covers exactly the paths that mount does, and its
+// error handler is still the one enclosing the request.
+func Test_Domain_UseMountInheritsEqualDepthAncestor(t *testing.T) {
+	t.Parallel()
+
+	child := New() // no handler of its own
+	child.Get("/boom", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	subApp := New(Config{ErrorHandler: func(c Ctx, _ error) error {
+		return c.Status(607).SendString("sub")
+	}})
+	subApp.Domain("api.example.com").Use("/", child)
+
+	app := New()
+	app.Use("/mid", subApp)
+
+	req := httptest.NewRequest(MethodGet, "/mid/boom", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 607, resp.StatusCode)
+}
+
+// Test_Domain_UseMountTreeVisitsEachMountOnce verifies that recording a mount
+// does not walk a descendant once per route through the app lists leading to
+// it: those lists hold descendants, so an unguarded walk grows exponentially
+// with the depth of the tree.
+func Test_Domain_UseMountTreeVisitsEachMountOnce(t *testing.T) {
+	t.Parallel()
+
+	const depth = 12
+
+	apps := make([]*App, depth+1)
+	for i := range apps {
+		apps[i] = New()
+	}
+
+	for i := depth; i > 0; i-- {
+		apps[i-1].Use("/layer", apps[i])
+	}
+
+	// Quadratic at worst: an app is walked again only when it is reached
+	// through a longer chain than one it has already been reached with.
+	require.Less(t, len(apps[0].mountTree()), (depth+1)*(depth+1))
+}
+
 // Test_Domain_UseMountInheritsDomainViews verifies the same inheritance for the
 // view engine: a child of a domain-mounted app renders through that app's
 // engine rather than the root's.

--- a/helpers.go
+++ b/helpers.go
@@ -1183,6 +1183,19 @@ func (app *App) methodInt(s string) int {
 	return slices.Index(app.config.RequestMethods, s)
 }
 
+// routesForMethod returns the routes registered for an HTTP method, or nil if
+// the app does not serve it. Use this instead of indexing another app's stack
+// with your own method index: RequestMethods is configurable, so two apps'
+// tables can differ in both order and length.
+func (app *App) routesForMethod(method string) []*Route {
+	m := app.methodInt(method)
+	if m < 0 || m >= len(app.stack) {
+		return nil
+	}
+
+	return app.stack[m]
+}
+
 func (app *App) method(methodInt int) string {
 	// methodInt is -1 for methods not registered in RequestMethods (the
 	// router responds 501 before dispatch, but contexts acquired directly

--- a/helpers.go
+++ b/helpers.go
@@ -1196,6 +1196,21 @@ func (app *App) routesForMethod(method string) []*Route {
 	return app.stack[m]
 }
 
+// hasEndpoint reports whether the app registered an endpoint at path for the
+// given method. Middleware and mount placeholders do not count: they match a
+// prefix rather than name a route of their own.
+func (app *App) hasEndpoint(method, path string) bool {
+	normalized := app.normalizePath(path)
+
+	for _, route := range app.routesForMethod(method) {
+		if !route.use && !route.mount && route.path == normalized {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (app *App) method(methodInt int) string {
 	// methodInt is -1 for methods not registered in RequestMethods (the
 	// router responds 501 before dispatch, but contexts acquired directly

--- a/helpers.go
+++ b/helpers.go
@@ -1196,21 +1196,6 @@ func (app *App) routesForMethod(method string) []*Route {
 	return app.stack[m]
 }
 
-// hasEndpoint reports whether the app registered an endpoint at path for the
-// given method. Middleware and mount placeholders do not count: they match a
-// prefix rather than name a route of their own.
-func (app *App) hasEndpoint(method, path string) bool {
-	normalized := app.normalizePath(path)
-
-	for _, route := range app.routesForMethod(method) {
-		if !route.use && !route.mount && route.path == normalized {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (app *App) method(methodInt int) string {
 	// methodInt is -1 for methods not registered in RequestMethods (the
 	// router responds 501 before dispatch, but contexts acquired directly

--- a/mount.go
+++ b/mount.go
@@ -42,6 +42,9 @@ type mountFields struct {
 	subAppsRoutesAdded sync.Once
 	// check mounted sub-apps
 	subAppsProcessed sync.Once
+	// Whether this app's routes only answer for the hostnames the mount they
+	// came from matches, which is true of the wrapper a domain mount builds
+	hostScopedRoutes bool
 }
 
 // domainMountedApp is a sub-app mounted through a domain router. Its config —
@@ -232,12 +235,53 @@ func (o domainOwner) ties(plainDepth int) bool {
 	return o.app != nil && plainDepth == o.depth
 }
 
-// hasViews reports whether this owner configures a view engine of its own. One
-// that does not leaves the plain mounts and the root to render, rather than
-// borrowing the engine of a mount that did not serve the request — its layout
-// still applies, as a plain mount's does when it has no engine either.
-func (o domainOwner) hasViews() bool {
-	return o.app != nil && o.app.config.Views != nil
+// appHasErrorHandler, appHasViews and appHasViewsLayout are the settings a
+// request inherits from the domain mounts it was reached through.
+func appHasErrorHandler(app *App) bool { return app.configured.ErrorHandler != nil }
+
+func appHasViews(app *App) bool { return app.config.Views != nil }
+
+func appHasViewsLayout(app *App) bool { return app.config.ViewsLayout != "" }
+
+// domainMountConfig returns the app a setting is taken from: the owner when it
+// configures one, and otherwise the deepest domain mount enclosing it that
+// does — the inheritance an ordinarily nested mount gets from the app it sits
+// in. Mounts at the owner's own depth are siblings that did not serve the
+// request, and configure nothing on its behalf.
+func (app *App) domainMountConfig(c Ctx, owner domainOwner, want func(*App) bool) *App {
+	if owner.app == nil {
+		return nil
+	}
+
+	if want(owner.app) {
+		return owner.app
+	}
+
+	var (
+		found *App
+		best  int
+	)
+
+	path := app.normalizePath(c.Path())
+
+	for i := range app.mountFields.domainAppList {
+		mount := &app.mountFields.domainAppList[i]
+
+		depth := mount.depth()
+		if depth >= owner.depth || !want(mount.app) {
+			continue
+		}
+
+		if !mount.covers(path) || !mount.matchesHost(c.Hostname()) {
+			continue
+		}
+
+		if found == nil || depth > best {
+			found, best = mount.app, depth
+		}
+	}
+
+	return found
 }
 
 // domainMountOwner returns the domain mount that owns this request: the app the

--- a/mount.go
+++ b/mount.go
@@ -208,24 +208,28 @@ func (grp *Group) mount(prefix string, subApp *App) Router {
 	return grp
 }
 
-// domainOwner is the domain-mounted app a request belongs to, together with
-// what is known about how specific that answer is.
+// domainOwner is the domain-mounted app a request belongs to, and how deep the
+// mount it was reached through is.
 type domainOwner struct {
 	app *App
-	// depth is how many path segments the mount covers, which ranks an
-	// inferred owner against the plain mounts covering the same request.
+	// depth is how many path segments the mount covers, which ranks the owner
+	// against the plain mounts covering the same request.
 	depth int
-	// exact marks an owner taken from the route that actually ran. Nothing
-	// outranks it: the request was served by that app, not merely covered by
-	// its mount path.
-	exact bool
 }
 
 // outranks reports whether this owner should answer for the request instead of
-// a plain mount whose path is plainDepth segments deep. An inferred owner wins
-// a tie, having matched the host as well.
+// a plain mount whose path is plainDepth segments deep. It wins a tie, having
+// matched the host as well, and gives way to a deeper plain mount, as a mounted
+// app gives way to one mounted below it.
 func (o domainOwner) outranks(plainDepth int) bool {
-	return o.app != nil && (o.exact || plainDepth <= o.depth)
+	return o.app != nil && plainDepth <= o.depth
+}
+
+// ties reports whether a plain mount is exactly as deep as this owner. Such a
+// mount is a sibling rather than an ancestor: the owner takes precedence over
+// it, and falls through past it to the mounts enclosing them both.
+func (o domainOwner) ties(plainDepth int) bool {
+	return o.app != nil && plainDepth == o.depth
 }
 
 // hasViews reports whether this owner configures a view engine of its own. One
@@ -248,7 +252,7 @@ func (app *App) domainMountOwner(c Ctx) domainOwner {
 	// that app served nothing.
 	routeApp := app.routeOwner(c.Route())
 
-	var owner domainOwner
+	var owner, byRoute domainOwner
 
 	path := app.normalizePath(c.Path())
 
@@ -258,15 +262,21 @@ func (app *App) domainMountOwner(c Ctx) domainOwner {
 			continue
 		}
 
+		depth := mount.depth()
+
 		// Two sub-apps mounted at one path behind overlapping patterns both
 		// cover the request and both match the host. Only one of them ran.
-		if mount.app == routeApp {
-			return domainOwner{app: mount.app, exact: true}
+		if mount.app == routeApp && (byRoute.app == nil || depth > byRoute.depth) {
+			byRoute.app, byRoute.depth = mount.app, depth
 		}
 
-		if depth := mount.depth(); owner.app == nil || depth > owner.depth {
+		if owner.app == nil || depth > owner.depth {
 			owner.app, owner.depth = mount.app, depth
 		}
+	}
+
+	if byRoute.app != nil {
+		return byRoute
 	}
 
 	return owner
@@ -289,6 +299,59 @@ func (app *App) mountedApps() []*App {
 	}
 
 	return apps
+}
+
+// mountedAppRef is an app reachable from another one: the path it is reachable
+// at, and the domain patterns a request has to satisfy to get there.
+type mountedAppRef struct {
+	app      *App
+	path     string
+	matchers []domainMatcher
+}
+
+// mountTree returns this app and every app mounted below it, plain or on a
+// domain, with the paths and the domain patterns composed along the way.
+//
+// It walks the mount metadata of each app in turn rather than reading the
+// flattened list of one: that list is filled in when an app is mounted, so an
+// app mounted on a descendant afterwards is missing from it until startup
+// repairs it — and a domain mount records its apps when it is registered.
+func (app *App) mountTree() []mountedAppRef {
+	return app.appendMountTree(nil, "", nil, nil)
+}
+
+// appendMountTree adds this app and its descendants to dst, reached at prefix
+// behind matchers. chain holds the apps above this one so a mount cycle
+// terminates; it is a slice because it is only ever a few entries deep, and an
+// app mounted on two branches is still reached through both.
+func (app *App) appendMountTree(dst []mountedAppRef, prefix string, matchers []domainMatcher, chain []*App) []mountedAppRef {
+	if slices.Contains(chain, app) {
+		return dst
+	}
+
+	dst = append(dst, mountedAppRef{app: app, path: prefix, matchers: matchers})
+	chain = append(chain, app)
+
+	// Patterns compose innermost first, the order a mount records them in: a
+	// request has to satisfy every one of them.
+	for _, mount := range app.domainMountsSnapshot() {
+		dst = mount.app.appendMountTree(
+			dst,
+			getGroupPath(prefix, mount.path),
+			append(slices.Clone(mount.matchers), matchers...),
+			chain,
+		)
+	}
+
+	for mountPrefix, mounted := range app.plainMountsSnapshot() {
+		if mounted == app {
+			continue
+		}
+
+		dst = mounted.appendMountTree(dst, getGroupPath(prefix, mountPrefix), matchers, chain)
+	}
+
+	return dst
 }
 
 // mountedAppsSnapshot returns the apps mounted directly on this one, plain or

--- a/mount.go
+++ b/mount.go
@@ -185,8 +185,14 @@ func (app *App) mountSkipsAutoHead(path string) bool {
 		if mountPath == "" || !strings.HasPrefix(normalizedPath, utils.AddTrailingSlashString(mountPath)) {
 			return false
 		}
+		if !mounted.config.DisableHeadAutoRegister && mounted.methodInt(MethodHead) >= 0 {
+			return false
+		}
 
-		return mounted.config.DisableHeadAutoRegister || mounted.methodInt(MethodHead) < 0
+		// Covering the path is not enough to own the route: a mount at "/"
+		// covers every path this app registered itself. Ask the mounted app
+		// whether the route is one of its own.
+		return mounted.hasEndpoint(MethodGet, strings.TrimPrefix(path, utils.TrimRight(mountPath, '/')))
 	}
 
 	for mountPath, mounted := range app.mountFields.appList {

--- a/mount.go
+++ b/mount.go
@@ -195,11 +195,16 @@ func (app *App) processSubAppsRoutes() {
 				continue
 			}
 
+			// Read the sub-app's routes by method rather than by stack index:
+			// an app is free to configure its own RequestMethods, and the two
+			// tables then neither line up nor have to be the same length.
+			subAppRoutes := route.group.app.routesForMethod(app.method(m))
+
 			// Create a slice to hold the sub-app's routes
-			subRoutes := make([]*Route, len(route.group.app.stack[m]))
+			subRoutes := make([]*Route, len(subAppRoutes))
 
 			// Iterate over the sub-app's routes
-			for j, subAppRoute := range route.group.app.stack[m] {
+			for j, subAppRoute := range subAppRoutes {
 				// Clone the sub-app's route
 				subAppRouteClone := app.copyRoute(subAppRoute)
 

--- a/mount.go
+++ b/mount.go
@@ -147,17 +147,12 @@ func (app *App) domainMountedViews(c Ctx) *App {
 		matchParts int
 	)
 
-	normalizedPath := utils.AddTrailingSlashString(c.Path())
-
 	for i := range app.mountFields.domainAppList {
 		mount := &app.mountFields.domainAppList[i]
-		if mount.path == "" || mount.app.config.Views == nil {
+		if mount.app.config.Views == nil {
 			continue
 		}
-		// Matched on the path, as ErrorHandler matches the same entries. The
-		// plain-mount scan in Render searches the whole URL instead, which also
-		// answers for a mount path appearing in a query string.
-		if !strings.HasPrefix(normalizedPath, utils.AddTrailingSlashString(mount.path)) || !mount.matchesHost(c.Hostname()) {
+		if !app.mountCoversPath(mount.path, c.Path()) || !mount.matchesHost(c.Hostname()) {
 			continue
 		}
 
@@ -167,6 +162,23 @@ func (app *App) domainMountedViews(c Ctx) *App {
 	}
 
 	return viewsApp
+}
+
+// mountCoversPath reports whether a mount registered at mountPath covers path.
+//
+// Both sides are put through this app's routing rules first: a mount path is
+// stored as the caller spelled it, so on a case-insensitive app a mount
+// registered as "/API" has to cover a request for "/api/x" the same way its
+// routes do.
+func (app *App) mountCoversPath(mountPath, path string) bool {
+	if mountPath == "" {
+		return false
+	}
+
+	return strings.HasPrefix(
+		utils.AddTrailingSlashString(app.normalizePath(path)),
+		utils.AddTrailingSlashString(app.normalizePath(mountPath)),
+	)
 }
 
 // mountSkipsAutoHead reports whether path belongs to a mounted app that does
@@ -179,10 +191,8 @@ func (app *App) domainMountedViews(c Ctx) *App {
 // route alone, leaving the middleware the mounted app registered for its own
 // methods out of the chain.
 func (app *App) mountSkipsAutoHead(path string) bool {
-	normalizedPath := utils.AddTrailingSlashString(path)
-
 	skips := func(mounted *App, mountPath string) bool {
-		if mountPath == "" || !strings.HasPrefix(normalizedPath, utils.AddTrailingSlashString(mountPath)) {
+		if !app.mountCoversPath(mountPath, path) {
 			return false
 		}
 		if !mounted.config.DisableHeadAutoRegister && mounted.methodInt(MethodHead) >= 0 {
@@ -192,7 +202,7 @@ func (app *App) mountSkipsAutoHead(path string) bool {
 		// Covering the path is not enough to own the route: a mount at "/"
 		// covers every path this app registered itself. Ask the mounted app
 		// whether the route is one of its own.
-		return mounted.hasEndpoint(MethodGet, strings.TrimPrefix(path, utils.TrimRight(mountPath, '/')))
+		return mounted.hasEndpoint(MethodGet, strings.TrimPrefix(path, utils.TrimRight(app.normalizePath(mountPath), '/')))
 	}
 
 	for mountPath, mounted := range app.mountFields.appList {

--- a/mount.go
+++ b/mount.go
@@ -34,6 +34,10 @@ type mountFields struct {
 	// resolves its config directly instead of inferring an owner from the host
 	// and the path
 	routeOwners map[*Route]*App
+	// Constraints each cloned route was parsed with, which are the ones of the
+	// apps its path was composed by. Two sibling mounts can name one constraint
+	// differently, and a route is only ever bound by the one its own app has.
+	routeConstraints map[*Route][]CustomConstraint
 	// Ordered keys of apps (sorted by key length for Render)
 	appListKeys []string
 	// guards one-time generation of appListKeys
@@ -599,6 +603,32 @@ func (app *App) markRouteOwner(route *Route, owner *App) {
 	app.mountFields.routeOwners[route] = owner
 }
 
+// markRouteConstraints records the constraints route was parsed with, so the
+// next app to re-parse it uses those rather than a registry merged from every
+// app it happens to have mounted.
+func (app *App) markRouteConstraints(route *Route, constraints []CustomConstraint) {
+	if len(constraints) == 0 {
+		return
+	}
+
+	if app.mountFields.routeConstraints == nil {
+		app.mountFields.routeConstraints = make(map[*Route][]CustomConstraint)
+	}
+
+	app.mountFields.routeConstraints[route] = constraints
+}
+
+// routeConstraintsFor returns the constraints route was parsed with, falling
+// back to those of the app holding it — which is where its own routes get
+// theirs from.
+func (app *App) routeConstraintsFor(route *Route) []CustomConstraint {
+	if recorded, ok := app.mountFields.routeConstraints[route]; ok {
+		return recorded
+	}
+
+	return app.customConstraints
+}
+
 // routeOwner returns the mounted app route was cloned out of, or nil when the
 // route did not come from a mount.
 func (app *App) routeOwner(route *Route) *App {
@@ -761,11 +791,6 @@ func (app *App) processSubAppsRoutes() {
 			// so its constraints have to be resolvable here too.
 			app.customConstraints = mergeCustomConstraints(app.customConstraints, route.group.app.customConstraints)
 
-			// The prefix is this app's, and may name a constraint only this
-			// app knows; the routes are the sub-app's, whose constraints win
-			// where both define a name.
-			constraints := mergeCustomConstraints(slices.Clone(route.group.app.customConstraints), app.customConstraints)
-
 			// A sub-app that registers no automatic HEAD routes of its own
 			// must not be given them here either: its middleware is
 			// registered for the methods it serves, and a HEAD route
@@ -780,8 +805,19 @@ func (app *App) processSubAppsRoutes() {
 				// Clone the sub-app's route
 				subAppRouteClone := app.copyRoute(subAppRoute)
 
+				// The prefix is this app's, and may name a constraint only this
+				// app knows; the route brings the constraints of the apps that
+				// composed its path, and those win where a name is defined
+				// twice. Kept per route: two apps mounted side by side can name
+				// one constraint differently, and neither binds the other.
+				constraints := mergeCustomConstraints(
+					slices.Clone(route.group.app.routeConstraintsFor(subAppRoute)),
+					app.customConstraints,
+				)
+
 				// Add the parent route's path as a prefix to the sub-app's route
 				app.addPrefixToRoute(route.path, subAppRouteClone, route.group.app.config.RegexHandler, constraints...)
+				app.markRouteConstraints(subAppRouteClone, constraints)
 
 				// Carry the sub-app's stance on automatic HEAD routes over to
 				// the clone, so this app's own routes at the same path keep

--- a/mount.go
+++ b/mount.go
@@ -91,7 +91,6 @@ func (app *App) mount(prefix string, subApp *App) Router {
 		subApp.mountFields.mountPath = path
 		app.mountFields.appList[path] = subApp
 	}
-	app.mountFields.domainAppList = appendDomainMounts(app.mountFields.domainAppList, subApp.mountFields.domainAppList, prefix)
 	app.mutex.Unlock()
 
 	// register mounted group
@@ -124,7 +123,6 @@ func (grp *Group) mount(prefix string, subApp *App) Router {
 		subApp.mountFields.mountPath = path
 		grp.app.mountFields.appList[path] = subApp
 	}
-	grp.app.mountFields.domainAppList = appendDomainMounts(grp.app.mountFields.domainAppList, subApp.mountFields.domainAppList, groupPath)
 	grp.app.mutex.Unlock()
 
 	// register mounted group
@@ -171,15 +169,52 @@ func (app *App) domainMountedViews(c Ctx) *App {
 	return viewsApp
 }
 
-// appendDomainMounts re-registers the domain mounts of a sub-app on the app it
-// is being mounted on, moving their paths under prefix. Their domain patterns
-// travel with them: the host still has to match for their config to apply.
+// mountSkipsAutoHead reports whether path belongs to a mounted app that does
+// not register automatic HEAD routes of its own, either because it does not
+// serve HEAD at all or because it turned them off.
+//
+// Once a mount is expanded, its routes sit in this app's stack and are
+// indistinguishable from its own, so the automatic-HEAD pass would synthesize
+// a HEAD route the mounted app never wanted — and synthesize it from the GET
+// route alone, leaving the middleware the mounted app registered for its own
+// methods out of the chain.
+func (app *App) mountSkipsAutoHead(path string) bool {
+	normalizedPath := utils.AddTrailingSlashString(path)
+
+	skips := func(mounted *App, mountPath string) bool {
+		if mountPath == "" || !strings.HasPrefix(normalizedPath, utils.AddTrailingSlashString(mountPath)) {
+			return false
+		}
+
+		return mounted.config.DisableHeadAutoRegister || mounted.methodInt(MethodHead) < 0
+	}
+
+	for mountPath, mounted := range app.mountFields.appList {
+		if skips(mounted, mountPath) {
+			return true
+		}
+	}
+
+	for i := range app.mountFields.domainAppList {
+		mount := &app.mountFields.domainAppList[i]
+		if skips(mount.app, mount.path) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// appendDomainMounts re-registers the domain mounts of a mounted app on the app
+// above it, moving their paths under prefix. Their domain patterns travel with
+// them: the host still has to match for their config to apply.
 func appendDomainMounts(dst, mounts []domainMountedApp, prefix string) []domainMountedApp {
 	for _, mount := range mounts {
-		path := getGroupPath(prefix, mount.path)
-
-		mount.app.mountFields.mountPath = path
-		dst = append(dst, domainMountedApp{app: mount.app, path: path, matchers: mount.matchers})
+		dst = append(dst, domainMountedApp{
+			app:      mount.app,
+			path:     getGroupPath(prefix, mount.path),
+			matchers: mount.matchers,
+		})
 	}
 
 	return dst
@@ -243,8 +278,13 @@ func (app *App) appendSubAppLists(appList map[string]*App, parent ...string) {
 			app.mountFields.appList[prefix] = subApp
 		}
 
+		// Domain mounts are kept out of appList, so collect them here instead.
+		// Doing it at startup rather than when the sub-app was mounted also
+		// picks up the ones registered in between.
+		app.mountFields.domainAppList = appendDomainMounts(app.mountFields.domainAppList, subApp.mountFields.domainAppList, prefix)
+
 		// The first element of appList is always the app itself. If there are no other sub apps, we should skip appending nested apps.
-		if len(subApp.mountFields.appList) > 1 {
+		if subApp.hasMountedApps() {
 			app.appendSubAppLists(subApp.mountFields.appList, prefix)
 		}
 	}

--- a/mount.go
+++ b/mount.go
@@ -252,13 +252,41 @@ func (o domainOwner) ties(plainDepth int) bool {
 	return o.app != nil && plainDepth == o.depth
 }
 
-// appHasErrorHandler, appHasViews and appHasViewsLayout are the settings a
-// request inherits from the domain mounts it was reached through.
+// appHasErrorHandler is the setting a request inherits from the domain mounts
+// it was reached through.
 func appHasErrorHandler(app *App) bool { return app.configured.ErrorHandler != nil }
 
-func appHasViews(app *App) bool { return app.config.Views != nil }
+// domainMountRender resolves what a domain mount contributes to a render: the
+// nearest app configuring a view engine, and the layout of the nearest app at
+// or below that one which configures a layout.
+//
+// The layout search stops where rendering does. An app with an engine of its
+// own renders through it and takes no layout from further out, exactly as the
+// scan over the ordinary mounts stops at the first engine it covers; only when
+// nothing below configures an engine does the layout travel outward with the
+// search for one.
+func domainMountRender(owner domainOwner) (*App, string) { //nolint:gocritic // unnamedResult: named returns conflict with nonamedreturns linter
+	if owner.app == nil {
+		return nil, ""
+	}
 
-func appHasViewsLayout(app *App) bool { return app.config.ViewsLayout != "" }
+	layout := owner.app.config.ViewsLayout
+	if owner.app.config.Views != nil {
+		return owner.app, layout
+	}
+
+	for _, ancestor := range slices.Backward(owner.ancestors) {
+		if layout == "" {
+			layout = ancestor.config.ViewsLayout
+		}
+
+		if ancestor.config.Views != nil {
+			return ancestor, layout
+		}
+	}
+
+	return nil, layout
+}
 
 // domainMountConfig returns the app a setting is taken from: the owner when it
 // configures one, and otherwise the deepest domain mount enclosing it that

--- a/mount.go
+++ b/mount.go
@@ -255,25 +255,38 @@ func (app *App) mountedApps() []*App {
 	apps := []*App{app}
 
 	for i := 0; i < len(apps); i++ {
-		current := apps[i]
-		if current.mountFields == nil {
-			continue
-		}
-
-		for _, mounted := range current.mountFields.appList {
+		for _, mounted := range apps[i].mountedAppsSnapshot() {
 			if !slices.Contains(apps, mounted) {
-				apps = append(apps, mounted)
-			}
-		}
-
-		for j := range current.mountFields.domainAppList {
-			if mounted := current.mountFields.domainAppList[j].app; !slices.Contains(apps, mounted) {
 				apps = append(apps, mounted)
 			}
 		}
 	}
 
 	return apps
+}
+
+// mountedAppsSnapshot returns the apps mounted directly on this one, read
+// under its own lock: App.mount writes those lists under it, and a walk that
+// read them unguarded would race a concurrent mount. One app is locked at a
+// time, so a caller may hold none of them.
+func (app *App) mountedAppsSnapshot() []*App {
+	if app.mountFields == nil {
+		return nil
+	}
+
+	app.mutex.Lock()
+	defer app.mutex.Unlock()
+
+	mounted := make([]*App, 0, len(app.mountFields.appList)+len(app.mountFields.domainAppList))
+	for _, sub := range app.mountFields.appList {
+		mounted = append(mounted, sub)
+	}
+
+	for i := range app.mountFields.domainAppList {
+		mounted = append(mounted, app.mountFields.domainAppList[i].app)
+	}
+
+	return mounted
 }
 
 // mountCoversPath reports whether a mount registered at mountPath covers path.

--- a/mount.go
+++ b/mount.go
@@ -60,18 +60,23 @@ type domainMountedApp struct {
 	// matchers are the patterns of the domain routers this app was mounted
 	// behind, outermost last. A request has to satisfy all of them.
 	matchers []domainMatcher
+	// ancestors are the apps this one is mounted inside, outermost first. They
+	// are what its configuration is inherited from: a mount that merely covers
+	// the same path encloses nothing.
+	ancestors []*App
 }
 
 // newDomainMount records a mount of mounted at path, normalized and parsed
 // with the routing rules of the app it is being mounted on, so the lookups
 // recognize it the same way the router recognizes its routes.
-func (app *App) newDomainMount(mounted *App, path string, matchers []domainMatcher) domainMountedApp {
+func (app *App) newDomainMount(mounted *App, path string, matchers []domainMatcher, ancestors []*App) domainMountedApp {
 	normalized := app.normalizePath(path)
 
 	mount := domainMountedApp{
-		app:      mounted,
-		path:     normalized,
-		matchers: matchers,
+		app:       mounted,
+		path:      normalized,
+		matchers:  matchers,
+		ancestors: ancestors,
 	}
 
 	if parser := parseRoute(normalized, app.config.RegexHandler, app.customConstraints...); len(parser.params) > 0 {
@@ -215,6 +220,9 @@ func (grp *Group) mount(prefix string, subApp *App) Router {
 // mount it was reached through is.
 type domainOwner struct {
 	app *App
+	// ancestors are the apps the owner is mounted inside, outermost first, and
+	// are what it inherits configuration from.
+	ancestors []*App
 	// depth is how many path segments the mount covers, which ranks the owner
 	// against the plain mounts covering the same request.
 	depth int
@@ -248,7 +256,7 @@ func appHasViewsLayout(app *App) bool { return app.config.ViewsLayout != "" }
 // does — the inheritance an ordinarily nested mount gets from the app it sits
 // in. Mounts at the owner's own depth are siblings that did not serve the
 // request, and configure nothing on its behalf.
-func (app *App) domainMountConfig(c Ctx, owner domainOwner, want func(*App) bool) *App {
+func domainMountConfig(owner domainOwner, want func(*App) bool) *App {
 	if owner.app == nil {
 		return nil
 	}
@@ -257,31 +265,17 @@ func (app *App) domainMountConfig(c Ctx, owner domainOwner, want func(*App) bool
 		return owner.app
 	}
 
-	var (
-		found *App
-		best  int
-	)
-
-	path := app.normalizePath(c.Path())
-
-	for i := range app.mountFields.domainAppList {
-		mount := &app.mountFields.domainAppList[i]
-
-		depth := mount.depth()
-		if depth >= owner.depth || !want(mount.app) {
-			continue
-		}
-
-		if !mount.covers(path) || !mount.matchesHost(c.Hostname()) {
-			continue
-		}
-
-		if found == nil || depth > best {
-			found, best = mount.app, depth
+	// Innermost first, so the nearest app configuring the setting answers. Only
+	// the apps the owner is mounted inside are consulted: a mount that reaches
+	// the same paths on the same hosts is a sibling, and configures nothing on
+	// the owner's behalf.
+	for _, ancestor := range slices.Backward(owner.ancestors) {
+		if want(ancestor) {
+			return ancestor
 		}
 	}
 
-	return found
+	return nil
 }
 
 // domainMountOwner returns the domain mount that owns this request: the app the
@@ -311,16 +305,25 @@ func (app *App) domainMountOwner(c Ctx) domainOwner {
 		// Two sub-apps mounted at one path behind overlapping patterns both
 		// cover the request and both match the host. Only one of them ran.
 		if mount.app == routeApp && (byRoute.app == nil || depth > byRoute.depth) {
-			byRoute.app, byRoute.depth = mount.app, depth
+			byRoute.app, byRoute.depth, byRoute.ancestors = mount.app, depth, mount.ancestors
 		}
 
 		if owner.app == nil || depth > owner.depth {
-			owner.app, owner.depth = mount.app, depth
+			owner.app, owner.depth, owner.ancestors = mount.app, depth, mount.ancestors
 		}
 	}
 
 	if byRoute.app != nil {
 		return byRoute
+	}
+
+	// A route that names an app none of these mounts describe was served by an
+	// ordinary mount, or by one whose host these patterns reject. Either way
+	// this request is not a domain mount's to answer for, and only one that ran
+	// no mounted route at all — a 404, or an error raised above them — is left
+	// to the mount covering its path.
+	if routeApp != nil {
+		return domainOwner{}
 	}
 
 	return owner
@@ -348,9 +351,10 @@ func (app *App) mountedApps() []*App {
 // mountedAppRef is an app reachable from another one: the path it is reachable
 // at, and the domain patterns a request has to satisfy to get there.
 type mountedAppRef struct {
-	app      *App
-	path     string
-	matchers []domainMatcher
+	app       *App
+	path      string
+	matchers  []domainMatcher
+	ancestors []*App
 }
 
 // mountTree returns this app and every app mounted below it, plain or on a
@@ -373,7 +377,7 @@ func (app *App) appendMountTree(dst []mountedAppRef, prefix string, matchers []d
 		return dst
 	}
 
-	dst = append(dst, mountedAppRef{app: app, path: prefix, matchers: matchers})
+	dst = append(dst, mountedAppRef{app: app, path: prefix, matchers: matchers, ancestors: slices.Clone(chain)})
 	chain = append(chain, app)
 
 	// Patterns compose innermost first, the order a mount records them in: a
@@ -516,7 +520,8 @@ func (app *App) routeOwner(route *Route) *App {
 func (app *App) appendDomainMounts(dst, mounts []domainMountedApp, prefix string) []domainMountedApp {
 	for i := range mounts {
 		mount := &mounts[i]
-		dst = addDomainMount(dst, app.newDomainMount(mount.app, getGroupPath(prefix, mount.path), mount.matchers))
+		moved := app.newDomainMount(mount.app, getGroupPath(prefix, mount.path), mount.matchers, mount.ancestors)
+		dst = addDomainMount(dst, &moved)
 	}
 
 	return dst
@@ -525,14 +530,14 @@ func (app *App) appendDomainMounts(dst, mounts []domainMountedApp, prefix string
 // addDomainMount appends a domain mount unless the same one is already
 // recorded. An app list holds the descendants of the apps it lists, so the
 // startup walk reaches the same mount once per path that leads to it.
-func addDomainMount(dst []domainMountedApp, mount domainMountedApp) []domainMountedApp {
+func addDomainMount(dst []domainMountedApp, mount *domainMountedApp) []domainMountedApp {
 	for i := range dst {
-		if dst[i].equals(&mount) {
+		if dst[i].equals(mount) {
 			return dst
 		}
 	}
 
-	return append(dst, mount)
+	return append(dst, *mount)
 }
 
 // MountPath returns the route pattern where the current app instance was mounted as a sub-application.

--- a/mount.go
+++ b/mount.go
@@ -149,12 +149,17 @@ func (app *App) domainMountedViews(c Ctx) *App {
 		matchParts int
 	)
 
+	normalizedPath := utils.AddTrailingSlashString(c.Path())
+
 	for i := range app.mountFields.domainAppList {
 		mount := &app.mountFields.domainAppList[i]
 		if mount.path == "" || mount.app.config.Views == nil {
 			continue
 		}
-		if !strings.Contains(c.OriginalURL(), mount.path) || !mount.matchesHost(c.Hostname()) {
+		// Matched on the path, as ErrorHandler matches the same entries. The
+		// plain-mount scan in Render searches the whole URL instead, which also
+		// answers for a mount path appearing in a query string.
+		if !strings.HasPrefix(normalizedPath, utils.AddTrailingSlashString(mount.path)) || !mount.matchesHost(c.Hostname()) {
 			continue
 		}
 

--- a/mount.go
+++ b/mount.go
@@ -64,12 +64,15 @@ type domainMountedApp struct {
 	// are what its configuration is inherited from: a mount that merely covers
 	// the same path encloses nothing.
 	ancestors []*App
+	// declared are the constraints of the apps whose mount prefixes the path is
+	// composed of, which is where a constraint named in one of them is defined
+	declared []CustomConstraint
 }
 
 // newDomainMount records a mount of mounted at path, normalized and parsed
 // with the routing rules of the app it is being mounted on, so the lookups
 // recognize it the same way the router recognizes its routes.
-func (app *App) newDomainMount(mounted *App, path string, matchers []domainMatcher, ancestors []*App) domainMountedApp {
+func (app *App) newDomainMount(mounted *App, path string, matchers []domainMatcher, ancestors []*App, declared []CustomConstraint) domainMountedApp {
 	normalized := app.normalizePath(path)
 
 	mount := domainMountedApp{
@@ -77,9 +80,15 @@ func (app *App) newDomainMount(mounted *App, path string, matchers []domainMatch
 		path:      normalized,
 		matchers:  matchers,
 		ancestors: ancestors,
+		declared:  declared,
 	}
 
-	if parser := parseRoute(normalized, app.config.RegexHandler, app.customConstraints...); len(parser.params) > 0 {
+	// A mount prefix is written in the terms of the app it was registered on,
+	// and may name a constraint only that app knows. Those win where both
+	// define a name, as they do when a mount's routes are re-parsed.
+	constraints := mergeCustomConstraints(slices.Clone(declared), app.customConstraints)
+
+	if parser := parseRoute(normalized, app.config.RegexHandler, constraints...); len(parser.params) > 0 {
 		mount.parser = &parser
 	}
 
@@ -355,6 +364,7 @@ type mountedAppRef struct {
 	path      string
 	matchers  []domainMatcher
 	ancestors []*App
+	declared  []CustomConstraint
 }
 
 // mountTree returns this app and every app mounted below it, plain or on a
@@ -365,20 +375,31 @@ type mountedAppRef struct {
 // app mounted on a descendant afterwards is missing from it until startup
 // repairs it — and a domain mount records its apps when it is registered.
 func (app *App) mountTree() []mountedAppRef {
-	return app.appendMountTree(nil, "", nil, nil)
+	return app.appendMountTree(nil, "", nil, nil, nil)
 }
 
 // appendMountTree adds this app and its descendants to dst, reached at prefix
 // behind matchers. chain holds the apps above this one so a mount cycle
 // terminates; it is a slice because it is only ever a few entries deep, and an
 // app mounted on two branches is still reached through both.
-func (app *App) appendMountTree(dst []mountedAppRef, prefix string, matchers []domainMatcher, chain []*App) []mountedAppRef {
+func (app *App) appendMountTree(dst []mountedAppRef, prefix string, matchers []domainMatcher, declared []CustomConstraint, chain []*App) []mountedAppRef {
 	if slices.Contains(chain, app) {
 		return dst
 	}
 
-	dst = append(dst, mountedAppRef{app: app, path: prefix, matchers: matchers, ancestors: slices.Clone(chain)})
+	dst = append(dst, mountedAppRef{
+		app:       app,
+		path:      prefix,
+		matchers:  matchers,
+		ancestors: slices.Clone(chain),
+		declared:  declared,
+	})
 	chain = append(chain, app)
+
+	// The prefixes below are written in this app's terms, so a constraint only
+	// it knows travels with them. Its own win where a name is defined twice,
+	// the way a mounted app's do when its routes are re-parsed.
+	declared = mergeCustomConstraints(slices.Clone(app.customConstraints), declared)
 
 	// Patterns compose innermost first, the order a mount records them in: a
 	// request has to satisfy every one of them.
@@ -387,6 +408,7 @@ func (app *App) appendMountTree(dst []mountedAppRef, prefix string, matchers []d
 			dst,
 			getGroupPath(prefix, mount.path),
 			append(slices.Clone(mount.matchers), matchers...),
+			declared,
 			chain,
 		)
 	}
@@ -396,7 +418,7 @@ func (app *App) appendMountTree(dst []mountedAppRef, prefix string, matchers []d
 			continue
 		}
 
-		dst = mounted.appendMountTree(dst, getGroupPath(prefix, mountPrefix), matchers, chain)
+		dst = mounted.appendMountTree(dst, getGroupPath(prefix, mountPrefix), matchers, declared, chain)
 	}
 
 	return dst
@@ -520,7 +542,7 @@ func (app *App) routeOwner(route *Route) *App {
 func (app *App) appendDomainMounts(dst, mounts []domainMountedApp, prefix string) []domainMountedApp {
 	for i := range mounts {
 		mount := &mounts[i]
-		moved := app.newDomainMount(mount.app, getGroupPath(prefix, mount.path), mount.matchers, mount.ancestors)
+		moved := app.newDomainMount(mount.app, getGroupPath(prefix, mount.path), mount.matchers, mount.ancestors, mount.declared)
 		dst = addDomainMount(dst, &moved)
 	}
 
@@ -532,9 +554,20 @@ func (app *App) appendDomainMounts(dst, mounts []domainMountedApp, prefix string
 // startup walk reaches the same mount once per path that leads to it.
 func addDomainMount(dst []domainMountedApp, mount *domainMountedApp) []domainMountedApp {
 	for i := range dst {
-		if dst[i].equals(mount) {
-			return dst
+		if !dst[i].equals(mount) {
+			continue
 		}
+
+		// An app list holds the descendants of the apps it lists, so a mount is
+		// reached both through the app it was registered on and as an entry of
+		// the app above that one. Only the first walk passes through its real
+		// parent; the other arrives with a prefix of that chain, and which one
+		// is seen first is up to map iteration order.
+		if len(mount.ancestors) > len(dst[i].ancestors) {
+			dst[i].ancestors = mount.ancestors
+		}
+
+		return dst
 	}
 
 	return append(dst, *mount)

--- a/mount.go
+++ b/mount.go
@@ -5,6 +5,7 @@
 package fiber
 
 import (
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -29,9 +30,9 @@ type mountFields struct {
 	// routes, kept by route because a path can belong to a mount and to this
 	// app at once
 	noAutoHeadRoutes map[*Route]struct{}
-	// Domain-mounted app each cloned route came from, so the request that ran
-	// one resolves its config directly instead of inferring an owner from the
-	// host and the path
+	// Mounted app each cloned route came from, so the request that ran one
+	// resolves its config directly instead of inferring an owner from the host
+	// and the path
 	routeOwners map[*Route]*App
 	// Ordered keys of apps (sorted by key length for Render)
 	appListKeys []string
@@ -227,17 +228,12 @@ func (o domainOwner) outranks(plainDepth int) bool {
 	return o.app != nil && (o.exact || plainDepth <= o.depth)
 }
 
-// domainMountedViews returns the domain mount whose view engine answers for
-// this request, and no owner when it configures none — leaving the plain mounts
-// and the root to answer rather than borrowing the engine of a mount that did
-// not serve the request.
-func (app *App) domainMountedViews(c Ctx) domainOwner {
-	owner := app.domainMountOwner(c)
-	if owner.app == nil || owner.app.config.Views == nil {
-		return domainOwner{}
-	}
-
-	return owner
+// hasViews reports whether this owner configures a view engine of its own. One
+// that does not leaves the plain mounts and the root to render, rather than
+// borrowing the engine of a mount that did not serve the request — its layout
+// still applies, as a plain mount's does when it has no engine either.
+func (o domainOwner) hasViews() bool {
+	return o.app != nil && o.app.config.Views != nil
 }
 
 // domainMountOwner returns the domain mount that owns this request: the app the
@@ -295,11 +291,30 @@ func (app *App) mountedApps() []*App {
 	return apps
 }
 
-// mountedAppsSnapshot returns the apps mounted directly on this one, read
-// under its own lock: App.mount writes those lists under it, and a walk that
-// read them unguarded would race a concurrent mount. One app is locked at a
-// time, so a caller may hold none of them.
+// mountedAppsSnapshot returns the apps mounted directly on this one, plain or
+// on a domain.
 func (app *App) mountedAppsSnapshot() []*App {
+	plain := app.plainMountsSnapshot()
+	domain := app.domainMountsSnapshot()
+
+	mounted := make([]*App, 0, len(plain)+len(domain))
+	for _, sub := range plain {
+		mounted = append(mounted, sub)
+	}
+
+	for i := range domain {
+		mounted = append(mounted, domain[i].app)
+	}
+
+	return mounted
+}
+
+// plainMountsSnapshot copies this app's list of ordinarily mounted apps, read
+// under its own lock: App.mount writes it under that lock, and a read left
+// unguarded would race a concurrent mount. Only this app is locked, and only
+// for the copy, so a caller may hold no other app's lock — mounting an app on
+// itself would otherwise take one lock twice.
+func (app *App) plainMountsSnapshot() map[string]*App {
 	if app.mountFields == nil {
 		return nil
 	}
@@ -307,16 +322,20 @@ func (app *App) mountedAppsSnapshot() []*App {
 	app.mutex.Lock()
 	defer app.mutex.Unlock()
 
-	mounted := make([]*App, 0, len(app.mountFields.appList)+len(app.mountFields.domainAppList))
-	for _, sub := range app.mountFields.appList {
-		mounted = append(mounted, sub)
+	return maps.Clone(app.mountFields.appList)
+}
+
+// domainMountsSnapshot copies this app's domain mount records, under the same
+// lock and with the same restriction as plainMountsSnapshot.
+func (app *App) domainMountsSnapshot() []domainMountedApp {
+	if app.mountFields == nil {
+		return nil
 	}
 
-	for i := range app.mountFields.domainAppList {
-		mounted = append(mounted, app.mountFields.domainAppList[i].app)
-	}
+	app.mutex.Lock()
+	defer app.mutex.Unlock()
 
-	return mounted
+	return slices.Clone(app.mountFields.domainAppList)
 }
 
 // mountCoversPath reports whether a mount registered at mountPath covers path.
@@ -357,10 +376,15 @@ func (app *App) skipsAutoHeadFor(route *Route) bool {
 	return ok
 }
 
-// markRouteOwner records that route was cloned out of owner, a sub-app mounted
-// on a domain. Ownership is kept by route for the same reason the automatic
+// markRouteOwner records that route was cloned out of owner, the app it was
+// mounted from. Ownership is kept by route for the same reason the automatic
 // HEAD provenance is: host and path do not identify the app on their own, since
 // two sub-apps can be mounted at one path behind patterns that both match.
+//
+// Ordinary mounts are recorded as well as domain ones. A sub-app that has
+// already expanded its own mounts carries its children's routes in its stack,
+// and the domain mount that clones them next would otherwise take them all for
+// its own.
 func (app *App) markRouteOwner(route *Route, owner *App) {
 	if app.mountFields.routeOwners == nil {
 		app.mountFields.routeOwners = make(map[*Route]*App)
@@ -369,8 +393,8 @@ func (app *App) markRouteOwner(route *Route, owner *App) {
 	app.mountFields.routeOwners[route] = owner
 }
 
-// routeOwner returns the domain-mounted app route was cloned out of, or nil
-// when the route did not come from one.
+// routeOwner returns the mounted app route was cloned out of, or nil when the
+// route did not come from a mount.
 func (app *App) routeOwner(route *Route) *App {
 	if route == nil || len(app.mountFields.routeOwners) == 0 {
 		return nil
@@ -541,12 +565,15 @@ func (app *App) processSubAppsRoutes() {
 					app.markSkipAutoHead(subAppRouteClone)
 				}
 
-				// Carry the domain mount each route came from over as well: the
-				// sub-app here is the wrapper the domain router built, and the
-				// apps behind it are the ones whose config has to answer.
-				if owner := route.group.app.routeOwner(subAppRoute); owner != nil {
-					app.markRouteOwner(subAppRouteClone, owner)
+				// Carry the app each route came from over as well. The sub-app
+				// here is the wrapper the domain router built when the mount is
+				// a domain one, and the apps behind it are the ones whose config
+				// has to answer; an ordinary mount is its own routes' owner.
+				owner := route.group.app.routeOwner(subAppRoute)
+				if owner == nil {
+					owner = route.group.app
 				}
+				app.markRouteOwner(subAppRouteClone, owner)
 
 				// Add the cloned sub-app's route to the slice of sub-app routes
 				subRoutes[j] = subAppRouteClone

--- a/mount.go
+++ b/mount.go
@@ -5,6 +5,7 @@
 package fiber
 
 import (
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -24,6 +25,10 @@ type mountFields struct {
 	// path for different hosts would displace each other, and a lookup would
 	// answer for hosts the domain pattern rejects.
 	domainAppList []domainMountedApp
+	// Routes that arrived from a mount which registers no automatic HEAD
+	// routes, kept by route because a path can belong to a mount and to this
+	// app at once
+	noAutoHeadRoutes map[*Route]struct{}
 	// Ordered keys of apps (sorted by key length for Render)
 	appListKeys []string
 	// guards one-time generation of appListKeys
@@ -51,6 +56,23 @@ type domainMountedApp struct {
 func (m *domainMountedApp) matchesHost(hostname string) bool {
 	for i := range m.matchers {
 		if matched, _ := m.matchers[i].match(hostname); !matched {
+			return false
+		}
+	}
+
+	return true
+}
+
+// equals reports whether two records describe the same mount: the same app,
+// at the same path, behind the same domain patterns.
+func (m *domainMountedApp) equals(other domainMountedApp) bool {
+	if m.app != other.app || m.path != other.path || len(m.matchers) != len(other.matchers) {
+		return false
+	}
+
+	for i := range m.matchers {
+		// parts carries the pattern the rest of the matcher is derived from.
+		if !slices.Equal(m.matchers[i].parts, other.matchers[i].parts) {
 			return false
 		}
 	}
@@ -137,31 +159,66 @@ func (grp *Group) mount(prefix string, subApp *App) Router {
 	return grp
 }
 
-// domainMountedViews returns the view engine owner among the app's domain
-// mounts for this request: the deepest mount whose path is part of the URL,
-// whose patterns match the host, and which configures views. It returns nil
-// when none does, leaving the plain mounts to answer.
+// domainMountedViews returns the view engine of the domain mount that owns this
+// request: the deepest one covering the path whose patterns match the host, and
+// among equally deep ones the first registered, matching the order their routes
+// are matched in.
+//
+// It returns nil when the owner configures no views, leaving the plain mounts
+// and the root to answer — rather than borrowing the engine of a mount that did
+// not serve the request.
 func (app *App) domainMountedViews(c Ctx) *App {
 	var (
-		viewsApp   *App
+		owner      *App
 		matchParts int
 	)
 
 	for i := range app.mountFields.domainAppList {
 		mount := &app.mountFields.domainAppList[i]
-		if mount.app.config.Views == nil {
-			continue
-		}
 		if !app.mountCoversPath(mount.path, c.Path()) || !mount.matchesHost(c.Hostname()) {
 			continue
 		}
 
 		if parts := mount.prefixParts(); parts > matchParts {
-			viewsApp, matchParts = mount.app, parts
+			owner, matchParts = mount.app, parts
 		}
 	}
 
-	return viewsApp
+	if owner == nil || owner.config.Views == nil {
+		return nil
+	}
+
+	return owner
+}
+
+// mountedApps returns this app and every app mounted below it, plain or on a
+// domain, for the operations that touch each mounted app's config.
+//
+// It walks the mount metadata itself rather than reading the flattened lists,
+// which are only complete once the app has been through its startup process.
+func (app *App) mountedApps() []*App {
+	apps := []*App{app}
+
+	for i := 0; i < len(apps); i++ {
+		current := apps[i]
+		if current.mountFields == nil {
+			continue
+		}
+
+		for _, mounted := range current.mountFields.appList {
+			if !slices.Contains(apps, mounted) {
+				apps = append(apps, mounted)
+			}
+		}
+
+		for j := range current.mountFields.domainAppList {
+			if mounted := current.mountFields.domainAppList[j].app; !slices.Contains(apps, mounted) {
+				apps = append(apps, mounted)
+			}
+		}
+	}
+
+	return apps
 }
 
 // mountCoversPath reports whether a mount registered at mountPath covers path.
@@ -181,44 +238,24 @@ func (app *App) mountCoversPath(mountPath, path string) bool {
 	)
 }
 
-// mountSkipsAutoHead reports whether path belongs to a mounted app that does
-// not register automatic HEAD routes of its own, either because it does not
-// serve HEAD at all or because it turned them off.
-//
-// Once a mount is expanded, its routes sit in this app's stack and are
-// indistinguishable from its own, so the automatic-HEAD pass would synthesize
-// a HEAD route the mounted app never wanted — and synthesize it from the GET
-// route alone, leaving the middleware the mounted app registered for its own
-// methods out of the chain.
-func (app *App) mountSkipsAutoHead(path string) bool {
-	skips := func(mounted *App, mountPath string) bool {
-		if !app.mountCoversPath(mountPath, path) {
-			return false
-		}
-		if !mounted.config.DisableHeadAutoRegister && mounted.methodInt(MethodHead) >= 0 {
-			return false
-		}
-
-		// Covering the path is not enough to own the route: a mount at "/"
-		// covers every path this app registered itself. Ask the mounted app
-		// whether the route is one of its own.
-		return mounted.hasEndpoint(MethodGet, strings.TrimPrefix(path, utils.TrimRight(app.normalizePath(mountPath), '/')))
+// markSkipAutoHead records that a route must not be given an automatic HEAD
+// companion. Provenance is kept by route rather than by path: once a mount is
+// expanded, its routes sit in this app's stack next to the app's own, and a
+// path can belong to both.
+func (app *App) markSkipAutoHead(route *Route) {
+	if app.mountFields.noAutoHeadRoutes == nil {
+		app.mountFields.noAutoHeadRoutes = make(map[*Route]struct{})
 	}
 
-	for mountPath, mounted := range app.mountFields.appList {
-		if skips(mounted, mountPath) {
-			return true
-		}
-	}
+	app.mountFields.noAutoHeadRoutes[route] = struct{}{}
+}
 
-	for i := range app.mountFields.domainAppList {
-		mount := &app.mountFields.domainAppList[i]
-		if skips(mount.app, mount.path) {
-			return true
-		}
-	}
+// skipsAutoHeadFor reports whether route came from a mount that registers no
+// automatic HEAD routes of its own.
+func (app *App) skipsAutoHeadFor(route *Route) bool {
+	_, ok := app.mountFields.noAutoHeadRoutes[route]
 
-	return false
+	return ok
 }
 
 // appendDomainMounts re-registers the domain mounts of a mounted app on the app
@@ -226,7 +263,7 @@ func (app *App) mountSkipsAutoHead(path string) bool {
 // them: the host still has to match for their config to apply.
 func appendDomainMounts(dst, mounts []domainMountedApp, prefix string) []domainMountedApp {
 	for _, mount := range mounts {
-		dst = append(dst, domainMountedApp{
+		dst = addDomainMount(dst, domainMountedApp{
 			app:      mount.app,
 			path:     getGroupPath(prefix, mount.path),
 			matchers: mount.matchers,
@@ -234,6 +271,17 @@ func appendDomainMounts(dst, mounts []domainMountedApp, prefix string) []domainM
 	}
 
 	return dst
+}
+
+// addDomainMount appends a domain mount unless the same one is already
+// recorded. An app list holds the descendants of the apps it lists, so the
+// startup walk reaches the same mount once per path that leads to it.
+func addDomainMount(dst []domainMountedApp, mount domainMountedApp) []domainMountedApp {
+	if slices.ContainsFunc(dst, mount.equals) {
+		return dst
+	}
+
+	return append(dst, mount)
 }
 
 // MountPath returns the route pattern where the current app instance was mounted as a sub-application.
@@ -344,6 +392,17 @@ func (app *App) processSubAppsRoutes() {
 			// so its constraints have to be resolvable here too.
 			app.customConstraints = mergeCustomConstraints(app.customConstraints, route.group.app.customConstraints)
 
+			// The prefix is this app's, and may name a constraint only this
+			// app knows; the routes are the sub-app's, whose constraints win
+			// where both define a name.
+			constraints := mergeCustomConstraints(slices.Clone(route.group.app.customConstraints), app.customConstraints)
+
+			// A sub-app that registers no automatic HEAD routes of its own
+			// must not be given them here either: its middleware is
+			// registered for the methods it serves, and a HEAD route
+			// synthesized from the GET one would run without it.
+			skipsAutoHead := route.group.app.config.DisableHeadAutoRegister || route.group.app.methodInt(MethodHead) < 0
+
 			// Create a slice to hold the sub-app's routes
 			subRoutes := make([]*Route, len(subAppRoutes))
 
@@ -353,7 +412,14 @@ func (app *App) processSubAppsRoutes() {
 				subAppRouteClone := app.copyRoute(subAppRoute)
 
 				// Add the parent route's path as a prefix to the sub-app's route
-				app.addPrefixToRoute(route.path, subAppRouteClone, route.group.app.config.RegexHandler, route.group.app.customConstraints...)
+				app.addPrefixToRoute(route.path, subAppRouteClone, route.group.app.config.RegexHandler, constraints...)
+
+				// Carry the sub-app's stance on automatic HEAD routes over to
+				// the clone, so this app's own routes at the same path keep
+				// theirs and the sub-app's descendants keep skipping.
+				if skipsAutoHead || route.group.app.skipsAutoHeadFor(subAppRoute) {
+					app.markSkipAutoHead(subAppRouteClone)
+				}
 
 				// Add the cloned sub-app's route to the slice of sub-app routes
 				subRoutes[j] = subAppRouteClone

--- a/mount.go
+++ b/mount.go
@@ -200,6 +200,10 @@ func (app *App) processSubAppsRoutes() {
 			// tables then neither line up nor have to be the same length.
 			subAppRoutes := route.group.app.routesForMethod(app.method(m))
 
+			// The sub-app's routes are about to be re-parsed against this app,
+			// so its constraints have to be resolvable here too.
+			app.customConstraints = mergeCustomConstraints(app.customConstraints, route.group.app.customConstraints)
+
 			// Create a slice to hold the sub-app's routes
 			subRoutes := make([]*Route, len(subAppRoutes))
 

--- a/mount.go
+++ b/mount.go
@@ -402,19 +402,45 @@ type mountedAppRef struct {
 // app mounted on a descendant afterwards is missing from it until startup
 // repairs it — and a domain mount records its apps when it is registered.
 func (app *App) mountTree() []mountedAppRef {
-	return app.appendMountTree(nil, "", nil, nil, nil)
+	walk := mountWalk{seen: make(map[mountWalkKey]int)}
+	walk.add(app, "", nil, nil, nil)
+
+	return walk.refs
 }
 
-// appendMountTree adds this app and its descendants to dst, reached at prefix
+// mountWalk carries the state of one walk over an app's mounts.
+type mountWalk struct {
+	// seen holds the longest chain each app has already been reached at, per
+	// path. An app list holds the descendants of the apps it lists, so a
+	// descendant is reachable through every combination of the lists leading to
+	// it — walking one again pays for itself only when the chain is longer than
+	// one it was reached with before, since only the longest is kept.
+	seen map[mountWalkKey]int
+	refs []mountedAppRef
+}
+
+// mountWalkKey identifies an app at the path it was reached at.
+type mountWalkKey struct {
+	app  *App
+	path string
+}
+
+// add records this app and its descendants, reached at prefix
 // behind matchers. chain holds the apps above this one so a mount cycle
 // terminates; it is a slice because it is only ever a few entries deep, and an
 // app mounted on two branches is still reached through both.
-func (app *App) appendMountTree(dst []mountedAppRef, prefix string, matchers []domainMatcher, declared []CustomConstraint, chain []*App) []mountedAppRef {
+func (w *mountWalk) add(app *App, prefix string, matchers []domainMatcher, declared []CustomConstraint, chain []*App) {
 	if slices.Contains(chain, app) {
-		return dst
+		return
 	}
 
-	dst = append(dst, mountedAppRef{
+	key := mountWalkKey{app: app, path: prefix}
+	if reached, ok := w.seen[key]; ok && reached >= len(chain) {
+		return
+	}
+	w.seen[key] = len(chain)
+
+	w.refs = append(w.refs, mountedAppRef{
 		app:       app,
 		path:      prefix,
 		matchers:  matchers,
@@ -431,8 +457,8 @@ func (app *App) appendMountTree(dst []mountedAppRef, prefix string, matchers []d
 	// Patterns compose innermost first, the order a mount records them in: a
 	// request has to satisfy every one of them.
 	for _, mount := range app.domainMountsSnapshot() {
-		dst = mount.app.appendMountTree(
-			dst,
+		w.add(
+			mount.app,
 			getGroupPath(prefix, mount.path),
 			append(slices.Clone(mount.matchers), matchers...),
 			declared,
@@ -445,10 +471,8 @@ func (app *App) appendMountTree(dst []mountedAppRef, prefix string, matchers []d
 			continue
 		}
 
-		dst = mounted.appendMountTree(dst, getGroupPath(prefix, mountPrefix), matchers, declared, chain)
+		w.add(mounted, getGroupPath(prefix, mountPrefix), matchers, declared, chain)
 	}
-
-	return dst
 }
 
 // mountedAppsSnapshot returns the apps mounted directly on this one, plain or
@@ -566,10 +590,15 @@ func (app *App) routeOwner(route *Route) *App {
 // appendDomainMounts re-registers the domain mounts of a mounted app on the app
 // above it, moving their paths under prefix. Their domain patterns travel with
 // them: the host still has to match for their config to apply.
-func (app *App) appendDomainMounts(dst, mounts []domainMountedApp, prefix string) []domainMountedApp {
+func (app *App) appendDomainMounts(dst, mounts []domainMountedApp, prefix string, owner *App) []domainMountedApp {
 	for i := range mounts {
 		mount := &mounts[i]
-		moved := app.newDomainMount(mount.app, getGroupPath(prefix, mount.path), mount.matchers, mount.ancestors, mount.declared)
+
+		// The app they were registered on encloses them from here: their own
+		// ancestors are the apps between it and them, and it is the outermost.
+		ancestors := append([]*App{owner}, mount.ancestors...)
+
+		moved := app.newDomainMount(mount.app, getGroupPath(prefix, mount.path), mount.matchers, ancestors, mount.declared)
 		dst = addDomainMount(dst, &moved)
 	}
 
@@ -663,7 +692,7 @@ func (app *App) appendSubAppLists(appList map[string]*App, parent ...string) {
 		// Domain mounts are kept out of appList, so collect them here instead.
 		// Doing it at startup rather than when the sub-app was mounted also
 		// picks up the ones registered in between.
-		app.mountFields.domainAppList = app.appendDomainMounts(app.mountFields.domainAppList, subApp.mountFields.domainAppList, prefix)
+		app.mountFields.domainAppList = app.appendDomainMounts(app.mountFields.domainAppList, subApp.mountFields.domainAppList, prefix, subApp)
 
 		// The first element of appList is always the app itself. If there are no other sub apps, we should skip appending nested apps.
 		if subApp.hasMountedApps() {

--- a/mount.go
+++ b/mount.go
@@ -293,11 +293,10 @@ func domainMountRender(owner domainOwner) (*App, string) { //nolint:gocritic // 
 // does — the inheritance an ordinarily nested mount gets from the app it sits
 // in. Mounts at the owner's own depth are siblings that did not serve the
 // request, and configure nothing on its behalf.
+//
+// There has to be an owner: nothing outranks a plain mount without one, so a
+// caller reaches this having established it.
 func domainMountConfig(owner domainOwner, want func(*App) bool) *App {
-	if owner.app == nil {
-		return nil
-	}
-
 	if want(owner.app) {
 		return owner.app
 	}

--- a/mount.go
+++ b/mount.go
@@ -44,11 +44,45 @@ type mountFields struct {
 // hostname matches every domain pattern the app was mounted behind.
 type domainMountedApp struct {
 	app *App
-	// path is the full mount path, as appList would key it
+	// parser matches path when it carries parameters, and is nil otherwise: a
+	// mount can be registered at "/:tenant" the same way a route can
+	parser *routeParser
+	// path is the full mount path, normalized by the app it is mounted on
 	path string
 	// matchers are the patterns of the domain routers this app was mounted
 	// behind, outermost last. A request has to satisfy all of them.
 	matchers []domainMatcher
+}
+
+// newDomainMount records a mount of mounted at path, normalized and parsed
+// with the routing rules of the app it is being mounted on, so the lookups
+// recognize it the same way the router recognizes its routes.
+func (app *App) newDomainMount(mounted *App, path string, matchers []domainMatcher) domainMountedApp {
+	normalized := app.normalizePath(path)
+
+	mount := domainMountedApp{
+		app:      mounted,
+		path:     normalized,
+		matchers: matchers,
+	}
+
+	if parser := parseRoute(normalized, app.config.RegexHandler, app.customConstraints...); len(parser.params) > 0 {
+		mount.parser = &parser
+	}
+
+	return mount
+}
+
+// covers reports whether this mount covers path, which is matched as a pattern
+// when the mount path carries parameters.
+func (m *domainMountedApp) covers(path string) bool {
+	if m.parser != nil {
+		var params [maxParams]string
+
+		return m.parser.getMatch(path, path, &params, true)
+	}
+
+	return strings.HasPrefix(utils.AddTrailingSlashString(path), utils.AddTrailingSlashString(m.path))
 }
 
 // matchesHost reports whether hostname satisfies every domain pattern the app
@@ -65,7 +99,7 @@ func (m *domainMountedApp) matchesHost(hostname string) bool {
 
 // equals reports whether two records describe the same mount: the same app,
 // at the same path, behind the same domain patterns.
-func (m *domainMountedApp) equals(other domainMountedApp) bool {
+func (m *domainMountedApp) equals(other *domainMountedApp) bool {
 	if m.app != other.app || m.path != other.path || len(m.matchers) != len(other.matchers) {
 		return false
 	}
@@ -80,10 +114,20 @@ func (m *domainMountedApp) equals(other domainMountedApp) bool {
 	return true
 }
 
-// prefixParts counts the path segments of the mount path, so the deepest mount
-// covering a request can be picked the same way appList entries are.
-func (m *domainMountedApp) prefixParts() int {
-	return strings.Count(m.path, "/") + 1
+// depth counts the path segments a mount path covers, so the deepest mount
+// covering a request can be picked. The root mount covers none of its own,
+// which leaves any named mount more specific than it.
+func mountDepth(path string) int {
+	if path == "" || path == "/" {
+		return 0
+	}
+
+	return strings.Count(path, "/")
+}
+
+// depth counts the path segments this mount covers.
+func (m *domainMountedApp) depth() int {
+	return mountDepth(m.path)
 }
 
 // Create empty mountFields instance
@@ -167,28 +211,39 @@ func (grp *Group) mount(prefix string, subApp *App) Router {
 // It returns nil when the owner configures no views, leaving the plain mounts
 // and the root to answer — rather than borrowing the engine of a mount that did
 // not serve the request.
-func (app *App) domainMountedViews(c Ctx) *App {
+func (app *App) domainMountedViews(c Ctx) (*App, int) { //nolint:gocritic // unnamedResult: named returns conflict with nonamedreturns linter
+	owner, depth := app.domainMountOwner(c)
+	if owner == nil || owner.config.Views == nil {
+		return nil, 0
+	}
+
+	return owner, depth
+}
+
+// domainMountOwner returns the domain mount that owns this request and the
+// depth it matched at: the deepest one covering the path whose patterns match
+// the host, and among equally deep ones the first registered, matching the
+// order their routes are matched in.
+func (app *App) domainMountOwner(c Ctx) (*App, int) { //nolint:gocritic // unnamedResult: named returns conflict with nonamedreturns linter
 	var (
-		owner      *App
-		matchParts int
+		owner *App
+		best  int
 	)
+
+	path := app.normalizePath(c.Path())
 
 	for i := range app.mountFields.domainAppList {
 		mount := &app.mountFields.domainAppList[i]
-		if !app.mountCoversPath(mount.path, c.Path()) || !mount.matchesHost(c.Hostname()) {
+		if !mount.covers(path) || !mount.matchesHost(c.Hostname()) {
 			continue
 		}
 
-		if parts := mount.prefixParts(); parts > matchParts {
-			owner, matchParts = mount.app, parts
+		if depth := mount.depth(); owner == nil || depth > best {
+			owner, best = mount.app, depth
 		}
 	}
 
-	if owner == nil || owner.config.Views == nil {
-		return nil
-	}
-
-	return owner
+	return owner, best
 }
 
 // mountedApps returns this app and every app mounted below it, plain or on a
@@ -223,10 +278,11 @@ func (app *App) mountedApps() []*App {
 
 // mountCoversPath reports whether a mount registered at mountPath covers path.
 //
-// Both sides are put through this app's routing rules first: a mount path is
-// stored as the caller spelled it, so on a case-insensitive app a mount
+// Both sides are put through this app's routing rules first: an app list is
+// keyed by the path the caller spelled, so on a case-insensitive app a mount
 // registered as "/API" has to cover a request for "/api/x" the same way its
-// routes do.
+// routes do. A parametric mount path is matched literally here — the app list
+// keeps no parsed form of its keys.
 func (app *App) mountCoversPath(mountPath, path string) bool {
 	if mountPath == "" {
 		return false
@@ -261,13 +317,10 @@ func (app *App) skipsAutoHeadFor(route *Route) bool {
 // appendDomainMounts re-registers the domain mounts of a mounted app on the app
 // above it, moving their paths under prefix. Their domain patterns travel with
 // them: the host still has to match for their config to apply.
-func appendDomainMounts(dst, mounts []domainMountedApp, prefix string) []domainMountedApp {
-	for _, mount := range mounts {
-		dst = addDomainMount(dst, domainMountedApp{
-			app:      mount.app,
-			path:     getGroupPath(prefix, mount.path),
-			matchers: mount.matchers,
-		})
+func (app *App) appendDomainMounts(dst, mounts []domainMountedApp, prefix string) []domainMountedApp {
+	for i := range mounts {
+		mount := &mounts[i]
+		dst = addDomainMount(dst, app.newDomainMount(mount.app, getGroupPath(prefix, mount.path), mount.matchers))
 	}
 
 	return dst
@@ -277,8 +330,10 @@ func appendDomainMounts(dst, mounts []domainMountedApp, prefix string) []domainM
 // recorded. An app list holds the descendants of the apps it lists, so the
 // startup walk reaches the same mount once per path that leads to it.
 func addDomainMount(dst []domainMountedApp, mount domainMountedApp) []domainMountedApp {
-	if slices.ContainsFunc(dst, mount.equals) {
-		return dst
+	for i := range dst {
+		if dst[i].equals(&mount) {
+			return dst
+		}
 	}
 
 	return append(dst, mount)
@@ -345,7 +400,7 @@ func (app *App) appendSubAppLists(appList map[string]*App, parent ...string) {
 		// Domain mounts are kept out of appList, so collect them here instead.
 		// Doing it at startup rather than when the sub-app was mounted also
 		// picks up the ones registered in between.
-		app.mountFields.domainAppList = appendDomainMounts(app.mountFields.domainAppList, subApp.mountFields.domainAppList, prefix)
+		app.mountFields.domainAppList = app.appendDomainMounts(app.mountFields.domainAppList, subApp.mountFields.domainAppList, prefix)
 
 		// The first element of appList is always the app itself. If there are no other sub apps, we should skip appending nested apps.
 		if subApp.hasMountedApps() {

--- a/mount.go
+++ b/mount.go
@@ -29,6 +29,10 @@ type mountFields struct {
 	// routes, kept by route because a path can belong to a mount and to this
 	// app at once
 	noAutoHeadRoutes map[*Route]struct{}
+	// Domain-mounted app each cloned route came from, so the request that ran
+	// one resolves its config directly instead of inferring an owner from the
+	// host and the path
+	routeOwners map[*Route]*App
 	// Ordered keys of apps (sorted by key length for Render)
 	appListKeys []string
 	// guards one-time generation of appListKeys
@@ -203,32 +207,52 @@ func (grp *Group) mount(prefix string, subApp *App) Router {
 	return grp
 }
 
-// domainMountedViews returns the view engine of the domain mount that owns this
-// request: the deepest one covering the path whose patterns match the host, and
-// among equally deep ones the first registered, matching the order their routes
-// are matched in.
-//
-// It returns nil when the owner configures no views, leaving the plain mounts
-// and the root to answer — rather than borrowing the engine of a mount that did
-// not serve the request.
-func (app *App) domainMountedViews(c Ctx) (*App, int) { //nolint:gocritic // unnamedResult: named returns conflict with nonamedreturns linter
-	owner, depth := app.domainMountOwner(c)
-	if owner == nil || owner.config.Views == nil {
-		return nil, 0
-	}
-
-	return owner, depth
+// domainOwner is the domain-mounted app a request belongs to, together with
+// what is known about how specific that answer is.
+type domainOwner struct {
+	app *App
+	// depth is how many path segments the mount covers, which ranks an
+	// inferred owner against the plain mounts covering the same request.
+	depth int
+	// exact marks an owner taken from the route that actually ran. Nothing
+	// outranks it: the request was served by that app, not merely covered by
+	// its mount path.
+	exact bool
 }
 
-// domainMountOwner returns the domain mount that owns this request and the
-// depth it matched at: the deepest one covering the path whose patterns match
-// the host, and among equally deep ones the first registered, matching the
-// order their routes are matched in.
-func (app *App) domainMountOwner(c Ctx) (*App, int) { //nolint:gocritic // unnamedResult: named returns conflict with nonamedreturns linter
-	var (
-		owner *App
-		best  int
-	)
+// outranks reports whether this owner should answer for the request instead of
+// a plain mount whose path is plainDepth segments deep. An inferred owner wins
+// a tie, having matched the host as well.
+func (o domainOwner) outranks(plainDepth int) bool {
+	return o.app != nil && (o.exact || plainDepth <= o.depth)
+}
+
+// domainMountedViews returns the domain mount whose view engine answers for
+// this request, and no owner when it configures none — leaving the plain mounts
+// and the root to answer rather than borrowing the engine of a mount that did
+// not serve the request.
+func (app *App) domainMountedViews(c Ctx) domainOwner {
+	owner := app.domainMountOwner(c)
+	if owner.app == nil || owner.app.config.Views == nil {
+		return domainOwner{}
+	}
+
+	return owner
+}
+
+// domainMountOwner returns the domain mount that owns this request: the app the
+// route that ran was mounted from, or — for an error raised before any of them
+// matched — the deepest mount covering the path whose patterns match the host,
+// and among equally deep ones the first registered, matching the order their
+// routes are matched in.
+func (app *App) domainMountOwner(c Ctx) domainOwner {
+	// The app the route that ran was mounted from, if it was mounted at all.
+	// Its mount still has to match the request: a domain-wrapped handler that
+	// declined the host left the route it belongs to as the one that ran, and
+	// that app served nothing.
+	routeApp := app.routeOwner(c.Route())
+
+	var owner domainOwner
 
 	path := app.normalizePath(c.Path())
 
@@ -238,12 +262,18 @@ func (app *App) domainMountOwner(c Ctx) (*App, int) { //nolint:gocritic // unnam
 			continue
 		}
 
-		if depth := mount.depth(); owner == nil || depth > best {
-			owner, best = mount.app, depth
+		// Two sub-apps mounted at one path behind overlapping patterns both
+		// cover the request and both match the host. Only one of them ran.
+		if mount.app == routeApp {
+			return domainOwner{app: mount.app, exact: true}
+		}
+
+		if depth := mount.depth(); owner.app == nil || depth > owner.depth {
+			owner.app, owner.depth = mount.app, depth
 		}
 	}
 
-	return owner, best
+	return owner
 }
 
 // mountedApps returns this app and every app mounted below it, plain or on a
@@ -325,6 +355,28 @@ func (app *App) skipsAutoHeadFor(route *Route) bool {
 	_, ok := app.mountFields.noAutoHeadRoutes[route]
 
 	return ok
+}
+
+// markRouteOwner records that route was cloned out of owner, a sub-app mounted
+// on a domain. Ownership is kept by route for the same reason the automatic
+// HEAD provenance is: host and path do not identify the app on their own, since
+// two sub-apps can be mounted at one path behind patterns that both match.
+func (app *App) markRouteOwner(route *Route, owner *App) {
+	if app.mountFields.routeOwners == nil {
+		app.mountFields.routeOwners = make(map[*Route]*App)
+	}
+
+	app.mountFields.routeOwners[route] = owner
+}
+
+// routeOwner returns the domain-mounted app route was cloned out of, or nil
+// when the route did not come from one.
+func (app *App) routeOwner(route *Route) *App {
+	if route == nil || len(app.mountFields.routeOwners) == 0 {
+		return nil
+	}
+
+	return app.mountFields.routeOwners[route]
 }
 
 // appendDomainMounts re-registers the domain mounts of a mounted app on the app
@@ -487,6 +539,13 @@ func (app *App) processSubAppsRoutes() {
 				// theirs and the sub-app's descendants keep skipping.
 				if skipsAutoHead || route.group.app.skipsAutoHeadFor(subAppRoute) {
 					app.markSkipAutoHead(subAppRouteClone)
+				}
+
+				// Carry the domain mount each route came from over as well: the
+				// sub-app here is the wrapper the domain router built, and the
+				// apps behind it are the ones whose config has to answer.
+				if owner := route.group.app.routeOwner(subAppRoute); owner != nil {
+					app.markRouteOwner(subAppRouteClone, owner)
 				}
 
 				// Add the cloned sub-app's route to the slice of sub-app routes

--- a/mount.go
+++ b/mount.go
@@ -561,10 +561,12 @@ func addDomainMount(dst []domainMountedApp, mount *domainMountedApp) []domainMou
 		// An app list holds the descendants of the apps it lists, so a mount is
 		// reached both through the app it was registered on and as an entry of
 		// the app above that one. Only the first walk passes through its real
-		// parent; the other arrives with a prefix of that chain, and which one
-		// is seen first is up to map iteration order.
+		// parent; the other arrives with a prefix of that chain, and with the
+		// constraints of the apps it skipped missing from its path — and which
+		// one is seen first is up to map iteration order. The complete record
+		// replaces the partial one whichever way round they arrive.
 		if len(mount.ancestors) > len(dst[i].ancestors) {
-			dst[i].ancestors = mount.ancestors
+			dst[i] = *mount
 		}
 
 		return dst

--- a/mount.go
+++ b/mount.go
@@ -6,6 +6,7 @@ package fiber
 
 import (
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -18,6 +19,11 @@ type mountFields struct {
 	appList map[string]*App
 	// Prefix of app if it was mounted
 	mountPath string
+	// Apps mounted through a domain router. They are kept out of appList
+	// because that map is keyed by path alone: two apps mounted at the same
+	// path for different hosts would displace each other, and a lookup would
+	// answer for hosts the domain pattern rejects.
+	domainAppList []domainMountedApp
 	// Ordered keys of apps (sorted by key length for Render)
 	appListKeys []string
 	// guards one-time generation of appListKeys
@@ -26,6 +32,36 @@ type mountFields struct {
 	subAppsRoutesAdded sync.Once
 	// check mounted sub-apps
 	subAppsProcessed sync.Once
+}
+
+// domainMountedApp is a sub-app mounted through a domain router. Its config —
+// the ErrorHandler and the view engine — applies only to requests whose
+// hostname matches every domain pattern the app was mounted behind.
+type domainMountedApp struct {
+	app *App
+	// path is the full mount path, as appList would key it
+	path string
+	// matchers are the patterns of the domain routers this app was mounted
+	// behind, outermost last. A request has to satisfy all of them.
+	matchers []domainMatcher
+}
+
+// matchesHost reports whether hostname satisfies every domain pattern the app
+// was mounted behind.
+func (m *domainMountedApp) matchesHost(hostname string) bool {
+	for i := range m.matchers {
+		if matched, _ := m.matchers[i].match(hostname); !matched {
+			return false
+		}
+	}
+
+	return true
+}
+
+// prefixParts counts the path segments of the mount path, so the deepest mount
+// covering a request can be picked the same way appList entries are.
+func (m *domainMountedApp) prefixParts() int {
+	return strings.Count(m.path, "/") + 1
 }
 
 // Create empty mountFields instance
@@ -55,6 +91,7 @@ func (app *App) mount(prefix string, subApp *App) Router {
 		subApp.mountFields.mountPath = path
 		app.mountFields.appList[path] = subApp
 	}
+	app.mountFields.domainAppList = appendDomainMounts(app.mountFields.domainAppList, subApp.mountFields.domainAppList, prefix)
 	app.mutex.Unlock()
 
 	// register mounted group
@@ -87,6 +124,7 @@ func (grp *Group) mount(prefix string, subApp *App) Router {
 		subApp.mountFields.mountPath = path
 		grp.app.mountFields.appList[path] = subApp
 	}
+	grp.app.mountFields.domainAppList = appendDomainMounts(grp.app.mountFields.domainAppList, subApp.mountFields.domainAppList, groupPath)
 	grp.app.mutex.Unlock()
 
 	// register mounted group
@@ -101,6 +139,47 @@ func (grp *Group) mount(prefix string, subApp *App) Router {
 	return grp
 }
 
+// domainMountedViews returns the view engine owner among the app's domain
+// mounts for this request: the deepest mount whose path is part of the URL,
+// whose patterns match the host, and which configures views. It returns nil
+// when none does, leaving the plain mounts to answer.
+func (app *App) domainMountedViews(c Ctx) *App {
+	var (
+		viewsApp   *App
+		matchParts int
+	)
+
+	for i := range app.mountFields.domainAppList {
+		mount := &app.mountFields.domainAppList[i]
+		if mount.path == "" || mount.app.config.Views == nil {
+			continue
+		}
+		if !strings.Contains(c.OriginalURL(), mount.path) || !mount.matchesHost(c.Hostname()) {
+			continue
+		}
+
+		if parts := mount.prefixParts(); parts > matchParts {
+			viewsApp, matchParts = mount.app, parts
+		}
+	}
+
+	return viewsApp
+}
+
+// appendDomainMounts re-registers the domain mounts of a sub-app on the app it
+// is being mounted on, moving their paths under prefix. Their domain patterns
+// travel with them: the host still has to match for their config to apply.
+func appendDomainMounts(dst, mounts []domainMountedApp, prefix string) []domainMountedApp {
+	for _, mount := range mounts {
+		path := getGroupPath(prefix, mount.path)
+
+		mount.app.mountFields.mountPath = path
+		dst = append(dst, domainMountedApp{app: mount.app, path: path, matchers: mount.matchers})
+	}
+
+	return dst
+}
+
 // MountPath returns the route pattern where the current app instance was mounted as a sub-application.
 func (app *App) MountPath() string {
 	return app.mountFields.mountPath
@@ -108,7 +187,7 @@ func (app *App) MountPath() string {
 
 // hasMountedApps Checks if there are any mounted apps in the current application.
 func (app *App) hasMountedApps() bool {
-	return len(app.mountFields.appList) > 1
+	return len(app.mountFields.appList) > 1 || len(app.mountFields.domainAppList) > 0
 }
 
 // mountStartupProcess Handles the startup process of mounted apps by appending sub-app routes, generating app list keys, and processing sub-app routes.

--- a/mount.go
+++ b/mount.go
@@ -235,21 +235,28 @@ type domainOwner struct {
 	// depth is how many path segments the mount covers, which ranks the owner
 	// against the plain mounts covering the same request.
 	depth int
+	// exact marks an owner taken from the route that ran rather than inferred
+	// from the host and the path
+	exact bool
 }
 
 // outranks reports whether this owner should answer for the request instead of
-// a plain mount whose path is plainDepth segments deep. It wins a tie, having
-// matched the host as well, and gives way to a deeper plain mount, as a mounted
-// app gives way to one mounted below it.
+// a plain mount whose path is plainDepth segments deep.
+//
+// An owner taken from the route that ran always does: that route was served by
+// it, and a plain mount is only ever ranked by depth because path is all there
+// is to go on. An inferred one wins a tie, having matched the host as well, and
+// gives way to a deeper plain mount as a mounted app gives way to one below it.
 func (o domainOwner) outranks(plainDepth int) bool {
-	return o.app != nil && plainDepth <= o.depth
+	return o.app != nil && (o.exact || plainDepth <= o.depth)
 }
 
-// ties reports whether a plain mount is exactly as deep as this owner. Such a
-// mount is a sibling rather than an ancestor: the owner takes precedence over
-// it, and falls through past it to the mounts enclosing them both.
-func (o domainOwner) ties(plainDepth int) bool {
-	return o.app != nil && plainDepth == o.depth
+// supersedes reports whether this owner replaces a plain mount rather than
+// inheriting from it. One at or below the owner's own depth did not serve the
+// request; only the apps the owner is mounted inside enclose it, and those it
+// inherits from however deep they are.
+func (o domainOwner) supersedes(plainDepth int, plain *App) bool {
+	return o.app != nil && plainDepth >= o.depth && !slices.Contains(o.ancestors, plain)
 }
 
 // appHasErrorHandler is the setting a request inherits from the domain mounts
@@ -341,7 +348,7 @@ func (app *App) domainMountOwner(c Ctx) domainOwner {
 		// Two sub-apps mounted at one path behind overlapping patterns both
 		// cover the request and both match the host. Only one of them ran.
 		if mount.app == routeApp && (byRoute.app == nil || depth > byRoute.depth) {
-			byRoute.app, byRoute.depth, byRoute.ancestors = mount.app, depth, mount.ancestors
+			byRoute = domainOwner{app: mount.app, ancestors: mount.ancestors, depth: depth, exact: true}
 		}
 
 		if owner.app == nil || depth > owner.depth {
@@ -419,10 +426,25 @@ type mountWalk struct {
 	refs []mountedAppRef
 }
 
-// mountWalkKey identifies an app at the path it was reached at.
+// mountWalkKey identifies an app at the path it was reached at, behind the
+// patterns it was reached through: the same app can be mounted at one path for
+// two hostnames, and each of those is a mount of its own.
 type mountWalkKey struct {
-	app  *App
-	path string
+	app      *App
+	path     string
+	matchers string
+}
+
+// matchersKey identifies a set of domain patterns. Labels carry neither
+// separator, so the parts of one pattern and the patterns of one mount cannot
+// run together.
+func matchersKey(matchers []domainMatcher) string {
+	patterns := make([]string, len(matchers))
+	for i := range matchers {
+		patterns[i] = strings.Join(matchers[i].parts, ".")
+	}
+
+	return strings.Join(patterns, "\n")
 }
 
 // add records this app and its descendants, reached at prefix
@@ -434,7 +456,7 @@ func (w *mountWalk) add(app *App, prefix string, matchers []domainMatcher, decla
 		return
 	}
 
-	key := mountWalkKey{app: app, path: prefix}
+	key := mountWalkKey{app: app, path: prefix, matchers: matchersKey(matchers)}
 	if reached, ok := w.seen[key]; ok && reached >= len(chain) {
 		return
 	}

--- a/mount_test.go
+++ b/mount_test.go
@@ -634,3 +634,94 @@ func Test_Ctx_Render_MountGroup(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "<h1>Hello doe!</h1>", string(body))
 }
+
+// Test_App_Mount_FewerRequestMethods verifies that a sub-app serving only some
+// of the parent's request methods can be mounted: the parent must read the
+// sub-app's routes by method, not by its own stack index.
+func Test_App_Mount_FewerRequestMethods(t *testing.T) {
+	t.Parallel()
+
+	micro := New(Config{RequestMethods: []string{MethodGet}})
+	micro.Get("/doe", func(c Ctx) error {
+		return c.SendString("doe")
+	})
+
+	app := New()
+	app.Use("/john", micro)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/john/doe", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "doe", string(body))
+}
+
+// Test_App_Mount_FewerRequestMethodsNested verifies the same for a sub-app
+// reached through another mount.
+func Test_App_Mount_FewerRequestMethodsNested(t *testing.T) {
+	t.Parallel()
+
+	micro := New(Config{RequestMethods: []string{MethodGet}})
+	micro.Get("/doe", func(c Ctx) error {
+		return c.SendString("doe")
+	})
+
+	sub := New()
+	sub.Use("/v1", micro)
+
+	app := New()
+	app.Use("/john", sub)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/john/v1/doe", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "doe", string(body))
+}
+
+// Test_App_Mount_ReorderedRequestMethods verifies that a sub-app which lists
+// the same request methods in a different order keeps serving each route under
+// the method it was registered with.
+func Test_App_Mount_ReorderedRequestMethods(t *testing.T) {
+	t.Parallel()
+
+	// Swap GET and POST, so the two apps' stack indexes disagree.
+	methods := append([]string{}, DefaultMethods...)
+	for i, method := range methods {
+		switch method {
+		case MethodGet:
+			methods[i] = MethodPost
+		case MethodPost:
+			methods[i] = MethodGet
+		}
+	}
+
+	micro := New(Config{RequestMethods: methods})
+	micro.Get("/doe", func(c Ctx) error {
+		return c.SendString("get doe")
+	})
+	micro.Post("/doe", func(c Ctx) error {
+		return c.SendString("post doe")
+	})
+
+	app := New()
+	app.Use("/john", micro)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/john/doe", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "get doe", string(body))
+
+	resp, err = app.Test(httptest.NewRequest(MethodPost, "/john/doe", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "post doe", string(body))
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -740,6 +740,73 @@ func (*onlyBarConstraint) Name() string { return "onlybar" }
 
 func (*onlyBarConstraint) Execute(param string, _ ...string) bool { return param == "bar" }
 
+// sameNameFooConstraint and sameNameBarConstraint share a name and accept
+// different values, as two apps mounted side by side are free to do.
+type sameNameFooConstraint struct{}
+
+func (*sameNameFooConstraint) Name() string { return "same" }
+
+func (*sameNameFooConstraint) Execute(param string, _ ...string) bool { return param == "foo" }
+
+type sameNameBarConstraint struct{}
+
+func (*sameNameBarConstraint) Name() string { return "same" }
+
+func (*sameNameBarConstraint) Execute(param string, _ ...string) bool { return param == "bar" }
+
+// Test_App_Mount_SiblingConstraintNames verifies that a constraint binds only
+// the routes of the app that registered it: two apps mounted side by side can
+// name one differently, and the app above them must not hold either to the
+// other's.
+func Test_App_Mount_SiblingConstraintNames(t *testing.T) {
+	t.Parallel()
+
+	// A fresh tree per case: mounting one app on two parents would have the
+	// first expand it before the second cloned it.
+	build := func() *App {
+		handler := func(c Ctx) error { return c.SendString("ok") }
+
+		foo := New()
+		foo.RegisterCustomConstraint(&sameNameFooConstraint{})
+		foo.Get("/:value<same>", handler)
+
+		bar := New()
+		bar.RegisterCustomConstraint(&sameNameBarConstraint{})
+		bar.Get("/:value<same>", handler)
+
+		subApp := New()
+		subApp.Use("/foo", foo)
+		subApp.Use("/bar", bar)
+
+		return subApp
+	}
+
+	plain := New()
+	plain.Use("/sub", build())
+
+	domain := New()
+	domain.Domain("api.example.com").Use("/sub", build())
+
+	want := map[string]int{
+		"/sub/foo/foo": StatusOK,
+		"/sub/foo/bar": StatusNotFound,
+		"/sub/bar/bar": StatusOK,
+		"/sub/bar/foo": StatusNotFound,
+	}
+
+	for path, status := range want {
+		resp, err := plain.Test(httptest.NewRequest(MethodGet, path, http.NoBody))
+		require.NoError(t, err)
+		require.Equal(t, status, resp.StatusCode, "plain "+path)
+
+		req := httptest.NewRequest(MethodGet, path, http.NoBody)
+		req.Host = "api.example.com"
+		resp, err = domain.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, status, resp.StatusCode, "domain "+path)
+	}
+}
+
 // Test_App_Mount_PreservesNestedCustomConstraint verifies that a custom
 // constraint registered on an app reached through two mounts still validates.
 // Expanding a mount re-parses the routes against the app above, so the

--- a/mount_test.go
+++ b/mount_test.go
@@ -803,3 +803,35 @@ func Test_App_Mount_CarriesDomainMount(t *testing.T) {
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, StatusNotFound, resp.StatusCode, "Status code")
 }
+
+// Test_App_Mount_AutoHeadKeepsMiddleware verifies that a mounted app which does
+// not serve HEAD gets no synthesized HEAD routes once its routes are expanded
+// into the parent — they would run without the middleware it registered.
+func Test_App_Mount_AutoHeadKeepsMiddleware(t *testing.T) {
+	t.Parallel()
+
+	micro := New(Config{RequestMethods: []string{MethodGet, MethodPost}})
+	micro.Use(func(c Ctx) error {
+		return c.SendStatus(StatusUnauthorized)
+	})
+	micro.Get("/doe", func(c Ctx) error {
+		c.Set("X-Secret", "leaked")
+		return c.SendString("doe")
+	})
+
+	app := New()
+	app.Use("/john", micro)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/john/doe", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusUnauthorized, resp.StatusCode, "Status code")
+
+	// Twice: app.Test runs the startup process on every call, and the second
+	// pass sees the mount already expanded into the parent's stack.
+	for range 2 {
+		resp, err = app.Test(httptest.NewRequest(MethodHead, "/john/doe", http.NoBody))
+		require.NoError(t, err, "app.Test(req)")
+		require.Equal(t, StatusMethodNotAllowed, resp.StatusCode, "Status code")
+		require.Empty(t, resp.Header.Get("X-Secret"))
+	}
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -767,3 +767,39 @@ func Test_App_Mount_PreservesNestedCustomConstraint(t *testing.T) {
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, StatusNotFound, resp.StatusCode, "Status code")
 }
+
+// Test_App_Mount_CarriesDomainMount verifies that mounting an app which has a
+// domain mount of its own carries that mount's config along, host check
+// included.
+func Test_App_Mount_CarriesDomainMount(t *testing.T) {
+	t.Parallel()
+
+	micro := New(Config{
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(596).SendString("micro error")
+		},
+	})
+	micro.Get("/doe", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	sub := New()
+	sub.Domain("api.example.com").Use("/v1", micro)
+
+	app := New()
+	app.Use("/john", sub)
+
+	req := httptest.NewRequest(MethodGet, "/john/v1/doe", http.NoBody)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, 596, resp.StatusCode, "Status code")
+
+	// The route does not match on another host, and the sub-app's error
+	// handler must not answer for it either.
+	req = httptest.NewRequest(MethodGet, "/john/v1/doe", http.NoBody)
+	req.Host = "www.example.com"
+	resp, err = app.Test(req)
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusNotFound, resp.StatusCode, "Status code")
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -861,3 +861,118 @@ func Test_App_Mount_RootMountKeepsParentAutoHead(t *testing.T) {
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, StatusMethodNotAllowed, resp.StatusCode, "the mounted app serves no HEAD")
 }
+
+// Test_App_Mount_ParametricPrefix verifies that a mount prefix carrying a
+// parameter is matched as a pattern. The prefix rewrites every route of the
+// mounted app, so the parameters it introduces have to be rebuilt onto them.
+func Test_App_Mount_ParametricPrefix(t *testing.T) {
+	t.Parallel()
+
+	micro := New()
+	micro.Get("/doe", func(c Ctx) error {
+		return c.SendString("version=" + c.Params("Version"))
+	})
+
+	app := New()
+	app.Use("/v1/:Version", micro)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/v1/42/doe", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "version=42", string(body))
+}
+
+// Test_App_Mount_ParametricPrefixNested verifies the same when the prefix is
+// applied a second time, by an outer mount.
+func Test_App_Mount_ParametricPrefixNested(t *testing.T) {
+	t.Parallel()
+
+	micro := New()
+	micro.Get("/doe", func(c Ctx) error {
+		return c.SendString("version=" + c.Params("version"))
+	})
+
+	sub := New()
+	sub.Use("/v1/:version", micro)
+
+	app := New()
+	app.Use("/john", sub)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/john/v1/42/doe", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "version=42", string(body))
+}
+
+// Test_App_Mount_CaseInsensitivePath verifies that a mount path is matched by
+// the app's own routing rules when its config is resolved: a case-insensitive
+// app serves "/api/doe" from a mount registered as "/API", so the mounted app's
+// error handler has to answer for it too.
+func Test_App_Mount_CaseInsensitivePath(t *testing.T) {
+	t.Parallel()
+
+	micro := New(Config{
+		ErrorHandler: func(c Ctx, _ error) error {
+			return c.Status(599).SendString("micro error")
+		},
+	})
+	micro.Get("/doe", func(_ Ctx) error {
+		return errors.New("boom")
+	})
+
+	app := New()
+	app.Use("/API", micro)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/api/doe", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, 599, resp.StatusCode, "Status code")
+
+	// A case-sensitive app keeps the two apart.
+	strict := New(Config{CaseSensitive: true})
+	strict.Use("/API", micro)
+
+	resp, err = strict.Test(httptest.NewRequest(MethodGet, "/API/doe", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, 599, resp.StatusCode, "Status code")
+
+	resp, err = strict.Test(httptest.NewRequest(MethodGet, "/api/doe", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusNotFound, resp.StatusCode, "Status code")
+}
+
+// Test_App_Mount_ViewsPathOnly verifies that a mounted app's views are chosen
+// by the request path, not by its mount path appearing anywhere in the URL.
+func Test_App_Mount_ViewsPathOnly(t *testing.T) {
+	t.Parallel()
+
+	subEngine := &testTemplateEngine{path: "testdata2"}
+	require.NoError(t, subEngine.Load())
+
+	parentEngine := &testTemplateEngine{}
+	require.NoError(t, parentEngine.Load())
+
+	micro := New(Config{Views: subEngine})
+	micro.Get("/view", func(c Ctx) error {
+		return c.Render("bruh.tmpl", Map{})
+	})
+
+	app := New(Config{Views: parentEngine})
+	app.Use("/john", micro)
+	app.Get("/elsewhere", func(c Ctx) error {
+		return c.Render("index.tmpl", Map{"Title": "parent"})
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/elsewhere?next=/john/view", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "<h1>parent</h1>", string(body))
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -835,3 +835,29 @@ func Test_App_Mount_AutoHeadKeepsMiddleware(t *testing.T) {
 		require.Empty(t, resp.Header.Get("X-Secret"))
 	}
 }
+
+// Test_App_Mount_RootMountKeepsParentAutoHead verifies that a mounted app which
+// does not serve HEAD only withholds automatic HEAD routes from its own routes.
+// A mount at "/" covers every path, and the app above keeps its own.
+func Test_App_Mount_RootMountKeepsParentAutoHead(t *testing.T) {
+	t.Parallel()
+
+	micro := New(Config{RequestMethods: []string{MethodGet, MethodPost}})
+	micro.Get("/doe", func(c Ctx) error {
+		return c.SendString("doe")
+	})
+
+	app := New()
+	app.Get("/own", func(c Ctx) error {
+		return c.SendString("own")
+	})
+	app.Use("/", micro)
+
+	resp, err := app.Test(httptest.NewRequest(MethodHead, "/own", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusOK, resp.StatusCode, "the app's own route keeps its HEAD route")
+
+	resp, err = app.Test(httptest.NewRequest(MethodHead, "/doe", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusMethodNotAllowed, resp.StatusCode, "the mounted app serves no HEAD")
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -976,3 +976,27 @@ func Test_App_Mount_ViewsPathOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "<h1>parent</h1>", string(body))
 }
+
+// Test_App_Mount_ParametricPrefixConstraint verifies that a constraint named in
+// a mount prefix is enforced. The prefix belongs to the app doing the mounting,
+// so its constraints have to reach the re-parse of the mounted routes.
+func Test_App_Mount_ParametricPrefixConstraint(t *testing.T) {
+	t.Parallel()
+
+	micro := New()
+	micro.Get("/doe", func(c Ctx) error {
+		return c.SendString("name=" + c.Params("name"))
+	})
+
+	app := New()
+	app.RegisterCustomConstraint(&onlyFooConstraint{})
+	app.Use("/:name<onlyfoo>", micro)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/foo/doe", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
+
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/bar/doe", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusNotFound, resp.StatusCode, "the prefix constraint still rejects")
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -725,3 +725,45 @@ func Test_App_Mount_ReorderedRequestMethods(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "post doe", string(body))
 }
+
+// onlyFooConstraint and onlyBarConstraint are custom constraints used to check
+// that a mounted app's constraints survive the mount's route expansion.
+type onlyFooConstraint struct{}
+
+func (*onlyFooConstraint) Name() string { return "onlyfoo" }
+
+func (*onlyFooConstraint) Execute(param string, _ ...string) bool { return param == "foo" }
+
+type onlyBarConstraint struct{}
+
+func (*onlyBarConstraint) Name() string { return "onlybar" }
+
+func (*onlyBarConstraint) Execute(param string, _ ...string) bool { return param == "bar" }
+
+// Test_App_Mount_PreservesNestedCustomConstraint verifies that a custom
+// constraint registered on an app reached through two mounts still validates.
+// Expanding a mount re-parses the routes against the app above, so the
+// constraint has to travel with them or it silently stops rejecting anything.
+func Test_App_Mount_PreservesNestedCustomConstraint(t *testing.T) {
+	t.Parallel()
+
+	micro := New()
+	micro.RegisterCustomConstraint(&onlyFooConstraint{})
+	micro.Get("/doe/:name<onlyfoo>", func(c Ctx) error {
+		return c.SendString(c.Params("name"))
+	})
+
+	sub := New()
+	sub.Use("/v1", micro)
+
+	app := New()
+	app.Use("/john", sub)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/john/v1/doe/foo", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusOK, resp.StatusCode, "Status code")
+
+	resp, err = app.Test(httptest.NewRequest(MethodGet, "/john/v1/doe/bar", http.NoBody))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, StatusNotFound, resp.StatusCode, "Status code")
+}

--- a/res.go
+++ b/res.go
@@ -901,7 +901,37 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 
 	rootApp := r.c.app
 	var rendered bool
+
+	// A sub-app mounted on a domain is checked first: its views only apply to
+	// a matching host, so it cannot be found by the path scan below, and having
+	// matched the host makes it the more specific of two mounts at one path.
+	if viewsApp := rootApp.domainMountedViews(r.c); viewsApp != nil {
+		if len(layouts) == 0 && viewsApp.config.ViewsLayout != "" {
+			layouts = []string{viewsApp.config.ViewsLayout}
+		}
+
+		if err := func() error {
+			viewsLock := getViewsLock(viewsApp.config.Views)
+			viewsLock.RLock()
+			defer viewsLock.RUnlock()
+
+			if err := viewsApp.config.Views.Render(buf, name, bind, layouts...); err != nil {
+				return fmt.Errorf("failed to render: %w", err)
+			}
+
+			return nil
+		}(); err != nil {
+			return err
+		}
+
+		rendered = true
+	}
+
 	for _, prefix := range slices.Backward(rootApp.mountFields.appListKeys) {
+		if rendered {
+			break
+		}
+
 		app := rootApp.mountFields.appList[prefix]
 		if prefix == "" || strings.Contains(r.c.OriginalURL(), prefix) {
 			if len(layouts) == 0 && app.config.ViewsLayout != "" {

--- a/res.go
+++ b/res.go
@@ -923,12 +923,11 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 				break
 			}
 
-			// With no engine of its own the search goes on above the owner,
-			// as it does for an ordinary mount — but not through a mount as
-			// deep as the owner, which is a sibling that did not serve the
-			// request and whose engine is not the owner's to borrow. One the
-			// owner sits inside is not beside it, however deep it is.
-			if domain.ties(mountDepth(prefix)) && !slices.Contains(domain.ancestors, app) {
+			// With no engine of its own the search goes on above the owner, as
+			// it does for an ordinary mount — but not through a mount the
+			// owner supersedes, which did not serve the request and whose
+			// engine is not the owner's to borrow.
+			if domain.supersedes(mountDepth(prefix), app) {
 				continue
 			}
 		}

--- a/res.go
+++ b/res.go
@@ -902,37 +902,17 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 	rootApp := r.c.app
 	var rendered bool
 
-	// A sub-app mounted on a domain is checked first: its views only apply to
-	// a matching host, so it cannot be found by the path scan below, and having
-	// matched the host makes it the more specific of two mounts at one path.
-	if viewsApp := rootApp.domainMountedViews(r.c); viewsApp != nil {
-		if len(layouts) == 0 && viewsApp.config.ViewsLayout != "" {
-			layouts = []string{viewsApp.config.ViewsLayout}
-		}
-
-		if err := func() error {
-			viewsLock := getViewsLock(viewsApp.config.Views)
-			viewsLock.RLock()
-			defer viewsLock.RUnlock()
-
-			if err := viewsApp.config.Views.Render(buf, name, bind, layouts...); err != nil {
-				return fmt.Errorf("failed to render: %w", err)
-			}
-
-			return nil
-		}(); err != nil {
-			return err
-		}
-
-		rendered = true
-	}
+	// A sub-app mounted on a domain only applies to a matching host, so the
+	// path scan below cannot find it. Rank it against the plain mounts by how
+	// deep its mount path is, so neither borrows the other's engine; a tie
+	// goes to the domain mount, which matched the host as well.
+	domainApp, domainDepth := rootApp.domainMountedViews(r.c)
 
 	for _, prefix := range slices.Backward(rootApp.mountFields.appListKeys) {
-		if rendered {
+		app := rootApp.mountFields.appList[prefix]
+		if domainApp != nil && app.config.Views != nil && mountDepth(prefix) <= domainDepth {
 			break
 		}
-
-		app := rootApp.mountFields.appList[prefix]
 		if prefix == "" || rootApp.mountCoversPath(prefix, r.c.Path()) {
 			if len(layouts) == 0 && app.config.ViewsLayout != "" {
 				layouts = []string{
@@ -960,6 +940,28 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 				break
 			}
 		}
+	}
+
+	if !rendered && domainApp != nil {
+		if len(layouts) == 0 && domainApp.config.ViewsLayout != "" {
+			layouts = []string{domainApp.config.ViewsLayout}
+		}
+
+		if err := func() error {
+			viewsLock := getViewsLock(domainApp.config.Views)
+			viewsLock.RLock()
+			defer viewsLock.RUnlock()
+
+			if err := domainApp.config.Views.Render(buf, name, bind, layouts...); err != nil {
+				return fmt.Errorf("failed to render: %w", err)
+			}
+
+			return nil
+		}(); err != nil {
+			return err
+		}
+
+		rendered = true
 	}
 
 	if !rendered {

--- a/res.go
+++ b/res.go
@@ -906,11 +906,11 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 	// path scan below cannot find it. Rank it against the plain mounts by how
 	// deep its mount path is, so neither borrows the other's engine; a tie
 	// goes to the domain mount, which matched the host as well.
-	domainApp, domainDepth := rootApp.domainMountedViews(r.c)
+	domain := rootApp.domainMountedViews(r.c)
 
 	for _, prefix := range slices.Backward(rootApp.mountFields.appListKeys) {
 		app := rootApp.mountFields.appList[prefix]
-		if domainApp != nil && app.config.Views != nil && mountDepth(prefix) <= domainDepth {
+		if app.config.Views != nil && domain.outranks(mountDepth(prefix)) {
 			break
 		}
 		if prefix == "" || rootApp.mountCoversPath(prefix, r.c.Path()) {
@@ -942,17 +942,17 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 		}
 	}
 
-	if !rendered && domainApp != nil {
-		if len(layouts) == 0 && domainApp.config.ViewsLayout != "" {
-			layouts = []string{domainApp.config.ViewsLayout}
+	if !rendered && domain.app != nil {
+		if len(layouts) == 0 && domain.app.config.ViewsLayout != "" {
+			layouts = []string{domain.app.config.ViewsLayout}
 		}
 
 		if err := func() error {
-			viewsLock := getViewsLock(domainApp.config.Views)
+			viewsLock := getViewsLock(domain.app.config.Views)
 			viewsLock.RLock()
 			defer viewsLock.RUnlock()
 
-			if err := domainApp.config.Views.Render(buf, name, bind, layouts...); err != nil {
+			if err := domain.app.config.Views.Render(buf, name, bind, layouts...); err != nil {
 				return fmt.Errorf("failed to render: %w", err)
 			}
 

--- a/res.go
+++ b/res.go
@@ -907,6 +907,8 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 	// deep its mount path is, so neither borrows the other's engine; a tie
 	// goes to the domain mount, which matched the host as well.
 	domain := rootApp.domainMountOwner(r.c)
+	domainViews := rootApp.domainMountConfig(r.c, domain, appHasViews)
+	domainLayout := rootApp.domainMountConfig(r.c, domain, appHasViewsLayout)
 
 	for _, prefix := range slices.Backward(rootApp.mountFields.appListKeys) {
 		app := rootApp.mountFields.appList[prefix]
@@ -914,11 +916,11 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 			// The layout applies whether or not the owner brought an engine:
 			// a mount configuring only a layout renders through the engine
 			// above it, exactly as an ordinary one does.
-			if len(layouts) == 0 && domain.app.config.ViewsLayout != "" {
-				layouts = []string{domain.app.config.ViewsLayout}
+			if len(layouts) == 0 && domainLayout != nil {
+				layouts = []string{domainLayout.config.ViewsLayout}
 			}
 
-			if domain.hasViews() {
+			if domainViews != nil {
 				break
 			}
 
@@ -961,13 +963,13 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 
 	// The layout is already settled: the scan above visits the root mount at
 	// worst, which every owner outranks, and applies the owner's layout there.
-	if !rendered && domain.hasViews() {
+	if !rendered && domainViews != nil {
 		if err := func() error {
-			viewsLock := getViewsLock(domain.app.config.Views)
+			viewsLock := getViewsLock(domainViews.config.Views)
 			viewsLock.RLock()
 			defer viewsLock.RUnlock()
 
-			if err := domain.app.config.Views.Render(buf, name, bind, layouts...); err != nil {
+			if err := domainViews.config.Views.Render(buf, name, bind, layouts...); err != nil {
 				return fmt.Errorf("failed to render: %w", err)
 			}
 

--- a/res.go
+++ b/res.go
@@ -907,8 +907,8 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 	// deep its mount path is, so neither borrows the other's engine; a tie
 	// goes to the domain mount, which matched the host as well.
 	domain := rootApp.domainMountOwner(r.c)
-	domainViews := rootApp.domainMountConfig(r.c, domain, appHasViews)
-	domainLayout := rootApp.domainMountConfig(r.c, domain, appHasViewsLayout)
+	domainViews := domainMountConfig(domain, appHasViews)
+	domainLayout := domainMountConfig(domain, appHasViewsLayout)
 
 	for _, prefix := range slices.Backward(rootApp.mountFields.appListKeys) {
 		app := rootApp.mountFields.appList[prefix]

--- a/res.go
+++ b/res.go
@@ -933,7 +933,7 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 		}
 
 		app := rootApp.mountFields.appList[prefix]
-		if prefix == "" || strings.Contains(r.c.OriginalURL(), prefix) {
+		if prefix == "" || rootApp.mountCoversPath(prefix, r.c.Path()) {
 			if len(layouts) == 0 && app.config.ViewsLayout != "" {
 				layouts = []string{
 					app.config.ViewsLayout,

--- a/res.go
+++ b/res.go
@@ -906,12 +906,21 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 	// path scan below cannot find it. Rank it against the plain mounts by how
 	// deep its mount path is, so neither borrows the other's engine; a tie
 	// goes to the domain mount, which matched the host as well.
-	domain := rootApp.domainMountedViews(r.c)
+	domain := rootApp.domainMountOwner(r.c)
 
 	for _, prefix := range slices.Backward(rootApp.mountFields.appListKeys) {
 		app := rootApp.mountFields.appList[prefix]
-		if app.config.Views != nil && domain.outranks(mountDepth(prefix)) {
-			break
+		if domain.outranks(mountDepth(prefix)) {
+			// The layout applies whether or not the owner brought an engine:
+			// a mount configuring only a layout renders through the engine
+			// above it, exactly as an ordinary one does.
+			if len(layouts) == 0 && domain.app.config.ViewsLayout != "" {
+				layouts = []string{domain.app.config.ViewsLayout}
+			}
+
+			if app.config.Views != nil && domain.hasViews() {
+				break
+			}
 		}
 		if prefix == "" || rootApp.mountCoversPath(prefix, r.c.Path()) {
 			if len(layouts) == 0 && app.config.ViewsLayout != "" {
@@ -942,7 +951,7 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 		}
 	}
 
-	if !rendered && domain.app != nil {
+	if !rendered && domain.hasViews() {
 		if len(layouts) == 0 && domain.app.config.ViewsLayout != "" {
 			layouts = []string{domain.app.config.ViewsLayout}
 		}

--- a/res.go
+++ b/res.go
@@ -918,8 +918,16 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 				layouts = []string{domain.app.config.ViewsLayout}
 			}
 
-			if app.config.Views != nil && domain.hasViews() {
+			if domain.hasViews() {
 				break
+			}
+
+			// With no engine of its own the search goes on above the owner,
+			// as it does for an ordinary mount — but not through a mount as
+			// deep as the owner, which is a sibling that did not serve the
+			// request and whose engine is not the owner's to borrow.
+			if domain.ties(mountDepth(prefix)) {
+				continue
 			}
 		}
 		if prefix == "" || rootApp.mountCoversPath(prefix, r.c.Path()) {

--- a/res.go
+++ b/res.go
@@ -926,8 +926,9 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 			// With no engine of its own the search goes on above the owner,
 			// as it does for an ordinary mount — but not through a mount as
 			// deep as the owner, which is a sibling that did not serve the
-			// request and whose engine is not the owner's to borrow.
-			if domain.ties(mountDepth(prefix)) {
+			// request and whose engine is not the owner's to borrow. One the
+			// owner sits inside is not beside it, however deep it is.
+			if domain.ties(mountDepth(prefix)) && !slices.Contains(domain.ancestors, app) {
 				continue
 			}
 		}

--- a/res.go
+++ b/res.go
@@ -907,8 +907,7 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 	// deep its mount path is, so neither borrows the other's engine; a tie
 	// goes to the domain mount, which matched the host as well.
 	domain := rootApp.domainMountOwner(r.c)
-	domainViews := domainMountConfig(domain, appHasViews)
-	domainLayout := domainMountConfig(domain, appHasViewsLayout)
+	domainViews, domainLayout := domainMountRender(domain)
 
 	for _, prefix := range slices.Backward(rootApp.mountFields.appListKeys) {
 		app := rootApp.mountFields.appList[prefix]
@@ -916,8 +915,8 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 			// The layout applies whether or not the owner brought an engine:
 			// a mount configuring only a layout renders through the engine
 			// above it, exactly as an ordinary one does.
-			if len(layouts) == 0 && domainLayout != nil {
-				layouts = []string{domainLayout.config.ViewsLayout}
+			if len(layouts) == 0 && domainLayout != "" {
+				layouts = []string{domainLayout}
 			}
 
 			if domainViews != nil {

--- a/res.go
+++ b/res.go
@@ -951,11 +951,9 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 		}
 	}
 
+	// The layout is already settled: the scan above visits the root mount at
+	// worst, which every owner outranks, and applies the owner's layout there.
 	if !rendered && domain.hasViews() {
-		if len(layouts) == 0 && domain.app.config.ViewsLayout != "" {
-			layouts = []string{domain.app.config.ViewsLayout}
-		}
-
 		if err := func() error {
 			viewsLock := getViewsLock(domain.app.config.Views)
 			viewsLock.RLock()

--- a/router.go
+++ b/router.go
@@ -1170,6 +1170,11 @@ func (app *App) ensureAutoHeadRoutesLocked() {
 		headRoute.group = route.group
 		headRoute.Method = MethodHead
 		headRoute.autoHead = true
+		// The synthesized route belongs to whichever app the GET route came
+		// from, so a HEAD request resolves the same config a GET one does.
+		if owner := app.routeOwner(route); owner != nil {
+			app.markRouteOwner(headRoute, owner)
+		}
 		// Fasthttp automatically omits response bodies when transmitting
 		// HEAD responses, so the copied GET handler stack can execute
 		// unchanged while still producing an empty body on the wire.

--- a/router.go
+++ b/router.go
@@ -1193,10 +1193,12 @@ func (app *App) ensureAutoHeadRoutesLocked() {
 		headRoute.Method = MethodHead
 		headRoute.autoHead = true
 		// The synthesized route belongs to whichever app the GET route came
-		// from, so a HEAD request resolves the same config a GET one does.
+		// from, so a HEAD request resolves the same config a GET one does, and
+		// an app re-parsing it later holds it to the same constraints.
 		if owner := app.routeOwner(route); owner != nil {
 			app.markRouteOwner(headRoute, owner)
 		}
+		app.markRouteConstraints(headRoute, app.mountFields.routeConstraints[route])
 		// Fasthttp automatically omits response bodies when transmitting
 		// HEAD responses, so the copied GET handler stack can execute
 		// unchanged while still producing an empty body on the wire.

--- a/router.go
+++ b/router.go
@@ -1129,6 +1129,28 @@ func (app *App) ensureAutoHeadRoutes() {
 	app.ensureAutoHeadRoutesLocked()
 }
 
+// autoHeadKey identifies the route an automatic HEAD companion would collide
+// with.
+type autoHeadKey struct {
+	// owner is set only where routes are host-scoped, and is what keeps the
+	// HEAD route of one mounted app from standing in for another app's GET
+	owner *App
+	path  string
+}
+
+// autoHeadKey returns the key route is deduplicated under. Where an app's
+// routes are host-scoped — the wrapper a domain mount builds — a HEAD route
+// only covers the GET routes of the same mounted app: on a hostname that app's
+// pattern rejects it declines, leaving a GET route of another one there without
+// a companion to answer for it.
+func (app *App) autoHeadKey(route *Route) autoHeadKey {
+	if !app.mountFields.hostScopedRoutes {
+		return autoHeadKey{path: route.path}
+	}
+
+	return autoHeadKey{owner: app.routeOwner(route), path: route.path}
+}
+
 func (app *App) ensureAutoHeadRoutesLocked() {
 	if app.config.DisableHeadAutoRegister {
 		return
@@ -1141,12 +1163,12 @@ func (app *App) ensureAutoHeadRoutesLocked() {
 	}
 
 	headStack := app.stack[headIndex]
-	existing := make(map[string]struct{}, len(headStack))
+	existing := make(map[autoHeadKey]struct{}, len(headStack))
 	for _, route := range headStack {
 		if route.mount || route.use {
 			continue
 		}
-		existing[route.path] = struct{}{}
+		existing[app.autoHeadKey(route)] = struct{}{}
 	}
 
 	if len(app.stack[getIndex]) == 0 {
@@ -1159,7 +1181,7 @@ func (app *App) ensureAutoHeadRoutesLocked() {
 		if route.mount || route.use {
 			continue
 		}
-		if _, ok := existing[route.path]; ok {
+		if _, ok := existing[app.autoHeadKey(route)]; ok {
 			continue
 		}
 		if app.skipsAutoHeadFor(route) {
@@ -1180,7 +1202,7 @@ func (app *App) ensureAutoHeadRoutesLocked() {
 		// unchanged while still producing an empty body on the wire.
 
 		headStack = append(headStack, headRoute)
-		existing[route.path] = struct{}{}
+		existing[app.autoHeadKey(route)] = struct{}{}
 		app.hasRoutesRefreshed = true
 		added = true
 

--- a/router.go
+++ b/router.go
@@ -1162,7 +1162,7 @@ func (app *App) ensureAutoHeadRoutesLocked() {
 		if _, ok := existing[route.path]; ok {
 			continue
 		}
-		if app.mountSkipsAutoHead(route.path) {
+		if app.skipsAutoHeadFor(route) {
 			continue
 		}
 

--- a/router.go
+++ b/router.go
@@ -825,7 +825,7 @@ func (app *App) customRequestHandler(rctx *fasthttp.RequestCtx) {
 	}
 }
 
-func (app *App) addPrefixToRoute(prefix string, route *Route, regexHandler any, customConstraints ...CustomConstraint) *Route {
+func (app *App) addPrefixToRoute(prefix string, route *Route, regexHandler any, customConstraints ...CustomConstraint) {
 	prefixedPath := getGroupPath(prefix, route.Path)
 	prettyPath := prefixedPath
 	// Case-sensitive routing, all to lowercase
@@ -847,8 +847,6 @@ func (app *App) addPrefixToRoute(prefix string, route *Route, regexHandler any, 
 	// path and parser a filter is derived from, so refresh it here too rather
 	// than depend on a caller marking the routes refreshed.
 	route.buildPrefixFilter()
-
-	return route
 }
 
 func (*App) copyRoute(route *Route) *Route {

--- a/router.go
+++ b/router.go
@@ -849,6 +849,16 @@ func (app *App) addPrefixToRoute(prefix string, route *Route, regexHandler any, 
 	route.buildPrefixFilter()
 }
 
+// copyRoute clones a route, deliberately leaving group behind: a clone belongs
+// to whichever app it is being placed in, and Name() would otherwise prefix it
+// with the group name of the app it came from. Callers that do want the group —
+// ensureAutoHeadRoutesLocked, which copies a route in place — assign it back.
+//
+// The omission is load-bearing for a mount placeholder, whose target app lives
+// in group.app: carrying it over would let a clone of the placeholder expand
+// the mounted app's handlers verbatim, which for a domain mount means serving
+// them on every host. domainRouter.cloneRoutesForDomain expands the mount
+// instead, so no placeholder is ever cloned.
 func (*App) copyRoute(route *Route) *Route {
 	return &Route{
 		// Leading-byte filter

--- a/router.go
+++ b/router.go
@@ -840,6 +840,17 @@ func (app *App) addPrefixToRoute(prefix string, route *Route, regexHandler any, 
 	route.Path = prefixedPath
 	route.path = RemoveEscapeChar(prettyPath)
 	route.routeParser = parseRoute(prettyPath, regexHandler, customConstraints...)
+	// A prefix can introduce parameters of its own — a sub-app mounted at
+	// "/v1/:version" is prefixing every one of its routes with one. Params
+	// decides whether the router matches a route by pattern or by string
+	// equality, so it has to be rebuilt along with the parser or the route
+	// stops matching entirely. Read from the unprettified path, as register
+	// does, so parameter names keep the case they were registered with.
+	if prettyPath == prefixedPath {
+		route.Params = route.routeParser.params
+	} else {
+		route.Params = parseRoute(prefixedPath, regexHandler, customConstraints...).params
+	}
 	route.root = false
 	route.star = false
 	route.caseSensitive = app.config.CaseSensitive

--- a/router.go
+++ b/router.go
@@ -1151,6 +1151,9 @@ func (app *App) ensureAutoHeadRoutesLocked() {
 		if _, ok := existing[route.path]; ok {
 			continue
 		}
+		if app.mountSkipsAutoHead(route.path) {
+			continue
+		}
 
 		headRoute := app.copyRoute(route)
 		headRoute.group = route.group


### PR DESCRIPTION
# Description

Mounting a sub-app on a domain router panicked on the first request when that sub-app itself mounted another app:

```go
app.Domain("api.example").Use("/api", sub)   // where sub.Use("/v1", child)
```

`domainRouter.mount` clones the sub-app's routes into a wrapper app so the original is left alone. `copyRoute` does not carry the unexported `group` field over, and a **mount placeholder** keeps its target app in `route.group.app` — so the cloned placeholder reached startup with `mount` set and `group` nil, and `processSubAppsRoutes` dereferenced it. The panic surfaces from `startupProcess`, i.e. on the first request or `Listen`, not at registration.

The clone is now recursive: an app the sub-app has mounted is expanded in its placeholder's position, so no placeholder survives into the wrapper and the nested handlers go through `wrapHandlers` like the rest. Restoring `group` alone would have expanded those handlers verbatim and served them on every host — trading the panic for a host-filtering hole — so the two halves belong together.

Fixes #4618

## How this grew

The panic itself is `5e31ca3`, and it is small. Everything else came out of review rounds — CodeRabbit and Codex between them raised findings on almost every commit, and each one that reproduced got its own fix and its own test. Every test added here was run against the unfixed code first to confirm it fails there.

Two things are worth a reviewer's attention up front:

**The work splits cleanly in two.** The panic fix and the mount-expansion fixes have been quiet since `b088e52`. The host-scoped `ErrorHandler`/`Views` feature (`28891f4`) has drawn a finding in every round since, and accounts for most of the diff and nearly all of the churn. If you would rather ship #4618 on its own, reverting `28891f4` and its follow-ups leaves the panic fixed and the branch much smaller. Say the word and I will do the split; the feature can come back as its own PR where a behaviour change to config resolution gets the attention it deserves.

**Fixing it well meant recording provenance rather than inferring it.** Three separate classes of bug here came from guessing which app a request belongs to from its host and path. Routes now carry the app they were cloned from, the constraints they were parsed with, and whether their mount registers automatic HEAD routes; mount records carry the apps they are registered inside and the patterns that reach them. Each time an inference was replaced with a recorded fact, a whole class of finding closed rather than one instance of it.

## What changed

**The #4618 panic** — `5e31ca3`. Each app in the mount tree is snapshotted under its own lock and cloned once, mounted apps flattened once and reused across method indexes; no two app locks are ever held at once, and the walk carries the branch it came from so a mount cycle terminates. Route values are copied under the source app's lock (`5212e93`), since registering a route on a path an app already serves appends to that route's handlers in place.

**Expanding a mount by method, not by stack index** — `3b134a6`. `processSubAppsRoutes` read `route.group.app.stack[m]`, where `m` indexes the *parent's* `RequestMethods`. That table is per-app configurable, so the two need not agree: a sub-app serving fewer methods panicked with an index out of range, and one listing the same methods in another order had its routes served under the wrong verb — a GET reaching the POST handler.

**Automatic HEAD routes** — `525c305`, `85b4f43`, `6885aa3`, `49c746c`. Domain-mounted GET routes answered HEAD with 405 where a plain mount answered 200, because the wrapper is deliberately outside the parent's app list and nothing generated them. Generating them then exposed the opposite problem: a sub-app that omits HEAD from `RequestMethods` contributes no HEAD middleware, so a synthesized HEAD route would run its handler with the `Use` gate missing — `HEAD /api/secret` returning 200 where GET returned 401. The opt-out is recorded per route as the routes are cloned, covering the app that opted out and the apps it stands in front of, and nothing else. Deduplication is per mounted app inside a wrapper (`e4a24ea`), where several apps' routes sit side by side under different patterns.

**Custom constraints** — `77e4771`, `2f3e62b`. Expanding a mount re-parses the sub-app's routes against the app they move into, and an app two mounts deep had its constraints dropped: `findConstraintHandler` returns nil for a name it has never seen, the constraint is silently discarded, and the route goes on matching while validating nothing. On `main` that means a value every constraint rejects is accepted. Constraints travel with each route now, per route rather than merged into a shared registry — two apps mounted side by side may name one constraint differently, and neither binds the other.

**Route params and mount-path matching** — `b088e52`. `addPrefixToRoute` rebuilt the path without rebuilding `Params`, and mount paths were compared literally where the router would normalize them.

**Host-scoped config** — `28891f4` and follow-ups. Mounting registered the sub-app in `mountFields.appList`, keyed by path alone: two sub-apps mounted at the same path on different domains displaced each other, and a sub-app's `ErrorHandler` and view engine answered on hosts its own pattern rejects. Domain mounts now live in a list of their own carrying the patterns they were mounted behind. Resolving them took the rest of the rounds: the owner comes from the route that ran, inheritance follows recorded mount ancestry rather than path coverage, a mount is superseded only by one that did not serve the request, and the view engine and layout are resolved in one walk that stops where rendering does.

**Locking** — `b77c2ef`, `3009488`, `5212e93`. Two app locks are never held at once; `ReloadViews` walks the mount tree taking each app's lock in turn; each app's mount path is written under its own lock.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

- [x] Documentation Update: [`docs/api/app.md`](https://github.com/gofiber/fiber/blob/main/docs/api/app.md) — the `Domain` note now covers nested mounts and the host-scoped `ErrorHandler`/`Views` resolution.
- [x] Examples: the reproduction in #4618 now serves `/api/v1/x` on the matching host and 404s elsewhere.
- [ ] Benchmarks: not applicable — the new work is all registration-time. Request-time behaviour is unchanged apart from a hostname check in `ErrorHandler` and `Render`, and only for apps that have domain mounts.
- [ ] Migration Guide: not needed.

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the `/docs/` directory.
- [x] Added or updated unit tests to validate the effectiveness of the changes.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential — none were added.
- [x] Aimed for optimal performance with minimal allocations in the new code.

Full suite, `go test -race`, `golangci-lint` (repo-pinned v2.12.2), `gofumpt` and `go vet` are clean, along with `go test -count=3` on the root package — the repeated CI job caught a bug a single local run had missed, since map iteration order decides which of two paths through the mount tree is recorded. Patch coverage is complete.

## Known limitations, left alone deliberately

All three are pre-existing and reproduce on `main` with ordinary `Use`, with no domain router involved. Fixing any of them changes how `Use` behaves generally, which seemed worth a maintainer's decision rather than a unilateral divergence on the domain path:

- **A nested app's `Config.RegexHandler` is dropped** when its routes are expanded. `processSubAppsRoutes` re-parses a composed path with the *mounted* app's compiler, so the compiler of the app that wrote the prefix is lost at the first level of nesting — `mid` alone, with no parent, already fails to apply its own. Unlike the constraint list it is a single function, and a composed path can carry segments from several apps, so it cannot simply be merged.
- **`App.mount` and `Group.mount` write the mounted app's `mountPath` while holding only the mounting app's lock**, which races a route registration on the mounted app. The domain path was fixed here; the ordinary one is untouched.
- **A cyclic mount graph** (`a.Use("/b", b)` with `b.Use("/a", a)`) hangs at startup in `appendSubAppLists`. The walks added here terminate on such a graph, but that does not make the app servable.

---
_Generated by [Claude Code](https://claude.ai/code/session_017fX7w3sDadh6r9fhuuXR2e)_