### PR TITLE
🧹 chore: consolidate entity-tag parsing into internal/etag

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gofiber/fiber/v3/binder"
 	"github.com/gofiber/fiber/v3/internal/contextvalue"
+	etagpkg "github.com/gofiber/fiber/v3/internal/etag"
 	"github.com/gofiber/fiber/v3/internal/mediatype"
 	"github.com/gofiber/fiber/v3/log"
 
@@ -926,82 +927,11 @@ func sortAcceptedTypes(at []acceptedType) {
 	}
 }
 
-// normalizeEtag validates an entity tag and returns the
-// value without quotes. weak is true if the tag has the "W/" prefix.
-func normalizeEtag(t string) (value string, weak, ok bool) { //nolint:nonamedreturns // gocritic unnamedResult requires naming the parsed ETag components
-	weak = strings.HasPrefix(t, "W/")
-	if weak {
-		t = t[2:]
-	}
-
-	if len(t) < 2 || t[0] != '"' || t[len(t)-1] != '"' {
-		return "", weak, false
-	}
-	return t[1 : len(t)-1], weak, true
-}
-
-// matchEtag performs a weak comparison of entity tags according to
-// RFC 9110 §8.8.3.2. The weak indicator ("W/") is ignored, but both tags must
-// be properly quoted. Invalid tags result in a mismatch.
-func matchEtag(s, etag string) bool {
-	n1, _, ok1 := normalizeEtag(s)
-	n2, _, ok2 := normalizeEtag(etag)
-	if !ok1 || !ok2 {
-		return false
-	}
-
-	return n1 == n2
-}
-
-// matchEtagStrong performs a strong entity-tag comparison following
-// RFC 9110 §8.8.3.1. A weak tag never matches a strong one, even if the quoted
-// values are identical.
-func matchEtagStrong(s, etag string) bool {
-	n1, w1, ok1 := normalizeEtag(s)
-	n2, w2, ok2 := normalizeEtag(etag)
-	if !ok1 || !ok2 || w1 || w2 {
-		return false
-	}
-
-	return n1 == n2
-}
-
 // isEtagStale reports whether a response with the given ETag would be considered
 // stale when presented with the raw If-None-Match header value. Comparison is
 // weak as defined by RFC 9110 §8.8.3.2.
 func (app *App) isEtagStale(etag string, noneMatchBytes []byte) bool {
-	header := utils.TrimSpace(app.toString(noneMatchBytes))
-
-	// Short-circuit the wildcard case: "*" never counts as stale.
-	if header == "*" {
-		return false
-	}
-
-	// Split the header on commas that sit outside DQUOTE-delimited opaque-tags:
-	// etagc permits "," inside the quoted tag (RFC 9110 §8.8.3), so `"v1,v2"`
-	// is a single entity tag, not two list elements. Only '"' and ','
-	// affect the split, so jump between them instead of visiting every byte.
-	start := 0
-	pos := 0
-	inQuotes := false
-	for {
-		i := utils.IndexAny2(header[pos:], '"', ',')
-		if i == -1 {
-			break
-		}
-		i += pos
-		pos = i + 1
-		if header[i] == '"' {
-			inQuotes = !inQuotes
-		} else if !inQuotes {
-			if matchEtag(utils.TrimSpace(header[start:i]), etag) {
-				return false
-			}
-			start = i + 1
-		}
-	}
-
-	return !matchEtag(utils.TrimSpace(header[start:]), etag)
+	return !etagpkg.AnyMatch(app.toString(noneMatchBytes), etag)
 }
 
 func parseAddr(raw string) (host, port string) { //nolint:nonamedreturns // gocritic unnamedResult requires naming host and port parts for clarity

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1629,28 +1629,6 @@ func Test_ParamsMatch_InvalidEscape(t *testing.T) {
 	require.False(t, match)
 }
 
-func Test_MatchEtag(t *testing.T) {
-	t.Parallel()
-
-	require.True(t, matchEtag(`"a"`, `"a"`))
-	require.True(t, matchEtag(`W/"a"`, `"a"`))
-	require.True(t, matchEtag(`"a"`, `W/"a"`))
-	require.False(t, matchEtag(`"a"`, `"b"`))
-	require.False(t, matchEtag(`a`, `"a"`))
-	require.False(t, matchEtag(`"a"`, `b`))
-}
-
-func Test_MatchEtagStrong(t *testing.T) {
-	t.Parallel()
-
-	require.True(t, matchEtagStrong(`"a"`, `"a"`))
-	require.False(t, matchEtagStrong(`W/"a"`, `"a"`))
-	require.False(t, matchEtagStrong(`"a"`, `W/"a"`))
-	require.False(t, matchEtagStrong(`"a"`, `"b"`))
-	require.False(t, matchEtagStrong(`a`, `"a"`))
-	require.False(t, matchEtagStrong(`"a"`, `b`))
-}
-
 func Test_IsEtagStale(t *testing.T) {
 	t.Parallel()
 	app := New()

--- a/internal/etag/etag.go
+++ b/internal/etag/etag.go
@@ -1,0 +1,92 @@
+// Package etag parses and compares HTTP entity tags (RFC 9110 Section 8.8.3).
+// It is shared by the core conditional-request path (Ctx.Fresh) and the ETag
+// middleware, which previously carried divergent parsers: the middleware split
+// If-None-Match on every comma, mis-parsing an opaque-tag that contains one.
+package etag
+
+import (
+	"strings"
+
+	"github.com/gofiber/utils/v2"
+)
+
+// weakPrefix marks a weak entity tag (RFC 9110 Section 8.8.3).
+const weakPrefix = "W/"
+
+// Parse validates an entity tag and returns the value without quotes.
+// weak is true if the tag has the "W/" prefix.
+func Parse(t string) (value string, weak, ok bool) { //nolint:nonamedreturns // gocritic unnamedResult requires naming the parsed ETag components
+	weak = strings.HasPrefix(t, weakPrefix)
+	if weak {
+		t = t[len(weakPrefix):]
+	}
+
+	if len(t) < 2 || t[0] != '"' || t[len(t)-1] != '"' {
+		return "", weak, false
+	}
+	return t[1 : len(t)-1], weak, true
+}
+
+// Match performs a weak comparison of entity tags according to
+// RFC 9110 Section 8.8.3.2. The weak indicator ("W/") is ignored, but both tags
+// must be properly quoted. Invalid tags result in a mismatch.
+func Match(s, etag string) bool {
+	n1, _, ok1 := Parse(s)
+	n2, _, ok2 := Parse(etag)
+	if !ok1 || !ok2 {
+		return false
+	}
+
+	return n1 == n2
+}
+
+// MatchStrong performs a strong entity-tag comparison following
+// RFC 9110 Section 8.8.3.1. A weak tag never matches a strong one, even if the
+// quoted values are identical.
+func MatchStrong(s, etag string) bool {
+	n1, w1, ok1 := Parse(s)
+	n2, w2, ok2 := Parse(etag)
+	if !ok1 || !ok2 || w1 || w2 {
+		return false
+	}
+
+	return n1 == n2
+}
+
+// AnyMatch reports whether any entity tag in the raw If-None-Match field value
+// matches etag. Comparison is weak as defined by RFC 9110 Section 8.8.3.2, and
+// "*" matches every entity tag. An empty field value matches nothing.
+func AnyMatch(header, etag string) bool {
+	header = utils.TrimSpace(header)
+
+	// Short-circuit the wildcard case: "*" matches any entity tag.
+	if header == "*" {
+		return true
+	}
+
+	// Split the header on commas that sit outside DQUOTE-delimited opaque-tags:
+	// etagc permits "," inside the quoted tag (RFC 9110 Section 8.8.3), so
+	// `"v1,v2"` is a single entity tag, not two list elements. Only '"' and ','
+	// affect the split, so jump between them instead of visiting every byte.
+	start := 0
+	pos := 0
+	inQuotes := false
+	for {
+		i := utils.IndexAny2(header[pos:], '"', ',')
+		if i == -1 {
+			break
+		}
+		i += pos
+		pos = i + 1
+		if header[i] == '"' {
+			inQuotes = !inQuotes
+		} else if !inQuotes {
+			if Match(utils.TrimSpace(header[start:i]), etag) {
+				return true
+			}
+			start = i + 1
+		}
+	}
+
+	return Match(utils.TrimSpace(header[start:]), etag)
+}

--- a/internal/etag/etag_test.go
+++ b/internal/etag/etag_test.go
@@ -1,0 +1,109 @@
+package etag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Parse(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		tag   string
+		value string
+		weak  bool
+		ok    bool
+	}{
+		{name: "strong tag", tag: `"abc"`, value: "abc", ok: true},
+		{name: "weak tag", tag: `W/"abc"`, value: "abc", weak: true, ok: true},
+		{name: "empty opaque-tag", tag: `""`, value: "", ok: true},
+		{name: "comma inside opaque-tag", tag: `"a,b"`, value: "a,b", ok: true},
+		{name: "unquoted", tag: `abc`},
+		{name: "missing closing quote", tag: `"abc`},
+		{name: "missing opening quote", tag: `abc"`},
+		{name: "single quote", tag: `"`},
+		{name: "empty", tag: ``},
+		{name: "weak prefix only", tag: `W/`, weak: true},
+		// The weak indicator is case-sensitive per RFC 9110 Section 8.8.3.
+		{name: "lowercase weak indicator", tag: `w/"abc"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			value, weak, ok := Parse(tc.tag)
+			require.Equal(t, tc.value, value)
+			require.Equal(t, tc.weak, weak)
+			require.Equal(t, tc.ok, ok)
+		})
+	}
+}
+
+func Test_Match(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, Match(`"a"`, `"a"`))
+	require.True(t, Match(`W/"a"`, `"a"`))
+	require.True(t, Match(`"a"`, `W/"a"`))
+	require.True(t, Match(`W/"a"`, `W/"a"`))
+	require.False(t, Match(`"a"`, `"b"`))
+	require.False(t, Match(`a`, `"a"`))
+	require.False(t, Match(`"a"`, `b`))
+	require.False(t, Match(``, `"a"`))
+	require.False(t, Match(`"a"`, ``))
+	require.False(t, Match(`W/`, `"a"`))
+}
+
+func Test_MatchStrong(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, MatchStrong(`"a"`, `"a"`))
+	require.False(t, MatchStrong(`W/"a"`, `"a"`))
+	require.False(t, MatchStrong(`"a"`, `W/"a"`))
+	require.False(t, MatchStrong(`W/"a"`, `W/"a"`))
+	require.False(t, MatchStrong(`"a"`, `"b"`))
+	require.False(t, MatchStrong(`a`, `"a"`))
+	require.False(t, MatchStrong(`"a"`, `b`))
+}
+
+func Test_AnyMatch(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		header string
+		etag   string
+		want   bool
+	}{
+		{name: "empty header", header: ``, etag: `"a"`},
+		{name: "single match", header: `"a"`, etag: `"a"`, want: true},
+		{name: "single mismatch", header: `"b"`, etag: `"a"`},
+		{name: "wildcard", header: `*`, etag: `"a"`, want: true},
+		{name: "wildcard with surrounding space", header: "  *\t", etag: `"a"`, want: true},
+		// RFC 9110 Section 13.1.2 allows "*" only as the sole field value, so
+		// inside a list it is an ordinary, unquoted and therefore invalid tag.
+		{name: "wildcard inside a list", header: `*, "b"`, etag: `"a"`},
+		{name: "list, first matches", header: `"a", "b"`, etag: `"a"`, want: true},
+		{name: "list, last matches", header: `"a", "b"`, etag: `"b"`, want: true},
+		{name: "list, none match", header: `"a", "b"`, etag: `"c"`},
+		{name: "list without OWS", header: `"a","b"`, etag: `"b"`, want: true},
+		{name: "weak tag in list", header: `"a", W/"b"`, etag: `"b"`, want: true},
+		{name: "weak response tag", header: `"a", "b"`, etag: `W/"b"`, want: true},
+		{name: "unquoted response tag", header: `"a"`, etag: `a`},
+		// A comma is a legal etagc byte, so `"a,b"` is one entity tag. Splitting
+		// on every comma would compare the fragments `"a` and `b"` instead.
+		{name: "comma inside opaque-tag", header: `"a,b"`, etag: `"a,b"`, want: true},
+		{name: "comma inside opaque-tag in a list", header: `"x", "a,b"`, etag: `"a,b"`, want: true},
+		{name: "comma inside opaque-tag, later element matches", header: `"a,b", "c"`, etag: `"c"`, want: true},
+		{name: "fragment of a split tag never matches", header: `"a,b"`, etag: `"a`},
+		{name: "unbalanced quote", header: `"a, "b`, etag: `"a"`},
+		{name: "unbalanced quote, no match on remainder", header: `"a, "b`, etag: `"b"`},
+		{name: "only a comma", header: `,`, etag: `"a"`},
+		{name: "empty list element", header: `"a", , "b"`, etag: `"b"`, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, AnyMatch(tc.header, tc.etag))
+		})
+	}
+}

