### PR TITLE
🐛 bug: order rewrite rules as written instead of by map iteration

### DIFF
--- a/docs/middleware/rewrite.md
+++ b/docs/middleware/rewrite.md
@@ -17,22 +17,22 @@ func New(config ...Config) fiber.Handler
 | Property | Type                  | Description                                           | Default    |
 |:---------|:----------------------|:------------------------------------------------------|:-----------|
 | Next     | `func(fiber.Ctx) bool` | Skip when function returns `true`.                    | `nil`      |
-| RuleList | `[]Rule`              | Rules tried in order; the first match wins. Use `$1`, `$2` for wildcard captures.| (Required) |
-| Rules    | `map[string]string`   | Deprecated. Same rules as a map, ranked most specific first.| `nil`      |
+| OrderedRules | `[]Rule`          | Rules tried in order, first match wins; `$1`, `$2` insert wildcard captures. | Required |
+| Rules    | `map[string]string`   | **Deprecated.** Use `OrderedRules`. A map has no order, so precedence is decided by a heuristic. | nil |
 
-A rule's `From` is path text: `*` matches a run of any length and every other
-byte stands for itself, so `/preis-1.000-euro` rewrites that path and not
-`/preis-1X000-euro`.
+A rule's `From` is path text: `*` matches a run of any bytes but a newline, and
+every other byte stands for itself, so `/preis-1.000-euro` rewrites that path
+and not `/preis-1X000-euro`. There is no escape for a literal `*`.
 
-Put the specific rules before the catch-alls. Setting both `RuleList` and
+Put the specific rules before the catch-alls. Setting both `OrderedRules` and
 `Rules` panics.
 
 :::note
-`Rules` is deprecated because a map has no order, so which rule answered a path
-two rules both matched was decided by map iteration, which Go randomizes per
-run. It keeps working for the whole of v3: its keys are ranked most path text
-before the first `*`, then most path text overall, then fewest asterisks, then
-the key itself.
+`Rules` keeps working for the whole of v3. Its keys are ranked by a heuristic
+rather than by the author: most path text before the first `*`, then most path
+text overall, then fewest asterisks, then the key itself. That is a rough
+reading of "most specific", not an exact one, so a long wildcard rule can still
+outrank a shorter exact one. `OrderedRules` gives exact control.
 :::
 
 ## Examples
