### PR TITLE
🧹 chore: consolidate comma-list header scanning into internal/headerlist

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gofiber/fiber/v3/internal/headerlist"
 	"github.com/gofiber/utils/v2"
 	"github.com/valyala/bytebufferpool"
 	"github.com/valyala/fasthttp"
@@ -551,18 +552,13 @@ func hasTransferEncodingBody(hdr *fasthttp.RequestHeader) bool {
 // transferEncodingLineHasBody reports whether a single Transfer-Encoding
 // field line contains a transfer coding other than "identity".
 func transferEncodingLineHasBody(te string) bool {
-	for raw := range strings.SplitSeq(te, ",") {
-		token := utils.TrimSpace(raw)
-		if token == "" {
-			continue
-		}
+	for token := range headerlist.All(te) {
+		// A transfer coding may carry parameters ("chunked;q=1"), which name the
+		// coding no more than the bare token does (RFC 9110 Section 10.1.4).
 		if idx := strings.IndexByte(token, ';'); idx >= 0 {
 			token = utils.TrimSpace(token[:idx])
 		}
-		if token == "" {
-			continue
-		}
-		if utils.EqualFold(token, "identity") {
+		if token == "" || utils.EqualFold(token, "identity") {
 			continue
 		}
 		return true
@@ -589,15 +585,14 @@ func (c *DefaultCtx) IsWebSocket() bool {
 // ignored when comparing; valid Connection members never contain "/", so
 // this is safe for both headers.
 func headerListContainsToken(lines [][]byte, token string) bool {
-	for _, line := range lines {
-		for v := range strings.SplitSeq(utils.UnsafeString(line), ",") {
-			element := utils.TrimSpace(v)
-			if i := strings.IndexByte(element, '/'); i >= 0 {
-				element = element[:i]
-			}
-			if utils.EqualFold(element, token) {
-				return true
-			}
+	for element := range headerlist.AllLines(lines) {
+		// Connection and Upgrade carry protocol names, which may name a version
+		// after a slash ("HTTP/2.0"). Match on the name alone.
+		if i := strings.IndexByte(element, '/'); i >= 0 {
+			element = element[:i]
+		}
+		if utils.EqualFold(element, token) {
+			return true
 		}
 	}
 	return false

--- a/helpers.go
+++ b/helpers.go
@@ -454,47 +454,6 @@ func paramsMatch(specParamStr headerParams, offerParams string) bool {
 	return allSpecParamsMatch
 }
 
-// getSplicedStrList function takes a string and a string slice as an argument, divides the string into different
-// elements divided by ',' and stores these elements in the string slice.
-// It returns the populated string slice as an output.
-//
-// Empty list elements are parsed and ignored, as required by
-// RFC 9110 Section 5.6.1.2 for all comma-separated field values.
-//
-// If the given slice hasn't enough space, it will allocate more and return.
-func getSplicedStrList(headerValue string, dst []string) []string {
-	if headerValue == "" {
-		return nil
-	}
-
-	dst = dst[:0]
-	segmentStart := 0
-	for i := 0; i < len(headerValue); i++ {
-		if headerValue[i] == ',' {
-			if segment := utils.TrimSpace(headerValue[segmentStart:i]); segment != "" {
-				dst = append(dst, segment)
-			}
-			segmentStart = i + 1
-		}
-	}
-	if segment := utils.TrimSpace(headerValue[segmentStart:]); segment != "" {
-		dst = append(dst, segment)
-	}
-
-	return dst
-}
-
-func joinHeaderValues(headers [][]byte) []byte {
-	switch len(headers) {
-	case 0:
-		return nil
-	case 1:
-		return headers[0]
-	default:
-		return bytes.Join(headers, []byte{','})
-	}
-}
-
 // joinedHeaderValue accumulates the combined value of a header's field lines
 // (RFC 9110 Section 5.2). It allocates only in the rare multi-line case; the
 // single-line result aliases the header storage.

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -538,93 +538,6 @@ func Test_Utils_AcceptsOfferType(t *testing.T) {
 	}
 }
 
-func Test_Utils_GetSplicedStrList(t *testing.T) {
-	t.Parallel()
-	testCases := []struct {
-		description  string
-		headerValue  string
-		expectedList []string
-	}{
-		{
-			description:  "normal case",
-			headerValue:  "gzip, deflate,br",
-			expectedList: []string{"gzip", "deflate", "br"},
-		},
-		{
-			description:  "no matter the value",
-			headerValue:  "   gzip,deflate, br, zip",
-			expectedList: []string{"gzip", "deflate", "br", "zip"},
-		},
-		{
-			description:  "comma with trailing spaces around values",
-			headerValue:  "gzip , br",
-			expectedList: []string{"gzip", "br"},
-		},
-		{
-			description:  "comma with tabbed whitespace",
-			headerValue:  "gzip\t,br",
-			expectedList: []string{"gzip", "br"},
-		},
-		{
-			description:  "headerValue is empty",
-			headerValue:  "",
-			expectedList: nil,
-		},
-		{
-			// RFC 9110 §5.6.1.2: empty list elements are parsed and ignored.
-			description:  "has a comma without element",
-			headerValue:  "gzip,",
-			expectedList: []string{"gzip"},
-		},
-		{
-			description:  "has a space between words",
-			headerValue:  "  foo bar, hello  world",
-			expectedList: []string{"foo bar", "hello  world"},
-		},
-		{
-			description:  "single comma",
-			headerValue:  ",",
-			expectedList: []string{},
-		},
-		{
-			description:  "multiple comma",
-			headerValue:  ",,",
-			expectedList: []string{},
-		},
-		{
-			description:  "comma with space",
-			headerValue:  ",  ,",
-			expectedList: []string{},
-		},
-		{
-			description:  "empty element between values",
-			headerValue:  "gzip, , br",
-			expectedList: []string{"gzip", "br"},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			tc := tc // create a new 'tc' variable for the goroutine
-			t.Parallel()
-			dst := make([]string, 10)
-			result := getSplicedStrList(tc.headerValue, dst)
-			require.Equal(t, tc.expectedList, result)
-		})
-	}
-}
-
-func Benchmark_Utils_GetSplicedStrList(b *testing.B) {
-	destination := make([]string, 5)
-	result := destination
-	const input = `deflate, gzip,br,brotli,zstd`
-	b.ReportAllocs()
-	for b.Loop() {
-		result = getSplicedStrList(input, destination)
-	}
-	require.Equal(b, []string{"deflate", "gzip", "br", "brotli", "zstd"}, result)
-}
-
 func Test_Utils_SortAcceptedTypes(t *testing.T) {
 	t.Parallel()
 	acceptedTypes := []acceptedType{
@@ -879,60 +792,6 @@ func Benchmark_Utils_IsNoCache(b *testing.B) {
 }
 
 // go test -run Test_HeaderContainsValue
-func Test_HeaderContainsValue(t *testing.T) {
-	t.Parallel()
-	testCases := []struct {
-		header   string
-		value    string
-		expected bool
-	}{
-		// Exact match
-		{header: "gzip", value: "gzip", expected: true},
-		{header: "gzip", value: "deflate", expected: false},
-		// Prefix match (value at start with comma)
-		{header: "gzip, deflate", value: "gzip", expected: true},
-		{header: "gzip,deflate", value: "gzip", expected: true},
-		// Suffix match (value at end)
-		{header: "deflate, gzip", value: "gzip", expected: true},
-		{header: "deflate,gzip", value: "gzip", expected: true}, // No space - OWS is optional per RFC 9110
-		{header: "br, gzip", value: "gzip", expected: true},
-		// Middle match (value in middle)
-		{header: "deflate, gzip, br", value: "gzip", expected: true},
-		{header: "deflate,gzip,br", value: "gzip", expected: true}, // No spaces - OWS is optional per RFC 9110
-		// No match - similar but not equal
-		{header: "gzip2", value: "gzip", expected: false},
-		{header: "2gzip", value: "gzip", expected: false},
-		{header: "gzip2, deflate", value: "gzip", expected: false},
-		// Whitespace handling (OWS per RFC 9110)
-		{header: "  gzip  ,  deflate  ", value: "gzip", expected: true},
-		{header: "deflate,  gzip  ", value: "gzip", expected: true},
-		// Empty cases
-		{header: "", value: "gzip", expected: false},
-		{header: "gzip", value: "", expected: false},
-		{header: "", value: "", expected: false}, // Both empty - should return false
-	}
-
-	for _, tc := range testCases {
-		result := headerContainsValue(tc.header, tc.value)
-		require.Equal(t, tc.expected, result,
-			"headerContainsValue(%q, %q) = %v, want %v",
-			tc.header, tc.value, result, tc.expected)
-	}
-}
-
-// go test -v -run=^$ -bench=Benchmark_HeaderContainsValue -benchmem -count=4
-func Benchmark_HeaderContainsValue(b *testing.B) {
-	var ok bool
-	b.ReportAllocs()
-	for b.Loop() {
-		_ = headerContainsValue("gzip", "gzip")
-		_ = headerContainsValue("gzip, deflate, br", "deflate")
-		_ = headerContainsValue("deflate, gzip", "gzip")
-		ok = headerContainsValue("deflate, gzip, br", "gzip")
-	}
-	require.True(b, ok)
-}
-
 type testGenericParseTypeIntCase struct {
 	value int64
 	bits  int
@@ -1614,13 +1473,6 @@ func Test_UnescapeHeaderValue(t *testing.T) {
 			require.Error(t, err, tc.in)
 		}
 	}
-}
-
-func Test_JoinHeaderValues(t *testing.T) {
-	t.Parallel()
-	require.Nil(t, joinHeaderValues(nil))
-	require.Equal(t, []byte("a"), joinHeaderValues([][]byte{[]byte("a")}))
-	require.Equal(t, []byte("a,b"), joinHeaderValues([][]byte{[]byte("a"), []byte("b")}))
 }
 
 func Test_ParamsMatch_InvalidEscape(t *testing.T) {

--- a/internal/etag/etag.go
+++ b/internal/etag/etag.go
@@ -7,6 +7,7 @@ package etag
 import (
 	"strings"
 
+	"github.com/gofiber/fiber/v3/internal/headerlist"
 	"github.com/gofiber/utils/v2"
 )
 
@@ -64,29 +65,20 @@ func AnyMatch(header, etag string) bool {
 		return true
 	}
 
-	// Split the header on commas that sit outside DQUOTE-delimited opaque-tags:
-	// etagc permits "," inside the quoted tag (RFC 9110 Section 8.8.3), so
-	// `"v1,v2"` is a single entity tag, not two list elements. Only '"' and ','
-	// affect the split, so jump between them instead of visiting every byte.
-	start := 0
-	pos := 0
-	inQuotes := false
-	for {
-		i := utils.IndexAny2(header[pos:], '"', ',')
-		if i == -1 {
-			break
-		}
-		i += pos
-		pos = i + 1
-		if header[i] == '"' {
-			inQuotes = !inQuotes
-		} else if !inQuotes {
-			if Match(utils.TrimSpace(header[start:i]), etag) {
-				return true
-			}
-			start = i + 1
+	// etag is the same for every element, so parse it once rather than through
+	// Match on each. An unparseable one matches nothing (RFC 9110 8.8.3.2).
+	want, _, ok := Parse(etag)
+	if !ok {
+		return false
+	}
+
+	// Commas inside the opaque-tag do not separate: etagc permits "," within the
+	// quoted tag (RFC 9110 Section 8.8.3), so `"v1,v2"` is one entity tag.
+	for tag := range headerlist.AllQuoted(header) {
+		if got, _, ok := Parse(tag); ok && got == want {
+			return true
 		}
 	}
 
-	return Match(utils.TrimSpace(header[start:]), etag)
+	return false
 }

--- a/internal/headerlist/headerlist.go
+++ b/internal/headerlist/headerlist.go
@@ -1,0 +1,232 @@
+// Package headerlist walks the comma-separated list values that RFC 9110
+// Section 5.6.1 defines, and joins the field lines that Section 5.3 says are
+// equivalent to one.
+//
+// Seven scanners used to spell this out separately: three in the core
+// (helpers.go, ctx.go, res.go) and four in middleware (adaptor, proxy, compress,
+// cache). They agreed on splitting at commas and trimming OWS, and disagreed on
+// everything after that, so the divergences are named here rather than left to
+// be rediscovered per call site:
+//
+//   - Case. [Contains] compares exactly, [ContainsFold] under ASCII case
+//     folding. Both exist because the callers genuinely differ: a Vary field
+//     name is echoed back to the client as it was written, while a token like
+//     "close" or "gzip" is matched however it arrives.
+//   - Quoting. [All] treats every comma as a separator, which is what a list of
+//     bare tokens wants. [AllQuoted] keeps commas that sit inside a quoted
+//     string, which is what a list of entity tags or media-type parameters
+//     needs, since those may contain one.
+//
+// Empty elements are skipped throughout: "a,,b" yields "a" and "b". A list is
+// permitted to carry them (RFC 9110 Section 5.6.1 allows the empty element for
+// legacy reasons) and no caller here has ever wanted one.
+package headerlist
+
+import (
+	"iter"
+
+	"github.com/gofiber/utils/v2"
+)
+
+// All yields each non-empty element of a comma-separated list value, with
+// leading and trailing OWS removed.
+//
+// Every comma separates. Use [AllQuoted] for a list whose elements may contain
+// a quoted comma.
+func All(list string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		start := 0
+		for i := range len(list) {
+			if list[i] != ',' {
+				continue
+			}
+			if element := utils.TrimSpace(list[start:i]); element != "" {
+				if !yield(element) {
+					return
+				}
+			}
+			start = i + 1
+		}
+		if element := utils.TrimSpace(list[start:]); element != "" {
+			yield(element)
+		}
+	}
+}
+
+// AllQuoted is [All] for lists whose elements may contain a comma inside a
+// quoted string, such as If-None-Match, where the opaque-tag `"v1,v2"` is one
+// entity tag and not two elements (RFC 9110 Section 8.8.3).
+//
+// Only '"' and ',' can affect where an element ends, so the walk jumps between
+// them instead of visiting every byte. A quoted string left open by a malformed
+// value swallows the rest of the list, which keeps a truncated field from
+// splitting into elements the sender did not write.
+func AllQuoted(list string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		start, pos := 0, 0
+		inQuotes := false
+		for {
+			i := utils.IndexAny2(list[pos:], '"', ',')
+			if i == -1 {
+				break
+			}
+			i += pos
+			pos = i + 1
+
+			if list[i] == '"' {
+				inQuotes = !inQuotes
+				continue
+			}
+			if inQuotes {
+				continue
+			}
+			if element := utils.TrimSpace(list[start:i]); element != "" {
+				if !yield(element) {
+					return
+				}
+			}
+			start = i + 1
+		}
+		if element := utils.TrimSpace(list[start:]); element != "" {
+			yield(element)
+		}
+	}
+}
+
+// AllLines yields the elements of every field line in order, so that a header
+// sent as one line and the same header sent as several read alike (RFC 9110
+// Section 5.3).
+//
+// The lines are read as-is; the caller keeps whatever storage they alias.
+func AllLines(lines [][]byte) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for _, line := range lines {
+			for element := range All(utils.UnsafeString(line)) {
+				if !yield(element) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Contains reports whether list has an element equal to value, compared byte
+// for byte. An empty value is never present.
+//
+// value is matched against the elements [All] yields, so it is expected to be
+// one element and to carry no OWS of its own: " gzip " is not an element of
+// " gzip ", though "gzip" is.
+//
+// Use [ContainsFold] to match a token whose case the sender chose.
+func Contains(list, value string) bool {
+	if value == "" {
+		return false
+	}
+
+	for element := range All(list) {
+		if element == value {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsFold reports whether list has an element equal to value under ASCII
+// case folding. An empty value is never present.
+func ContainsFold(list, value string) bool {
+	if value == "" {
+		return false
+	}
+
+	for element := range All(list) {
+		if utils.EqualFold(element, value) {
+			return true
+		}
+	}
+	return false
+}
+
+// Append appends the elements of list to dst and returns it, reusing dst's
+// storage. It returns nil for an empty list, leaving dst untouched.
+//
+// This is the allocation-free counterpart to [All], for the callers that need
+// the elements to outlive the walk. It is written as a loop rather than over
+// [All] because it sits on the per-request Accept-Encoding path.
+func Append(dst []string, list string) []string {
+	if list == "" {
+		return nil
+	}
+
+	dst = dst[:0]
+	start := 0
+	for i := range len(list) {
+		if list[i] != ',' {
+			continue
+		}
+		if element := utils.TrimSpace(list[start:i]); element != "" {
+			dst = append(dst, element)
+		}
+		start = i + 1
+	}
+	if element := utils.TrimSpace(list[start:]); element != "" {
+		dst = append(dst, element)
+	}
+
+	return dst
+}
+
+// Join renders the field lines of one header as the single combined value that
+// RFC 9110 Section 5.3 says they are equivalent to, separated by a bare comma.
+//
+// A lone line is returned as it stands, so the result aliases the caller's
+// storage and must not be retained past it. Only the multi-line case allocates,
+// and that case is rare.
+func Join(lines [][]byte) []byte {
+	switch len(lines) {
+	case 0:
+		return nil
+	case 1:
+		return lines[0]
+	}
+
+	n := len(lines) - 1
+	for _, line := range lines {
+		n += len(line)
+	}
+
+	joined := make([]byte, 0, n)
+	for i, line := range lines {
+		if i > 0 {
+			joined = append(joined, ',')
+		}
+		joined = append(joined, line...)
+	}
+	return joined
+}
+
+// AppendUnique adds each value that list does not already carry, separated by
+// ", ", and returns the result. It returns "" when nothing was added, so a
+// caller can tell "unchanged" from "changed" without comparing the strings.
+//
+// Presence is decided by [Contains], byte for byte: a value already listed in
+// another case is added again rather than silently dropped, since the field
+// this serves is echoed to the client as written.
+func AppendUnique(list string, values []string) string {
+	original := list
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		switch {
+		case list == "":
+			list = value
+		case !Contains(list, value):
+			list += ", " + value
+		}
+	}
+
+	if list == original {
+		return ""
+	}
+	return list
+}

--- a/internal/headerlist/headerlist_test.go
+++ b/internal/headerlist/headerlist_test.go
@@ -1,0 +1,305 @@
+package headerlist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Append(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description  string
+		headerValue  string
+		expectedList []string
+	}{
+		{
+			description:  "normal case",
+			headerValue:  "gzip, deflate,br",
+			expectedList: []string{"gzip", "deflate", "br"},
+		},
+		{
+			description:  "no matter the value",
+			headerValue:  "   gzip,deflate, br, zip",
+			expectedList: []string{"gzip", "deflate", "br", "zip"},
+		},
+		{
+			description:  "comma with trailing spaces around values",
+			headerValue:  "gzip , br",
+			expectedList: []string{"gzip", "br"},
+		},
+		{
+			description:  "comma with tabbed whitespace",
+			headerValue:  "gzip\t,br",
+			expectedList: []string{"gzip", "br"},
+		},
+		{
+			description:  "headerValue is empty",
+			headerValue:  "",
+			expectedList: nil,
+		},
+		{
+			// RFC 9110 §5.6.1.2: empty list elements are parsed and ignored.
+			description:  "has a comma without element",
+			headerValue:  "gzip,",
+			expectedList: []string{"gzip"},
+		},
+		{
+			description:  "has a space between words",
+			headerValue:  "  foo bar, hello  world",
+			expectedList: []string{"foo bar", "hello  world"},
+		},
+		{
+			description:  "single comma",
+			headerValue:  ",",
+			expectedList: []string{},
+		},
+		{
+			description:  "multiple comma",
+			headerValue:  ",,",
+			expectedList: []string{},
+		},
+		{
+			description:  "comma with space",
+			headerValue:  ",  ,",
+			expectedList: []string{},
+		},
+		{
+			description:  "empty element between values",
+			headerValue:  "gzip, , br",
+			expectedList: []string{"gzip", "br"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			tc := tc // create a new 'tc' variable for the goroutine
+			t.Parallel()
+			dst := make([]string, 10)
+			result := Append(dst, tc.headerValue)
+			require.Equal(t, tc.expectedList, result)
+		})
+	}
+}
+
+func Benchmark_Append(b *testing.B) {
+	destination := make([]string, 5)
+	result := destination
+	const input = `deflate, gzip,br,brotli,zstd`
+	b.ReportAllocs()
+	for b.Loop() {
+		result = Append(destination, input)
+	}
+	require.Equal(b, []string{"deflate", "gzip", "br", "brotli", "zstd"}, result)
+}
+
+func Test_Contains(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		header   string
+		value    string
+		expected bool
+	}{
+		// Exact match
+		{header: "gzip", value: "gzip", expected: true},
+		{header: "gzip", value: "deflate", expected: false},
+		// Prefix match (value at start with comma)
+		{header: "gzip, deflate", value: "gzip", expected: true},
+		{header: "gzip,deflate", value: "gzip", expected: true},
+		// Suffix match (value at end)
+		{header: "deflate, gzip", value: "gzip", expected: true},
+		{header: "deflate,gzip", value: "gzip", expected: true}, // No space - OWS is optional per RFC 9110
+		{header: "br, gzip", value: "gzip", expected: true},
+		// Middle match (value in middle)
+		{header: "deflate, gzip, br", value: "gzip", expected: true},
+		{header: "deflate,gzip,br", value: "gzip", expected: true}, // No spaces - OWS is optional per RFC 9110
+		// No match - similar but not equal
+		{header: "gzip2", value: "gzip", expected: false},
+		{header: "2gzip", value: "gzip", expected: false},
+		{header: "gzip2, deflate", value: "gzip", expected: false},
+		// Whitespace handling (OWS per RFC 9110)
+		{header: "  gzip  ,  deflate  ", value: "gzip", expected: true},
+		{header: "deflate,  gzip  ", value: "gzip", expected: true},
+		// Empty cases
+		{header: "", value: "gzip", expected: false},
+		{header: "gzip", value: "", expected: false},
+		{header: "", value: "", expected: false}, // Both empty - should return false
+	}
+
+	for _, tc := range testCases {
+		result := Contains(tc.header, tc.value)
+		require.Equal(t, tc.expected, result,
+			"Contains(%q, %q) = %v, want %v",
+			tc.header, tc.value, result, tc.expected)
+	}
+}
+
+// go test -v -run=^$ -bench=Benchmark_Contains -benchmem -count=4
+func Benchmark_Contains(b *testing.B) {
+	var ok bool
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = Contains("gzip", "gzip")
+		_ = Contains("gzip, deflate, br", "deflate")
+		_ = Contains("deflate, gzip", "gzip")
+		ok = Contains("deflate, gzip, br", "gzip")
+	}
+	require.True(b, ok)
+}
+
+func Test_Join(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, Join(nil))
+	require.Equal(t, []byte("a"), Join([][]byte{[]byte("a")}))
+	require.Equal(t, []byte("a,b"), Join([][]byte{[]byte("a"), []byte("b")}))
+}
+
+func collect(seq func(func(string) bool)) []string {
+	var got []string
+	for v := range seq {
+		got = append(got, v)
+	}
+	return got
+}
+
+func Test_All(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		list string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "gzip", []string{"gzip"}},
+		{"trims OWS", "  gzip ,\tbr\t", []string{"gzip", "br"}},
+		{"skips empty elements", "gzip, , br", []string{"gzip", "br"}},
+		{"only separators", ",  ,", nil},
+		{"quotes are not special", `"a,b"`, []string{`"a`, `b"`}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, collect(All(tc.list)))
+		})
+	}
+}
+
+func Test_AllQuoted(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		list string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"comma inside quotes is kept", `"v1,v2"`, []string{`"v1,v2"`}},
+		{"separates outside quotes", `"a", "b"`, []string{`"a"`, `"b"`}},
+		{"weak tags", `W/"a", W/"b,c"`, []string{`W/"a"`, `W/"b,c"`}},
+		{"unterminated quote swallows rest", `"a, b`, []string{`"a, b`}},
+		{"skips empty elements", `"a", , "b"`, []string{`"a"`, `"b"`}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, collect(AllQuoted(tc.list)))
+		})
+	}
+}
+
+func Test_AllLines(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, collect(AllLines(nil)))
+	require.Equal(t,
+		[]string{"gzip", "br", "zstd"},
+		collect(AllLines([][]byte{[]byte("gzip, br"), []byte(" zstd ")})),
+	)
+	// A header split across lines reads the same as one line (RFC 9110 5.3).
+	require.Equal(t,
+		collect(All("gzip,br")),
+		collect(AllLines([][]byte{[]byte("gzip"), []byte("br")})),
+	)
+}
+
+func Test_All_EarlyExit(t *testing.T) {
+	t.Parallel()
+	// Each iterator must stop when the caller breaks, not run to completion.
+	for _, seq := range []func(func(string) bool){
+		All("a,b,c"),
+		AllQuoted(`"a","b","c"`),
+		AllLines([][]byte{[]byte("a"), []byte("b,c")}),
+	} {
+		n := 0
+		for range seq {
+			n++
+			break
+		}
+		require.Equal(t, 1, n)
+	}
+}
+
+func Test_ContainsFold(t *testing.T) {
+	t.Parallel()
+	require.True(t, ContainsFold("gzip, BR", "br"))
+	require.True(t, ContainsFold("GZIP", "gzip"))
+	require.True(t, ContainsFold(" close ", "CLOSE"))
+	require.False(t, ContainsFold("gzip2", "gzip"))
+	require.False(t, ContainsFold("gzip", ""))
+	require.False(t, ContainsFold("", "gzip"))
+}
+
+func Test_Contains_MatchesElementsNotRawList(t *testing.T) {
+	t.Parallel()
+	// Contains compares against what All yields, so OWS around the element is
+	// not part of it. A value carrying its own OWS is not an element, and that
+	// holds whether or not it happens to span the whole list.
+	require.True(t, Contains(" gzip ", "gzip"))
+	require.False(t, Contains(" gzip ", " gzip "))
+	require.False(t, Contains("br, gzip", " gzip "))
+	require.Equal(t, []string{"gzip"}, collect(All(" gzip ")))
+}
+
+func Test_Contains_IsCaseSensitive(t *testing.T) {
+	t.Parallel()
+	// The documented split from ContainsFold: Contains compares byte for byte.
+	require.False(t, Contains("Accept-Encoding", "accept-encoding"))
+	require.True(t, ContainsFold("Accept-Encoding", "accept-encoding"))
+}
+
+func Test_AppendUnique(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		list   string
+		want   string
+		values []string
+	}{
+		{"into empty", "", "Accept", []string{"Accept"}},
+		{"appends new", "Accept", "Accept, Origin", []string{"Origin"}},
+		{"skips present", "Accept, Origin", "", []string{"Accept"}},
+		{"skips empty values", "Accept", "", []string{""}},
+		{"nothing to add", "Accept", "", nil},
+		{"partial add", "Accept", "Accept, Origin", []string{"Accept", "Origin"}},
+		{"case counts as different", "Accept", "Accept, accept", []string{"accept"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, AppendUnique(tc.list, tc.values))
+		})
+	}
+}
+
+func Test_Join_AliasesSingleLine(t *testing.T) {
+	t.Parallel()
+	line := []byte("gzip")
+	require.Equal(t, &line[0], &Join([][]byte{line})[0], "a lone line must be returned as it stands")
+}
+
+func Test_Append_ReusesStorage(t *testing.T) {
+	t.Parallel()
+	dst := make([]string, 0, 4)
+	got := Append(dst, "a, b")
+	require.Equal(t, []string{"a", "b"}, got)
+	require.Equal(t, &dst[:1][0], &got[0], "Append must reuse dst's storage")
+	require.Nil(t, Append(dst, ""), "an empty list yields nil")
+}