--- a/middleware/etag/etag.go
+++ b/middleware/etag/etag.go
@@ -1,13 +1,13 @@
 package etag
 
 import (
-	"bytes"
 	"hash/crc32"
 	"math"
 	"slices"
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
+	internaletag "github.com/gofiber/fiber/v3/internal/etag"
 	"github.com/gofiber/utils/v2"
 	"github.com/valyala/bytebufferpool"
 )
@@ -99,7 +99,9 @@ func New(config ...Config) fiber.Handler {
 		// Get ETag header from request
 		clientEtag := c.Request().Header.Peek(fiber.HeaderIfNoneMatch)
 
-		if isNoneMatch(clientEtag, etag) {
+		// Both slices are only read for the duration of the comparison and
+		// neither is retained, so the unsafe views cannot outlive them.
+		if internaletag.AnyMatch(utils.UnsafeString(clientEtag), utils.UnsafeString(etag)) {
 			c.RequestCtx().ResetBody()
 
 			return c.SendStatus(fiber.StatusNotModified)
@@ -107,47 +109,6 @@ func New(config ...Config) fiber.Handler {
 
 		return nil
 	}
-}
-
-// isNoneMatch reports whether any entity tag in the If-None-Match header value
-// matches the response ETag, using the weak comparison required for
-// If-None-Match by RFC 9110 §8.8.3.2.
-func isNoneMatch(header, etag []byte) bool {
-	header = utils.TrimSpace(header)
-	if len(header) == 0 {
-		return false
-	}
-	if len(header) == 1 && header[0] == '*' {
-		return true
-	}
-
-	for len(header) > 0 {
-		// RFC 9110 allows a comma inside an opaque-tag, so this split can
-		// mis-parse such tags. It fails open and Fiber's ETags never contain
-		// commas, so it is acceptable here.
-		entry, rest, _ := bytes.Cut(header, []byte(","))
-		header = rest
-		if etagWeakMatch(utils.TrimSpace(entry), etag) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// etagWeakMatch compares two entity tags, ignoring weak indicators
-// (RFC 9110 §8.8.3.2). Both tags must be quoted to match.
-func etagWeakMatch(a, b []byte) bool {
-	a = bytes.TrimPrefix(a, weakPrefix)
-	b = bytes.TrimPrefix(b, weakPrefix)
-	if len(a) < 2 || a[0] != '"' || a[len(a)-1] != '"' {
-		return false
-	}
-	if len(b) < 2 || b[0] != '"' || b[len(b)-1] != '"' {
-		return false
-	}
-
-	return bytes.Equal(a, b)
 }
 
 // isEventStream reports whether the response is a Server-Sent Events stream.

--- a/middleware/etag/etag_test.go
+++ b/middleware/etag/etag_test.go
@@ -379,33 +379,3 @@ func Test_ETag_WeakComparison(t *testing.T) {
 		})
 	}
 }
-
-// go test -run Test_ETag_etagWeakMatch
-func Test_ETag_etagWeakMatch(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name     string
-		a        string
-		b        string
-		expected bool
-	}{
-		{name: "identical strong tags", a: `"abc"`, b: `"abc"`, expected: true},
-		{name: "weak client vs strong server", a: `W/"abc"`, b: `"abc"`, expected: true},
-		{name: "strong client vs weak server", a: `"abc"`, b: `W/"abc"`, expected: true},
-		{name: "both weak", a: `W/"abc"`, b: `W/"abc"`, expected: true},
-		{name: "different values", a: `"abc"`, b: `"def"`, expected: false},
-		{name: "unquoted client tag", a: `abc`, b: `"abc"`, expected: false},
-		{name: "unquoted server tag", a: `"abc"`, b: `abc`, expected: false},
-		{name: "empty client tag", a: ``, b: `"abc"`, expected: false},
-		{name: "empty server tag", a: `"abc"`, b: ``, expected: false},
-		{name: "weak prefix only", a: `W/`, b: `"abc"`, expected: false},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, tc.expected, etagWeakMatch([]byte(tc.a), []byte(tc.b)))
-		})
-	}
-}


