### PR TITLE
🩹 Fix: Decode a path parameter exactly once in FromParam

### DIFF
--- a/extractors/extractors.go
+++ b/extractors/extractors.go
@@ -28,6 +28,7 @@ package extractors
 import (
 	"errors"
 	"net/url"
+	"strings"
 	"unsafe"
 
 	"github.com/gofiber/fiber/v3"
@@ -469,6 +470,19 @@ func FromParam(param string) Extractor {
 		value := c.Params(param)
 		if value == "" {
 			return "", ErrNotFound
+		}
+		// Without a percent sign there is nothing to decode, and this is
+		// the common case, so it skips the config read below.
+		if !strings.Contains(value, "%") {
+			return value, nil
+		}
+		// UnescapePath already decoded the path once in the router, so
+		// decoding again here would spend the client's escaping twice: a
+		// literal "%20" sent as "%2520" would arrive as a space. Decode
+		// only when the router left the value raw, which keeps the number
+		// of decodes at one whatever the config says.
+		if c.App().Config().UnescapePath {
+			return value, nil
 		}
 		unescapedValue, err := url.PathUnescape(value)
 		if err != nil {

--- a/extractors/extractors_test.go
+++ b/extractors/extractors_test.go
@@ -1836,3 +1836,39 @@ func Test_Extractor_Chain_ExtractSource(t *testing.T) {
 		require.Equal(t, SourceQuery, src)
 	})
 }
+
+// Test_FromParam_DecodesOnce pins that a parameter is percent-decoded exactly
+// once whatever UnescapePath is set to. With UnescapePath enabled the router
+// already decoded the path, so a second decode here turned "%2520" into a
+// space instead of the "%20" the client sent.
+func Test_FromParam_DecodesOnce(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		unescapePath bool
+	}{
+		{name: "UnescapePath disabled", unescapePath: false},
+		{name: "UnescapePath enabled", unescapePath: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := fiber.New(fiber.Config{UnescapePath: tc.unescapePath})
+			app.Get("/test/:token", func(c fiber.Ctx) error {
+				token, err := FromParam("token").Extract(c)
+				require.NoError(t, err)
+				// The client sent "%2520", which stands for the literal
+				// four-character string "%20".
+				require.Equal(t, "%20", token)
+				return nil
+			})
+
+			resp, err := app.Test(newRequest("/test/%2520"))
+			require.NoError(t, err)
+			require.Equal(t, fiber.StatusOK, resp.StatusCode)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Fix-first item 3 of #4604.

`extractors.FromParam` always ran `url.PathUnescape` on `c.Params()`. With the default `UnescapePath: false` that is the single decode and it is correct. With `UnescapePath: true` the router already decoded the path in `configDependentPaths`, so the value was decoded a second time here — the number of decodes depended on a config flag the extractor never looked at.

Effect: a client sending a literal `%20` (on the wire as `%2520`) reached the extractor as a space.

    UnescapePath: false → "%2520" → router leaves it → FromParam decodes once → "%20"   ✅
    UnescapePath: true  → "%2520" → router decodes → "%20" → FromParam decodes again → " "   ❌

The decode now happens only when the router left the value raw, so the count is exactly one under either setting. A value with no percent sign returns immediately, which skips both the config read and the decode on the common path.

This matters beyond the extractor package: `FromParam` backs the parameter-based token lookups used by middleware such as keyauth and csrf, so under `UnescapePath: true` a token containing a percent-escape was compared in a form the client never sent.

## Changes introduced

- [ ] Benchmarks: no benchmark added; the change removes work on the common path (an early return before the config read) and adds none.
- [ ] Documentation Update: not needed, the documented behavior ("retrieves a value from a URL parameter") is what now actually happens.
- [ ] Changelog/What's New: happy to add an entry if you would like one.
- [ ] Migration Guide: not needed. Only affects apps running `UnescapePath: true` with percent-escaped parameter values, which were receiving over-decoded values.
- [ ] API Alignment with Express: n/a, no public API change.
- [x] API Longevity: no exported surface changed.
- [ ] Examples: n/a.

Test added: `Test_FromParam_DecodesOnce` runs the same request (`/test/%2520`) under both `UnescapePath` settings and requires the same extracted value, `"%20"`. It fails on `main` for the enabled case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Conducted a self-review of the code and provided comments for the reasoning.
- [ ] Documentation update not required for this change.
- [x] Added a unit test that fails before the change and passes after.
- [x] Ensured that new and existing unit tests pass locally (`go test ./... -race -shuffle=on`).
- [x] No new dependencies.
- [x] Aimed for optimal performance: the common case now returns before reading the config.
- [x] `make lint` (golangci-lint v2.12.2) reports 0 issues; `gofumpt -l .` is clean.
