### PR TITLE
🐛 bug: unify cookie SameSite handling

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1,5 +1,9 @@
 package fiber
 
+import (
+	internalcookie "github.com/gofiber/fiber/v3/internal/cookie"
+)
+
 // HTTP methods were copied from net/http.
 const (
 	MethodGet     = "GET"     // RFC 7231, 4.3.1
@@ -312,10 +316,10 @@ const (
 // Cookie SameSite
 // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7
 const (
-	CookieSameSiteDisabled   = "disabled" // not in RFC, just control "SameSite" attribute will not be set.
-	CookieSameSiteLaxMode    = "Lax"
-	CookieSameSiteStrictMode = "Strict"
-	CookieSameSiteNoneMode   = "None"
+	CookieSameSiteDisabled   = internalcookie.SameSiteDisabled // not in RFC, just control "SameSite" attribute will not be set.
+	CookieSameSiteLaxMode    = internalcookie.SameSiteLax
+	CookieSameSiteStrictMode = internalcookie.SameSiteStrict
+	CookieSameSiteNoneMode   = internalcookie.SameSiteNone
 )
 
 // Route Constraints

--- a/docs/middleware/session.md
+++ b/docs/middleware/session.md
@@ -73,7 +73,9 @@ app.Use(session.New(session.Config{
 Notes:
 
 - AbsoluteTimeout must be greater than or equal to IdleTimeout; otherwise, the middleware panics during configuration.
-- If CookieSameSite is set to "None", the middleware automatically forces CookieSecure=true when setting the cookie.
+- CookieSameSite accepts `"Disabled"`, `"Lax"`, `"Strict"`, or `"None"` case-insensitively; other values panic during configuration.
+- If CookieSameSite is set to `"Disabled"`, the cookie omits the SameSite attribute and preserves `CookieSecure`.
+- If CookieSameSite is set to `"None"`, the middleware automatically forces `CookieSecure=true` when setting the cookie.
 ```
 
 ## Usage Patterns
@@ -719,7 +721,7 @@ extractors.Chain(extractors ...extractors.Extractor) extractors.Extractor
 | `AbsoluteTimeout`   | `time.Duration`             | Maximum session duration    | `0` (unlimited)                            |
 | `CookieSecure`      | `bool`                      | HTTPS only                  | `false`                                    |
 | `CookieHTTPOnly`    | `bool`                      | No JavaScript access        | `false`                                    |
-| `CookieSameSite`    | `string`                    | SameSite attribute          | `"Lax"`                                    |
+| `CookieSameSite`    | `string`                    | SameSite mode: `Disabled`, `Lax`, `Strict`, or `None` | `"Lax"`                    |
 | `CookiePath`        | `string`                    | Cookie path                 | `""`                                       |
 | `CookieDomain`      | `string`                    | Cookie domain               | `""`                                       |
 | `CookieSessionOnly` | `bool`                      | Session cookie              | `false`                                    |

--- a/docs/middleware/session.md
+++ b/docs/middleware/session.md
@@ -69,6 +69,7 @@ app.Use(session.New(session.Config{
     AbsoluteTimeout:   24 * time.Hour,    // Maximum session life
     Extractor:         extractors.FromCookie("__Host-session_id"),
 }))
+```
 
 Notes:
 
@@ -76,7 +77,6 @@ Notes:
 - CookieSameSite accepts `"Disabled"`, `"Lax"`, `"Strict"`, or `"None"` case-insensitively; other values panic during configuration.
 - If CookieSameSite is set to `"Disabled"`, the cookie omits the SameSite attribute and preserves `CookieSecure`.
 - If CookieSameSite is set to `"None"`, the middleware automatically forces `CookieSecure=true` when setting the cookie.
-```
 
 ## Usage Patterns
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -3316,5 +3316,16 @@ app.Use(session.New(session.Config{
 }))
 ```
 
+`CookieSameSite` is now read the same way as it is for `Ctx.Cookie`:
+
+- **`"Disabled"` omits the attribute.** The session used to ignore
+  `CookieSameSiteDisabled` and send `SameSite=Lax`, while `Ctx.Cookie` honored
+  it, so one constant meant two things. A session cookie configured this way now
+  carries no `SameSite` attribute, which is weaker than what was sent before. Set
+  `CookieSameSite: "Lax"` explicitly to keep the old cookie.
+- **Any other value panics** during configuration instead of silently falling
+  back to `Lax`, matching how `AbsoluteTimeout` is already validated. `Disabled`,
+  `Lax`, `Strict` and `None` are accepted case-insensitively.
+
 See the [Session Middleware Migration Guide](./middleware/session.md#migration-guide)
 for complete details.

--- a/internal/cookie/samesite.go
+++ b/internal/cookie/samesite.go
@@ -1,0 +1,58 @@
+// Package cookie centralizes cookie policy shared by Fiber core and middleware.
+package cookie
+
+import (
+	"net/http"
+
+	"github.com/gofiber/utils/v2"
+	"github.com/valyala/fasthttp"
+)
+
+// SameSite mode names accepted by Fiber's cookie APIs.
+const (
+	SameSiteDisabled = "disabled"
+	SameSiteLax      = "Lax"
+	SameSiteStrict   = "Strict"
+	SameSiteNone     = "None"
+)
+
+// SameSite maps one Fiber SameSite mode to the cookie implementations Fiber
+// validates with and writes through.
+type SameSite struct {
+	HTTPMode       http.SameSite
+	FastHTTPMode   fasthttp.CookieSameSite
+	RequiresSecure bool
+}
+
+// ParseSameSite parses value case-insensitively. Unsupported values return the
+// Lax mapping and false, allowing callers to choose fallback or rejection.
+func ParseSameSite(value string) (SameSite, bool) {
+	switch {
+	case utils.EqualFold(value, SameSiteDisabled):
+		return SameSite{
+			HTTPMode:     0,
+			FastHTTPMode: fasthttp.CookieSameSiteDisabled,
+		}, true
+	case utils.EqualFold(value, SameSiteLax):
+		return SameSite{
+			HTTPMode:     http.SameSiteLaxMode,
+			FastHTTPMode: fasthttp.CookieSameSiteLaxMode,
+		}, true
+	case utils.EqualFold(value, SameSiteStrict):
+		return SameSite{
+			HTTPMode:     http.SameSiteStrictMode,
+			FastHTTPMode: fasthttp.CookieSameSiteStrictMode,
+		}, true
+	case utils.EqualFold(value, SameSiteNone):
+		return SameSite{
+			HTTPMode:       http.SameSiteNoneMode,
+			FastHTTPMode:   fasthttp.CookieSameSiteNoneMode,
+			RequiresSecure: true,
+		}, true
+	default:
+		return SameSite{
+			HTTPMode:     http.SameSiteLaxMode,
+			FastHTTPMode: fasthttp.CookieSameSiteLaxMode,
+		}, false
+	}
+}

--- a/internal/cookie/samesite_test.go
+++ b/internal/cookie/samesite_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+// Test_ParseSameSite covers every accepted mode, case-insensitive matching,
+// Secure requirements, and the invalid-to-Lax fallback contract.
 func Test_ParseSameSite(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cookie/samesite_test.go
+++ b/internal/cookie/samesite_test.go
@@ -1,0 +1,77 @@
+package cookie
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+func Test_ParseSameSite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  SameSite
+		valid bool
+	}{
+		{
+			name:  "disabled",
+			value: "DISABLED",
+			want: SameSite{
+				HTTPMode:     0,
+				FastHTTPMode: fasthttp.CookieSameSiteDisabled,
+			},
+			valid: true,
+		},
+		{
+			name:  "lax",
+			value: "lax",
+			want: SameSite{
+				HTTPMode:     http.SameSiteLaxMode,
+				FastHTTPMode: fasthttp.CookieSameSiteLaxMode,
+			},
+			valid: true,
+		},
+		{
+			name:  "strict",
+			value: "STRICT",
+			want: SameSite{
+				HTTPMode:     http.SameSiteStrictMode,
+				FastHTTPMode: fasthttp.CookieSameSiteStrictMode,
+			},
+			valid: true,
+		},
+		{
+			name:  "none",
+			value: "NoNe",
+			want: SameSite{
+				HTTPMode:       http.SameSiteNoneMode,
+				FastHTTPMode:   fasthttp.CookieSameSiteNoneMode,
+				RequiresSecure: true,
+			},
+			valid: true,
+		},
+		{
+			name:  "invalid falls back to lax",
+			value: "invalid",
+			want: SameSite{
+				HTTPMode:     http.SameSiteLaxMode,
+				FastHTTPMode: fasthttp.CookieSameSiteLaxMode,
+			},
+			valid: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, valid := ParseSameSite(test.value)
+			require.Equal(t, test.valid, valid)
+			require.Equal(t, test.want, got)
+		})
+	}
+}

--- a/middleware/session/config.go
+++ b/middleware/session/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/extractors"
+	internalcookie "github.com/gofiber/fiber/v3/internal/cookie"
 	"github.com/gofiber/fiber/v3/log"
 	"github.com/gofiber/utils/v2"
 )
@@ -46,6 +47,7 @@ type Config struct {
 	CookiePath string
 
 	// CookieSameSite specifies the SameSite attribute of the cookie.
+	// Accepted values are "Disabled", "Lax", "Strict", and "None", case-insensitively.
 	//
 	// Optional. Default: "Lax"
 	CookieSameSite string
@@ -94,7 +96,7 @@ var ConfigDefault = Config{
 	IdleTimeout:    30 * time.Minute,
 	KeyGenerator:   utils.SecureToken,
 	Extractor:      extractors.FromCookie("session_id"),
-	CookieSameSite: "Lax",
+	CookieSameSite: fiber.CookieSameSiteLaxMode,
 }
 
 // DefaultErrorHandler logs the error and sends a 500 status code.
@@ -129,13 +131,11 @@ func DefaultErrorHandler(c fiber.Ctx, err error) {
 //	cfg := configDefault()
 //	cfg := configDefault(customConfig)
 func configDefault(config ...Config) Config {
-	// Return default config if nothing provided
-	if len(config) < 1 {
-		return ConfigDefault
+	cfg := ConfigDefault
+	if len(config) > 0 {
+		// Override default config
+		cfg = config[0]
 	}
-
-	// Override default config
-	cfg := config[0]
 
 	// Set default values
 	if cfg.IdleTimeout <= 0 {
@@ -158,6 +158,10 @@ func configDefault(config ...Config) Config {
 
 	if cfg.CookieSameSite == "" {
 		cfg.CookieSameSite = ConfigDefault.CookieSameSite
+	}
+
+	if _, valid := internalcookie.ParseSameSite(cfg.CookieSameSite); !valid {
+		panic("[session] CookieSameSite must be one of Disabled, Lax, Strict, or None")
 	}
 
 	return cfg

--- a/middleware/session/config_test.go
+++ b/middleware/session/config_test.go
@@ -54,3 +54,22 @@ func TestAbsoluteTimeoutValidation(t *testing.T) {
 		})
 	})
 }
+
+func TestCookieSameSiteValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"", "disabled", "LAX", "Strict", "none"} {
+		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+			require.NotPanics(t, func() {
+				configDefault(Config{CookieSameSite: value})
+			})
+		})
+	}
+
+	require.PanicsWithValue(
+		t,
+		"[session] CookieSameSite must be one of Disabled, Lax, Strict, or None",
+		func() { NewStore(Config{CookieSameSite: "invalid"}) },
+	)
+}

--- a/middleware/session/config_test.go
+++ b/middleware/session/config_test.go
@@ -55,6 +55,8 @@ func TestAbsoluteTimeoutValidation(t *testing.T) {
 	})
 }
 