### PR DESCRIPTION
# Description

Core and the ETag middleware carried two entity-tag parsers. The core one is quote-aware; the middleware one split `If-None-Match` on every comma, which its own comment admitted mis-parses an opaque-tag containing one:

```go
// RFC 9110 allows a comma inside an opaque-tag, so this split can
// mis-parse such tags. It fails open and Fiber's ETags never contain
// commas, so it is acceptable here.
```

This moves the core implementation into `internal/etag` and deletes both copies of the duplicated logic, so one parser serves `Ctx.Fresh()` and the middleware.

This is cluster 6 of the consolidation issue:

> **6. ETag:** `middleware/etag` `isNoneMatch` splits If-None-Match naively on commas (its own comment admits commas inside opaque-tags mis-parse) while core `isEtagStale` is quote-aware; `etagWeakMatch` duplicates core `matchEtag`/`matchEtagStrong`, which additionally factor through `normalizeEtag`. **Target:** internal/etag Parse/Match/Format used by both `Fresh()` and the middleware.

Related #4604

## Changes introduced

- **New `internal/etag`** (no new public API): `Parse`, `Match`, `MatchStrong` moved verbatim from `helpers.go`, plus `AnyMatch` for a raw `If-None-Match` field value — the quote-aware splitter that was the body of `app.isEtagStale`, inverted to report a match rather than staleness.
- **`helpers.go`**: `normalizeEtag`, `matchEtag`, `matchEtagStrong` and the body of `isEtagStale` deleted. `isEtagStale` survives as the wrapper applying `app.toString`, which is what honors `Immutable`, so the `Ctx.Fresh()` call site is untouched.
- **`middleware/etag`**: `isNoneMatch` and `etagWeakMatch` deleted, along with the caveat above.

