### PR TITLE
🐛 bug: use HTTP quoted strings in auth challenges

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -8142,6 +8142,11 @@ func Test_Ctx_Links(t *testing.T) {
 	// quoted-string stays grammar-valid (RFC 9110 §5.6.4).
 	c.Links("http://example.com", `next" x`)
 	require.Equal(t, `<http://example.com>; rel="next\" x"`, string(c.Response().Header.Peek(HeaderLink)))
+
+	// Unlike Attachment filenames, rel values are not sanitized first, so the
+	// shared serializer must also encode controls here.
+	c.Links("http://example.com", "next\t\x01\n\r\x7f")
+	require.Equal(t, `<http://example.com>; rel="next%09%01\n\r%7F"`, string(c.Response().Header.Peek(HeaderLink)))
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Ctx_Links -benchmem -count=4

--- a/docs/middleware/basicauth.md
+++ b/docs/middleware/basicauth.md
@@ -6,7 +6,7 @@ id: basicauth
 
 Basic Authentication middleware for [Fiber](https://github.com/gofiber/fiber) that provides HTTP basic auth. It calls the next handler for valid credentials and returns [`401 Unauthorized`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) for missing or invalid credentials, [`400 Bad Request`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) for malformed `Authorization` headers, or [`431 Request Header Fields Too Large`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/431) when the header exceeds size limits. Credentials may omit Base64 padding as permitted by RFC 7235's `token68` syntax.
 
-The default unauthorized response includes the header `WWW-Authenticate: Basic realm="Restricted", charset="UTF-8"`, sets `Cache-Control: no-store`, and adds a `Vary: Authorization` header. Only the `UTF-8` charset is supported; any other value will panic.
+The default unauthorized response includes the header `WWW-Authenticate: Basic realm="Restricted", charset="UTF-8"`, sets `Cache-Control: no-store`, and adds a `Vary: Authorization` header. Only the `UTF-8` charset is supported; any other value will panic. Generated realm and charset values are escaped as RFC 9110 HTTP quoted strings.
 
 ## Signatures
 

--- a/docs/middleware/keyauth.md
+++ b/docs/middleware/keyauth.md
@@ -291,6 +291,9 @@ Refer to the [Extractors Guide](../guide/extractors) for details, security notes
 | ErrorURI        | `string`                                 | URI identifying a human-readable web page with information about the `error` in Bearer challenges. Requires `Error` and must be an absolute URI. | `""` |
 | Scope           | `string`                                 | Space-delimited list of scopes for the `scope` parameter in Bearer challenges. Each token must conform to the RFC 6750 `scope-token` syntax and requires `Error` set to `insufficient_scope`. | `""` |
 
+Generated challenge parameter values are escaped as RFC 9110 HTTP quoted
+strings. A custom `Challenge` value is emitted verbatim.
+
 ## Default Config
 
 ```go

--- a/helpers.go
+++ b/helpers.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gofiber/fiber/v3/internal/mediatype"
 	"github.com/gofiber/fiber/v3/log"
 
-	"github.com/valyala/bytebufferpool"
 	"github.com/valyala/fasthttp"
 )
 
@@ -167,90 +166,6 @@ func readContent(rf io.ReaderFrom, name string) (int64, error) {
 		return n, fmt.Errorf("failed to read: %w", readErr)
 	}
 	return n, nil
-}
-
-// quoteEscapeMask marks the lanes of w holding bytes quoteRawString must
-// escape: '\\', '"', any C0 control (including HTAB), or DEL. Lanes >= 0x80
-// are never marked; non-ASCII bytes pass through verbatim. This is
-// utils.IndexNonQuotable's RFC 9110 set widened by HTAB, which the RFC
-// permits as qdtext but this function has always percent-encoded.
-func quoteEscapeMask(w uint64) uint64 {
-	return swar.MatchByteMask(w, '\\') | swar.MatchByteMask(w, '"') |
-		swar.MatchRangeMask(w, 0x00, 0x1f) | swar.MatchByteMask(w, 0x7f)
-}
-
-// indexQuoteEscape returns the index of the first byte quoteEscapeMask
-// matches, or -1 if raw needs no escaping. It scans eight bytes at a time,
-// finishing inputs of 8+ bytes with one overlapping word; shorter inputs
-// are checked byte-wise.
-func indexQuoteEscape(raw string) int {
-	n := len(raw)
-	i := 0
-	for ; i+swar.WordLen <= n; i += swar.WordLen {
-		if m := quoteEscapeMask(swar.Load8(raw, i)); m != 0 {
-			return i + swar.FirstLane(m)
-		}
-	}
-	if i == n {
-		return -1
-	}
-	if n >= swar.WordLen {
-		if m := quoteEscapeMask(swar.Load8(raw, n-swar.WordLen)); m != 0 {
-			return n - swar.WordLen + swar.FirstLane(m)
-		}
-		return -1
-	}
-	for ; i < n; i++ {
-		if c := raw[i]; c == '\\' || c == '"' || c < 0x20 || c == 0x7f {
-			return i
-		}
-	}
-	return -1
-}
-
-// quoteRawString escapes the characters that need quoting inside an RFC 9110
-// quoted-string (https://www.rfc-editor.org/rfc/rfc9110#section-5.6.4), plus
-// HTAB, which the RFC permits as qdtext but this function has always
-// percent-encoded. The result may contain non-ASCII bytes.
-func (*App) quoteRawString(raw string) string {
-	// Fast path: most values need no escaping at all; avoid the pooled
-	// buffer and the string allocation entirely.
-	end := indexQuoteEscape(raw)
-	if end == -1 {
-		return raw
-	}
-
-	const hex = "0123456789ABCDEF"
-	bb := bytebufferpool.Get()
-	defer bytebufferpool.Put(bb)
-
-	// Every byte before end is quotable and tab-free, so it hits the
-	// verbatim case of the switch below; copy it in one append.
-	bb.B = append(bb.B, raw[:end]...)
-	for i := end; i < len(raw); i++ {
-		c := raw[i]
-		switch {
-		case c == '\\' || c == '"':
-			// escape backslash and quote
-			bb.B = append(bb.B, '\\', c)
-		case c == '\n':
-			bb.B = append(bb.B, '\\', 'n')
-		case c == '\r':
-			bb.B = append(bb.B, '\\', 'r')
-		case c < 0x20 || c == 0x7f:
-			// percent-encode control and DEL
-			bb.B = append(
-				bb.B,
-				'%',
-				hex[c>>4],
-				hex[c&0x0f],
-			)
-		default:
-			bb.B = append(bb.B, c)
-		}
-	}
-
-	return string(bb.B)
 }
 
 // appendLowerASCII writes the ASCII-lowercased bytes of src into dst[:0],

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1695,47 +1695,6 @@ func Test_IsEtagStale(t *testing.T) {
 	require.True(t, app.isEtagStale(`"v2"`, []byte(`"v1,v2"`)))
 }
 
-func Test_App_quoteRawString(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name string
-		in   string
-		out  string
-	}{
-		{"empty", "", ""},
-		{"simple", "simple", "simple"},
-		{"backslash", "A\\B", "A\\\\B"},
-		{"quote", `He said "Yo"`, `He said \"Yo\"`},
-		{"newline", "Hello\n", "Hello\\n"},
-		{"carriage", "Hello\r", "Hello\\r"},
-		{"controls", string([]byte{0, 31, 127}), "%00%1F%7F"},
-		{"tab", "a\tb", "a%09b"},
-		{"mixed", "test \"A\n\r" + string([]byte{1}) + "\\", `test \"A\n\r%01\\`},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			app := New()
-			require.Equal(t, tc.out, app.quoteRawString(tc.in))
-		})
-	}
-}
-
-func Test_App_quoteRawString_DetachesFromPooledBuffer(t *testing.T) {
-	t.Parallel()
-
-	app := New()
-
-	first := app.quoteRawString(`A\B`)
-	second := app.quoteRawString(`C"D`)
-
-	require.Equal(t, `A\\B`, first)
-	require.Equal(t, `C\"D`, second)
-	require.Equal(t, `A\\B`, first)
-}
-
 func TestStoreInContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/quotedstring/quotedstring.go