+// TestCookieSameSiteValidation verifies that initialization accepts every
+// supported mode and rejects unsupported non-empty values.
 func TestCookieSameSiteValidation(t *testing.T) {
 	t.Parallel()
 

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/extractors"
+	internalcookie "github.com/gofiber/fiber/v3/internal/cookie"
 	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
@@ -547,22 +548,11 @@ func (s *Session) delSession() {
 
 // setCookieAttributes sets the cookie attributes based on the session config.
 func (s *Session) setCookieAttributes(fcookie *fasthttp.Cookie) {
-	// Set SameSite attribute
-	switch {
-	case utils.EqualFold(s.config.CookieSameSite, fiber.CookieSameSiteStrictMode):
-		fcookie.SetSameSite(fasthttp.CookieSameSiteStrictMode)
-	case utils.EqualFold(s.config.CookieSameSite, fiber.CookieSameSiteNoneMode):
-		fcookie.SetSameSite(fasthttp.CookieSameSiteNoneMode)
-	default:
-		fcookie.SetSameSite(fasthttp.CookieSameSiteLaxMode)
-	}
-
-	// The Secure attribute is required for SameSite=None
-	if fcookie.SameSite() == fasthttp.CookieSameSiteNoneMode {
-		fcookie.SetSecure(true)
-	} else {
-		fcookie.SetSecure(s.config.CookieSecure)
-	}
+	sameSite, _ := internalcookie.ParseSameSite(s.config.CookieSameSite)
+	fcookie.SetSameSite(sameSite.FastHTTPMode)
+	// The Secure attribute is required for SameSite=None; every other mode
+	// preserves the configured value.
+	fcookie.SetSecure(s.config.CookieSecure || sameSite.RequiresSecure)
 
 	fcookie.SetHTTPOnly(s.config.CookieHTTPOnly)
 }

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -3,7 +3,6 @@ package session
 import (
 	"context"
 	"errors"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1100,64 +1099,73 @@ func Test_Session_Cookie_SameSite(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		expectedInHeader string
 		name             string
 		sameSite         string
+		expectedSameSite string
 		initialSecure    bool
+		expectSecure     bool
 	}{
 		{
 			name:             "Lax should not force secure",
 			sameSite:         "Lax",
-			initialSecure:    false,
-			expectedInHeader: "SameSite=Lax",
+			expectedSameSite: "SameSite=Lax",
 		},
 		{
 			name:             "Lax with secure should stay secure",
 			sameSite:         "Lax",
+			expectedSameSite: "SameSite=Lax",
 			initialSecure:    true,
-			expectedInHeader: "SameSite=Lax; secure",
+			expectSecure:     true,
 		},
 		{
 			name:             "Strict should not force secure",
 			sameSite:         "Strict",
-			initialSecure:    false,
-			expectedInHeader: "SameSite=Strict",
+			expectedSameSite: "SameSite=Strict",
 		},
 		{
 			name:             "Strict with secure should stay secure",
 			sameSite:         "Strict",
+			expectedSameSite: "SameSite=Strict",
 			initialSecure:    true,
-			expectedInHeader: "SameSite=Strict; secure",
+			expectSecure:     true,
 		},
 		{
 			name:             "None should force secure",
 			sameSite:         "None",
-			initialSecure:    false,
-			expectedInHeader: "SameSite=None; secure",
+			expectedSameSite: "SameSite=None",
+			expectSecure:     true,
 		},
 		{
 			name:             "None with secure should stay secure",
 			sameSite:         "None",
+			expectedSameSite: "SameSite=None",
 			initialSecure:    true,
-			expectedInHeader: "SameSite=None; secure",
+			expectSecure:     true,
 		},
 		{
 			name:             "Case-insensitive none should force secure",
 			sameSite:         "none",
-			initialSecure:    false,
-			expectedInHeader: "SameSite=None; secure",
+			expectedSameSite: "SameSite=None",
+			expectSecure:     true,
 		},
 		{
 			name:             "Case-insensitive strict should not force secure",
 			sameSite:         "strict",
-			initialSecure:    false,
-			expectedInHeader: "SameSite=Strict",
+			expectedSameSite: "SameSite=Strict",
 		},
 		{
-			name:             "Default should be Lax",
-			sameSite:         "invalid",
-			initialSecure:    false,
-			expectedInHeader: "SameSite=Lax",
+			name:     "Disabled should omit SameSite",
+			sameSite: fiber.CookieSameSiteDisabled,
+		},
+		{
+			name:          "Case-insensitive disabled should preserve secure",
+			sameSite:      "DISABLED",
+			initialSecure: true,
+			expectSecure:  true,
+		},
+		{
+			name:             "Empty should default to Lax",
+			expectedSameSite: "SameSite=Lax",
 		},
 	}
 
@@ -1188,15 +1196,15 @@ func Test_Session_Cookie_SameSite(t *testing.T) {
 
 			// check cookie
 			cookie := string(ctx.Response().Header.PeekCookie("session_id"))
-			// The order of attributes in the cookie string is not guaranteed.
-			// Instead of checking for a single substring, we check for the presence of each part.
-			parts := strings.SplitSeq(tc.expectedInHeader, "; ")
-			for part := range parts {
-				require.Contains(t, cookie, part)
+			if tc.expectedSameSite == "" {
+				require.NotContains(t, cookie, "SameSite")
+			} else {
+				require.Contains(t, cookie, tc.expectedSameSite)
 			}
 
-			// Also check that secure is NOT present when it shouldn't be
-			if !tc.initialSecure && tc.sameSite != "None" && tc.sameSite != "none" {
+			if tc.expectSecure {
+				require.Contains(t, cookie, "secure")
+			} else {
 				require.NotContains(t, cookie, "secure")
 			}
 		})

--- a/middleware/session/session_test.go
+++ b/middleware/session/session_test.go
@@ -1094,7 +1094,8 @@ func Test_Session_Cookie(t *testing.T) {
 	require.Regexp(t, `^session_id=[A-Za-z0-9\-_]{43}; max-age=\d+; path=/; SameSite=Lax$`, string(cookie))
 }
 
-// go test -run Test_Session_Cookie_SameSite
+// Test_Session_Cookie_SameSite verifies every supported mode's emitted
+// attribute and interaction with the Secure flag.
 func Test_Session_Cookie_SameSite(t *testing.T) {
 	t.Parallel()
 

--- a/res.go
+++ b/res.go
@@ -16,6 +16,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	internalcookie "github.com/gofiber/fiber/v3/internal/cookie"
 	"github.com/gofiber/fiber/v3/internal/quotedstring"
 	"github.com/gofiber/utils/v2"
 	"github.com/valyala/bytebufferpool"
@@ -324,21 +325,10 @@ func (r *DefaultRes) Cookie(cookie *Cookie) {
 		c.Expires = time.Time{}
 	}
 
-	var sameSite http.SameSite
-
-	switch {
-	case utils.EqualFold(c.SameSite, CookieSameSiteStrictMode):
-		sameSite = http.SameSiteStrictMode
-	case utils.EqualFold(c.SameSite, CookieSameSiteNoneMode):
-		sameSite = http.SameSiteNoneMode
+	sameSite, _ := internalcookie.ParseSameSite(c.SameSite)
+	if sameSite.RequiresSecure {
 		// SameSite=None requires Secure=true per RFC and browser requirements
 		c.Secure = true
-	case utils.EqualFold(c.SameSite, CookieSameSiteDisabled):
-		sameSite = 0
-	case utils.EqualFold(c.SameSite, CookieSameSiteLaxMode):
-		sameSite = http.SameSiteLaxMode
-	default:
-		sameSite = http.SameSiteLaxMode
 	}
 
 	// Partitioned requires Secure=true per CHIPS spec
@@ -346,7 +336,8 @@ func (r *DefaultRes) Cookie(cookie *Cookie) {
 		c.Secure = true
 	}
 
-	// create/validate cookie using net/http
+	// Validate before fasthttp's setters can silently replace CR/LF or semicolons;
+	// rejection, rather than mutation, is this API's existing contract.
 	hc := &http.Cookie{ //nolint:gosec // G124: http.Cookie missing or has insecure Secure, HttpOnly, or SameSite attribute
 		Name:        c.Name,
 		Value:       c.Value,
@@ -356,7 +347,7 @@ func (r *DefaultRes) Cookie(cookie *Cookie) {
 		MaxAge:      c.MaxAge,
 		Secure:      c.Secure,
 		HttpOnly:    c.HTTPOnly,
-		SameSite:    sameSite,
+		SameSite:    sameSite.HTTPMode,
 		Partitioned: c.Partitioned,
 	}
 
@@ -380,16 +371,7 @@ func (r *DefaultRes) Cookie(cookie *Cookie) {
 	fcookie.SetSecure(hc.Secure)
 	fcookie.SetHTTPOnly(hc.HttpOnly)
 
-	switch sameSite {
-	case http.SameSiteLaxMode:
-		fcookie.SetSameSite(fasthttp.CookieSameSiteLaxMode)
-	case http.SameSiteStrictMode:
-		fcookie.SetSameSite(fasthttp.CookieSameSiteStrictMode)
-	case http.SameSiteNoneMode:
-		fcookie.SetSameSite(fasthttp.CookieSameSiteNoneMode)
-	default:
-		fcookie.SetSameSite(fasthttp.CookieSameSiteDisabled)
-	}
+	fcookie.SetSameSite(sameSite.FastHTTPMode)
 
 	fcookie.SetPartitioned(hc.Partitioned)
 


### PR DESCRIPTION
## Summary

- add one internal, case-insensitive SameSite parser that owns Fiber's public mode strings and maps each mode to both `net/http` and fasthttp cookie values
- use that mapping in `DefaultRes.Cookie` and session cookie emission, removing the two divergent switch statements
- make session honor `CookieSameSiteDisabled`, preserve an explicitly configured `CookieSecure` value for every non-None mode, and continue forcing Secure for SameSite=None
- reject unsupported session SameSite modes during initialization and document the accepted values
- document why core validates with `net/http.Cookie.Valid` before fasthttp can silently mutate invalid cookie bytes

## Behavior changes

- session `CookieSameSite: "Disabled"` now omits the SameSite attribute instead of silently becoming Lax
- invalid non-empty session SameSite values now panic during configuration instead of silently becoming Lax
- core `Cookie` keeps its existing invalid/empty-to-Lax compatibility behavior

## Validation

- internal SameSite mapper: 100% statement coverage
- complete core cookie and session packages pass with race detection
- `go vet ./...` passes
- `govulncheck ./...` reports no reachable vulnerabilities with Go 1.25.13
- generation and gofumpt produce no additional changes
- golangci-lint v2.12.2 reports 0 issues
- repository-wide race run completed 5,195 tests; its only failure is the unrelated TEST-NET dial assertion because this sandbox routes `192.0.2.1:1`

Related #4604

AI disclosure: OpenAI Codex assisted with implementation, tests, documentation, and validation. I reviewed the resulting diff and remain responsible for the contribution.