Net **+207 / −167**. All 30 existing HTTP-level middleware tests pass **unedited** — that is the intended proof that behavior is unchanged.

### Behavior changes: none

The middleware's comma split is a latent defect, not an observable one, and I would rather say so than overclaim a fix:

- RFC 9110 `etagc` excludes DQUOTE, so a fragment produced by splitting a valid tag on an interior comma can never be quoted at both ends — and `etagWeakMatch` required both ends quoted, so the naive split already failed closed.
- Middleware-generated tags (`"<len>-<crc32>"`) never contain a comma.
- The middleware early-returns when the response already carries an `ETag` header, so a handler-supplied tag with a comma never reaches the comparison.

No request could observe a difference. `Fresh()` was already correct. This matches the issue's acceptance criterion that outputs stay byte-identical unless a divergence was a bug.

### Note on `MatchStrong`

`matchEtagStrong` has no production caller today — it was exercised only by `helpers_test.go`. I kept it in the new package as the RFC 9110 §8.8.3.1 counterpart an `If-Match` implementation would need, rather than silently dropping it. Happy to remove it if you would prefer not to carry it.

### Follow-up, deliberately not in this PR

`middleware/compress/compress.go` does a fourth ad-hoc inspection (`strings.HasPrefix(tag, "W/")`). Routing it through `Parse` would change behavior for malformed ETags — an unquoted tag would stop being regenerated — which is a policy decision rather than a consolidation, so it is left alone.