+++ b/internal/quotedstring/quotedstring.go
@@ -1,0 +1,80 @@
+// Package quotedstring encodes values placed inside HTTP quoted strings.
+package quotedstring
+
+import (
+	"github.com/gofiber/utils/v2/swar"
+	"github.com/valyala/bytebufferpool"
+)
+
+// escapeMask marks the lanes of w holding bytes Escape must encode: '\\',
+// '"', any C0 control (including HTAB), or DEL. Lanes >= 0x80 are never
+// marked; non-ASCII bytes pass through verbatim.
+func escapeMask(w uint64) uint64 {
+	return swar.MatchByteMask(w, '\\') | swar.MatchByteMask(w, '"') |
+		swar.MatchRangeMask(w, 0x00, 0x1f) | swar.MatchByteMask(w, 0x7f)
+}
+
+// indexEscape returns the index of the first byte escapeMask matches, or -1
+// when raw needs no escaping. It scans eight bytes at a time, finishing inputs
+// of 8+ bytes with one overlapping word; shorter inputs are checked byte-wise.
+func indexEscape(raw string) int {
+	n := len(raw)
+	i := 0
+	for ; i+swar.WordLen <= n; i += swar.WordLen {
+		if m := escapeMask(swar.Load8(raw, i)); m != 0 {
+			return i + swar.FirstLane(m)
+		}
+	}
+	if i == n {
+		return -1
+	}
+	if n >= swar.WordLen {
+		if m := escapeMask(swar.Load8(raw, n-swar.WordLen)); m != 0 {
+			return n - swar.WordLen + swar.FirstLane(m)
+		}
+		return -1
+	}
+	for ; i < n; i++ {
+		if c := raw[i]; c == '\\' || c == '"' || c < 0x20 || c == 0x7f {
+			return i
+		}
+	}
+	return -1
+}
+
+// Escape encodes raw for placement inside an RFC 9110 quoted-string. Quotes
+// and backslashes use quoted-pair escaping, LF and CR use their conventional
+// backslash forms, and other C0 controls plus DEL are percent-encoded. HTAB is
+// encoded even though RFC 9110 permits it as qdtext. Non-ASCII bytes pass
+// through verbatim. The returned value excludes the surrounding quotes.
+// Escape is a serializer, not input validation; callers apply their own
+// rejection or sanitization policy before calling it.
+func Escape(raw string) string {
+	end := indexEscape(raw)
+	if end == -1 {
+		return raw
+	}
+
+	const hex = "0123456789ABCDEF"
+	bb := bytebufferpool.Get()
+	defer bytebufferpool.Put(bb)
+
+	bb.B = append(bb.B, raw[:end]...)
+	for i := end; i < len(raw); i++ {
+		c := raw[i]
+		switch {
+		case c == '\\' || c == '"':
+			bb.B = append(bb.B, '\\', c)
+		case c == '\n':
+			bb.B = append(bb.B, '\\', 'n')
+		case c == '\r':
+			bb.B = append(bb.B, '\\', 'r')
+		case c < 0x20 || c == 0x7f:
+			bb.B = append(bb.B, '%', hex[c>>4], hex[c&0x0f])
+		default:
+			bb.B = append(bb.B, c)
+		}
+	}
+
+	return string(bb.B)
+}