@@ -49,7 +49,7 @@ func main() {
     app := fiber.New()
 
     app.Use(rewrite.New(rewrite.Config{
-      RuleList: []rewrite.Rule{
+      OrderedRules: []rewrite.Rule{
         {From: "/old", To: "/new"},
         {From: "/old/*", To: "/new/$1"},
       },

--- a/docs/middleware/rewrite.md
+++ b/docs/middleware/rewrite.md
@@ -17,8 +17,10 @@ func New(config ...Config) fiber.Handler
 | Property | Type                  | Description                                           | Default    |
 |:---------|:----------------------|:------------------------------------------------------|:-----------|
 | Next     | `func(fiber.Ctx) bool` | Skip when function returns `true`.                    | `nil`      |
-| RuleList | `[]Rule`          | Rules tried in order, first match wins; `$1`, `$2` insert wildcard captures. | Required |
+| RuleList | `[]Rule`          | Rules tried in order, first match wins; `$1`, `$2` insert wildcard captures. | nil |
 | Rules    | `map[string]string`   | **Deprecated.** Use `RuleList`. A map has no order, so precedence is decided by a heuristic. | nil |
+
+Set one of `RuleList` or `Rules`. With neither, the middleware rewrites nothing.
 
 A rule's `From` is path text: `*` matches a run of any bytes but a newline, and
 every other byte stands for itself, so `/preis-1.000-euro` rewrites that path

--- a/docs/middleware/rewrite.md
+++ b/docs/middleware/rewrite.md
@@ -17,14 +17,14 @@ func New(config ...Config) fiber.Handler
 | Property | Type                  | Description                                           | Default    |
 |:---------|:----------------------|:------------------------------------------------------|:-----------|
 | Next     | `func(fiber.Ctx) bool` | Skip when function returns `true`.                    | `nil`      |
-| OrderedRules | `[]Rule`          | Rules tried in order, first match wins; `$1`, `$2` insert wildcard captures. | Required |
-| Rules    | `map[string]string`   | **Deprecated.** Use `OrderedRules`. A map has no order, so precedence is decided by a heuristic. | nil |
+| RuleList | `[]Rule`          | Rules tried in order, first match wins; `$1`, `$2` insert wildcard captures. | Required |
+| Rules    | `map[string]string`   | **Deprecated.** Use `RuleList`. A map has no order, so precedence is decided by a heuristic. | nil |
 
 A rule's `From` is path text: `*` matches a run of any bytes but a newline, and
 every other byte stands for itself, so `/preis-1.000-euro` rewrites that path
 and not `/preis-1X000-euro`. There is no escape for a literal `*`.
 
-Put the specific rules before the catch-alls. Setting both `OrderedRules` and
+Put the specific rules before the catch-alls. Setting both `RuleList` and
 `Rules` panics.
 
 :::note
@@ -32,7 +32,7 @@ Put the specific rules before the catch-alls. Setting both `OrderedRules` and
 rather than by the author: most path text before the first `*`, then most path
 text overall, then fewest asterisks, then the key itself. That is a rough
 reading of "most specific", not an exact one, so a long wildcard rule can still
-outrank a shorter exact one. `OrderedRules` gives exact control.
+outrank a shorter exact one. `RuleList` gives exact control.
 :::
 
 ## Examples
@@ -49,7 +49,7 @@ func main() {
     app := fiber.New()
 
     app.Use(rewrite.New(rewrite.Config{
-      OrderedRules: []rewrite.Rule{
+      RuleList: []rewrite.Rule{
         {From: "/old", To: "/new"},
         {From: "/old/*", To: "/new/$1"},
       },

--- a/docs/middleware/rewrite.md
+++ b/docs/middleware/rewrite.md
@@ -4,7 +4,7 @@ id: rewrite
 
 # Rewrite
 
-The Rewrite middleware remaps the request path using custom rules, helping with backward compatibility and cleaner URLs.
+The Rewrite middleware remaps the request path using custom rules, helping with backward compatibility and cleaner URLs. Rules are tried in the order you write them and the first match wins.
 
 ## Signatures
 
@@ -24,15 +24,30 @@ A rule's `From` is path text: `*` matches a run of any bytes but a newline, and
 every other byte stands for itself, so `/preis-1.000-euro` rewrites that path
 and not `/preis-1X000-euro`. There is no escape for a literal `*`.
 
-Put the specific rules before the catch-alls. Setting both `RuleList` and
-`Rules` panics.
+Setting both `RuleList` and `Rules` panics.
+
+## Rule order
+
+Rules are tried in the order you write them and the first one whose `From`
+matches answers, exactly as [routes](../guide/routing.md) are matched. Nothing
+reorders a `RuleList`. Put the specific rules before the catch-alls:
+
+```go
+RuleList: []rewrite.Rule{
+    {From: "/api/users", To: "/v2/users"},  // checked first
+    {From: "/api/*", To: "/v2/$1"},         // takes everything else
+}
+```
+
+Written the other way round, `/api/*` answers `/api/users` too and the second
+rule never fires.
 
 :::note
-`Rules` keeps working for the whole of v3. Its keys are ranked by a heuristic
-rather than by the author: most path text before the first `*`, then most path
-text overall, then fewest asterisks, then the key itself. That is a rough
-reading of "most specific", not an exact one, so a long wildcard rule can still
-outrank a shorter exact one. `RuleList` gives exact control.
+The deprecated `Rules` map has no order of its own, so Fiber sorts it: most path
+text before the first `*` wins, then most path text overall, then fewest
+asterisks, then the key itself. That is a rough reading of "most specific", not
+an exact one, so a long wildcard rule can still outrank a shorter exact one.
+`RuleList` is the exact control.
 :::
 
 ## Examples

--- a/docs/middleware/rewrite.md
+++ b/docs/middleware/rewrite.md
@@ -17,10 +17,22 @@ func New(config ...Config) fiber.Handler
 | Property | Type                  | Description                                           | Default    |
 |:---------|:----------------------|:------------------------------------------------------|:-----------|
 | Next     | `func(fiber.Ctx) bool` | Skip when function returns `true`.                    | `nil`      |
-| Rules    | `map[string]string`   | Map paths to new values; use `$1`, `$2` for wildcard captures.| (Required) |
+| RuleList | `[]Rule`              | Rules tried in order; the first match wins. Use `$1`, `$2` for wildcard captures.| (Required) |
+| Rules    | `map[string]string`   | Deprecated. Same rules as a map, ranked most specific first.| `nil`      |
+
+A rule's `From` is path text: `*` matches a run of any length and every other
+byte stands for itself, so `/preis-1.000-euro` rewrites that path and not
+`/preis-1X000-euro`.
+
+Put the specific rules before the catch-alls. Setting both `RuleList` and
+`Rules` panics.
 
 :::note
-Rules are stored in a map, so iteration order is undefined. Avoid overlapping patterns if precedence matters.
+`Rules` is deprecated because a map has no order, so which rule answered a path
+two rules both matched was decided by map iteration, which Go randomizes per
+run. It keeps working for the whole of v3: its keys are ranked most path text
+before the first `*`, then most path text overall, then fewest asterisks, then
+the key itself.
 :::
 
 ## Examples
@@ -37,9 +49,9 @@ func main() {
     app := fiber.New()
 
     app.Use(rewrite.New(rewrite.Config{
-      Rules: map[string]string{
-        "/old":   "/new",
-        "/old/*": "/new/$1",
+      RuleList: []rewrite.Rule{
+        {From: "/old", To: "/new"},
+        {From: "/old/*", To: "/new/$1"},
       },
     }))
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1740,6 +1740,34 @@ The new `KeepConnectionHeader` option (default `false`) drops the `Connection` h
 
 The Recover middleware allows customizing the error it returns. Set a `PanicHandler` in its `Config` to change the default behavior.
 
+### Rewrite
+
+- **Ordered rules**: `Rules map[string]string` is deprecated in favour of `RuleList []Rule`. A map has no order, so which rule answered a path two rules both matched was decided by map iteration, which Go randomizes per run: the same request could be rewritten differently from one call to the next. Rules in a `RuleList` are tried in the order written and the first match wins, exactly as routes are matched.
+
+```go
+// Before
+app.Use(rewrite.New(rewrite.Config{
+    Rules: map[string]string{
+        "/old":   "/new",
+        "/old/*": "/new/$1",
+    },
+}))
+
+// After
+app.Use(rewrite.New(rewrite.Config{
+    RuleList: []rewrite.Rule{
+        {From: "/old", To: "/new"},
+        {From: "/old/*", To: "/new/$1"},
+    },
+}))
+```
+
+`Rules` keeps working for the whole of v3; its keys are ranked most path text before the first `*`, then most path text overall, then fewest asterisks, then the key. Setting both fields panics.
+
+- **A rule is path text**: `From` is no longer compiled as an unescaped regular expression. `*` matches a run of any length and every other byte stands for itself, so `/preis-1.000-euro` rewrites that path and no longer also `/preis-1X000-euro`, and `/faq?` no longer rewrites `/fa`. Rules written with path text and `*` are unaffected; a rule relying on regular-expression syntax now matches the literal characters it spells.
+
+- **Anchoring holds across the whole rule**: the pattern is grouped before the anchors are applied, so a rule can no longer match a path by prefix or suffix alone.
+
 ### Session
 
 The Session middleware has undergone key changes in v3 to improve functionality and flexibility. While v2 methods remain available for backward compatibility, we now recommend using the new middleware handler for session management.

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -3239,7 +3239,7 @@ app.Get("/gif", proxy.Forward("https://i.imgur.com/IWaBepg.gif"))
 
 #### Rewrite
 
-- **Ordered rules**: `Rules map[string]string` is deprecated in favour of `OrderedRules []Rule`. A map has no order, so which rule answered a path two rules both matched was decided by map iteration, which Go randomizes per run: the same request could be rewritten differently from one call to the next. Rules in an `OrderedRules` list are tried in the order written and the first match wins, exactly as routes are matched.
+- **Ordered rules**: `Rules map[string]string` is deprecated in favour of `RuleList []Rule`. A map has no order, so which rule answered a path two rules both matched was decided by map iteration, which Go randomizes per run: the same request could be rewritten differently from one call to the next. Rules in an `RuleList` list are tried in the order written and the first match wins, exactly as routes are matched.
 
 ```go
 // Before
@@ -3252,7 +3252,7 @@ app.Use(rewrite.New(rewrite.Config{
 
 // After
 app.Use(rewrite.New(rewrite.Config{
-    OrderedRules: []rewrite.Rule{
+    RuleList: []rewrite.Rule{
         {From: "/old", To: "/new"},
         {From: "/old/*", To: "/new/$1"},
     },

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1740,34 +1740,6 @@ The new `KeepConnectionHeader` option (default `false`) drops the `Connection` h
 
 The Recover middleware allows customizing the error it returns. Set a `PanicHandler` in its `Config` to change the default behavior.
 
-### Rewrite
-
-- **Ordered rules**: `Rules map[string]string` is deprecated in favour of `RuleList []Rule`. A map has no order, so which rule answered a path two rules both matched was decided by map iteration, which Go randomizes per run: the same request could be rewritten differently from one call to the next. Rules in a `RuleList` are tried in the order written and the first match wins, exactly as routes are matched.
-
-```go
-// Before
-app.Use(rewrite.New(rewrite.Config{
-    Rules: map[string]string{
-        "/old":   "/new",
-        "/old/*": "/new/$1",
-    },
-}))
-
-// After
-app.Use(rewrite.New(rewrite.Config{
-    RuleList: []rewrite.Rule{
-        {From: "/old", To: "/new"},
-        {From: "/old/*", To: "/new/$1"},
-    },
-}))
-```
-
-`Rules` keeps working for the whole of v3; its keys are ranked most path text before the first `*`, then most path text overall, then fewest asterisks, then the key. Setting both fields panics.
-
-- **A rule is path text**: `From` is no longer compiled as an unescaped regular expression. `*` matches a run of any length and every other byte stands for itself, so `/preis-1.000-euro` rewrites that path and no longer also `/preis-1X000-euro`, and `/faq?` no longer rewrites `/fa`. Rules written with path text and `*` are unaffected; a rule relying on regular-expression syntax now matches the literal characters it spells.
-
-- **Anchoring holds across the whole rule**: the pattern is grouped before the anchors are applied, so a rule can no longer match a path by prefix or suffix alone.
-
 ### Session
 
 The Session middleware has undergone key changes in v3 to improve functionality and flexibility. While v2 methods remain available for backward compatibility, we now recommend using the new middleware handler for session management.
@@ -3264,6 +3236,32 @@ app.Get("/gif", proxy.Forward("https://i.imgur.com/IWaBepg.gif"))
 ```
 
 `proxy.Balancer` also adopts the common middleware signature pattern and now accepts an optional variadic config: call `proxy.Balancer()` to use the defaults or continue passing a single `proxy.Config` value as in v2.
+
+#### Rewrite
+
+- **Ordered rules**: `Rules map[string]string` is deprecated in favour of `OrderedRules []Rule`. A map has no order, so which rule answered a path two rules both matched was decided by map iteration, which Go randomizes per run: the same request could be rewritten differently from one call to the next. Rules in an `OrderedRules` list are tried in the order written and the first match wins, exactly as routes are matched.
+
+```go
+// Before
+app.Use(rewrite.New(rewrite.Config{
+    Rules: map[string]string{
+        "/old":   "/new",
+        "/old/*": "/new/$1",
+    },
+}))
+
+// After
+app.Use(rewrite.New(rewrite.Config{
+    OrderedRules: []rewrite.Rule{
+        {From: "/old", To: "/new"},
+        {From: "/old/*", To: "/new/$1"},
+    },
+}))
+```
+
+`Rules` keeps working for the whole of v3; its keys are ranked most path text before the first `*`, then most path text overall, then fewest asterisks, then the key. Setting both fields panics.
+
+- **A rule is path text**: `From` is no longer compiled as an unescaped regular expression. `*` matches a run of any bytes but a newline and every other byte stands for itself, so `/preis-1.000-euro` rewrites that path and no longer also `/preis-1X000-euro`, and `/faq?` no longer rewrites `/fa`. This also completes the anchoring fix from #4476: `"^" + "/a|/b" + "$"` parsed as `(^/a)|(/b$)`, so a rule could match by prefix or suffix alone. Rules written with path text and `*` are unaffected; a rule relying on regular-expression syntax now matches the literal characters it spells.
 
 #### Session
 

--- a/middleware/rewrite/config.go
+++ b/middleware/rewrite/config.go
@@ -27,13 +27,13 @@ type Config struct {
 	// Rules defines the URL path rewrite rules. The values captured in asterisk can be
 	// retrieved by index e.g. $1, $2 and so on.
 	//
-	// Deprecated: Use OrderedRules instead. A map has no order, so the rule
+	// Deprecated: Use RuleList instead. A map has no order, so the rule
 	// answering a path two rules both match is decided by a documented heuristic
 	// rather than by the author. Retained for backward compatibility with
 	// existing configurations.
 	Rules map[string]string
 
-	// OrderedRules defines the URL path rewrite rules, tried in the order given:
+	// RuleList defines the URL path rewrite rules, tried in the order given:
 	// the first rule whose From matches the request path wins, as routes do.
 	// Put the specific rules before the catch-alls.
 	// Required. Example:
@@ -41,7 +41,7 @@ type Config struct {
 	// {From: "/api/*", To: "/$1"},
 	// {From: "/js/*", To: "/public/javascript/$1"},
 	// {From: "/users/*/orders/*", To: "/user/$1/order/$2"},
-	OrderedRules []Rule
+	RuleList []Rule
 }
 
 // Helper function to set default values
@@ -54,8 +54,8 @@ func configDefault(config ...Config) Config {
 	// Override default config
 	cfg := config[0]
 
-	if len(cfg.Rules) > 0 && len(cfg.OrderedRules) > 0 {
-		panic("rewrite: set either Rules (deprecated) or OrderedRules, not both")
+	if len(cfg.Rules) > 0 && len(cfg.RuleList) > 0 {
+		panic("rewrite: set either Rules (deprecated) or RuleList, not both")
 	}
 
 	return cfg

--- a/middleware/rewrite/config.go
+++ b/middleware/rewrite/config.go
@@ -36,8 +36,9 @@ type Config struct {
 	// RuleList defines the URL path rewrite rules. They are tried in the order
 	// given and the first rule whose From matches the request path wins, as
 	// routes do; nothing reorders the list. Put the specific rules before the
-	// catch-alls.
-	// Required. Example:
+	// catch-alls. Set this or the deprecated Rules, not both.
+	//
+	// Example:
 	// {From: "/old", To: "/new"},
 	// {From: "/api/*", To: "/$1"},
 	// {From: "/js/*", To: "/public/javascript/$1"},

--- a/middleware/rewrite/config.go
+++ b/middleware/rewrite/config.go
@@ -1,10 +1,20 @@
 package rewrite
 
 import (
-	"regexp"
-
 	"github.com/gofiber/fiber/v3"
 )
+
+// Rule is one rewrite: the path pattern to match and the path to rewrite it
+// to. The values captured in asterisk can be retrieved by index e.g. $1, $2
+// and so on.
+type Rule struct {
+	// From is the path pattern, where "*" matches a run of any length.
+	From string
+
+	// To is the new path, where "$1", "$2" and so on stand for what the
+	// asterisks of From captured.
+	To string
+}
 
 // Config defines the config for middleware.
 type Config struct {
@@ -14,14 +24,24 @@ type Config struct {
 
 	// Rules defines the URL path rewrite rules. The values captured in asterisk can be
 	// retrieved by index e.g. $1, $2 and so on.
-	// Required. Example:
-	// "/old":              "/new",
-	// "/api/*":            "/$1",
-	// "/js/*":             "/public/javascript/$1",
-	// "/users/*/orders/*": "/user/$1/order/$2",
+	//
+	// Deprecated: Use RuleList instead. A map has no order, so the rule answering
+	// a path two rules both match was decided by map iteration, which Go
+	// randomizes per run. Retained for backward compatibility with existing
+	// configurations.
 	Rules map[string]string
 
-	rulesRegex map[*regexp.Regexp]string
+	// RuleList defines the URL path rewrite rules, tried in the order given:
+	// the first rule whose From matches the request path wins, as routes do.
+	// Put the specific rules before the catch-alls.
+	// Required. Example:
+	// {From: "/old", To: "/new"},
+	// {From: "/api/*", To: "/$1"},
+	// {From: "/js/*", To: "/public/javascript/$1"},
+	// {From: "/users/*/orders/*", To: "/user/$1/order/$2"},
+	RuleList []Rule
+
+	rules []compiledRule
 }
 
 // Helper function to set default values
@@ -33,6 +53,10 @@ func configDefault(config ...Config) Config {
 
 	// Override default config
 	cfg := config[0]
+
+	if len(cfg.Rules) > 0 && len(cfg.RuleList) > 0 {
+		panic("rewrite: set either Rules (deprecated) or RuleList, not both")
+	}
 
 	return cfg
 }

--- a/middleware/rewrite/config.go
+++ b/middleware/rewrite/config.go
@@ -33,9 +33,10 @@ type Config struct {
 	// existing configurations.
 	Rules map[string]string
 
-	// RuleList defines the URL path rewrite rules, tried in the order given:
-	// the first rule whose From matches the request path wins, as routes do.
-	// Put the specific rules before the catch-alls.
+	// RuleList defines the URL path rewrite rules. They are tried in the order
+	// given and the first rule whose From matches the request path wins, as
+	// routes do; nothing reorders the list. Put the specific rules before the
+	// catch-alls.
 	// Required. Example:
 	// {From: "/old", To: "/new"},
 	// {From: "/api/*", To: "/$1"},

--- a/middleware/rewrite/config.go
+++ b/middleware/rewrite/config.go
@@ -8,7 +8,9 @@ import (
 // to. The values captured in asterisk can be retrieved by index e.g. $1, $2
 // and so on.
 type Rule struct {
-	// From is the path pattern, where "*" matches a run of any length.
+	// From is the path pattern, where "*" matches a run of any bytes but a
+	// newline and every other byte stands for itself. There is no escape for a
+	// literal "*".
 	From string
 
 	// To is the new path, where "$1", "$2" and so on stand for what the
@@ -25,13 +27,13 @@ type Config struct {
 	// Rules defines the URL path rewrite rules. The values captured in asterisk can be
 	// retrieved by index e.g. $1, $2 and so on.
 	//
-	// Deprecated: Use RuleList instead. A map has no order, so the rule answering
-	// a path two rules both match was decided by map iteration, which Go
-	// randomizes per run. Retained for backward compatibility with existing
-	// configurations.
+	// Deprecated: Use OrderedRules instead. A map has no order, so the rule
+	// answering a path two rules both match is decided by a documented heuristic
+	// rather than by the author. Retained for backward compatibility with
+	// existing configurations.
 	Rules map[string]string
 
-	// RuleList defines the URL path rewrite rules, tried in the order given:
+	// OrderedRules defines the URL path rewrite rules, tried in the order given:
 	// the first rule whose From matches the request path wins, as routes do.
 	// Put the specific rules before the catch-alls.
 	// Required. Example:
@@ -39,9 +41,7 @@ type Config struct {
 	// {From: "/api/*", To: "/$1"},
 	// {From: "/js/*", To: "/public/javascript/$1"},
 	// {From: "/users/*/orders/*", To: "/user/$1/order/$2"},
-	RuleList []Rule
-
-	rules []compiledRule
+	OrderedRules []Rule
 }
 
 // Helper function to set default values
@@ -54,8 +54,8 @@ func configDefault(config ...Config) Config {
 	// Override default config
 	cfg := config[0]
 
-	if len(cfg.Rules) > 0 && len(cfg.RuleList) > 0 {
-		panic("rewrite: set either Rules (deprecated) or RuleList, not both")
+	if len(cfg.Rules) > 0 && len(cfg.OrderedRules) > 0 {
+		panic("rewrite: set either Rules (deprecated) or OrderedRules, not both")
 	}
 
 	return cfg

--- a/middleware/rewrite/rewrite.go
+++ b/middleware/rewrite/rewrite.go
@@ -21,16 +21,16 @@ func New(config ...Config) fiber.Handler {
 
 	// Initialize
 	rules := orderedRules(cfg)
-	cfg.rules = make([]compiledRule, 0, len(rules))
+	compiled := make([]compiledRule, 0, len(rules))
 	for _, rule := range rules {
-		cfg.rules = append(cfg.rules, compiledRule{
+		compiled = append(compiled, compiledRule{
 			pattern: compilePattern(rule.From),
 			to:      rule.To,
 		})
 	}
 
-	// Bound before the closure so it captures these alone.
-	compiled, next := cfg.rules, cfg.Next
+	// Bound before the closure so it captures this alone.
+	next := cfg.Next
 
 	// Middleware function
 	return func(c fiber.Ctx) error {
@@ -52,21 +52,22 @@ func New(config ...Config) fiber.Handler {
 
 // compilePattern turns a rule into the regexp that matches it. Everything but
 // "*" is quoted, so a rule is the path text it spells: "/preis-1.000" matches
-// that path and not "/preis-1X000".
+// that path and not "/preis-1X000". "*" stands for any run of bytes except a
+// newline, which is what "." excludes and no ordinary path carries.
 func compilePattern(from string) *regexp.Regexp {
 	pattern := strings.ReplaceAll(regexp.QuoteMeta(from), `\*`, "(.*)")
 	// Anchor both ends so a rule matches the whole path rather than any suffix
-	// (see issue #4476). Grouped because concatenation binds looser than "|",
-	// which quoting now rules out but the group costs nothing and says so.
+	// (see issue #4476). The group is belt and braces: quoting already rules out
+	// the "|" that made "^/a|/b$" parse as "(^/a)|(/b$)".
 	return regexp.MustCompile("^(?:" + pattern + ")$")
 }
 
-// orderedRules returns the rules to try, in the order to try them. RuleList is
+// orderedRules returns the rules to try, in the order to try them. OrderedRules is
 // the author's own order, first match wins. The deprecated map has none, so its
 // keys are ranked most-specific first and that order is documented.
 func orderedRules(cfg Config) []Rule {
-	if len(cfg.RuleList) > 0 {
-		return cfg.RuleList
+	if len(cfg.OrderedRules) > 0 {
+		return cfg.OrderedRules
 	}
 
 	keys := make([]string, 0, len(cfg.Rules))
@@ -82,8 +83,9 @@ func orderedRules(cfg Config) []Rule {
 		if d := cmp.Compare(pinnedLen(b), pinnedLen(a)); d != 0 {
 			return d
 		}
-		// A second wildcard matches everything the first does and more, so the
-		// rule carrying fewer of them is the narrower claim.
+		// A second wildcard usually widens the claim, so the rule carrying fewer
+		// of them goes first. Two adjacent asterisks mean no more than one, and
+		// there the count misreads which rule is narrower.
 		if d := cmp.Compare(strings.Count(a, "*"), strings.Count(b, "*")); d != 0 {
 			return d
 		}

--- a/middleware/rewrite/rewrite.go
+++ b/middleware/rewrite/rewrite.go
@@ -1,38 +1,48 @@
 package rewrite
 
 import (
+	"cmp"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
 )
 
+type compiledRule struct {
+	pattern *regexp.Regexp
+	to      string
+}
+
 // New creates a new middleware handler
 func New(config ...Config) fiber.Handler {
 	cfg := configDefault(config...)
 
 	// Initialize
-	cfg.rulesRegex = map[*regexp.Regexp]string{}
-	for k, v := range cfg.Rules {
-		k = strings.ReplaceAll(k, "*", "(.*)")
-		// Anchor both ends so a rule matches the whole path. Without the leading
-		// "^" the pattern matches any suffix, so a rule fires on unrelated routes
-		// (e.g. "/users/*" would also rewrite "/api/users/1"). See issue #4476.
-		k = "^" + k + "$"
-		cfg.rulesRegex[regexp.MustCompile(k)] = v
+	rules := orderedRules(cfg)
+	cfg.rules = make([]compiledRule, 0, len(rules))
+	for _, rule := range rules {
+		cfg.rules = append(cfg.rules, compiledRule{
+			pattern: compilePattern(rule.From),
+			to:      rule.To,
+		})
 	}
+
+	// Bound before the closure so it captures these alone.
+	compiled, next := cfg.rules, cfg.Next
+
 	// Middleware function
 	return func(c fiber.Ctx) error {
 		// Next request to skip middleware
-		if cfg.Next != nil && cfg.Next(c) {
+		if next != nil && next(c) {
 			return c.Next()
 		}
 		// Rewrite
-		for k, v := range cfg.rulesRegex {
-			replacer := captureTokens(k, c.Path())
+		for _, rule := range compiled {
+			replacer := captureTokens(rule.pattern, c.Path())
 			if replacer != nil {
-				c.Path(replacer.Replace(v))
+				c.Path(replacer.Replace(rule.to))
 				break
 			}
 		}
@@ -40,13 +50,75 @@ func New(config ...Config) fiber.Handler {
 	}
 }
 
+// compilePattern turns a rule into the regexp that matches it. Everything but
+// "*" is quoted, so a rule is the path text it spells: "/preis-1.000" matches
+// that path and not "/preis-1X000".
+func compilePattern(from string) *regexp.Regexp {
+	pattern := strings.ReplaceAll(regexp.QuoteMeta(from), `\*`, "(.*)")
+	// Anchor both ends so a rule matches the whole path rather than any suffix
+	// (see issue #4476). Grouped because concatenation binds looser than "|",
+	// which quoting now rules out but the group costs nothing and says so.
+	return regexp.MustCompile("^(?:" + pattern + ")$")
+}
+
+// orderedRules returns the rules to try, in the order to try them. RuleList is
+// the author's own order, first match wins. The deprecated map has none, so its
+// keys are ranked most-specific first and that order is documented.
+func orderedRules(cfg Config) []Rule {
+	if len(cfg.RuleList) > 0 {
+		return cfg.RuleList
+	}
+
+	keys := make([]string, 0, len(cfg.Rules))
+	for k := range cfg.Rules {
+		keys = append(keys, k)
+	}
+	slices.SortFunc(keys, func(a, b string) int {
+		// What each pins before its first wildcard, then in total: "/api/users"
+		// outranks the "/api/*" that would otherwise answer for it.
+		if d := cmp.Compare(pinnedPrefixLen(b), pinnedPrefixLen(a)); d != 0 {
+			return d
+		}
+		if d := cmp.Compare(pinnedLen(b), pinnedLen(a)); d != 0 {
+			return d
+		}
+		// A second wildcard matches everything the first does and more, so the
+		// rule carrying fewer of them is the narrower claim.
+		if d := cmp.Compare(strings.Count(a, "*"), strings.Count(b, "*")); d != 0 {
+			return d
+		}
+		return cmp.Compare(a, b)
+	})
+
+	rules := make([]Rule, 0, len(keys))
+	for _, k := range keys {
+		rules = append(rules, Rule{From: k, To: cfg.Rules[k]})
+	}
+	return rules
+}
+
+// pinnedPrefixLen returns how many bytes of a path a rule pins before its first
+// wildcard, which is what makes one rule more specific than another it overlaps.
+func pinnedPrefixLen(rule string) int {
+	if i := strings.IndexByte(rule, '*'); i >= 0 {
+		return i
+	}
+	return len(rule)
+}
+
+// pinnedLen returns how many bytes of a rule stand for themselves, which
+// separates two rules whose wildcards start together: "/cdn/*" and "/cdn/*x".
+func pinnedLen(rule string) int {
+	return len(rule) - strings.Count(rule, "*")
+}
+
 // https://github.com/labstack/echo/blob/master/middleware/rewrite.go
 func captureTokens(pattern *regexp.Regexp, input string) *strings.Replacer {
-	groups := pattern.FindAllStringSubmatch(input, -1)
+	groups := pattern.FindStringSubmatch(input)
 	if groups == nil {
 		return nil
 	}
-	values := groups[0][1:]
+	values := groups[1:]
 	replace := make([]string, 2*len(values))
 	for i, v := range values {
 		j := 2 * i

--- a/middleware/rewrite/rewrite.go
+++ b/middleware/rewrite/rewrite.go
@@ -62,12 +62,12 @@ func compilePattern(from string) *regexp.Regexp {
 	return regexp.MustCompile("^(?:" + pattern + ")$")
 }
 
-// orderedRules returns the rules to try, in the order to try them. OrderedRules is
+// orderedRules returns the rules to try, in the order to try them. RuleList is
 // the author's own order, first match wins. The deprecated map has none, so its
 // keys are ranked most-specific first and that order is documented.
 func orderedRules(cfg Config) []Rule {
-	if len(cfg.OrderedRules) > 0 {
-		return cfg.OrderedRules
+	if len(cfg.RuleList) > 0 {
+		return cfg.RuleList
 	}
 
 	keys := make([]string, 0, len(cfg.Rules))

--- a/middleware/rewrite/rewrite_test.go
+++ b/middleware/rewrite/rewrite_test.go
@@ -443,14 +443,14 @@ func rewritten(t *testing.T, cfg Config, path string) string {
 	return string(body)
 }
 
-func Test_Rewrite_OrderedRulesOrderWins(t *testing.T) {
+func Test_Rewrite_RuleListOrderWins(t *testing.T) {
 	t.Parallel()
 
-	narrowFirst := Config{OrderedRules: []Rule{
+	narrowFirst := Config{RuleList: []Rule{
 		{From: "/p/a*", To: "/narrow/$1"},
 		{From: "/p/*", To: "/broad/$1"},
 	}}
-	broadFirst := Config{OrderedRules: []Rule{
+	broadFirst := Config{RuleList: []Rule{
 		{From: "/p/*", To: "/broad/$1"},
 		{From: "/p/a*", To: "/narrow/$1"},
 	}}
@@ -500,7 +500,7 @@ func Test_Rewrite_PatternIsPathTextNotRegexp(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := Config{OrderedRules: []Rule{{From: tc.from, To: "/hit"}}}
+			cfg := Config{RuleList: []Rule{{From: tc.from, To: "/hit"}}}
 			require.Equal(t, tc.want, rewritten(t, cfg, tc.path))
 		})
 	}
@@ -513,7 +513,7 @@ func Test_Rewrite_AlternationNoLongerEscapesTheAnchors(t *testing.T) {
 	// branch each and the rule fired on any path starting "/a" or ending "/b"
 	// (issue #4476). Quoted, "|" is path text and the rule claims no path a
 	// client can send, since the byte arrives percent-encoded.
-	cfg := Config{OrderedRules: []Rule{{From: "/a|/b", To: "/hit"}}}
+	cfg := Config{RuleList: []Rule{{From: "/a|/b", To: "/hit"}}}
 
 	for _, path := range []string{"/a", "/b", "/xx/b", "/a/yy"} {
 		require.Equal(t, path, rewritten(t, cfg, path))
@@ -525,13 +525,13 @@ func Test_Rewrite_BothRuleFieldsPanic(t *testing.T) {
 
 	require.Panics(t, func() {
 		New(Config{
-			Rules:        map[string]string{"/old": "/new"},
-			OrderedRules: []Rule{{From: "/old", To: "/new"}},
+			Rules:    map[string]string{"/old": "/new"},
+			RuleList: []Rule{{From: "/old", To: "/new"}},
 		})
 	})
 }
 
-func Test_Rewrite_OrderedRulesRanking(t *testing.T) {
+func Test_Rewrite_RuleListRanking(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/middleware/rewrite/rewrite_test.go
+++ b/middleware/rewrite/rewrite_test.go
@@ -443,14 +443,14 @@ func rewritten(t *testing.T, cfg Config, path string) string {
 	return string(body)
 }
 
-func Test_Rewrite_RuleListOrderWins(t *testing.T) {
+func Test_Rewrite_OrderedRulesOrderWins(t *testing.T) {
 	t.Parallel()
 
-	narrowFirst := Config{RuleList: []Rule{
+	narrowFirst := Config{OrderedRules: []Rule{
 		{From: "/p/a*", To: "/narrow/$1"},
 		{From: "/p/*", To: "/broad/$1"},
 	}}
-	broadFirst := Config{RuleList: []Rule{
+	broadFirst := Config{OrderedRules: []Rule{
 		{From: "/p/*", To: "/broad/$1"},
 		{From: "/p/a*", To: "/narrow/$1"},
 	}}
@@ -500,7 +500,7 @@ func Test_Rewrite_PatternIsPathTextNotRegexp(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := Config{RuleList: []Rule{{From: tc.from, To: "/hit"}}}
+			cfg := Config{OrderedRules: []Rule{{From: tc.from, To: "/hit"}}}
 			require.Equal(t, tc.want, rewritten(t, cfg, tc.path))
 		})
 	}
@@ -513,7 +513,7 @@ func Test_Rewrite_AlternationNoLongerEscapesTheAnchors(t *testing.T) {
 	// branch each and the rule fired on any path starting "/a" or ending "/b"
 	// (issue #4476). Quoted, "|" is path text and the rule claims no path a
 	// client can send, since the byte arrives percent-encoded.
-	cfg := Config{RuleList: []Rule{{From: "/a|/b", To: "/hit"}}}
+	cfg := Config{OrderedRules: []Rule{{From: "/a|/b", To: "/hit"}}}
 
 	for _, path := range []string{"/a", "/b", "/xx/b", "/a/yy"} {
 		require.Equal(t, path, rewritten(t, cfg, path))
@@ -525,8 +525,67 @@ func Test_Rewrite_BothRuleFieldsPanic(t *testing.T) {
 
 	require.Panics(t, func() {
 		New(Config{
-			Rules:    map[string]string{"/old": "/new"},
-			RuleList: []Rule{{From: "/old", To: "/new"}},
+			Rules:        map[string]string{"/old": "/new"},
+			OrderedRules: []Rule{{From: "/old", To: "/new"}},
 		})
 	})
+}
+
+func Test_Rewrite_OrderedRulesRanking(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		rules map[string]string
+		want  []string
+	}{
+		{
+			name:  "longer pinned prefix first",
+			rules: map[string]string{"/api/*": "/a", "/api/users/*": "/b"},
+			want:  []string{"/api/users/*", "/api/*"},
+		},
+		{
+			name:  "same prefix, more pinned text first",
+			rules: map[string]string{"/cdn/*": "/a", "/cdn/*x": "/b"},
+			want:  []string{"/cdn/*x", "/cdn/*"},
+		},
+		{
+			name:  "same pinned text, fewer wildcards first",
+			rules: map[string]string{"/p/*a*b": "/a", "/p/*ab": "/b"},
+			want:  []string{"/p/*ab", "/p/*a*b"},
+		},
+		{
+			name:  "otherwise the key, so the order is total",
+			rules: map[string]string{"/b/*": "/x", "/a/*": "/y"},
+			want:  []string{"/a/*", "/b/*"},
+		},
+		{
+			name:  "a rule without a wildcard pins its whole length",
+			rules: map[string]string{"/exact": "/a", "/ex*": "/b"},
+			want:  []string{"/exact", "/ex*"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := make([]string, 0, len(tc.rules))
+			for _, rule := range orderedRules(Config{Rules: tc.rules}) {
+				got = append(got, rule.From)
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func Test_Rewrite_DeprecatedRulesAreQuotedToo(t *testing.T) {
+	t.Parallel()
+
+	// Both entry points share compilePattern, so a future split cannot quietly
+	// leave the map path compiling its keys as regular expressions.
+	cfg := Config{Rules: map[string]string{"/preis-1.000-euro": "/hit"}}
+
+	require.Equal(t, "/preis-1X000-euro", rewritten(t, cfg, "/preis-1X000-euro"))
+	require.Equal(t, "/hit", rewritten(t, cfg, "/preis-1.000-euro"))
 }

--- a/middleware/rewrite/rewrite_test.go
+++ b/middleware/rewrite/rewrite_test.go
@@ -491,7 +491,7 @@ func Test_Rewrite_PatternIsPathTextNotRegexp(t *testing.T) {
 		{name: "brackets are text", from: "/v[1]", path: "/v1", want: "/v1"},
 		{name: "brackets match themselves", from: "/v[1]", path: "/v[1]", want: "/hit"},
 		// A rule spelling "?" can never fire: the byte starts the query, so no
-		// path carries it. Quoted it is inert, where as a regexp it made the
+		// path carries it. Quoted it is inert, whereas as a regexp it made the
 		// preceding byte optional and fired on a path the author never wrote.
 		{name: "question mark no longer eats a shorter path", from: "/faq?", path: "/fa", want: "/fa"},
 	}
@@ -531,7 +531,7 @@ func Test_Rewrite_BothRuleFieldsPanic(t *testing.T) {
 	})
 }
 
-func Test_Rewrite_RuleListRanking(t *testing.T) {
+func Test_Rewrite_DeprecatedRulesRanking(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/middleware/rewrite/rewrite_test.go
+++ b/middleware/rewrite/rewrite_test.go
@@ -422,3 +422,111 @@ func Benchmark_Rewrite_Parallel(b *testing.B) {
 		})
 	})
 }
+
+// rewritten runs one request through a rewrite config and reports the path the
+// handler saw.
+func rewritten(t *testing.T, cfg Config, path string) string {
+	t.Helper()
+
+	app := fiber.New()
+	app.Use(New(cfg))
+	app.Use(func(c fiber.Ctx) error {
+		return c.SendString(c.Path())
+	})
+
+	req, err := http.NewRequestWithContext(context.Background(), fiber.MethodGet, path, http.NoBody)
+	require.NoError(t, err)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return string(body)
+}
+
+func Test_Rewrite_RuleListOrderWins(t *testing.T) {
+	t.Parallel()
+
+	narrowFirst := Config{RuleList: []Rule{
+		{From: "/p/a*", To: "/narrow/$1"},
+		{From: "/p/*", To: "/broad/$1"},
+	}}
+	broadFirst := Config{RuleList: []Rule{
+		{From: "/p/*", To: "/broad/$1"},
+		{From: "/p/a*", To: "/narrow/$1"},
+	}}
+
+	require.Equal(t, "/narrow/bc", rewritten(t, narrowFirst, "/p/abc"))
+	require.Equal(t, "/broad/abc", rewritten(t, broadFirst, "/p/abc"))
+}
+
+func Test_Rewrite_DeprecatedRulesOrderIsStable(t *testing.T) {
+	t.Parallel()
+
+	// A map has no order, so this pins that the ranking decides the winner
+	// rather than Go's randomized iteration.
+	cfg := Config{Rules: map[string]string{
+		"/p/*":  "/broad/$1",
+		"/p/a*": "/narrow/$1",
+	}}
+	for range 25 {
+		require.Equal(t, "/narrow/bc", rewritten(t, cfg, "/p/abc"))
+	}
+}
+
+func Test_Rewrite_PatternIsPathTextNotRegexp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		from string
+		path string
+		want string
+	}{
+		{name: "dot is a dot", from: "/preis-1.000-euro", path: "/preis-1X000-euro", want: "/preis-1X000-euro"},
+		{name: "dot matches itself", from: "/preis-1.000-euro", path: "/preis-1.000-euro", want: "/hit"},
+		{name: "parentheses are text", from: "/files(old)", path: "/filesold", want: "/filesold"},
+		{name: "parentheses match themselves", from: "/files(old)", path: "/files(old)", want: "/hit"},
+		{name: "plus is text", from: "/a+", path: "/aaa", want: "/aaa"},
+		{name: "plus matches itself", from: "/a+", path: "/a+", want: "/hit"},
+		{name: "brackets are text", from: "/v[1]", path: "/v1", want: "/v1"},
+		{name: "brackets match themselves", from: "/v[1]", path: "/v[1]", want: "/hit"},
+		// A rule spelling "?" can never fire: the byte starts the query, so no
+		// path carries it. Quoted it is inert, where as a regexp it made the
+		// preceding byte optional and fired on a path the author never wrote.
+		{name: "question mark no longer eats a shorter path", from: "/faq?", path: "/fa", want: "/fa"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := Config{RuleList: []Rule{{From: tc.from, To: "/hit"}}}
+			require.Equal(t, tc.want, rewritten(t, cfg, tc.path))
+		})
+	}
+}
+
+func Test_Rewrite_AlternationNoLongerEscapesTheAnchors(t *testing.T) {
+	t.Parallel()
+
+	// Read as a regexp, "^/a|/b$" is "(^/a)|(/b$)", so the anchors bound one
+	// branch each and the rule fired on any path starting "/a" or ending "/b"
+	// (issue #4476). Quoted, "|" is path text and the rule claims no path a
+	// client can send, since the byte arrives percent-encoded.
+	cfg := Config{RuleList: []Rule{{From: "/a|/b", To: "/hit"}}}
+
+	for _, path := range []string{"/a", "/b", "/xx/b", "/a/yy"} {
+		require.Equal(t, path, rewritten(t, cfg, path))
+	}
+}
+
+func Test_Rewrite_BothRuleFieldsPanic(t *testing.T) {
+	t.Parallel()
+
+	require.Panics(t, func() {
+		New(Config{
+			Rules:    map[string]string{"/old": "/new"},
+			RuleList: []Rule{{From: "/old", To: "/new"}},
+		})
+	})
+}


### PR DESCRIPTION
## Description

`middleware/rewrite` kept its compiled rules in a `map[*regexp.Regexp]string` that the handler ranged over, breaking on the first match. Go randomizes map iteration, so with two overlapping rules the winner was whichever key the runtime reached first, decided per request. Measured on `main`, 400 identical requests for `/p/abc` against `{"/p/*": "/broad/$1", "/p/a*": "/narrow/$1"}`:

```
/broad/abc  338
/narrow/bc   62
```

The same running server rewrote the same path two different ways.

`RuleList []Rule` is the author's own order, first match wins, exactly as routes are matched. `Rules` is deprecated and keeps working for the whole of v3, ranked by a documented heuristic so its order is at least stable.

## Changes introduced

- **`RuleList []Rule`**, tried in order; compiled into a slice, so the winner no longer depends on map iteration.
- **`Rules` deprecated**, ranked most path text before the first `*`, then most path text overall, then fewest asterisks, then the key. Setting both fields panics, which matches how `helmet`, `keyauth`, `csrf`, `cors`, `hostauthorization` and `proxy` handle a config contradiction.
- **A rule is path text.** `From` was compiled as an unescaped regular expression although only `*` was ever documented. `{"/preis-1.000-euro": "/p"}` rewrote `/preis-1X000-euro`, and `{"/faq?": "/f"}` rewrote `/fa`. Everything but `*` is quoted now.
- **The anchor fix from #4476 completes.** It landed as `"^" + p + "$"`, and concatenation binds looser than `|`, so `^/a|/b$` parsed as `(^/a)|(/b$)` and `{"/a|/b": "/hit"}` matched `/xx/b` and `/a/yy`. `redirect` got the grouped form; `rewrite` did not.
- `FindStringSubmatch` replaces `FindAllStringSubmatch(..., -1)`: the pattern is anchored, so the second match it scanned for cannot exist.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking

A rule relying on regular-expression syntax beyond `*` now matches the literal characters it spells. Rules written with path text and `*`, which is all the public usage I could find, are unaffected. Setting both `Rules` and `RuleList` panics. `docs/whats_new.md` carries the migration entry.

## Verification

- Coverage 87% to **100%** of statements.
- The pre-existing suite passes unchanged, but that proves nothing and I want to be plain about it: every rule map in it has exactly one key, so the comparator never runs. Under mutation testing, four of five deliberate breakages survived the old suite, including reversing every sort tier and removing the quoting entirely. All five are killed by the new tests.
- `regexp.QuoteMeta` with only `\*` re-expanded was checked against a reference implementation over 137,561 inputs covering every arrangement of `\ * . ( ) [ ] | ? + ^ $ - { }` up to length four: 0 mismatches.
- The deprecated map's ranking is a total order: 341 patterns, all pairs, no ties between distinct keys and no transitivity violations.

## Notes

- `*` stands for any run of bytes except a newline, and there is no escape for a literal `*`. Both are now documented rather than discovered.
- The ranking is a rough reading of "most specific", not an exact one: a long wildcard rule can still outrank a shorter exact one. `RuleList` is the exact control, which is the point of the change.
- `middleware/redirect` has the same `Rule`/`RuleList` shape in #4621. It still compiles `From` as a regular expression, so the two middlewares currently disagree about what a rule means. Worth settling deliberately.