- [x] Benchmarks: see below — 0 allocs unchanged, sec/op within noise.
- [x] Documentation Update: none needed; no public API or behavior change.
- [x] Changelog/What's New: none needed; internal refactor.
- [ ] Migration Guide: not applicable.
- [ ] API Alignment with Express: not applicable.
- [x] API Longevity: no public surface added — the new package is under `internal/`, as the issue requires.
- [ ] Examples: not applicable.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Benchmarks

`benchstat`, 10 runs each, baseline measured in the same session to control for drift (an initial naive before/after showed a uniform ~5% rise on benchmarks that never reach the ETag path, which was machine noise):

```
                           │   sec/op    │   sec/op     vs base               │
Benchmark_Ctx_Fresh_StaleEtag-10      354.2n ± 3%   351.8n ± 1%  -0.68% (p=0.005 n=10)
Benchmark_Ctx_Fresh_WithNoCache-10    77.70n ± 0%   76.61n ± 1%  -1.39% (p=0.000 n=10)
Benchmark_Ctx_Fresh_LastModified-10   107.4n ± 1%   107.0n ± 0%  -0.42% (p=0.034 n=10)
Benchmark_Etag-10                     79.19n ± 0%   78.50n ± 1%  -0.87% (p=0.000 n=10)
```

`B/op` and `allocs/op` are 0 before and after on all four ("all samples are equal").

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes.
- [x] Verified that any new dependencies are essential — none added.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.

## Validation

- `internal/etag`: **100.0%** statement coverage
- full suite: `go test ./... -race -count=1 -shuffle=on` passes
- `golangci-lint` v2.12.2: **0 issues**
- `go vet ./...`, `gofumpt`: clean, no diff
- `govulncheck ./...`: no reachable vulnerabilities