--- a/internal/quotedstring/quotedstring_test.go
+++ b/internal/quotedstring/quotedstring_test.go
@@ -1,0 +1,51 @@
+package quotedstring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test_Escape covers each output dialect and the no-allocation fast path.
+func Test_Escape(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{"empty", "", ""},
+		{"simple", "simple", "simple"},
+		{"long simple", "clean-value", "clean-value"},
+		{"backslash", "A\\B", "A\\\\B"},
+		{"quote", `He said "Yo"`, `He said \"Yo\"`},
+		{"quote in overlapping tail", `12345678"`, `12345678\"`},
+		{"newline", "Hello\n", "Hello\\n"},
+		{"carriage", "Hello\r", "Hello\\r"},
+		{"controls", string([]byte{0, 31, 127}), "%00%1F%7F"},
+		{"tab", "a\tb", "a%09b"},
+		{"mixed", "test \"A\n\r" + string([]byte{1}) + "\\", `test \"A\n\r%01\\`},
+		{"non-ASCII", "café", "café"},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.out, Escape(test.in))
+		})
+	}
+}
+
+// Test_Escape_DetachesFromPooledBuffer verifies that later pool reuse cannot
+// mutate an earlier result.
+func Test_Escape_DetachesFromPooledBuffer(t *testing.T) {
+	t.Parallel()
+
+	first := Escape(`A\B`)
+	second := Escape(`C"D`)
+
+	require.Equal(t, `A\\B`, first)
+	require.Equal(t, `C\"D`, second)
+	require.Equal(t, `A\\B`, first)
+}

