### PR TITLE
🧹 chore: use fasthttp parser for request charset

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -174,14 +174,15 @@ func Test_Ctx_Charset(t *testing.T) {
 			expected:    "",
 		},
 		{
-			name:        "empty_param_before_charset",
+			// VisitHeaderParams stops at the first malformed parameter.
+			name:        "empty_param_stops_before_charset",
 			contentType: "text/plain; ; charset=utf-8",
-			expected:    "utf-8",
+			expected:    "",
 		},
 		{
-			name:        "charset_with_spaces",
+			name:        "spaces_around_equals_stop_parsing",
 			contentType: "text/plain; charset = utf-8",
-			expected:    "utf-8",
+			expected:    "",
 		},
 		{
 			name:        "charset_in_middle",
@@ -240,10 +241,11 @@ func Test_Ctx_Charset(t *testing.T) {
 			expected:    "utf-8",
 		},
 		{
-			// A quoted value with trailing junk is not a valid quoted-string.
+			// VisitHeaderParams emits a complete quoted value before skipping
+			// trailing bytes up to the next parameter.
 			name:        "quoted_value_with_trailing_junk",
 			contentType: `text/plain; charset="utf-8"x`,
-			expected:    "",
+			expected:    "utf-8",
 		},
 		{
 			name:        "unterminated_quoted_value",
@@ -251,11 +253,11 @@ func Test_Ctx_Charset(t *testing.T) {
 			expected:    "",
 		},
 		{
-			// A bare-token value containing a DQUOTE is invalid; the
-			// parameter is skipped so the later well-formed charset wins.
+			// VisitHeaderParams emits the token prefix and the first charset
+			// parameter wins.
 			name:        "bare_value_with_quote_then_valid_charset",
 			contentType: `text/plain; a=b"; charset=bad"; charset=utf-8`,
-			expected:    "utf-8",
+			expected:    "bad",
 		},
 	}
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -174,10 +174,25 @@ func Test_Ctx_Charset(t *testing.T) {
 			expected:    "",
 		},
 		{
-			// VisitHeaderParams stops at the first malformed parameter.
-			name:        "empty_param_stops_before_charset",
+			// RFC 9110 §5.6.6 permits empty parameter elements.
+			name:        "empty_param_before_charset",
 			contentType: "text/plain; ; charset=utf-8",
-			expected:    "",
+			expected:    "utf-8",
+		},
+		{
+			name:        "empty_param_between_params",
+			contentType: "text/plain; foo=bar; ; charset=utf-8",
+			expected:    "utf-8",
+		},
+		{
+			name:        "multiple_empty_params",
+			contentType: "text/plain;;; charset=utf-8",
+			expected:    "utf-8",
+		},
+		{
+			name:        "empty_params_with_tabs",
+			contentType: "text/plain;\t;\t;\tcharset=utf-8",
+			expected:    "utf-8",
 		},
 		{
 			name:        "spaces_around_equals_stop_parsing",
@@ -219,6 +234,11 @@ func Test_Ctx_Charset(t *testing.T) {
 			// a parameter delimiter.
 			name:        "quoted_value_with_semicolon_before_charset",
 			contentType: `text/plain; title="x;charset=bad"; charset=utf-8`,
+			expected:    "utf-8",
+		},
+		{
+			name:        "empty_param_syntax_inside_quoted_value",
+			contentType: `text/plain; title="x; ;y"; charset=utf-8`,
 			expected:    "utf-8",
 		},
 		{
@@ -271,6 +291,20 @@ func Test_Ctx_Charset(t *testing.T) {
 			require.Equal(t, testCase.expected, c.Charset())
 		})
 	}
+}
+
+// go test -run=^$ -bench=Benchmark_Ctx_Charset -benchmem -count=4
+func Benchmark_Ctx_Charset(b *testing.B) {
+	app := New()
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	c.Request().Header.Set(HeaderContentType, "text/plain; charset=utf-8")
+
+	var charset string
+	b.ReportAllocs()
+	for b.Loop() {
+		charset = c.Charset()
+	}
+	require.Equal(b, "utf-8", charset)
 }
 
 // go test -run Test_Ctx_HeaderHelpers