--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -16,6 +16,7 @@ import (
 	"unsafe"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/internal/headerlist"
 	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttpadaptor"
@@ -355,17 +356,6 @@ type headerPair struct {
 	value string
 }
 
-// hasCloseToken reports whether a Connection field value lists "close" among its
-// tokens, which RFC 9110 Section 7.6.1 matches case-insensitively.
-func hasCloseToken(value string) bool {
-	for token := range strings.SplitSeq(value, ",") {
-		if utils.EqualFold(utils.TrimSpace(token), "close") {
-			return true
-		}
-	}
-	return false
-}
-
 // snapshotHeaders copies the non-framing headers of the converted request into
 // owned strings. fasthttpadaptor builds r.Header with b2s, so its keys and values
 // alias buffers the fiber header owns — writing back in place corrupted them.
@@ -465,7 +455,9 @@ func HTTPMiddleware(mw func(http.Handler) http.Handler) fiber.Handler {
 			if len(connection) > 0 {
 				joined := strings.Join(connection, ", ")
 				fhdr.Set(fiber.HeaderConnection, joined)
-				if hasCloseToken(joined) {
+				// RFC 9110 Section 7.6.1 matches connection options
+				// case-insensitively.
+				if headerlist.ContainsFold(joined, "close") {
 					// The close instruction is carried separately rather than
 					// written back here: fasthttp's request flag makes Peek answer
 					// "close" and hides the rest of the list (RFC 9110 §7.6.1),

--- a/middleware/cache/utils.go
+++ b/middleware/cache/utils.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/internal/fieldname"
+	"github.com/gofiber/fiber/v3/internal/headerlist"
 	"github.com/gofiber/fiber/v3/internal/mediatype"
 	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
@@ -196,28 +197,7 @@ func isIgnoredHeader(key []byte) bool {
 // may combine them into that form (RFC 9110 §5.2). Peek returns only the first,
 // so a second "Vary:" line was cached as if it had never been sent.
 func joinedHeader(h fieldname.Peeker, key string, normalized bool) []byte {
-	values := fieldname.Lines(h, key, normalized)
-	switch len(values) {
-	case 0:
-		return nil
-	case 1:
-		return values[0]
-	}
-
-	n := 0
-	for _, v := range values {
-		n += len(v) + 1
-	}
-	joined := make([]byte, 0, n)
-	for i, v := range values {
-		if i > 0 {
-			// A bare comma, matching package fiber's own field-line joiner, so
-			// the two render a combined value identically.
-			joined = append(joined, ',')
-		}
-		joined = append(joined, v...)
-	}
-	return joined
+	return headerlist.Join(fieldname.Lines(h, key, normalized))
 }
 
 func parseHTTPDate(dateBytes []byte) (uint64, bool) {

--- a/middleware/cache/vary.go
+++ b/middleware/cache/vary.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gofiber/fiber/v3/internal/headerlist"
 	"github.com/gofiber/utils/v2"
 	utilsstrings "github.com/gofiber/utils/v2/strings"
 	"github.com/valyala/fasthttp"
@@ -40,11 +41,8 @@ func parseVary(vary string) ([]string, bool) {
 	// exact size bought one allocation over this in a case that does not arise.
 	names := make([]string, 0, defaultVaryNames)
 	count := 0
-	for part := range strings.SplitSeq(vary, ",") {
-		name := utils.TrimSpace(utilsstrings.ToLower(part))
-		if name == "" {
-			continue
-		}
+	for part := range headerlist.All(vary) {
+		name := utilsstrings.ToLower(part)
 		if name == "*" {
 			return nil, true
 		}

--- a/middleware/compress/compress.go
+++ b/middleware/compress/compress.go
@@ -4,19 +4,10 @@ import (
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/internal/headerlist"
 	"github.com/gofiber/fiber/v3/middleware/etag"
-	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
-
-func hasToken(header, token string) bool {
-	for part := range strings.SplitSeq(header, ",") {
-		if utils.EqualFold(utils.TrimSpace(part), token) {
-			return true
-		}
-	}
-	return false
-}
 
 func shouldSkip(c fiber.Ctx) bool {
 	if c.Method() == fiber.MethodHead {
@@ -30,8 +21,8 @@ func shouldSkip(c fiber.Ctx) bool {
 		status == fiber.StatusNotModified ||
 		status == fiber.StatusPartialContent ||
 		c.Get(fiber.HeaderRange) != "" ||
-		hasToken(c.Get(fiber.HeaderCacheControl), "no-transform") ||
-		hasToken(c.GetRespHeader(fiber.HeaderCacheControl), "no-transform") {
+		headerlist.ContainsFold(c.Get(fiber.HeaderCacheControl), "no-transform") ||
+		headerlist.ContainsFold(c.GetRespHeader(fiber.HeaderCacheControl), "no-transform") {
 		return true
 	}
 
@@ -49,7 +40,7 @@ func appendVaryAcceptEncoding(c fiber.Ctx) {
 		c.Set(fiber.HeaderVary, fiber.HeaderAcceptEncoding)
 		return
 	}
-	if hasToken(vary, "*") || hasToken(vary, fiber.HeaderAcceptEncoding) {
+	if headerlist.ContainsFold(vary, "*") || headerlist.ContainsFold(vary, fiber.HeaderAcceptEncoding) {
 		return
 	}
 	c.Set(fiber.HeaderVary, vary+", "+fiber.HeaderAcceptEncoding)

--- a/middleware/proxy/security.go
+++ b/middleware/proxy/security.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/internal/fieldname"
+	"github.com/gofiber/fiber/v3/internal/headerlist"
 	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
@@ -267,13 +268,8 @@ func stripHopByHopResponseHeaders(res *fasthttp.Response, except ...string) {
 // rewrites other entries' key/value buffers — and Del does not retain the
 // name after returning.
 func delConnectionListedHeaders(h fieldname.Deleter, values [][]byte, normalized bool) { //nolint:revive // flag-parameter: normalized is a property of the header store
-	for _, v := range values {
-		for name := range strings.SplitSeq(utils.UnsafeString(v), ",") {
-			name = utils.TrimSpace(name)
-			if name != "" {
-				fieldname.Del(h, name, normalized)
-			}
-		}
+	for name := range headerlist.AllLines(values) {
+		fieldname.Del(h, name, normalized)
 	}
 }
 

--- a/req.go
+++ b/req.go
@@ -15,6 +15,7 @@ import (
 	"github.com/valyala/fasthttp"
 	"golang.org/x/net/idna"
 
+	"github.com/gofiber/fiber/v3/internal/headerlist"
 	"github.com/gofiber/fiber/v3/internal/mediatype"
 )
 
@@ -49,33 +50,33 @@ type DefaultReq struct {
 
 // Accepts checks if the specified extensions or content types are acceptable.
 func (r *DefaultReq) Accepts(offers ...string) string {
-	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderAccept))
+	header := headerlist.Join(r.c.fasthttp.Request.Header.PeekAll(HeaderAccept))
 	return getOffer(header, acceptsOfferType, offers...)
 }
 
 // AcceptsCharsets checks if the specified charset is acceptable.
 func (r *DefaultReq) AcceptsCharsets(offers ...string) string {
-	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptCharset))
+	header := headerlist.Join(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptCharset))
 	return getOffer(header, acceptsOffer, offers...)
 }
 
 // AcceptsEncodings checks if the specified encoding is acceptable.
 func (r *DefaultReq) AcceptsEncodings(offers ...string) string {
-	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptEncoding))
+	header := headerlist.Join(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptEncoding))
 	return getOffer(header, acceptsOffer, offers...)
 }
 
 // AcceptsLanguages checks if the specified language is acceptable using
 // RFC 4647 Basic Filtering.
 func (r *DefaultReq) AcceptsLanguages(offers ...string) string {
-	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage))
+	header := headerlist.Join(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage))
 	return getOffer(header, acceptsLanguageOfferBasic, offers...)
 }
 
 // AcceptsLanguagesExtended checks if the specified language is acceptable using
 // RFC 4647 Extended Filtering.
 func (r *DefaultReq) AcceptsLanguagesExtended(offers ...string) string {
-	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage))
+	header := headerlist.Join(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage))
 	return getOffer(header, acceptsLanguageOfferExtended, offers...)
 }
 
@@ -175,7 +176,7 @@ func (r *DefaultReq) Body() []byte {
 	// rule defined at: https://www.rfc-editor.org/rfc/rfc9110#section-8.4-5
 	// The splitter drops empty list elements (RFC 9110 Section 5.6.1.2), and
 	// headerEncoding was already lowercased wholesale above.
-	encodingOrder = getSplicedStrList(headerEncoding, encodingOrder)
+	encodingOrder = headerlist.Append(encodingOrder, headerEncoding)
 	if len(encodingOrder) == 0 {
 		return r.getBody()
 	}
@@ -237,14 +238,14 @@ func (c *DefaultCtx) Referer() string {
 // Repeated field lines are combined into one comma-joined list
 // (RFC 9110 Section 5.2), matching what AcceptsLanguages negotiates on.
 func (c *DefaultCtx) AcceptLanguage() string {
-	return c.app.toString(joinHeaderValues(c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage)))
+	return c.app.toString(headerlist.Join(c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage)))
 }
 
 // AcceptEncoding returns the Accept-Encoding request header.
 // Repeated field lines are combined into one comma-joined list
 // (RFC 9110 Section 5.2), matching what AcceptsEncodings negotiates on.
 func (c *DefaultCtx) AcceptEncoding() string {
-	return c.app.toString(joinHeaderValues(c.fasthttp.Request.Header.PeekAll(HeaderAcceptEncoding)))
+	return c.app.toString(headerlist.Join(c.fasthttp.Request.Header.PeekAll(HeaderAcceptEncoding)))
 }
 
 // HasHeader reports whether the request includes a header with the given key.
@@ -478,7 +479,7 @@ func (r *DefaultReq) Fresh() bool {
 	// List-based fields may be split across multiple field lines, which are
 	// semantically one comma-joined list (RFC 9110 Section 5.2).
 	modifiedSince := header.Peek(HeaderIfModifiedSince)
-	noneMatch := joinHeaderValues(header.PeekAll(HeaderIfNoneMatch))
+	noneMatch := headerlist.Join(header.PeekAll(HeaderIfNoneMatch))
 
 	// unconditional request
 	if len(modifiedSince) == 0 && len(noneMatch) == 0 {
@@ -488,7 +489,7 @@ func (r *DefaultReq) Fresh() bool {
 	// Always return stale when Cache-Control: no-cache
 	// to support end-to-end reload requests
 	// https://www.rfc-editor.org/rfc/rfc9111#section-5.2.1.4
-	cacheControl := joinHeaderValues(header.PeekAll(HeaderCacheControl))
+	cacheControl := headerlist.Join(header.PeekAll(HeaderCacheControl))
 	if len(cacheControl) > 0 && isNoCache(utils.UnsafeString(cacheControl)) {
 		return false
 	}

--- a/res.go
+++ b/res.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	internalcookie "github.com/gofiber/fiber/v3/internal/cookie"
+	"github.com/gofiber/fiber/v3/internal/headerlist"
 	"github.com/gofiber/fiber/v3/internal/quotedstring"
 	"github.com/gofiber/utils/v2"
 	"github.com/valyala/bytebufferpool"
@@ -146,7 +147,7 @@ func (r *DefaultRes) Append(field string, values ...string) {
 	// Consider all existing field lines combined (RFC 9110 Section 5.2) so
 	// the dedup check sees members added on later lines via Header.Add.
 	existing, multiLine := peekJoinedResponseHeader(&r.c.fasthttp.Response.Header, field)
-	updated := appendUniqueValues(utils.UnsafeString(existing), values)
+	updated := headerlist.AppendUnique(utils.UnsafeString(existing), values)
 	if updated == "" {
 		return
 	}
@@ -156,51 +157,6 @@ func (r *DefaultRes) Append(field string, values ...string) {
 		r.c.fasthttp.Response.Header.Del(field)
 	}
 	r.Set(field, updated)
-}
-
-// appendUniqueValues returns h extended with the non-empty values that are
-// not already listed in it, or "" when nothing was added (h only ever grows,
-// so a changed result is never empty).
-func appendUniqueValues(h string, values []string) string {
-	originalH := h
-	for _, value := range values {
-		if value == "" {
-			continue
-		}
-		if h == "" {
-			h = value
-		} else if !headerContainsValue(h, value) {
-			h += ", " + value
-		}
-	}
-	if originalH == h {
-		return ""
-	}
-	return h
-}
-
-// headerContainsValue checks if a header value already contains the given value
-// as a comma-separated element. Per RFC 9110, list elements are separated by commas
-// with optional whitespace (OWS) around them.
-func headerContainsValue(header, value string) bool {
-	// Empty value should never match
-	if value == "" {
-		return false
-	}
-
-	// Exact match (single value header)
-	if header == value {
-		return true
-	}
-
-	// Check each comma-separated element, handling optional whitespace (OWS)
-	for part := range strings.SplitSeq(header, ",") {
-		if utils.TrimSpace(part) == value {
-			return true
-		}
-	}
-
-	return false
 }
 
 func sanitizeFilename(filename string) string {
@@ -1343,7 +1299,7 @@ func (r *DefaultRes) Vary(fields ...string) {
 	// later line added via Header.Add is still honored.
 	existing, multiLine := peekJoinedResponseHeader(&r.c.fasthttp.Response.Header, HeaderVary)
 	existingStr := utils.UnsafeString(existing)
-	if slices.Contains(fields, "*") || headerContainsValue(existingStr, "*") {
+	if slices.Contains(fields, "*") || headerlist.Contains(existingStr, "*") {
 		if multiLine {
 			// setCanonical only rewrites the first field line.
 			r.c.fasthttp.Response.Header.Del(HeaderVary)
@@ -1351,7 +1307,7 @@ func (r *DefaultRes) Vary(fields ...string) {
 		r.setCanonical(HeaderVary, "*")
 		return
 	}
-	updated := appendUniqueValues(existingStr, fields)
+	updated := headerlist.AppendUnique(existingStr, fields)
 	if updated == "" {
 		return
 	}


### PR DESCRIPTION
# Description

Cluster 5 of #4604: comma-separated header list scanning.

Eight scanners spelled out the same walk over an RFC 9110 Section 5.6.1 list value. Four in the core (`helpers.go` `getSplicedStrList`, `ctx.go` `headerListContainsToken` and `transferEncodingLineHasBody`, `res.go` `headerContainsValue`) and four in middleware (adaptor `hasCloseToken`, proxy `delConnectionListedHeaders`, compress `hasToken`, cache `parseVary`), beside two field-line joiners that differed only in how they sized the buffer.

They agreed on splitting at commas and trimming OWS, and diverged after that without saying so anywhere. This adds `internal/headerlist` as the single implementation, and names the two divergences instead of leaving them to be rediscovered per call site:

- **Case.** `Contains` compares byte for byte, `ContainsFold` under ASCII folding. Both callers are real: a `Vary` field name is echoed back to the client as it was written, while a token like `close` or `gzip` is matched however it arrives. The old code made this choice four times without recording why.
- **Quoting.** `All` treats every comma as a separator, which is what a list of bare tokens wants. `AllQuoted` keeps commas inside a quoted string, which `If-None-Match` needs because an opaque-tag may contain one.

**Behavior is unchanged at every call site, with one deliberate exception noted below.** Calls made along the way:

- The `/` truncation in `headerListContainsToken` stays in `ctx.go`, now with a comment saying why it is there (`Connection` and `Upgrade` may name a protocol version after a slash, as in `HTTP/2.0`). It did not become a flag on the shared walk that exactly one caller would ever set. `transferEncodingLineHasBody` keeps its `;` parameter strip at the call site for the same reason.
- `Contains` stays **case**-exact even though case-insensitive matching would arguably be more correct for `Vary`. That is a behavior change and belongs in its own PR, not smuggled into a refactor.
- **The one behavior change.** `headerContainsValue` had a `header == value` fast path that bypassed OWS trimming, so `Contains(" gzip ", " gzip ")` was true while `All(" gzip ")` yields `"gzip"`. CodeRabbit flagged the inconsistency and it is a fair catch, so the fast path is gone and `Contains` now matches only what `All` yields.

  Reachable via `Res.Append(f, " x ")` or `Vary(" x ")` called twice: that used to dedup, and now appends. Worth knowing it already failed to dedup once the list had more than one member (`"a,  x "` never matched `" x "`), so this makes the behavior uniform rather than newly wrong. Removing it also turned out to be **faster**, not slower, since the branch was inhibiting inlining. Happy to restore bug-for-bug compatibility if you would rather keep it.

`etag.AnyMatch` now uses `AllQuoted`, which removes the last hand-rolled quote-aware splitter in the tree.

`transferEncodingLineHasBody` was not in the cluster's list of seven, but it is the same walk sitting in a file the PR already touches, so leaving it would have made the consolidation obviously incomplete.

Related #4604

## Changes introduced

Net **-140 lines** of production code (`+58/-198` across the call sites), replaced by one 232-line package.

- **New:** `internal/headerlist` with `All`, `AllQuoted`, `AllLines`, `Contains`, `ContainsFold`, `Append`, `Join`, `AppendUnique`.
- **Removed:** `getSplicedStrList`, `joinHeaderValues`, `headerContainsValue`, `appendUniqueValues` (core), `hasToken` (compress), `hasCloseToken` (adaptor), `joinedHeader` body (cache).
- **Rewritten over the shared walk:** `headerListContainsToken`, `transferEncodingLineHasBody`, `delConnectionListedHeaders`, `parseVary`, `etag.AnyMatch`.

**Benchmarks:** The two hot paths keep their hand-written loops rather than delegating to the iterator. `Append` sits on the per-request `Accept-Encoding` path, and `Join` still returns a lone field line as it stands, so neither allocates where it did not before. `etag.AnyMatch` now parses the tag it is matching against once rather than once per element, which is what keeps that path off a regression.

`benchstat`, interleaved A/B, `-count=10`:

```
                   │ before      │ after                        │
                   │ sec/op      │ sec/op       vs base         │
Ctx_AutoFormat-10     178.6n ± 1%   180.8n ± 5%  +1.23% (p=0.011)
Ctx_Links-10          46.29n ± 5%   47.91n ± 3%  +3.50% (p=0.022)
Ctx_Vary-10           41.75n ± 1%   40.44n ± 2%  -3.15% (p=0.000)
geomean               70.15n        70.49n       +0.49%

B/op and allocs/op: all samples equal, +0.00%
```

**Allocations are identical everywhere, and that is the part that held steady across every run I did.** Timing is flat overall.

Being straight about the timing rather than picking a flattering run: my first (non-interleaved) measurements showed `AutoFormat` at -2.12% and `Links` at +4.89%; re-running later gave +6.46% and +3.93%. Runs disagreed with each other by up to 8 percentage points on those two, which is drift on this laptop under sustained load, not signal. The interleaved numbers above are the trustworthy ones, and even there I would treat anything under 2% as noise.

`Ctx_Links` is worth singling out: it reaches none of this code (`Links` goes straight to `setCanonical`), yet it sits at +3.5% consistently. That points at binary layout shifting when functions leave `res.go` and `helpers.go`, not at a cost this PR imposes. `Ctx_Vary` is the one benchmark that moved in the same direction in every single run, and it moved faster.

Your CI benchmark job is better placed than my machine to judge this, so I would defer to it.

**Documentation Update:** None needed. `internal/` is not public API, and no exported behavior changed.

**Changelog/What's New:** Nothing user-visible.

**Migration Guide:** Not applicable.

**API Longevity:** Nothing here is exported from the module, so the surface can change freely as the remaining clusters in #4604 land.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features. The existing tests for the removed core helpers moved into the new package with their cases intact, and coverage was added for the new surface: the quote-aware walk, multi-line joining, early exit from every iterator, the documented case split, and the aliasing and storage-reuse contracts of `Join` and `Append`. `internal/headerlist` is at **100% statement coverage**.
- [x] Ensured that new and existing unit tests pass locally with the changes. All 50 packages pass, and the affected packages pass under `-race`.
- [x] Verified that any new dependencies are essential. None added.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.
- [x] `golangci-lint` (repo-pinned v2.12.2) reports 0 issues.
- [ ] Followed the inspiration of the Express.js framework. Not applicable, internal helper with no Express counterpart.
- [ ] Updated the documentation in `/docs/`. Not applicable, no public API change.