--- a/middleware/basicauth/basicauth_test.go
+++ b/middleware/basicauth/basicauth_test.go
@@ -244,6 +244,27 @@ func Test_BasicAuth_WWWAuthenticateHeader_UTF8(t *testing.T) {
 	require.Equal(t, `Basic realm="Restricted", charset="UTF-8"`, resp.Header.Get(fiber.HeaderWWWAuthenticate))
 }
 
+// Test_BasicAuth_WWWAuthenticateHeader_QuotedString verifies that generated
+// challenge parameters use HTTP quoted-string escaping rather than Go syntax.
+func Test_BasicAuth_WWWAuthenticateHeader_QuotedString(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		Users: map[string]string{"john": sha256Hash("doe")},
+		Realm: "area \"A\"\\\x01\t\n\r\x7f café",
+	}))
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+	require.Equal(
+		t,
+		`Basic realm="area \"A\"\\%01%09\n\r%7F café", charset="UTF-8"`,
+		resp.Header.Get(fiber.HeaderWWWAuthenticate),
+	)
+}
+
 func Test_BasicAuth_InvalidHeader(t *testing.T) {
 	t.Parallel()
 	app := fiber.New()

--- a/middleware/basicauth/config.go
+++ b/middleware/basicauth/config.go
@@ -9,10 +9,10 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/internal/quotedstring"
 	"github.com/gofiber/utils/v2"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -166,9 +166,9 @@ func configDefault(config ...Config) Config {
 
 	if cfg.Unauthorized == nil {
 		cfg.Unauthorized = func(c fiber.Ctx) error {
-			header := "Basic realm=" + strconv.Quote(cfg.Realm)
+			header := `Basic realm="` + quotedstring.Escape(cfg.Realm) + `"`
 			if cfg.Charset != "" {
-				header += ", charset=" + strconv.Quote(cfg.Charset)
+				header += `, charset="` + quotedstring.Escape(cfg.Charset) + `"`
 			}
 			c.Set(fiber.HeaderWWWAuthenticate, header)
 			c.Set(fiber.HeaderCacheControl, "no-store")

--- a/middleware/keyauth/config.go
+++ b/middleware/keyauth/config.go
@@ -1,12 +1,12 @@
 package keyauth
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/extractors"
+	"github.com/gofiber/fiber/v3/internal/quotedstring"
 )
 
 const (
@@ -126,7 +126,7 @@ func configDefault(config ...Config) Config {
 	}
 
 	if len(getAuthSchemes(cfg.Extractor)) == 0 && cfg.Challenge == "" {
-		cfg.Challenge = fmt.Sprintf("ApiKey realm=%q", cfg.Realm)
+		cfg.Challenge = `ApiKey realm="` + quotedstring.Escape(cfg.Realm) + `"`
 	}
 
 	if cfg.Error != "" {

--- a/middleware/keyauth/keyauth.go
+++ b/middleware/keyauth/keyauth.go
@@ -2,12 +2,12 @@ package keyauth
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/extractors"
+	"github.com/gofiber/fiber/v3/internal/quotedstring"
 	"github.com/gofiber/fiber/v3/internal/redact"
 	"github.com/gofiber/fiber/v3/middleware/logger"
 	"github.com/gofiber/utils/v2"
@@ -43,23 +43,34 @@ func New(config ...Config) fiber.Handler {
 	if len(authSchemes) > 0 {
 		challenges := make([]string, 0, len(authSchemes))
 		for _, scheme := range authSchemes {
-			var b strings.Builder
-			fmt.Fprintf(&b, "%s realm=%q", scheme, cfg.Realm)
+			b := make([]byte, 0, len(scheme)+len(cfg.Realm)+16)
+			b = append(b, scheme...)
+			b = append(b, ` realm="`...)
+			b = append(b, quotedstring.Escape(cfg.Realm)...)
+			b = append(b, '"')
 			if utils.EqualFold(scheme, "Bearer") {
 				if cfg.Error != "" {
-					fmt.Fprintf(&b, ", error=%q", cfg.Error)
+					b = append(b, `, error="`...)
+					b = append(b, quotedstring.Escape(cfg.Error)...)
+					b = append(b, '"')
 					if cfg.ErrorDescription != "" {
-						fmt.Fprintf(&b, ", error_description=%q", cfg.ErrorDescription)
+						b = append(b, `, error_description="`...)
+						b = append(b, quotedstring.Escape(cfg.ErrorDescription)...)
+						b = append(b, '"')
 					}
 					if cfg.ErrorURI != "" {
-						fmt.Fprintf(&b, ", error_uri=%q", cfg.ErrorURI)
+						b = append(b, `, error_uri="`...)
+						b = append(b, quotedstring.Escape(cfg.ErrorURI)...)
+						b = append(b, '"')
 					}
 					if cfg.Error == ErrorInsufficientScope {
-						fmt.Fprintf(&b, ", scope=%q", cfg.Scope)
+						b = append(b, `, scope="`...)
+						b = append(b, quotedstring.Escape(cfg.Scope)...)
+						b = append(b, '"')
 					}
 				}
 			}
-			challenges = append(challenges, b.String())
+			challenges = append(challenges, string(b))
 		}
 		challengeValue = strings.Join(challenges, ", ")
 	}

--- a/middleware/keyauth/keyauth_test.go
+++ b/middleware/keyauth/keyauth_test.go
@@ -1012,6 +1012,50 @@ func Test_BearerErrorFields(t *testing.T) {
 	require.Equal(t, `Bearer realm="Restricted", error="invalid_token", error_description="token expired", error_uri="https://example.com"`, res.Header.Get("WWW-Authenticate"))
 }
 
+// Test_ChallengeQuotedStringEscaping verifies both default ApiKey and Bearer
+// challenges use HTTP quoted-string escaping rather than Go syntax.
+func Test_ChallengeQuotedStringEscaping(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default ApiKey challenge", func(t *testing.T) {
+		t.Parallel()
+
+		app := fiber.New()
+		app.Use(New(Config{
+			Extractor: extractors.FromQuery("key"),
+			Realm:     "area \"A\"\\\x01\n",
+			Validator: func(_ fiber.Ctx, _ string) (bool, error) { return false, errors.New("invalid") },
+		}))
+
+		res, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+		require.NoError(t, err)
+		require.Equal(t, `ApiKey realm="area \"A\"\\%01\n"`, res.Header.Get(fiber.HeaderWWWAuthenticate))
+	})
+
+	t.Run("Bearer parameters", func(t *testing.T) {
+		t.Parallel()
+
+		app := fiber.New()
+		app.Use(New(Config{
+			Realm:            "area \"A\"\\\x01",
+			Error:            ErrorInvalidToken,
+			ErrorDescription: "bad \"token\"\\\x02\n",
+			ErrorURI:         `https://example.com/docs?q="x"`,
+			Validator:        func(_ fiber.Ctx, _ string) (bool, error) { return false, errors.New("invalid") },
+		}))
+
+		req := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+		req.Header.Set(fiber.HeaderAuthorization, "Bearer bad")
+		res, err := app.Test(req)
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			`Bearer realm="area \"A\"\\%01", error="invalid_token", error_description="bad \"token\"\\%02\n", error_uri="https://example.com/docs?q=\"x\""`,
+			res.Header.Get(fiber.HeaderWWWAuthenticate),
+		)
+	})
+}
+
 func Test_BearerErrorURIOnly(t *testing.T) {
 	app := fiber.New()
 	app.Use(New(Config{

--- a/res.go
+++ b/res.go
@@ -16,6 +16,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/gofiber/fiber/v3/internal/quotedstring"
 	"github.com/gofiber/utils/v2"
 	"github.com/valyala/bytebufferpool"
 	"github.com/valyala/fasthttp"
@@ -262,8 +263,8 @@ func encodeExtValue(s string) string {
 // for a sanitized filename: the filename parameter is a quoted-string with
 // RFC 9110 §5.6.4 escaping, and non-ASCII names additionally carry an
 // RFC 8187 filename* ext-value for interoperability.
-func contentDispositionAttachment(app *App, fname string) string {
-	disp := `attachment; filename="` + app.quoteRawString(fname) + `"`
+func contentDispositionAttachment(fname string) string {
+	disp := `attachment; filename="` + quotedstring.Escape(fname) + `"`
 	if !utils.IsASCII(fname) {
 		disp += `; filename*=UTF-8''` + encodeExtValue(fname)
 	}
@@ -277,7 +278,7 @@ func (r *DefaultRes) Attachment(filename ...string) {
 		fname = sanitizeFilename(fname)
 		fname = fallbackFilenameIfInvalid(fname)
 		r.Type(filepath.Ext(fname))
-		r.setCanonical(HeaderContentDisposition, contentDispositionAttachment(r.c.app, fname))
+		r.setCanonical(HeaderContentDisposition, contentDispositionAttachment(fname))
 		return
 	}
 	r.setCanonical(HeaderContentDisposition, "attachment")
@@ -410,7 +411,7 @@ func (r *DefaultRes) Download(file string, filename ...string) error {
 	}
 	fname = sanitizeFilename(fname)
 	fname = fallbackFilenameIfInvalid(fname)
-	r.setCanonical(HeaderContentDisposition, contentDispositionAttachment(r.c.app, fname))
+	r.setCanonical(HeaderContentDisposition, contentDispositionAttachment(fname))
 	return r.SendFile(file)
 }
 
@@ -834,7 +835,7 @@ func (r *DefaultRes) Links(link ...string) {
 			bb.WriteString(`; rel="`)
 			// The rel value sits inside a quoted-string, so quotes and
 			// backslashes must be escaped (RFC 9110 Section 5.6.4).
-			bb.WriteString(r.c.app.quoteRawString(link[i]))
+			bb.WriteString(quotedstring.Escape(link[i]))
 			bb.WriteString(`",`)
 		}
 	}


### PR DESCRIPTION
## Summary

- move Fiber's existing RFC 9110 quoted-string encoder into `internal/quotedstring` and retain its zero-allocation clean-value fast path
- use the shared encoder for Content-Disposition filenames and Link `rel` values, deleting the core-only implementation
- replace BasicAuth's `strconv.Quote` and KeyAuth's `%q` formatting for generated challenge parameters
- cover quotes, backslashes, C0 controls, DEL, CR/LF, pooled-buffer detachment, and non-ASCII values across core, BasicAuth, and KeyAuth
- document generated challenge escaping; custom KeyAuth `Challenge` values remain verbatim

## Behavior changes

Generated BasicAuth and KeyAuth parameter values now use HTTP quoted-string syntax instead of Go string-literal syntax. Quotes and backslashes use quoted-pair escaping, CR/LF use `\\r`/`\\n`, and other C0 controls plus DEL are percent-encoded instead of producing invalid `\\uXXXX`/`\\xXX` forms. Ordinary values are byte-identical.

## Validation

- shared quoted-string package: 100% statement coverage
- complete core, BasicAuth, and KeyAuth packages pass with race detection
- affected documentation passes markdownlint-cli2
- `go vet ./...` passes
- `govulncheck ./...` reports no reachable vulnerabilities with Go 1.25.13
- generation and gofumpt produce no additional changes
- golangci-lint v2.12.2 reports 0 issues
- repository-wide race run completed 5,186 tests; its only failure is the unrelated TEST-NET dial assertion because this sandbox routes `192.0.2.1:1`

Related #4604

AI disclosure: OpenAI Codex assisted with implementation, tests, documentation, and validation. I reviewed the resulting diff and remain responsible for the contribution.