--- a/req.go
+++ b/req.go
@@ -267,19 +267,88 @@ func (c *DefaultCtx) MediaType() string {
 
 // Charset returns the charset parameter from the Content-Type header.
 func (c *DefaultCtx) Charset() string {
-	contentType := c.fasthttp.Request.Header.ContentType()
+	contentType := removeEmptyHeaderParams(c.fasthttp.Request.Header.ContentType())
 	charset := ""
 	fasthttp.VisitHeaderParams(contentType, func(key, value []byte) bool {
 		if !utils.EqualFold(key, []byte("charset")) {
 			return true
 		}
 		value, err := unescapeHeaderValue(value)
-		// VisitHeaderParams doesn't allow callback values to escape.
-		charset = string(value)
-		// A failed unescape leaves charset empty; keep looking for a valid value.
-		return err != nil
+		if err != nil {
+			// Keep looking for a valid charset after an invalid escaped value.
+			return true
+		}
+		charset = c.app.toString(value)
+		return false
 	})
 	return charset
+}
+
+// removeEmptyHeaderParams removes empty parameter elements allowed by RFC 9110
+// Section 5.6.6 because fasthttp treats them as invalid and stops visiting.
+// The usual path returns the original slice without allocating.
+func removeEmptyHeaderParams(header []byte) []byte {
+	firstSemicolon := bytes.IndexByte(header, ';')
+	if firstSemicolon == -1 || bytes.IndexByte(header[firstSemicolon+1:], ';') == -1 {
+		return header
+	}
+
+	var normalized []byte
+	segmentStart := 0
+	inQuotes := false
+	escaped := false
+
+	for i, ch := range header {
+		if i < segmentStart {
+			continue
+		}
+		if inQuotes {
+			switch {
+			case escaped:
+				escaped = false
+			case ch == '\\':
+				escaped = true
+			case ch == '"':
+				inQuotes = false
+			}
+			continue
+		}
+		if ch == '"' {
+			inQuotes = true
+			continue
+		}
+		if ch != ';' {
+			continue
+		}
+
+		next := i + 1
+		for next < len(header) && (header[next] == ' ' || header[next] == '\t') {
+			next++
+		}
+		if next >= len(header) || header[next] != ';' {
+			continue
+		}
+		if normalized == nil {
+			normalized = make([]byte, 0, len(header))
+		}
+		normalized = append(normalized, header[segmentStart:i]...)
+		normalized = append(normalized, ';')
+		segmentStart = next + 1
+		for segmentStart < len(header) {
+			for segmentStart < len(header) && (header[segmentStart] == ' ' || header[segmentStart] == '\t') {
+				segmentStart++
+			}
+			if segmentStart >= len(header) || header[segmentStart] != ';' {
+				break
+			}
+			segmentStart++
+		}
+	}
+
+	if normalized == nil {
+		return header
+	}
+	return append(normalized, header[segmentStart:]...)
 }
 
 // IsJSON reports whether the Content-Type header is JSON.

--- a/req.go
+++ b/req.go
@@ -268,80 +268,20 @@ func (c *DefaultCtx) MediaType() string {
 // Charset returns the charset parameter from the Content-Type header.
 func (c *DefaultCtx) Charset() string {
 	contentType := c.fasthttp.Request.Header.ContentType()
-	_, params, ok := bytes.Cut(contentType, []byte{';'})
-	if !ok {
-		return ""
-	}
-	for len(params) > 0 {
-		// Slice off the next parameter at the next ";" that sits outside a
-		// quoted-string: parameter values may be quoted and contain ";"
-		// (RFC 9110 Section 5.6.6). A DQUOTE only opens a quoted-string at
-		// the start of a value (after an "=" plus optional whitespace), so a
-		// stray quote later in an unquoted value cannot swallow the rest of
-		// the header.
-		param := params
-		end := -1
-		inQuotes := false
-		escaped := false
-		expectValue := false
-	scan:
-		for i := 0; i < len(params); i++ {
-			ch := params[i]
-			switch {
-			case escaped:
-				escaped = false
-			case inQuotes:
-				switch ch {
-				case '\\':
-					escaped = true
-				case '"':
-					inQuotes = false
-				}
-			case ch == '=':
-				expectValue = true
-			case ch == '"' && expectValue:
-				inQuotes = true
-				expectValue = false
-			case ch == ';':
-				end = i
-				break scan
-			case ch != ' ' && ch != '\t':
-				expectValue = false
-			}
+	charset := ""
+	fasthttp.VisitHeaderParams(contentType, func(key, value []byte) bool {
+		if !utils.EqualFold(key, []byte("charset")) {
+			return true
 		}
-		if end >= 0 {
-			param = params[:end]
-			params = params[end+1:]
-		} else {
-			params = nil
+		value, err := unescapeHeaderValue(value)
+		if err != nil {
+			return false
 		}
-
-		name, value, ok := bytes.Cut(param, []byte{'='})
-		if !ok || !utils.EqualFold(utils.TrimSpace(name), []byte("charset")) {
-			continue
-		}
-		v := utils.TrimSpace(value)
-		if len(v) > 0 && v[0] == '"' {
-			// A quoted value must be a complete quoted-string, and its
-			// quoted-pairs must be replaced with the escaped octet
-			// (RFC 9110 Section 5.6.4).
-			if len(v) < 2 || v[len(v)-1] != '"' {
-				return ""
-			}
-			unescaped, err := unescapeHeaderValue(v[1 : len(v)-1])
-			if err != nil {
-				return ""
-			}
-			v = unescaped
-		} else if bytes.IndexByte(v, '"') >= 0 {
-			// A bare token must not contain DQUOTE; skip the invalid
-			// parameter instead of surfacing garbage, so a well-formed
-			// charset parameter later in the header can still be found.
-			continue
-		}
-		return c.app.toString(v)
-	}
-	return ""
+		// VisitHeaderParams doesn't allow callback values to escape.
+		charset = string(value)
+		return false
+	})
+	return charset
 }
 
 // IsJSON reports whether the Content-Type header is JSON.

--- a/req.go
+++ b/req.go
@@ -274,12 +274,10 @@ func (c *DefaultCtx) Charset() string {
 			return true
 		}
 		value, err := unescapeHeaderValue(value)
-		if err != nil {
-			return false
-		}
 		// VisitHeaderParams doesn't allow callback values to escape.
 		charset = string(value)
-		return false
+		// A failed unescape leaves charset empty; keep looking for a valid value.
+		return err != nil
 	})
 	return charset
 }


### PR DESCRIPTION
## Summary

- replace the hand-written `DefaultCtx.Charset` parameter state machine with `fasthttp.VisitHeaderParams`
- preserve Fiber zero-copy string conversion through `c.app.toString`, while still honoring `Immutable`
- unescape quoted-pairs and continue after invalid escaped charset values
- normalize RFC 9110 Section 5.6.6 empty parameter elements before visiting, without treating `; ; charset=utf-8` as malformed
- avoid false empty-element matches inside quoted strings and cover consecutive elements plus SP/HTAB OWS

The normal path returns the original header slice and performs no normalization allocation. A temporary buffer is created only when an empty parameter element is actually present.

## Behavior

Valid Content-Type values retain their previous Fiber behavior. Empty parameter elements are skipped as RFC 9110 permits. Other malformed parameters continue to follow fasthttp parser behavior, including stopping on whitespace around `=` and exposing a complete quoted value before trailing junk.

## Performance

`Benchmark_Ctx_Charset` on the ordinary `text/plain; charset=utf-8` path:

- reviewed version: approximately 26.2 ns/op, 5 B/op, 1 alloc/op
- current version: 23.3–23.4 ns/op, 0 B/op, 0 alloc/op

## Validation

- focused charset package test passes with race detection
- `go mod verify` and `go vet ./...` pass
- `govulncheck ./...` reports no reachable vulnerabilities with Go 1.25.13
- generation and gofumpt produce no additional changes
- golangci-lint v2.12.2 reports 0 issues
- the repository-wide race run executed 5,185 tests; its only failure is the unrelated TEST-NET proxy assertion because this sandbox routes `192.0.2.1:1`
- the proxy package passes under race detection when that environment-specific assertion is skipped
- betteralign reports only the two existing intentionally ordered routing structs, `routeParser` and `Route`; no branch file has an alignment finding

Related #4605

AI disclosure: OpenAI Codex assisted with implementation, tests, benchmarking, and validation. I reviewed the resulting diff and remain responsible for the contribution.