### PR TITLE
🔥 feat: expand context, response and request helpers

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -221,9 +221,9 @@ func (c *DefaultCtx) ContentType() string {
 	return c.DefaultReq.ContentType()
 }
 
-// Cookies returns the request cookie with the given key, or defaultValue. Req
-// and Res both carry one, so on Ctx the request wins; use Res().Cookies() for
-// the response. Only valid within the handler unless Immutable is set.
+// Cookies returns the request cookie with the given key, or defaultValue. Only
+// valid within the handler unless Immutable is set. For the cookies the response
+// is set to send, use Res().GetCookies().
 func (c *DefaultCtx) Cookies(key string, defaultValue ...string) string {
 	return c.DefaultReq.Cookies(key, defaultValue...)
 }

--- a/ctx.go
+++ b/ctx.go
@@ -201,37 +201,29 @@ func (c *DefaultCtx) Response() *fasthttp.Response {
 }
 
 // Body returns the request body, decompressing it when the request declares a
-// Content-Encoding the app accepts.
-//
-// Req and Res both carry a Body, so on Ctx the request wins, as it does for
-// Get. Use Res().Body() for what the handler has written so far.
+// Content-Encoding the app accepts. Req and Res both carry a Body, so on Ctx
+// the request wins, as it does for Get; use Res().Body() for the response.
 func (c *DefaultCtx) Body() []byte {
 	return c.DefaultReq.Body()
 }
 
-// ContentLength returns the value of the Content-Length request header.
-//
-// Req and Res both carry a ContentLength, so on Ctx the request wins, as it
-// does for Get. Use Res().ContentLength() for the length of the response.
+// ContentLength returns the value of the Content-Length request header. Req and
+// Res both carry one, so on Ctx the request wins, as it does for Get; use
+// Res().ContentLength() for the response.
 func (c *DefaultCtx) ContentLength() int {
 	return c.DefaultReq.ContentLength()
 }
 
-// ContentType returns the Content-Type request header, parameters included.
-//
-// Req and Res both carry a ContentType, so on Ctx the request wins, as it does
-// for Get. Use Res().ContentType() for the type the response will send.
+// ContentType returns the Content-Type request header, parameters included. Req
+// and Res both carry one, so on Ctx the request wins, as it does for Get; use
+// Res().ContentType() for the response.
 func (c *DefaultCtx) ContentType() string {
 	return c.DefaultReq.ContentType()
 }
 
-// Cookies returns the value of the request cookie with the given key, or
-// defaultValue when the client did not send it.
-//
-// Req and Res both carry a Cookies, so on Ctx the request wins, as it does for
-// Get. Use Res().Cookies() for the cookies this response will set.
-// Returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting to use the value outside the Handler.
+// Cookies returns the request cookie with the given key, or defaultValue. Req
+// and Res both carry one, so on Ctx the request wins; use Res().Cookies() for
+// the response. Only valid within the handler unless Immutable is set.
 func (c *DefaultCtx) Cookies(key string, defaultValue ...string) string {
 	return c.DefaultReq.Cookies(key, defaultValue...)
 }
@@ -472,10 +464,9 @@ func (c *DefaultCtx) FullPath() string {
 	return c.Route().Path
 }
 
-// RouteName returns the name of the route currently executing, or an empty
-// string when the route is unnamed. Inside middleware this is the middleware's
-// own route; use Endpoint().Name to look ahead to the route that will handle
-// the request.
+// RouteName returns the name of the route currently executing, or "" when it is
+// unnamed. Inside middleware that is the middleware's own route; use
+// Endpoint().Name to look ahead to the one that will handle the request.
 func (c *DefaultCtx) RouteName() string {
 	// Route() builds a synthetic Route when none matched, and that one never
 	// carries a Name — so the allocation could only ever produce "".
@@ -486,23 +477,8 @@ func (c *DefaultCtx) RouteName() string {
 }
 
 // MountPath returns the prefix the sub-app owning the current route was mounted
-// under, or an empty string when the route belongs to the top-level app.
-//
-// Fiber mounts by cloning a sub-app's routes into the app that serves them with
-// the prefix already baked in, so Path inside a mounted handler is the whole
-// requested path, not one relative to the mount. MountPath is what tells such a
-// handler which prefix it is living under, to build links back into its own app
-// or to strip the prefix itself.
-//
-// It answers from the route that is running, unlike App.MountPath, which
-// describes the app it is called on however that app is being served: a sub-app
-// that is mounted and also listened on directly reports its mount prefix there
-// even for its own traffic, where this reports "".
-//
-// The prefix is the owning app's, so mounting one *App at two prefixes reports
-// the one it was mounted at last — the same limitation App.MountPath has, since
-// that is where the prefix is recorded. Mount separate instances when each needs
-// to know its own prefix.
+// under, or "" for a top-level route. Path is not relative to it. One *App
+// mounted twice reports its last prefix, as App.MountPath does.
 func (c *DefaultCtx) MountPath() string {
 	if c.app == nil {
 		return ""
@@ -535,15 +511,9 @@ func (c *DefaultCtx) IsMiddleware() bool {
 	return c.indexHandler+1 < len(c.route.Handlers)
 }
 
-// IsFinal returns true if no further handler of the current route runs after
-// this one. It is the exact complement of IsMiddleware, and false when no route
-// matched at all.
-//
-// It describes this route, not the whole request: a route registered with Use is
-// never final even when it is the last thing that runs, and another route can
-// still match after a final handler calls Next — a specific path followed by a
-// catch-all is the ordinary case. So this does not promise that the response is
-// finished; use it to tell an endpoint handler from a middleware one.
+// IsFinal reports whether no further handler of the current route runs after
+// this one, the exact complement of IsMiddleware. It describes the route, not
+// the request: another route can still match, and a Use route is never final.
 func (c *DefaultCtx) IsFinal() bool {
 	return c.route != nil && !c.IsMiddleware()
 }
@@ -631,14 +601,9 @@ func (c *DefaultCtx) SaveFileToStorage(fileheader *multipart.FileHeader, path st
 	return nil
 }
 
-// Error returns an *Error carrying the given status code, so a handler can
-// reject a request in one line:
-//
-//	return c.Error(fiber.StatusBadRequest, "id must be numeric")
-//
-// The message defaults to the status text when omitted. Returning the error
-// hands it to the app's ErrorHandler, which is what writes the response; Error
-// itself sets nothing on the response.
+// Error returns an *Error carrying the given status code, defaulting the message
+// to the status text. Returning it hands it to the app's ErrorHandler, which
+// writes the response; Error itself sets nothing.
 func (*DefaultCtx) Error(status int, message ...string) error {
 	return NewError(status, message...)
 }
@@ -650,10 +615,9 @@ func (c *DefaultCtx) Status(status int) Ctx {
 	return c
 }
 
-// ID returns the connection-unique identifier fasthttp assigned to this
-// request. It is cheap and always present, unlike RequestID, which reads a
-// header a client or proxy has to have set. It is not unique across processes
-// or restarts, so it is for correlating log lines within one server run.
+// ID returns the connection-unique identifier fasthttp assigned to this request,
+// unlike RequestID, which reads a header. It is not unique across processes or
+// restarts, so use it to correlate log lines within one server run.
 func (c *DefaultCtx) ID() uint64 {
 	return c.fasthttp.ID()
 }
@@ -684,12 +648,9 @@ func (c *DefaultCtx) RemoteAddr() net.Addr {
 	return c.fasthttp.RemoteAddr()
 }
 
-// Hijack registers a handler that takes over the connection once the current
-// response is sent, for protocols Fiber does not speak itself. The handler runs
-// on the connection's own goroutine, after which the connection is closed
-// unless the server has KeepHijackedConns set.
-//
-// The Ctx is pooled and reused, so the hijack handler must not touch it.
+// Hijack registers a handler that takes over the connection once the response is
+// sent, for protocols Fiber does not speak. The connection then closes unless
+// KeepHijackedConns is set, and the handler must not touch the pooled Ctx.
 func (c *DefaultCtx) Hijack(handler fasthttp.HijackHandler) {
 	c.fasthttp.Hijack(handler)
 }

--- a/ctx.go
+++ b/ctx.go
@@ -511,9 +511,9 @@ func (c *DefaultCtx) IsMiddleware() bool {
 	return c.indexHandler+1 < len(c.route.Handlers)
 }
 
-// IsFinal reports whether no further handler of the current route runs after
-// this one, the exact complement of IsMiddleware. It describes the route, not
-// the request: another route can still match, and a Use route is never final.
+// IsFinal reports whether this is the last handler of a matched non-middleware
+// route, so nothing further on that route runs. It describes the route, not the
+// request: another route can still match, and a Use route is never final.
 func (c *DefaultCtx) IsFinal() bool {
 	return c.route != nil && !c.IsMiddleware()
 }

--- a/ctx.go
+++ b/ctx.go
@@ -13,7 +13,6 @@ import (
 	"maps"
 	"mime/multipart"
 	"net"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -155,58 +154,6 @@ func (c *DefaultCtx) SetContext(ctx context.Context) {
 	c.isUserContextSet = true
 }
 
-// Copy returns a detached snapshot of the context that stays valid after the
-// handler returns.
-//
-// A live Ctx is pooled and its request buffers are handed to the next request
-// on the connection, so reading one from a goroutine that outlives the handler
-// returns whatever arrived next. Copy deep-copies the request, the path buffers
-// and the route parameters into a context that is never pooled, so the goroutine
-// sees the request the handler saw. Locals come across as they are: the entries
-// are copied, the values in them are shared.
-//
-// A request body that is still a stream is not copied; read it, or call Body, on
-// the original first. The copy is for reading otherwise: its response is a
-// detached buffer that never reaches the client, and it is always a *DefaultCtx
-// even under a custom Ctx, so writing to it, or driving the chain again with
-// Next or RestartRouting, changes nothing the client will see. It does not
-// observe the request's cancellation either; when the goroutine needs that, take
-// Context() from the original before the handler returns.
-func (c *DefaultCtx) Copy() Ctx {
-	cp := NewDefaultCtx(c.app)
-
-	fctx := new(fasthttp.RequestCtx)
-	c.fasthttp.Request.CopyTo(&fctx.Request)
-	c.fasthttp.VisitUserValuesAll(func(key, value any) {
-		fctx.SetUserValue(key, value)
-	})
-	cp.fasthttp = fctx
-	cp.isUserContextSet = c.isUserContextSet
-
-	// Routes are immutable once registered, so the pointer can be shared.
-	cp.route = c.route
-	cp.methodInt = c.methodInt
-	cp.indexRoute = c.indexRoute
-	cp.indexHandler = c.indexHandler
-	cp.firstMatchIndex = c.firstMatchIndex
-	cp.treePathHash = c.treePathHash
-	cp.pathSlashes = c.pathSlashes
-	cp.isMatched = c.isMatched
-	cp.shouldSkipNonUseRoutes = c.shouldSkipNonUseRoutes
-
-	// The path buffers, and the route parameter values cut out of them, alias
-	// storage the pool reuses, so each is copied rather than shared.
-	cp.path = append(cp.path[:0], c.path...)
-	cp.detectionPath = append(cp.detectionPath[:0], c.detectionPath...)
-	cp.pathOriginal = strings.Clone(c.pathOriginal)
-	cp.baseURI = strings.Clone(c.baseURI)
-	for i, value := range c.values {
-		cp.values[i] = strings.Clone(value)
-	}
-
-	return cp
-}
-
 // Deadline returns the time when work done on behalf of this context
 // should be canceled. Ctx carries no deadline, so ok is always false.
 //
@@ -268,6 +215,14 @@ func (c *DefaultCtx) Body() []byte {
 // does for Get. Use Res().ContentLength() for the length of the response.
 func (c *DefaultCtx) ContentLength() int {
 	return c.DefaultReq.ContentLength()
+}
+
+// ContentType returns the Content-Type request header, parameters included.
+//
+// Req and Res both carry a ContentType, so on Ctx the request wins, as it does
+// for Get. Use Res().ContentType() for the type the response will send.
+func (c *DefaultCtx) ContentType() string {
+	return c.DefaultReq.ContentType()
 }
 
 // Cookies returns the value of the request cookie with the given key, or
@@ -522,7 +477,12 @@ func (c *DefaultCtx) FullPath() string {
 // own route; use Endpoint().Name to look ahead to the route that will handle
 // the request.
 func (c *DefaultCtx) RouteName() string {
-	return c.Route().Name
+	// Route() builds a synthetic Route when none matched, and that one never
+	// carries a Name — so the allocation could only ever produce "".
+	if c.route == nil {
+		return ""
+	}
+	return c.route.Name
 }
 
 // MountPath returns the prefix the sub-app owning the current route was mounted
@@ -534,16 +494,28 @@ func (c *DefaultCtx) RouteName() string {
 // handler which prefix it is living under, to build links back into its own app
 // or to strip the prefix itself.
 //
-// It answers from the route that is running, unlike App.MountPath, which only
-// ever describes the app it is called on.
+// It answers from the route that is running, unlike App.MountPath, which
+// describes the app it is called on however that app is being served: a sub-app
+// that is mounted and also listened on directly reports its mount prefix there
+// even for its own traffic, where this reports "".
+//
+// The prefix is the owning app's, so mounting one *App at two prefixes reports
+// the one it was mounted at last — the same limitation App.MountPath has, since
+// that is where the prefix is recorded. Mount separate instances when each needs
+// to know its own prefix.
 func (c *DefaultCtx) MountPath() string {
-	if c.app == nil || c.app.mountFields == nil {
+	if c.app == nil {
 		return ""
 	}
-	if owner := c.app.routeOwner(c.route); owner != nil && owner.mountFields != nil {
-		return owner.mountFields.mountPath
+	// A route with no recorded owner is this app's own, so it is not under a
+	// mount at all — reading the app's own prefix here would answer with a
+	// mount the request never went through.
+	owner := c.app.routeOwner(c.route)
+	if owner == nil {
+		return ""
 	}
-	return c.app.mountFields.mountPath
+
+	return owner.MountPath()
 }
 
 // Matched returns true if the current request path was matched by the router.
@@ -563,9 +535,15 @@ func (c *DefaultCtx) IsMiddleware() bool {
 	return c.indexHandler+1 < len(c.route.Handlers)
 }
 
-// IsFinal returns true if the current request handler is the last one in the
-// chain, meaning nothing runs after it returns. It is the complement of
-// IsMiddleware, and false when no route matched at all.
+// IsFinal returns true if no further handler of the current route runs after
+// this one. It is the exact complement of IsMiddleware, and false when no route
+// matched at all.
+//
+// It describes this route, not the whole request: a route registered with Use is
+// never final even when it is the last thing that runs, and another route can
+// still match after a final handler calls Next — a specific path followed by a
+// catch-all is the ordinary case. So this does not promise that the response is
+// finished; use it to tell an endpoint handler from a middleware one.
 func (c *DefaultCtx) IsFinal() bool {
 	return c.route != nil && !c.IsMiddleware()
 }

--- a/ctx.go
+++ b/ctx.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"maps"
 	"mime/multipart"
+	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -154,6 +155,58 @@ func (c *DefaultCtx) SetContext(ctx context.Context) {
 	c.isUserContextSet = true
 }
 
+// Copy returns a detached snapshot of the context that stays valid after the
+// handler returns.
+//
+// A live Ctx is pooled and its request buffers are handed to the next request
+// on the connection, so reading one from a goroutine that outlives the handler
+// returns whatever arrived next. Copy deep-copies the request, the path buffers
+// and the route parameters into a context that is never pooled, so the goroutine
+// sees the request the handler saw. Locals come across as they are: the entries
+// are copied, the values in them are shared.
+//
+// A request body that is still a stream is not copied; read it, or call Body, on
+// the original first. The copy is for reading otherwise: its response is a
+// detached buffer that never reaches the client, and it is always a *DefaultCtx
+// even under a custom Ctx, so writing to it, or driving the chain again with
+// Next or RestartRouting, changes nothing the client will see. It does not
+// observe the request's cancellation either; when the goroutine needs that, take
+// Context() from the original before the handler returns.
+func (c *DefaultCtx) Copy() Ctx {
+	cp := NewDefaultCtx(c.app)
+
+	fctx := new(fasthttp.RequestCtx)
+	c.fasthttp.Request.CopyTo(&fctx.Request)
+	c.fasthttp.VisitUserValuesAll(func(key, value any) {
+		fctx.SetUserValue(key, value)
+	})
+	cp.fasthttp = fctx
+	cp.isUserContextSet = c.isUserContextSet
+
+	// Routes are immutable once registered, so the pointer can be shared.
+	cp.route = c.route
+	cp.methodInt = c.methodInt
+	cp.indexRoute = c.indexRoute
+	cp.indexHandler = c.indexHandler
+	cp.firstMatchIndex = c.firstMatchIndex
+	cp.treePathHash = c.treePathHash
+	cp.pathSlashes = c.pathSlashes
+	cp.isMatched = c.isMatched
+	cp.shouldSkipNonUseRoutes = c.shouldSkipNonUseRoutes
+
+	// The path buffers, and the route parameter values cut out of them, alias
+	// storage the pool reuses, so each is copied rather than shared.
+	cp.path = append(cp.path[:0], c.path...)
+	cp.detectionPath = append(cp.detectionPath[:0], c.detectionPath...)
+	cp.pathOriginal = strings.Clone(c.pathOriginal)
+	cp.baseURI = strings.Clone(c.baseURI)
+	for i, value := range c.values {
+		cp.values[i] = strings.Clone(value)
+	}
+
+	return cp
+}
+
 // Deadline returns the time when work done on behalf of this context
 // should be canceled. Ctx carries no deadline, so ok is always false.
 //
@@ -198,6 +251,34 @@ func (c *DefaultCtx) Response() *fasthttp.Response {
 		return nil
 	}
 	return &c.fasthttp.Response
+}
+
+// Body returns the request body, decompressing it when the request declares a
+// Content-Encoding the app accepts.
+//
+// Req and Res both carry a Body, so on Ctx the request wins, as it does for
+// Get. Use Res().Body() for what the handler has written so far.
+func (c *DefaultCtx) Body() []byte {
+	return c.DefaultReq.Body()
+}
+
+// ContentLength returns the value of the Content-Length request header.
+//
+// Req and Res both carry a ContentLength, so on Ctx the request wins, as it
+// does for Get. Use Res().ContentLength() for the length of the response.
+func (c *DefaultCtx) ContentLength() int {
+	return c.DefaultReq.ContentLength()
+}
+
+// Cookies returns the value of the request cookie with the given key, or
+// defaultValue when the client did not send it.
+//
+// Req and Res both carry a Cookies, so on Ctx the request wins, as it does for
+// Get. Use Res().Cookies() for the cookies this response will set.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting to use the value outside the Handler.
+func (c *DefaultCtx) Cookies(key string, defaultValue ...string) string {
+	return c.DefaultReq.Cookies(key, defaultValue...)
 }
 
 // Get returns the HTTP request header specified by field.
@@ -298,24 +379,6 @@ func (c *DefaultCtx) setHandlerCtx(ctx CustomCtx) {
 // Make copies or use the Immutable setting to use the value outside the Handler.
 func (c *DefaultCtx) OriginalURL() string {
 	return c.app.toString(c.fasthttp.Request.Header.RequestURI())
-}
-
-// Path returns the path part of the request URL.
-// Optionally, you could override the path.
-// Make copies or use the Immutable setting to use the value outside the Handler.
-func (c *DefaultCtx) Path(override ...string) string {
-	if len(override) != 0 && string(c.path) != override[0] {
-		// Set new path to context
-		c.pathOriginal = override[0]
-
-		// Set new path to request context
-		c.fasthttp.Request.URI().SetPath(c.pathOriginal)
-		// Prettify path
-		c.configDependentPaths()
-		// The detection path/tree hash changed; invalidate the lookahead index.
-		c.firstMatchIndex = -1
-	}
-	return c.app.toString(c.path)
 }
 
 // RequestID returns the request identifier from the response header or request header.
@@ -454,6 +517,35 @@ func (c *DefaultCtx) FullPath() string {
 	return c.Route().Path
 }
 
+// RouteName returns the name of the route currently executing, or an empty
+// string when the route is unnamed. Inside middleware this is the middleware's
+// own route; use Endpoint().Name to look ahead to the route that will handle
+// the request.
+func (c *DefaultCtx) RouteName() string {
+	return c.Route().Name
+}
+
+// MountPath returns the prefix the sub-app owning the current route was mounted
+// under, or an empty string when the route belongs to the top-level app.
+//
+// Fiber mounts by cloning a sub-app's routes into the app that serves them with
+// the prefix already baked in, so Path inside a mounted handler is the whole
+// requested path, not one relative to the mount. MountPath is what tells such a
+// handler which prefix it is living under, to build links back into its own app
+// or to strip the prefix itself.
+//
+// It answers from the route that is running, unlike App.MountPath, which only
+// ever describes the app it is called on.
+func (c *DefaultCtx) MountPath() string {
+	if c.app == nil || c.app.mountFields == nil {
+		return ""
+	}
+	if owner := c.app.routeOwner(c.route); owner != nil && owner.mountFields != nil {
+		return owner.mountFields.mountPath
+	}
+	return c.app.mountFields.mountPath
+}
+
 // Matched returns true if the current request path was matched by the router.
 func (c *DefaultCtx) Matched() bool {
 	return c.getMatched()
@@ -471,23 +563,11 @@ func (c *DefaultCtx) IsMiddleware() bool {
 	return c.indexHandler+1 < len(c.route.Handlers)
 }
 
-// HasBody returns true if the request declares a body via Content-Length, Transfer-Encoding, or already buffered payload data.
-func (c *DefaultCtx) HasBody() bool {
-	hdr := &c.fasthttp.Request.Header
-
-	switch cl := hdr.ContentLength(); {
-	case cl > 0:
-		return true
-	case cl == -1:
-		// fasthttp reports -1 for Transfer-Encoding: chunked bodies.
-		return true
-	case cl == 0:
-		if hasTransferEncodingBody(hdr) {
-			return true
-		}
-	}
-
-	return len(c.fasthttp.Request.Body()) > 0
+// IsFinal returns true if the current request handler is the last one in the
+// chain, meaning nothing runs after it returns. It is the complement of
+// IsMiddleware, and false when no route matched at all.
+func (c *DefaultCtx) IsFinal() bool {
+	return c.route != nil && !c.IsMiddleware()
 }
 
 // OverrideParam overwrites a route parameter value by name.
@@ -521,98 +601,6 @@ func (c *DefaultCtx) OverrideParam(name, value string) {
 			return
 		}
 	}
-}
-
-func hasTransferEncodingBody(hdr *fasthttp.RequestHeader) bool {
-	// Repeated field lines form one combined list (RFC 9110 Section 5.2),
-	// so every Transfer-Encoding line must be inspected, not just the first.
-	if lines := hdr.PeekAll(HeaderTransferEncoding); len(lines) > 0 {
-		for _, line := range lines {
-			if transferEncodingLineHasBody(utils.UnsafeString(line)) {
-				return true
-			}
-		}
-		return false
-	}
-
-	// Fallback scan for non-normalized header keys.
-	for key, value := range hdr.All() {
-		if !utils.EqualFold(utils.UnsafeString(key), HeaderTransferEncoding) {
-			continue
-		}
-		if transferEncodingLineHasBody(utils.UnsafeString(value)) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// transferEncodingLineHasBody reports whether a single Transfer-Encoding
-// field line contains a transfer coding other than "identity".
-func transferEncodingLineHasBody(te string) bool {
-	for raw := range strings.SplitSeq(te, ",") {
-		token := utils.TrimSpace(raw)
-		if token == "" {
-			continue
-		}
-		if idx := strings.IndexByte(token, ';'); idx >= 0 {
-			token = utils.TrimSpace(token[:idx])
-		}
-		if token == "" {
-			continue
-		}
-		if utils.EqualFold(token, "identity") {
-			continue
-		}
-		return true
-	}
-	return false
-}
-
-// IsWebSocket returns true if the request includes a WebSocket upgrade handshake.
-func (c *DefaultCtx) IsWebSocket() bool {
-	// Repeated field lines are equivalent to one combined comma-separated
-	// list (RFC 9110 Section 5.2), so inspect every Connection and Upgrade
-	// field line, not just the first.
-	if !headerListContainsToken(c.fasthttp.Request.Header.PeekAll(HeaderConnection), "upgrade") {
-		return false
-	}
-	// Upgrade is a list of protocols, each optionally carrying a "/version"
-	// suffix (RFC 9110 Section 7.8), e.g. "Upgrade: websocket, h2c".
-	return headerListContainsToken(c.fasthttp.Request.Header.PeekAll(HeaderUpgrade), "websocket")
-}
-
-// headerListContainsToken reports whether any comma-separated element across
-// the given field lines equals token case-insensitively. An optional
-// "/version" suffix (Upgrade protocol syntax, RFC 9110 Section 7.8) is
-// ignored when comparing; valid Connection members never contain "/", so
-// this is safe for both headers.
-func headerListContainsToken(lines [][]byte, token string) bool {
-	for _, line := range lines {
-		for v := range strings.SplitSeq(utils.UnsafeString(line), ",") {
-			element := utils.TrimSpace(v)
-			if i := strings.IndexByte(element, '/'); i >= 0 {
-				element = element[:i]
-			}
-			if utils.EqualFold(element, token) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// IsPreflight returns true if the request is a CORS preflight.
-func (c *DefaultCtx) IsPreflight() bool {
-	if c.Method() != MethodOptions {
-		return false
-	}
-	hdr := &c.fasthttp.Request.Header
-	if len(hdr.Peek(HeaderAccessControlRequestMethod)) == 0 {
-		return false
-	}
-	return len(hdr.Peek(HeaderOrigin)) > 0
 }
 
 // SaveFile saves any multipart file to disk.
@@ -665,9 +653,16 @@ func (c *DefaultCtx) SaveFileToStorage(fileheader *multipart.FileHeader, path st
 	return nil
 }
 
-// Secure returns whether a secure connection was established.
-func (c *DefaultCtx) Secure() bool {
-	return c.Scheme() == schemeHTTPS
+// Error returns an *Error carrying the given status code, so a handler can
+// reject a request in one line:
+//
+//	return c.Error(fiber.StatusBadRequest, "id must be numeric")
+//
+// The message defaults to the status text when omitted. Returning the error
+// hands it to the app's ErrorHandler, which is what writes the response; Error
+// itself sets nothing on the response.
+func (*DefaultCtx) Error(status int, message ...string) error {
+	return NewError(status, message...)
 }
 
 // Status sets the HTTP status for the response.
@@ -675,6 +670,57 @@ func (c *DefaultCtx) Secure() bool {
 func (c *DefaultCtx) Status(status int) Ctx {
 	c.fasthttp.Response.SetStatusCode(status)
 	return c
+}
+
+// ID returns the connection-unique identifier fasthttp assigned to this
+// request. It is cheap and always present, unlike RequestID, which reads a
+// header a client or proxy has to have set. It is not unique across processes
+// or restarts, so it is for correlating log lines within one server run.
+func (c *DefaultCtx) ID() uint64 {
+	return c.fasthttp.ID()
+}
+
+// StartTime returns the time the server began handling this request. It is the
+// reference point Elapsed measures from.
+func (c *DefaultCtx) StartTime() time.Time {
+	return c.fasthttp.Time()
+}
+
+// Elapsed returns how long this request has been handled so far, measured from
+// StartTime. Called after the handler chain has run, it is the request latency.
+func (c *DefaultCtx) Elapsed() time.Duration {
+	return time.Since(c.fasthttp.Time())
+}
+
+// LocalAddr returns the server-side address of the connection this request
+// arrived on. IP returns the client address as a string; this is the full
+// net.Addr, so the port, network, and unix socket path survive.
+func (c *DefaultCtx) LocalAddr() net.Addr {
+	return c.fasthttp.LocalAddr()
+}
+
+// RemoteAddr returns the address of the immediate peer, which is the proxy
+// rather than the client when the app sits behind one. Use IP or IPs for the
+// client address a trusted proxy forwarded.
+func (c *DefaultCtx) RemoteAddr() net.Addr {
+	return c.fasthttp.RemoteAddr()
+}
+
+// Hijack registers a handler that takes over the connection once the current
+// response is sent, for protocols Fiber does not speak itself. The handler runs
+// on the connection's own goroutine, after which the connection is closed
+// unless the server has KeepHijackedConns set.
+//
+// The Ctx is pooled and reused, so the hijack handler must not touch it.
+func (c *DefaultCtx) Hijack(handler fasthttp.HijackHandler) {
+	c.fasthttp.Hijack(handler)
+}
+
+// Hijacked returns true if Hijack has been called on this request, so a later
+// handler can tell that the connection is already spoken for and leave the
+// response alone.
+func (c *DefaultCtx) Hijacked() bool {
+	return c.fasthttp.Hijacked()
 }
 
 // String returns unique string representation of the ctx.
@@ -725,15 +771,6 @@ func (c *DefaultCtx) Value(key any) any {
 		return nil
 	}
 	return c.fasthttp.UserValue(key)
-}
-
-// xmlHTTPRequestBytes is precomputed for XHR detection
-var xmlHTTPRequestBytes = []byte("xmlhttprequest")
-
-// XHR returns a Boolean property, that is true, if the request's X-Requested-With header field is XMLHttpRequest,
-// indicating that the request was issued by a client library (such as jQuery).
-func (c *DefaultCtx) XHR() bool {
-	return utils.EqualFold(c.fasthttp.Request.Header.Peek(HeaderXRequestedWith), xmlHTTPRequestBytes)
 }
 
 // configDependentPaths set paths for route recognition and prepared paths for the user,

--- a/ctx_helpers_test.go
+++ b/ctx_helpers_test.go
@@ -1,0 +1,938 @@
+// ⚡️ Fiber is an Express inspired web framework written in Go with ☕️
+// 🤖 GitHub Repository: https://github.com/gofiber/fiber
+// 📌 API Documentation: https://docs.gofiber.io
+
+package fiber
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/utils/v2"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// -----------------------------------------------------------------------------
+// Req
+// -----------------------------------------------------------------------------
+
+// Test_Req_RequestHelpersOnReq pins the helpers to Req rather than Ctx. They
+// were first written with a *DefaultCtx receiver, which kept them off the Req
+// interface: c.UserAgent() compiled but c.Req().UserAgent() did not. Every call
+// here goes through Req, so that regression cannot come back unnoticed.
+func Test_Req_RequestHelpersOnReq(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.SetRequestURI("/path/here?q=1")
+	fctx.Request.Header.SetMethod(MethodPost)
+	fctx.Request.Header.SetHost("example.com")
+	fctx.Request.Header.SetUserAgent("fiber-test")
+	fctx.Request.Header.SetReferer("https://referer.example")
+	fctx.Request.Header.Set(HeaderAcceptLanguage, "en-US, de")
+	fctx.Request.Header.Set(HeaderAcceptEncoding, "gzip, br")
+	fctx.Request.Header.Set(HeaderAccept, MIMEApplicationJSON)
+	fctx.Request.Header.SetContentType(MIMEApplicationJSON + "; charset=utf-8")
+	fctx.Request.SetBody([]byte(`{"a":1}`))
+
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	r := c.Req()
+
+	require.Equal(t, "http://example.com/path/here?q=1", r.FullURL())
+	require.Equal(t, "fiber-test", r.UserAgent())
+	require.Equal(t, "https://referer.example", r.Referer())
+	require.Equal(t, "en-US, de", r.AcceptLanguage())
+	require.Equal(t, "gzip, br", r.AcceptEncoding())
+	require.True(t, r.HasHeader(HeaderUserAgent))
+	require.False(t, r.HasHeader("X-Absent"))
+	require.Equal(t, MIMEApplicationJSON, r.MediaType()) //nolint:testifylint // this is comparing content-type strings, not JSON content
+	require.Equal(t, "utf-8", r.Charset())
+	require.True(t, r.IsJSON())
+	require.False(t, r.IsForm())
+	require.False(t, r.IsMultipart())
+	require.True(t, r.AcceptsJSON())
+	require.False(t, r.AcceptsHTML())
+	require.False(t, r.AcceptsXML())
+	require.False(t, r.AcceptsEventStream())
+
+	require.Equal(t, "/path/here", r.Path())
+	require.False(t, r.Secure())
+	require.False(t, r.XHR())
+	require.True(t, r.HasBody())
+	require.False(t, r.IsWebSocket())
+	require.False(t, r.IsPreflight())
+
+	// Ctx keeps promoting all of them, so no caller loses an existing spelling.
+	require.Equal(t, r.FullURL(), c.FullURL())
+	require.Equal(t, r.UserAgent(), c.UserAgent())
+	require.Equal(t, r.MediaType(), c.MediaType())
+	require.Equal(t, r.Path(), c.Path())
+	require.Equal(t, r.HasBody(), c.HasBody())
+	require.Equal(t, r.IsPreflight(), c.IsPreflight())
+}
+
+func Test_Req_PathOverride(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.SetRequestURI("/original")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.Equal(t, "/original", c.Req().Path())
+	require.Equal(t, "/rewritten", c.Req().Path("/rewritten"))
+	require.Equal(t, "/rewritten", c.Path())
+	require.Equal(t, "/rewritten", string(c.Request().URI().Path()))
+}
+
+func Test_Req_GetAll(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.Add("X-Test", "first")
+	fctx.Request.Header.Add("X-Test", "second")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.Equal(t, []string{"first", "second"}, c.Req().GetAll("X-Test"))
+	// Field names are case-insensitive.
+	require.Equal(t, []string{"first", "second"}, c.Req().GetAll("x-test"))
+	// Get still answers with the first line only.
+	require.Equal(t, "first", c.Req().Get("X-Test"))
+	require.Nil(t, c.Req().GetAll("X-Absent"))
+}
+
+func Test_Req_ContentLength(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	var length int
+	app.Post("/", func(c Ctx) error {
+		length = c.Req().ContentLength()
+		return nil
+	})
+
+	_, err := app.Test(httptest.NewRequest(MethodPost, "/", strings.NewReader("0123456789")))
+	require.NoError(t, err)
+	require.Equal(t, 10, length)
+
+	chunked := &fasthttp.RequestCtx{}
+	chunked.Request.Header.SetContentLength(-1)
+	cc := app.AcquireCtx(chunked)
+	t.Cleanup(func() { app.ReleaseCtx(cc) })
+
+	require.Equal(t, -1, cc.Req().ContentLength(), "chunked bodies report an unknown length")
+	require.True(t, cc.Req().HasBody(), "an unknown length still means there is a body")
+}
+
+func Test_Req_BodyStream(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	buffered := &fasthttp.RequestCtx{}
+	buffered.Request.SetBody([]byte("buffered"))
+	bc := app.AcquireCtx(buffered)
+	t.Cleanup(func() { app.ReleaseCtx(bc) })
+	require.Nil(t, bc.Req().BodyStream(), "a buffered body is not a stream")
+
+	streamed := &fasthttp.RequestCtx{}
+	streamed.Request.SetBodyStream(strings.NewReader("streamed"), 8)
+	sc := app.AcquireCtx(streamed)
+	t.Cleanup(func() { app.ReleaseCtx(sc) })
+
+	stream := sc.Req().BodyStream()
+	require.NotNil(t, stream)
+	body, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	require.Equal(t, "streamed", string(body))
+}
+
+func Test_Req_URI(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.SetRequestURI("/search?q=fiber#frag")
+	fctx.Request.Header.SetHost("example.com")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	uri := c.Req().URI()
+	require.NotNil(t, uri)
+	require.Equal(t, "/search", string(uri.Path()))
+	require.Equal(t, "q=fiber", string(uri.QueryString()))
+	require.Equal(t, "frag", string(uri.Hash()))
+	require.Equal(t, "example.com", string(uri.Host()))
+}
+
+func Test_Req_Origin(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.Set(HeaderOrigin, "https://example.com")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+	require.Equal(t, "https://example.com", c.Req().Origin())
+
+	bare := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(bare) })
+	require.Empty(t, bare.Req().Origin())
+}
+
+func Test_Req_Authorization(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	tests := []struct {
+		name        string
+		header      string
+		scheme      string
+		credentials string
+		bearer      string
+	}{
+		{name: "absent"},
+		{name: "bearer", header: "Bearer abc123", scheme: "Bearer", credentials: "abc123", bearer: "abc123"},
+		{name: "bearer lowercase scheme", header: "bearer abc123", scheme: "bearer", credentials: "abc123", bearer: "abc123"},
+		{name: "basic", header: "Basic dXNlcjpwYXNz", scheme: "Basic", credentials: "dXNlcjpwYXNz"},
+		{name: "auth-param list", header: `Digest username="u", realm="r"`, scheme: "Digest", credentials: `username="u", realm="r"`},
+		{name: "extra whitespace", header: "  Bearer   abc123  ", scheme: "Bearer", credentials: "abc123", bearer: "abc123"},
+		{name: "tab separator", header: "Bearer\tabc123", scheme: "Bearer", credentials: "abc123", bearer: "abc123"},
+		{name: "scheme only", header: "Negotiate", scheme: "Negotiate"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fctx := &fasthttp.RequestCtx{}
+			if tc.header != "" {
+				fctx.Request.Header.Set(HeaderAuthorization, tc.header)
+			}
+			c := app.AcquireCtx(fctx)
+			t.Cleanup(func() { app.ReleaseCtx(c) })
+
+			scheme, credentials := c.Req().Authorization()
+			require.Equal(t, tc.scheme, scheme)
+			require.Equal(t, tc.credentials, credentials)
+			require.Equal(t, tc.bearer, c.Req().Bearer())
+		})
+	}
+}
+
+func Test_Req_IsSafe_IsIdempotent(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	tests := []struct {
+		method     string
+		safe       bool
+		idempotent bool
+	}{
+		{method: MethodGet, safe: true, idempotent: true},
+		{method: MethodHead, safe: true, idempotent: true},
+		{method: MethodOptions, safe: true, idempotent: true},
+		{method: MethodTrace, safe: true, idempotent: true},
+		{method: MethodPut, safe: false, idempotent: true},
+		{method: MethodDelete, safe: false, idempotent: true},
+		{method: MethodPost, safe: false, idempotent: false},
+		{method: MethodPatch, safe: false, idempotent: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.method, func(t *testing.T) {
+			t.Parallel()
+
+			fctx := &fasthttp.RequestCtx{}
+			fctx.Request.Header.SetMethod(tc.method)
+			c := app.AcquireCtx(fctx)
+			t.Cleanup(func() { app.ReleaseCtx(c) })
+
+			require.Equal(t, tc.safe, c.Req().IsSafe())
+			require.Equal(t, tc.idempotent, c.Req().IsIdempotent())
+		})
+	}
+}
+
+func Test_Req_CookieNames_AllCookies(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.SetCookie("session", "abc")
+	fctx.Request.Header.SetCookie("theme", "dark")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.ElementsMatch(t, []string{"session", "theme"}, c.Req().CookieNames())
+	require.Equal(t, map[string]string{"session": "abc", "theme": "dark"}, c.Req().AllCookies())
+
+	bare := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(bare) })
+	require.Empty(t, bare.Req().CookieNames())
+	require.Empty(t, bare.Req().AllCookies())
+}
+
+func Test_Req_IfNoneMatch(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	tests := []struct {
+		name   string
+		header string
+		want   []string
+	}{
+		{name: "absent"},
+		{name: "single", header: `"abc"`, want: []string{`"abc"`}},
+		{name: "list", header: `"a", W/"b"`, want: []string{`"a"`, `W/"b"`}},
+		{name: "wildcard", header: "*", want: []string{"*"}},
+		// etagc permits "," inside the quoted opaque-tag, so this is one tag.
+		{name: "comma inside tag", header: `"v1,v2"`, want: []string{`"v1,v2"`}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fctx := &fasthttp.RequestCtx{}
+			if tc.header != "" {
+				fctx.Request.Header.Set(HeaderIfNoneMatch, tc.header)
+			}
+			c := app.AcquireCtx(fctx)
+			t.Cleanup(func() { app.ReleaseCtx(c) })
+
+			require.Equal(t, tc.want, c.Req().IfNoneMatch())
+		})
+	}
+}
+
+func Test_Req_IfNoneMatch_MultipleFieldLines(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.Add(HeaderIfNoneMatch, `"a"`)
+	fctx.Request.Header.Add(HeaderIfNoneMatch, `"b"`)
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.Equal(t, []string{`"a"`, `"b"`}, c.Req().IfNoneMatch())
+}
+
+func Test_Req_IfModifiedSince(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	bare := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(bare) })
+	_, err := bare.Req().IfModifiedSince()
+	require.ErrorIs(t, err, ErrHeaderNotFound)
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.Set(HeaderIfModifiedSince, "Wed, 21 Oct 2015 07:28:00 GMT")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	got, err := c.Req().IfModifiedSince()
+	require.NoError(t, err)
+	require.True(t, got.Equal(time.Date(2015, time.October, 21, 7, 28, 0, 0, time.UTC)))
+
+	malformed := &fasthttp.RequestCtx{}
+	malformed.Request.Header.Set(HeaderIfModifiedSince, "not a date")
+	mc := app.AcquireCtx(malformed)
+	t.Cleanup(func() { app.ReleaseCtx(mc) })
+
+	_, err = mc.Req().IfModifiedSince()
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrHeaderNotFound, "a malformed date is not an absent header")
+}
+
+// -----------------------------------------------------------------------------
+// Res
+// -----------------------------------------------------------------------------
+
+func Test_Res_StatusCode(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.Equal(t, StatusOK, c.Res().StatusCode(), "an untouched response reports 200")
+	c.Status(StatusTeapot)
+	require.Equal(t, StatusTeapot, c.Res().StatusCode())
+	require.Equal(t, c.Response().StatusCode(), c.Res().StatusCode())
+}
+
+func Test_Res_Body_ResetBody_Written(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.Empty(t, c.Res().Body())
+	require.False(t, c.Res().Written())
+
+	// A status alone is not a body write.
+	c.Status(StatusCreated)
+	require.False(t, c.Res().Written())
+
+	require.NoError(t, c.SendString("hello"))
+	require.Equal(t, "hello", string(c.Res().Body()))
+	require.True(t, c.Res().Written())
+
+	c.Res().ResetBody()
+	require.Empty(t, c.Res().Body())
+	require.False(t, c.Res().Written())
+	require.Equal(t, StatusCreated, c.Res().StatusCode(), "ResetBody keeps the status")
+}
+
+func Test_Res_Written_BodyStream(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.NoError(t, c.SendStream(strings.NewReader("streamed"), 8))
+	// Written must answer without draining the stream, so the body still goes
+	// out as a stream afterwards.
+	require.True(t, c.Res().Written())
+	require.True(t, c.Response().IsBodyStream())
+}
+
+func Test_Res_Del(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	c.Set("X-Custom", "value")
+	require.Equal(t, "value", c.Res().Get("X-Custom"))
+	c.Res().Del("x-custom")
+	require.Empty(t, c.Res().Get("X-Custom"))
+
+	// Deleting an absent header is a no-op.
+	require.NotPanics(t, func() { c.Res().Del("X-Absent") })
+
+	// Every field line goes, not just the first.
+	c.Res().Add("X-Multi", "a")
+	c.Res().Add("X-Multi", "b")
+	require.Len(t, c.Response().Header.PeekAll("X-Multi"), 2)
+	c.Res().Del("X-Multi")
+	require.Empty(t, c.Response().Header.PeekAll("X-Multi"))
+
+	// Del(Set-Cookie) withdraws the cookies this response was going to set.
+	c.Cookie(&Cookie{Name: "a", Value: "1"})
+	require.NotEmpty(t, c.Res().Cookies())
+	c.Res().Del(HeaderSetCookie)
+	require.Empty(t, c.Res().Cookies())
+}
+
+func Test_Res_Add(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	c.Res().Add(HeaderWWWAuthenticate, `Basic realm="one"`)
+	c.Res().Add(HeaderWWWAuthenticate, `Bearer realm="two"`)
+
+	lines := c.Response().Header.PeekAll(HeaderWWWAuthenticate)
+	require.Len(t, lines, 2, "Add keeps challenges on separate field lines")
+	require.Equal(t, `Basic realm="one"`, string(lines[0]))
+	require.Equal(t, `Bearer realm="two"`, string(lines[1]))
+
+	// Append folds into one line instead, which is the difference between them.
+	c.Append("X-Folded", "a")
+	c.Append("X-Folded", "b")
+	require.Len(t, c.Response().Header.PeekAll("X-Folded"), 1)
+	require.Equal(t, "a, b", c.Res().Get("X-Folded"))
+}
+
+func Test_Res_ContentType_ContentLength(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.Equal(t, MIMETextPlainCharsetUTF8, c.Res().ContentType(), "an untouched response reports fasthttp's default")
+
+	require.NoError(t, c.JSON(Map{"a": 1}))
+	require.Equal(t, MIMEApplicationJSONCharsetUTF8, c.Res().ContentType()) //nolint:testifylint // this is comparing content-type headers, not JSON content
+
+	c.Type("html")
+	require.Equal(t, MIMETextHTMLCharsetUTF8, c.Res().ContentType(), "ContentType reads back what Type set")
+
+	// Content-Length reflects the header, which fasthttp only fills in as it
+	// serializes, so it stays 0 here even though the body is not empty.
+	require.NotEmpty(t, c.Res().Body())
+	require.Equal(t, 0, c.Res().ContentLength())
+
+	c.Set(HeaderContentLength, "42")
+	require.Equal(t, 42, c.Res().ContentLength())
+}
+
+func Test_Res_GetCookie_Cookies(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	_, ok := c.Res().GetCookie("absent")
+	require.False(t, ok)
+	require.Empty(t, c.Res().Cookies())
+
+	expires := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	c.Cookie(&Cookie{
+		Name:     "session",
+		Value:    "abc",
+		Path:     "/scoped",
+		Domain:   "example.com",
+		MaxAge:   60,
+		Expires:  expires,
+		Secure:   true,
+		HTTPOnly: true,
+		SameSite: CookieSameSiteStrictMode,
+	})
+
+	got, ok := c.Res().GetCookie("session")
+	require.True(t, ok)
+	require.Equal(t, "session", got.Name)
+	require.Equal(t, "abc", got.Value)
+	require.Equal(t, "/scoped", got.Path)
+	require.Equal(t, "example.com", got.Domain)
+	require.Equal(t, 60, got.MaxAge)
+	require.True(t, got.Secure)
+	require.True(t, got.HTTPOnly)
+	require.Equal(t, CookieSameSiteStrictMode, got.SameSite)
+	require.False(t, got.SessionOnly)
+
+	// A session cookie carries neither Max-Age nor Expires, and reads back as one.
+	c.Cookie(&Cookie{Name: "flash", Value: "x", SessionOnly: true})
+	flash, ok := c.Res().GetCookie("flash")
+	require.True(t, ok)
+	require.True(t, flash.SessionOnly)
+	require.Zero(t, flash.MaxAge)
+	require.True(t, flash.Expires.IsZero())
+
+	cookies := c.Res().Cookies()
+	require.Len(t, cookies, 2)
+	names := make([]string, 0, len(cookies))
+	for _, cookie := range cookies {
+		names = append(names, cookie.Name)
+	}
+	require.ElementsMatch(t, []string{"session", "flash"}, names)
+
+	// The returned struct is a copy: editing it leaves the response alone.
+	got.Value = "tampered"
+	again, ok := c.Res().GetCookie("session")
+	require.True(t, ok)
+	require.Equal(t, "abc", again.Value)
+}
+
+// Test_Res_GetCookie_RoundTrip pins the read-modify-write path GetCookie exists
+// for: middleware that rewrites a cookie an earlier handler set.
+func Test_Res_GetCookie_RoundTrip(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	c.Cookie(&Cookie{Name: "session", Value: "plain", Path: "/app", HTTPOnly: true, SameSite: CookieSameSiteLaxMode})
+
+	cookie, ok := c.Res().GetCookie("session")
+	require.True(t, ok)
+	cookie.Value = "encrypted"
+	c.Cookie(cookie)
+
+	rewritten, ok := c.Res().GetCookie("session")
+	require.True(t, ok)
+	require.Equal(t, "encrypted", rewritten.Value)
+	require.Equal(t, "/app", rewritten.Path, "the other attributes survive the round trip")
+	require.True(t, rewritten.HTTPOnly)
+	require.Equal(t, CookieSameSiteLaxMode, rewritten.SameSite)
+	require.Len(t, c.Res().Cookies(), 1, "rewriting replaces the cookie rather than adding one")
+}
+
+func Test_Res_NoContent(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.NoError(t, c.JSON(Map{"a": 1}))
+	require.NotEmpty(t, c.Res().Body())
+
+	require.NoError(t, c.Res().NoContent())
+	require.Equal(t, StatusNoContent, c.Res().StatusCode())
+	require.Empty(t, c.Res().Body())
+	require.False(t, c.Res().Written())
+	require.NotEqual(t, MIMEApplicationJSONCharsetUTF8, c.Res().ContentType(),
+		"the handler's Content-Type is gone; Test_Res_NoContent_OverHTTP pins that none is sent")
+}
+
+func Test_Res_NoContent_OverHTTP(t *testing.T) {
+	t.Parallel()
+	app := New()
+	app.Delete("/item", func(c Ctx) error {
+		return c.Res().NoContent()
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodDelete, "/item", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, StatusNoContent, resp.StatusCode)
+	require.Empty(t, resp.Header.Get(HeaderContentType))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Empty(t, body)
+}
+
+// -----------------------------------------------------------------------------
+// Ctx
+// -----------------------------------------------------------------------------
+
+// Test_Ctx_BodyContentLengthCookiesPreferRequest pins the three names Req and
+// Res both define. Ctx has to resolve them itself or the embedded selectors are
+// ambiguous and the package stops compiling; the request wins, as it does for
+// Get, and the response stays reachable through Res().
+func Test_Ctx_BodyContentLengthCookiesPreferRequest(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.SetBody([]byte("request body"))
+	fctx.Request.Header.SetContentLength(len("request body"))
+	fctx.Request.Header.SetCookie("who", "client")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.NoError(t, c.SendString("response body"))
+	c.Cookie(&Cookie{Name: "who", Value: "server"})
+
+	require.Equal(t, "request body", string(c.Body()))
+	require.Equal(t, "request body", string(c.Req().Body()))
+	require.Equal(t, "response body", string(c.Res().Body()))
+
+	require.Equal(t, len("request body"), c.ContentLength())
+	require.Equal(t, len("request body"), c.Req().ContentLength())
+
+	require.Equal(t, "client", c.Cookies("who"))
+	require.Equal(t, "client", c.Req().Cookies("who"))
+	require.Equal(t, "fallback", c.Cookies("absent", "fallback"))
+
+	serverCookies := c.Res().Cookies()
+	require.Len(t, serverCookies, 1)
+	require.Equal(t, "server", serverCookies[0].Value)
+}
+
+func Test_Ctx_ID_StartTime_Elapsed(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	var (
+		id      uint64
+		stable  bool
+		start   time.Time
+		elapsed time.Duration
+	)
+	app.Get("/", func(c Ctx) error {
+		id = c.ID()
+		stable = c.ID() == id
+		start = c.StartTime()
+		elapsed = c.Elapsed()
+		return nil
+	})
+
+	_, err := app.Test(httptest.NewRequest(MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+
+	require.NotZero(t, id)
+	require.True(t, stable, "ID is stable within a request")
+	require.False(t, start.IsZero())
+	require.GreaterOrEqual(t, elapsed, time.Duration(0))
+	require.Less(t, elapsed, time.Minute, "Elapsed measures from StartTime, not from the epoch")
+}
+
+func Test_Ctx_LocalAddr_RemoteAddr(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	var local, remote net.Addr
+	app.Get("/", func(c Ctx) error {
+		local = c.LocalAddr()
+		remote = c.RemoteAddr()
+		return nil
+	})
+
+	_, err := app.Test(httptest.NewRequest(MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+
+	require.NotNil(t, local)
+	require.NotNil(t, remote)
+	require.NotEmpty(t, remote.Network())
+}
+
+func Test_Ctx_Hijack(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.False(t, c.Hijacked())
+	c.Hijack(func(net.Conn) {})
+	require.True(t, c.Hijacked())
+}
+
+func Test_Ctx_RouteName(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	var mwName, handlerName string
+	app.Use(func(c Ctx) error {
+		mwName = c.RouteName()
+		return c.Next()
+	})
+	app.Get("/home", func(c Ctx) error {
+		handlerName = c.RouteName()
+		return nil
+	}).Name("home")
+
+	_, err := app.Test(httptest.NewRequest(MethodGet, "/home", http.NoBody))
+	require.NoError(t, err)
+
+	require.Equal(t, "home", handlerName)
+	require.Empty(t, mwName, "middleware reports its own unnamed route, not the endpoint's")
+}
+
+func Test_Ctx_RouteName_Unmatched(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.NotPanics(t, func() { require.Empty(t, c.RouteName()) })
+}
+
+func Test_Ctx_IsFinal(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	var (
+		inGlobalMW bool
+		inRouteMW  bool
+		inHandler  bool
+	)
+	app.Use(func(c Ctx) error {
+		inGlobalMW = c.IsFinal()
+		return c.Next()
+	})
+	app.Get("/chain", func(c Ctx) error {
+		inRouteMW = c.IsFinal()
+		return c.Next()
+	}, func(c Ctx) error {
+		inHandler = c.IsFinal()
+		return nil
+	})
+
+	_, err := app.Test(httptest.NewRequest(MethodGet, "/chain", http.NoBody))
+	require.NoError(t, err)
+
+	require.False(t, inGlobalMW)
+	require.False(t, inRouteMW, "a route handler with another after it is not final")
+	require.True(t, inHandler)
+
+	// No route matched at all: there is no final handler to be.
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+	require.False(t, c.IsFinal())
+	require.False(t, c.IsMiddleware())
+}
+
+func Test_Ctx_MountPath(t *testing.T) {
+	t.Parallel()
+
+	micro := New()
+	var mounted, mountedPath string
+	micro.Get("/doe", func(c Ctx) error {
+		mounted = c.MountPath()
+		// Path aliases the pooled request buffer, which the next request
+		// overwrites; clone it to read it after the handler returns.
+		mountedPath = strings.Clone(c.Path())
+		return nil
+	})
+
+	app := New()
+	var top string
+	app.Get("/top", func(c Ctx) error {
+		top = c.MountPath()
+		return nil
+	})
+	app.Use("/john", micro)
+
+	_, err := app.Test(httptest.NewRequest(MethodGet, "/john/doe", http.NoBody))
+	require.NoError(t, err)
+	_, err = app.Test(httptest.NewRequest(MethodGet, "/top", http.NoBody))
+	require.NoError(t, err)
+
+	require.Equal(t, "/john", mounted)
+	require.Equal(t, "/john/doe", mountedPath,
+		"Fiber bakes the prefix into the cloned route, so Path is not relative to the mount")
+	require.True(t, strings.HasPrefix(mountedPath, mounted), "the served path lives under MountPath")
+	require.Empty(t, top, "the top-level app is not mounted under anything")
+}
+
+func Test_Ctx_Error(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	err := c.Error(StatusTeapot)
+	var fiberErr *Error
+	require.ErrorAs(t, err, &fiberErr)
+	require.Equal(t, StatusTeapot, fiberErr.Code)
+	require.Equal(t, utils.StatusMessage(StatusTeapot), fiberErr.Message)
+
+	err = c.Error(StatusBadRequest, "id must be numeric")
+	require.ErrorAs(t, err, &fiberErr)
+	require.Equal(t, StatusBadRequest, fiberErr.Code)
+	require.Equal(t, "id must be numeric", fiberErr.Message)
+
+	require.Equal(t, StatusOK, c.Res().StatusCode(), "Error builds an error, it does not write the response")
+	require.False(t, c.Res().Written())
+}
+
+func Test_Ctx_Error_ReachesErrorHandler(t *testing.T) {
+	t.Parallel()
+	app := New()
+	app.Get("/", func(c Ctx) error {
+		return c.Error(StatusBadRequest, "id must be numeric")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, StatusBadRequest, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "id must be numeric", string(body))
+}
+
+// Test_Ctx_Copy is the point of Copy: the snapshot still reads the request the
+// handler saw after the ctx has gone back to the pool and other requests have
+// reused its buffers.
+func Test_Ctx_Copy(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	var snapshot Ctx
+	app.Get("/user/:id", func(c Ctx) error {
+		if snapshot != nil {
+			// The churn requests below match this same route; only the first
+			// one is the request the snapshot has to keep.
+			return c.SendString("ok")
+		}
+		c.Locals("who", "alice")
+		snapshot = c.Copy()
+		return c.SendString("ok")
+	})
+
+	_, err := app.Test(httptest.NewRequest(MethodGet, "/user/42?q=first", http.NoBody))
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+
+	// Drive more requests through the pooled ctx so its buffers are certainly
+	// rewritten under the snapshot.
+	for range 5 {
+		_, err := app.Test(httptest.NewRequest(MethodGet, "/user/other?q=second", http.NoBody))
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, "42", snapshot.Params("id"))
+	require.Equal(t, "/user/42", snapshot.Path())
+	require.Equal(t, "first", snapshot.Query("q"))
+	require.Equal(t, MethodGet, snapshot.Method())
+	require.Equal(t, "alice", snapshot.Locals("who"))
+	require.Equal(t, "/user/:id", snapshot.Route().Path)
+}
+
+func Test_Ctx_Copy_DetachedResponse(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.SetRequestURI("/original")
+	fctx.Request.SetBody([]byte("body"))
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.NoError(t, c.SendString("original"))
+	snapshot := c.Copy()
+
+	// Writing to the snapshot leaves the live response alone.
+	require.NoError(t, snapshot.SendString("detached"))
+	snapshot.Status(StatusTeapot)
+	require.Equal(t, "detached", string(snapshot.Res().Body()))
+	require.Equal(t, "original", string(c.Res().Body()))
+	require.Equal(t, StatusOK, c.Res().StatusCode())
+
+	// The request is a deep copy, so mutating the live one does not reach it.
+	c.Request().SetBody([]byte("rewritten"))
+	require.Equal(t, "body", string(snapshot.Body()))
+	require.Equal(t, "rewritten", string(c.Body()))
+}
+
+func Test_Ctx_Copy_BodyStreamNotCopied(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.SetBodyStream(strings.NewReader("streamed"), 8)
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	snapshot := c.Copy()
+	require.Nil(t, snapshot.Req().BodyStream(), "an unread stream does not survive the copy")
+	require.Empty(t, snapshot.Body())
+	// The original still has it, so a handler can read it after copying.
+	require.NotNil(t, c.Req().BodyStream())
+}
+
+func Test_Ctx_Copy_IsNotPooled(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.SetRequestURI("/keep")
+	c := app.AcquireCtx(fctx)
+
+	snapshot := c.Copy()
+	app.ReleaseCtx(c)
+
+	// Releasing the original must not have handed the snapshot back to the pool.
+	require.Equal(t, "/keep", snapshot.Path())
+	require.NotSame(t, c.RequestCtx(), snapshot.RequestCtx())
+}

--- a/ctx_helpers_test.go
+++ b/ctx_helpers_test.go
@@ -1188,3 +1188,66 @@ func Test_Res_SendStatus_DropsDeclaredContentLength(t *testing.T) {
 	require.Empty(t, get("/nocontent"))
 	require.Equal(t, []string{"0"}, get("/bare205"))
 }
+
+func Test_Req_AcceptsWithoutNormalizing(t *testing.T) {
+	t.Parallel()
+	app := New(Config{DisableHeaderNormalizing: true})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.DisableNormalizing()
+	fctx.Request.Header.Set("accept", "application/json")
+	fctx.Request.Header.Set("accept-charset", "utf-8")
+	fctx.Request.Header.Set("accept-encoding", "gzip")
+	fctx.Request.Header.Set("accept-language", "en-GB")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	r := c.Req()
+	require.Equal(t, "gzip", r.AcceptEncoding())
+	require.Equal(t, "en-GB", r.AcceptLanguage())
+
+	require.Equal(t, "application/json", r.Accepts("application/json", "text/html"))
+	require.Empty(t, r.Accepts("text/html"))
+	require.Equal(t, "utf-8", r.AcceptsCharsets("utf-8", "iso-8859-1"))
+	require.Empty(t, r.AcceptsCharsets("iso-8859-1"))
+	require.Equal(t, "gzip", r.AcceptsEncodings("gzip", "br"))
+	require.Empty(t, r.AcceptsEncodings("br"))
+	require.Equal(t, "en-GB", r.AcceptsLanguages("en-GB", "de"))
+	require.Empty(t, r.AcceptsLanguages("de"))
+}
+
+func Test_Req_FreshWithoutNormalizing(t *testing.T) {
+	t.Parallel()
+	app := New(Config{DisableHeaderNormalizing: true})
+
+	newCtx := func(t *testing.T, set func(h *fasthttp.RequestHeader)) Ctx {
+		t.Helper()
+		fctx := &fasthttp.RequestCtx{}
+		fctx.Request.Header.DisableNormalizing()
+		fctx.Request.Header.SetMethod(MethodGet)
+		set(&fctx.Request.Header)
+		c := app.AcquireCtx(fctx)
+		t.Cleanup(func() { app.ReleaseCtx(c) })
+		return c
+	}
+
+	c := newCtx(t, func(h *fasthttp.RequestHeader) {
+		h.Set("if-none-match", `"abc"`)
+	})
+	c.Res().Set(HeaderETag, `"abc"`)
+	require.True(t, c.Req().Fresh())
+	require.Equal(t, []string{`"abc"`}, c.Req().IfNoneMatch())
+
+	noCache := newCtx(t, func(h *fasthttp.RequestHeader) {
+		h.Set("if-none-match", `"abc"`)
+		h.Set("cache-control", "no-cache")
+	})
+	noCache.Res().Set(HeaderETag, `"abc"`)
+	require.False(t, noCache.Req().Fresh())
+
+	since := newCtx(t, func(h *fasthttp.RequestHeader) {
+		h.Set("if-modified-since", "Wed, 21 Oct 2015 07:28:00 GMT")
+	})
+	since.Res().Set(HeaderLastModified, "Tue, 20 Oct 2015 07:28:00 GMT")
+	require.True(t, since.Req().Fresh())
+}

--- a/ctx_helpers_test.go
+++ b/ctx_helpers_test.go
@@ -1019,3 +1019,69 @@ func Test_Ctx_Error_ReachesErrorHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "id must be numeric", string(body))
 }
+
+func Test_Req_HeaderFieldWithoutNormalizing(t *testing.T) {
+	t.Parallel()
+	app := New(Config{DisableHeaderNormalizing: true})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.DisableNormalizing()
+	fctx.Request.Header.Set("origin", "https://example.com")
+	fctx.Request.Header.Set("authorization", "Bearer abc123")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.Empty(t, c.Get(HeaderOrigin), "Ctx.Get is byte-exact and misses the lower-case spelling")
+	require.Equal(t, "https://example.com", c.Req().Origin())
+
+	scheme, credentials := c.Req().Authorization()
+	require.Equal(t, "Bearer", scheme)
+	require.Equal(t, "abc123", credentials)
+	require.Equal(t, "abc123", c.Req().Bearer())
+}
+
+func Test_Res_Cookies_UnparsableEntry(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	c.Cookie(&Cookie{Name: "good", Value: "1"})
+	c.Res().Add(HeaderSetCookie, "")
+
+	cookies := c.Res().Cookies()
+	require.Len(t, cookies, 1, "the unparsable entry is skipped")
+	require.Equal(t, "good", cookies[0].Name)
+
+	_, ok := c.Res().GetCookie("")
+	require.False(t, ok, "GetCookie reports failure rather than a half-parsed cookie")
+
+	good, ok := c.Res().GetCookie("good")
+	require.True(t, ok)
+	require.Equal(t, "1", good.Value)
+}
+
+func Test_Res_GetCookie_NoAttributes(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	c.Res().Add(HeaderSetCookie, "plain=value")
+
+	got, ok := c.Res().GetCookie("plain")
+	require.True(t, ok)
+	require.Equal(t, "value", got.Value)
+	require.Empty(t, got.Path)
+	require.Zero(t, got.MaxAge)
+	require.True(t, got.SessionOnly, "no Max-Age and no Expires is a session cookie")
+}
+
+func Test_Ctx_MountPath_NoApp(t *testing.T) {
+	t.Parallel()
+
+	var c DefaultCtx
+	require.NotPanics(t, func() { require.Empty(t, c.MountPath()) })
+}

--- a/ctx_helpers_test.go
+++ b/ctx_helpers_test.go
@@ -21,6 +21,17 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+// Splitting a handler into func(fiber.Req) and func(fiber.Res) and passing the
+// same Ctx to both is the reason the split exists, so Ctx has to satisfy each.
+// A name carried by Req and Res under different signatures breaks that on
+// assignment, which no test of the concrete types would catch.
+var (
+	_ Req = (*DefaultCtx)(nil)
+	_ Res = (*DefaultCtx)(nil)
+	_ Req = Ctx(nil)
+	_ Res = Ctx(nil)
+)
+
 func Test_Req_RequestHelpersOnReq(t *testing.T) {
 	t.Parallel()
 	app := New()
@@ -481,9 +492,9 @@ func Test_Res_Del(t *testing.T) {
 	require.Empty(t, c.Response().Header.PeekAll("X-Multi"))
 
 	c.Cookie(&Cookie{Name: "a", Value: "1"})
-	require.NotEmpty(t, c.Res().Cookies())
+	require.NotEmpty(t, c.Res().GetCookies())
 	c.Res().Del(HeaderSetCookie)
-	require.Empty(t, c.Res().Cookies())
+	require.Empty(t, c.Res().GetCookies())
 }
 
 func Test_Res_Add(t *testing.T) {
@@ -538,7 +549,7 @@ func Test_Res_GetCookie_Cookies(t *testing.T) {
 
 	_, ok := c.Res().GetCookie("absent")
 	require.False(t, ok)
-	require.Empty(t, c.Res().Cookies())
+	require.Empty(t, c.Res().GetCookies())
 
 	expires := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
 	c.Cookie(&Cookie{
@@ -572,7 +583,7 @@ func Test_Res_GetCookie_Cookies(t *testing.T) {
 	require.Zero(t, flash.MaxAge)
 	require.True(t, flash.Expires.IsZero())
 
-	cookies := c.Res().Cookies()
+	cookies := c.Res().GetCookies()
 	require.Len(t, cookies, 2)
 	names := make([]string, 0, len(cookies))
 	for _, cookie := range cookies {
@@ -597,7 +608,7 @@ func Test_Res_Cookies_RepeatedNames(t *testing.T) {
 	c.Res().Add(HeaderSetCookie, "sid=admin; path=/admin")
 	c.Cookie(&Cookie{Name: "other", Value: "z"})
 
-	cookies := c.Res().Cookies()
+	cookies := c.Res().GetCookies()
 	require.Len(t, cookies, 3)
 
 	type pair struct{ value, path string }
@@ -698,7 +709,7 @@ func Test_Res_GetCookie_RoundTrip(t *testing.T) {
 	require.Equal(t, "/app", rewritten.Path, "the other attributes survive the round trip")
 	require.True(t, rewritten.HTTPOnly)
 	require.Equal(t, CookieSameSiteLaxMode, rewritten.SameSite)
-	require.Len(t, c.Res().Cookies(), 1, "rewriting replaces the cookie rather than adding one")
+	require.Len(t, c.Res().GetCookies(), 1, "rewriting replaces the cookie rather than adding one")
 }
 
 func Test_Res_NoContent(t *testing.T) {
@@ -784,7 +795,7 @@ func Test_Ctx_BodyContentLengthCookiesPreferRequest(t *testing.T) {
 	require.Equal(t, "client", c.Req().Cookies("who"))
 	require.Equal(t, "fallback", c.Cookies("absent", "fallback"))
 
-	serverCookies := c.Res().Cookies()
+	serverCookies := c.Res().GetCookies()
 	require.Len(t, serverCookies, 1)
 	require.Equal(t, "server", serverCookies[0].Value)
 
@@ -1103,7 +1114,7 @@ func Test_Res_Cookies_UnparsableEntry(t *testing.T) {
 	c.Cookie(&Cookie{Name: "good", Value: "1"})
 	c.Res().Add(HeaderSetCookie, "")
 
-	cookies := c.Res().Cookies()
+	cookies := c.Res().GetCookies()
 	require.Len(t, cookies, 1, "the unparsable entry is skipped")
 	require.Equal(t, "good", cookies[0].Name)
 
@@ -1360,4 +1371,170 @@ func Test_Res_DelKeyCaseWithoutNormalizing(t *testing.T) {
 	c.Res().Set("X-Token", "secret")
 	c.Res().Del("x-token")
 	require.Empty(t, string(c.Response().Header.Peek("X-Token")))
+}
+
+func Test_Req_Res_AccessorsImmutable(t *testing.T) {
+	t.Parallel()
+
+	scrubHeader := func(field string) func(c Ctx) {
+		return func(c Ctx) {
+			raw := c.Request().Header.Peek(field)
+			for i := range raw {
+				raw[i] = 'X'
+			}
+		}
+	}
+
+	tests := []struct {
+		setup func(c Ctx)
+		read  func(c Ctx) string
+		scrub func(c Ctx)
+		name  string
+		want  string
+		// alwaysCopies marks an accessor that builds its own string whatever
+		// Immutable says, so the buffer it was read from cannot be observed.
+		alwaysCopies bool
+	}{
+		{
+			name:  "UserAgent",
+			setup: func(c Ctx) { c.Request().Header.Set(HeaderUserAgent, "agent-one") },
+			read:  func(c Ctx) string { return c.UserAgent() },
+			scrub: scrubHeader(HeaderUserAgent),
+			want:  "agent-one",
+		},
+		{
+			name:  "Referer",
+			setup: func(c Ctx) { c.Request().Header.Set(HeaderReferer, "https://ref.example/a") },
+			read:  func(c Ctx) string { return c.Referer() },
+			scrub: scrubHeader(HeaderReferer),
+			want:  "https://ref.example/a",
+		},
+		{
+			name:  "Origin",
+			setup: func(c Ctx) { c.Request().Header.Set(HeaderOrigin, "https://origin.example") },
+			read:  func(c Ctx) string { return c.Origin() },
+			scrub: scrubHeader(HeaderOrigin),
+			want:  "https://origin.example",
+		},
+		{
+			name:  "AcceptLanguage",
+			setup: func(c Ctx) { c.Request().Header.Set(HeaderAcceptLanguage, "en-GB,en;q=0.8") },
+			read:  func(c Ctx) string { return c.AcceptLanguage() },
+			scrub: scrubHeader(HeaderAcceptLanguage),
+			want:  "en-GB,en;q=0.8",
+		},
+		{
+			name:  "AcceptEncoding",
+			setup: func(c Ctx) { c.Request().Header.Set(HeaderAcceptEncoding, "gzip, br") },
+			read:  func(c Ctx) string { return c.AcceptEncoding() },
+			scrub: scrubHeader(HeaderAcceptEncoding),
+			want:  "gzip, br",
+		},
+		{
+			name:  "ContentType",
+			setup: func(c Ctx) { c.Request().Header.Set(HeaderContentType, "text/plain; charset=iso-8859-1") },
+			read:  func(c Ctx) string { return c.ContentType() },
+			scrub: scrubHeader(HeaderContentType),
+			want:  "text/plain; charset=iso-8859-1",
+		},
+		{
+			name:  "MediaType",
+			setup: func(c Ctx) { c.Request().Header.Set(HeaderContentType, "text/plain; charset=iso-8859-1") },
+			read:  func(c Ctx) string { return c.MediaType() },
+			scrub: scrubHeader(HeaderContentType),
+			want:  "text/plain",
+		},
+		{
+			name:  "Charset",
+			setup: func(c Ctx) { c.Request().Header.Set(HeaderContentType, "text/plain; charset=iso-8859-1") },
+			read:  func(c Ctx) string { return c.Charset() },
+			scrub: scrubHeader(HeaderContentType),
+			want:  "iso-8859-1",
+		},
+		{
+			name:  "Bearer",
+			setup: func(c Ctx) { c.Request().Header.Set(HeaderAuthorization, "Bearer tok-123") },
+			read:  func(c Ctx) string { return c.Bearer() },
+			scrub: scrubHeader(HeaderAuthorization),
+			want:  "tok-123",
+		},
+		{
+			name:  "Authorization",
+			setup: func(c Ctx) { c.Request().Header.Set(HeaderAuthorization, "Basic Y3JlZA==") },
+			read: func(c Ctx) string {
+				_, credentials := c.Authorization()
+				return credentials
+			},
+			scrub: scrubHeader(HeaderAuthorization),
+			want:  "Y3JlZA==",
+		},
+		{
+			name:  "GetAll",
+			setup: func(c Ctx) { c.Request().Header.Set("X-Multi", "one") },
+			read:  func(c Ctx) string { return strings.Join(c.GetAll("X-Multi"), "|") },
+			scrub: scrubHeader("X-Multi"),
+			want:  "one",
+		},
+		{
+			name:  "IfNoneMatch",
+			setup: func(c Ctx) { c.Request().Header.Set(HeaderIfNoneMatch, `"v1", "v2"`) },
+			read:  func(c Ctx) string { return c.IfNoneMatch()[0] },
+			scrub: scrubHeader(HeaderIfNoneMatch),
+			want:  `"v1"`,
+		},
+		{
+			name:         "AllCookies",
+			setup:        func(c Ctx) { c.Request().Header.Set(HeaderCookie, "sid=abc") },
+			read:         func(c Ctx) string { return c.AllCookies()["sid"] },
+			scrub:        scrubHeader(HeaderCookie),
+			want:         "abc",
+			alwaysCopies: true,
+		},
+		{
+			name:  "Res.ContentType",
+			setup: func(c Ctx) { c.Response().Header.Set(HeaderContentType, "application/xml") },
+			read:  func(c Ctx) string { return c.Res().ContentType() },
+			scrub: func(c Ctx) {
+				raw := c.Response().Header.Peek(HeaderContentType)
+				for i := range raw {
+					raw[i] = 'X'
+				}
+			},
+			want: "application/xml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := New(Config{Immutable: true})
+			c := app.AcquireCtx(&fasthttp.RequestCtx{})
+			tc.setup(c)
+
+			got := tc.read(c)
+			require.Equal(t, tc.want, got)
+
+			tc.scrub(c)
+			require.Equal(t, tc.want, got, "Immutable must hand back a copy, not a view of the header buffer")
+		})
+
+		if tc.alwaysCopies {
+			continue
+		}
+
+		t.Run(tc.name+"/scrubReachesTheBuffer", func(t *testing.T) {
+			t.Parallel()
+
+			app := New()
+			c := app.AcquireCtx(&fasthttp.RequestCtx{})
+			tc.setup(c)
+
+			got := tc.read(c)
+			require.Equal(t, tc.want, got)
+
+			tc.scrub(c)
+			require.NotEqual(t, tc.want, got, "without Immutable the value views the header buffer, so this guards the test above against a scrub that reaches nothing")
+		})
+	}
 }

--- a/ctx_helpers_test.go
+++ b/ctx_helpers_test.go
@@ -134,6 +134,68 @@ func Test_Req_ContentLength(t *testing.T) {
 
 	require.Equal(t, -1, cc.Req().ContentLength(), "chunked bodies report an unknown length")
 	require.True(t, cc.Req().HasBody(), "an unknown length still means there is a body")
+
+	// A bodyless GET reports -2, fasthttp's "Transfer-Encoding: identity"
+	// sentinel — not 0. Callers sizing a buffer from this would panic.
+	var bodyless int
+	app.Get("/", func(c Ctx) error {
+		bodyless = c.Req().ContentLength()
+		return nil
+	})
+	_, err = app.Test(httptest.NewRequest(MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, -2, bodyless)
+}
+
+// Test_Req_GetAll_AbsentSlottedHeaders pins that presence answers the same as
+// HasHeader. fasthttp's PeekAll appends the Content-Length and Trailer buffers
+// unconditionally, so an absent header used to come back as one empty line.
+func Test_Req_GetAll_AbsentSlottedHeaders(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	var got map[string][]string
+	var has map[string]bool
+	app.Get("/", func(c Ctx) error {
+		got = map[string][]string{}
+		has = map[string]bool{}
+		for _, key := range []string{HeaderContentLength, HeaderTrailer, "X-Absent"} {
+			got[key] = c.Req().GetAll(key)
+			has[key] = c.Req().HasHeader(key)
+		}
+		return nil
+	})
+
+	_, err := app.Test(httptest.NewRequest(MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+
+	for key, lines := range got {
+		require.Nil(t, lines, key)
+		require.False(t, has[key], key)
+		require.Equal(t, has[key], len(lines) > 0, "GetAll and HasHeader must agree on %s", key)
+	}
+}
+
+func Test_Req_ContentType(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.SetContentType(MIMEApplicationJSON + "; charset=utf-8")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.Equal(t, MIMEApplicationJSONCharsetUTF8, c.Req().ContentType())                      //nolint:testifylint // this is comparing content-type headers, not JSON content
+	require.Equal(t, MIMEApplicationJSON, c.Req().MediaType(), "MediaType drops the parameters") //nolint:testifylint // same
+	require.Equal(t, "utf-8", c.Req().Charset())
+
+	// Req and Res both define ContentType, so Ctx must resolve to the request
+	// the way it does for Get — otherwise c.ContentType() would silently report
+	// the response's default while c.Get(HeaderContentType) reports the request.
+	require.NoError(t, c.SendString("hi"))
+	c.Type("html")
+	require.Equal(t, c.Req().ContentType(), c.ContentType())
+	require.Equal(t, MIMETextHTMLCharsetUTF8, c.Res().ContentType())
 }
 
 func Test_Req_BodyStream(t *testing.T) {
@@ -277,6 +339,18 @@ func Test_Req_CookieNames_AllCookies(t *testing.T) {
 
 	require.ElementsMatch(t, []string{"session", "theme"}, c.Req().CookieNames())
 	require.Equal(t, map[string]string{"session": "abc", "theme": "dark"}, c.Req().AllCookies())
+
+	// A client can shadow a cookie by sending the name twice. Cookies(name)
+	// answers with the first, so AllCookies must too: validating one value and
+	// consuming the other is the bug this pins shut.
+	shadowed := &fasthttp.RequestCtx{}
+	shadowed.Request.Header.Set(HeaderCookie, "a=first; a=second")
+	sc := app.AcquireCtx(shadowed)
+	t.Cleanup(func() { app.ReleaseCtx(sc) })
+
+	require.Equal(t, "first", sc.Req().Cookies("a"))
+	require.Equal(t, "first", sc.Req().AllCookies()["a"])
+	require.Equal(t, []string{"a", "a"}, sc.Req().CookieNames(), "the repetition itself stays visible")
 
 	bare := app.AcquireCtx(&fasthttp.RequestCtx{})
 	t.Cleanup(func() { app.ReleaseCtx(bare) })
@@ -547,6 +621,117 @@ func Test_Res_GetCookie_Cookies(t *testing.T) {
 	require.Equal(t, "abc", again.Value)
 }
 
+// Test_Res_Cookies_RepeatedNames pins that a name written twice yields both
+// cookies. Resolving each entry by name instead of parsing it returned the
+// first cookie once per line and made the later ones unreachable.
+func Test_Res_Cookies_RepeatedNames(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	c.Cookie(&Cookie{Name: "sid", Value: "app", Path: "/app"})
+	c.Res().Add(HeaderSetCookie, "sid=admin; path=/admin")
+	c.Cookie(&Cookie{Name: "other", Value: "z"})
+
+	cookies := c.Res().Cookies()
+	require.Len(t, cookies, 3)
+
+	type pair struct{ value, path string }
+	got := make([]pair, 0, len(cookies))
+	for _, cookie := range cookies {
+		got = append(got, pair{cookie.Value, cookie.Path})
+	}
+	require.ElementsMatch(t, []pair{{"app", "/app"}, {"admin", "/admin"}, {"z", "/"}}, got)
+
+	// GetCookie resolves by name, so it answers with the first of a repeated one.
+	first, ok := c.Res().GetCookie("sid")
+	require.True(t, ok)
+	require.Equal(t, "app", first.Value)
+
+	// And all three really do reach the client, so none of them is an artifact
+	// of how Cookies reads them back.
+	over := New()
+	over.Get("/", func(c Ctx) error {
+		c.Cookie(&Cookie{Name: "sid", Value: "app", Path: "/app"})
+		c.Res().Add(HeaderSetCookie, "sid=admin; path=/admin")
+		c.Cookie(&Cookie{Name: "other", Value: "z"})
+		return nil
+	})
+	resp, err := over.Test(httptest.NewRequest(MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	require.Len(t, resp.Header.Values(HeaderSetCookie), 3)
+}
+
+// Test_Res_GetCookie_Deletion pins that a cookie deletion survives the
+// read-modify-write round trip. fasthttp writes a negative MaxAge as
+// "max-age=0" and parses it back as 0, which is also what an absent attribute
+// gives — so a logout cookie read and rewritten used to come back as an
+// ordinary session cookie, leaving the client logged in.
+func Test_Res_GetCookie_Deletion(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	c.Cookie(&Cookie{Name: "session", Value: "v", MaxAge: -1})
+	require.Contains(t, string(c.Response().Header.Peek(HeaderSetCookie)), "max-age=0")
+
+	got, ok := c.Res().GetCookie("session")
+	require.True(t, ok)
+	require.False(t, got.SessionOnly, "an explicit max-age=0 is a deletion, not a session cookie")
+	require.Negative(t, got.MaxAge)
+
+	// Rewriting an unrelated attribute must not resurrect the cookie.
+	got.Domain = "example.com"
+	c.Cookie(got)
+	require.Contains(t, string(c.Response().Header.Peek(HeaderSetCookie)), "max-age=0")
+
+	rewritten, ok := c.Res().GetCookie("session")
+	require.True(t, ok)
+	require.False(t, rewritten.SessionOnly)
+	require.Equal(t, "example.com", rewritten.Domain)
+}
+
+// Test_Res_Body_DoesNotDrainStream pins that reading the body leaves a streamed
+// response streamed. Draining it would buffer a whole SendFile into memory and
+// hang an SSE route.
+func Test_Res_Body_DoesNotDrainStream(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.NoError(t, c.SendStream(strings.NewReader("streamed"), 8))
+	require.True(t, c.Res().Written())
+	require.Nil(t, c.Res().Body(), "a streamed body is not materialized")
+	require.True(t, c.Response().IsBodyStream(), "and it is still a stream afterwards")
+}
+
+// Test_Res_Add_SpecialHeaders pins fasthttp's behavior for the headers it keeps
+// in a slot of their own: Add replaces them rather than appending, which is why
+// the doc names them.
+func Test_Res_Add_SpecialHeaders(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	c.Set(HeaderContentType, MIMEApplicationJSON)
+	c.Res().Add(HeaderContentType, MIMETextPlain)
+	require.Equal(t, MIMETextPlain, c.Res().ContentType(), "Content-Type is replaced, not appended")
+	require.Len(t, c.Response().Header.PeekAll(HeaderContentType), 1)
+
+	// A header with no slot of its own does append, which is the documented use.
+	c.Res().Add(HeaderLink, "</a>; rel=preload")
+	c.Res().Add(HeaderLink, "</b>; rel=preload")
+	require.Len(t, c.Response().Header.PeekAll(HeaderLink), 2)
+}
+
 // Test_Res_GetCookie_RoundTrip pins the read-modify-write path GetCookie exists
 // for: middleware that rewrites a cookie an earlier handler set.
 func Test_Res_GetCookie_RoundTrip(t *testing.T) {
@@ -607,6 +792,32 @@ func Test_Res_NoContent_OverHTTP(t *testing.T) {
 	require.Empty(t, body)
 }
 
+// Test_Res_NoContent_DiffersFromSendStatus pins the one thing NoContent adds
+// over SendStatus(204): SendStatus drops the body but keeps a Content-Type the
+// handler set, so the two are not interchangeable.
+func Test_Res_NoContent_DiffersFromSendStatus(t *testing.T) {
+	t.Parallel()
+	app := New()
+	app.Get("/sendstatus", func(c Ctx) error {
+		c.Type("json")
+		return c.SendStatus(StatusNoContent)
+	})
+	app.Get("/nocontent", func(c Ctx) error {
+		c.Type("json")
+		return c.Res().NoContent()
+	})
+
+	sent, err := app.Test(httptest.NewRequest(MethodGet, "/sendstatus", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, StatusNoContent, sent.StatusCode)
+	require.NotEmpty(t, sent.Header.Get(HeaderContentType))
+
+	none, err := app.Test(httptest.NewRequest(MethodGet, "/nocontent", http.NoBody))
+	require.NoError(t, err)
+	require.Equal(t, StatusNoContent, none.StatusCode)
+	require.Empty(t, none.Header.Get(HeaderContentType))
+}
+
 // -----------------------------------------------------------------------------
 // Ctx
 // -----------------------------------------------------------------------------
@@ -643,6 +854,9 @@ func Test_Ctx_BodyContentLengthCookiesPreferRequest(t *testing.T) {
 	serverCookies := c.Res().Cookies()
 	require.Len(t, serverCookies, 1)
 	require.Equal(t, "server", serverCookies[0].Value)
+
+	// Every name Req and Res share has to resolve the same way on Ctx.
+	require.Equal(t, c.Req().ContentType(), c.ContentType())
 }
 
 func Test_Ctx_ID_StartTime_Elapsed(t *testing.T) {
@@ -770,6 +984,39 @@ func Test_Ctx_IsFinal(t *testing.T) {
 	require.False(t, c.IsMiddleware())
 }
 
+// Test_Ctx_IsFinal_ScopedToTheRoute pins the two cases the doc calls out, so
+// nobody reads IsFinal as "the response is finished".
+func Test_Ctx_IsFinal_ScopedToTheRoute(t *testing.T) {
+	t.Parallel()
+
+	// A Use handler is never final, even when nothing runs after it.
+	terminal := New()
+	var inUse bool
+	terminal.Use(func(c Ctx) error {
+		inUse = c.IsFinal()
+		return c.SendString("done")
+	})
+	_, err := terminal.Test(httptest.NewRequest(MethodGet, "/anything", http.NoBody))
+	require.NoError(t, err)
+	require.False(t, inUse, "a Use route is middleware by registration, whatever its position")
+
+	// A final handler of one route can still be followed by another route.
+	overlapping := New()
+	var inSpecific, inCatchAll bool
+	overlapping.Get("/specific", func(c Ctx) error {
+		inSpecific = c.IsFinal()
+		return c.Next()
+	})
+	overlapping.Get("/*", func(_ Ctx) error {
+		inCatchAll = true
+		return nil
+	})
+	_, err = overlapping.Test(httptest.NewRequest(MethodGet, "/specific", http.NoBody))
+	require.NoError(t, err)
+	require.True(t, inSpecific, "it is the last handler of its own route")
+	require.True(t, inCatchAll, "but another route still matched after it")
+}
+
 func Test_Ctx_MountPath(t *testing.T) {
 	t.Parallel()
 
@@ -795,6 +1042,18 @@ func Test_Ctx_MountPath(t *testing.T) {
 	require.NoError(t, err)
 	_, err = app.Test(httptest.NewRequest(MethodGet, "/top", http.NoBody))
 	require.NoError(t, err)
+
+	// The same sub-app served directly is not under a mount, even though it is
+	// mounted elsewhere: MountPath answers from the route, App.MountPath does not.
+	var standalone string
+	micro.Get("/solo", func(c Ctx) error {
+		standalone = c.MountPath()
+		return nil
+	})
+	_, err = micro.Test(httptest.NewRequest(MethodGet, "/solo", http.NoBody))
+	require.NoError(t, err)
+	require.Empty(t, standalone)
+	require.Equal(t, "/john", micro.MountPath(), "App.MountPath still reports the mount")
 
 	require.Equal(t, "/john", mounted)
 	require.Equal(t, "/john/doe", mountedPath,
@@ -839,100 +1098,4 @@ func Test_Ctx_Error_ReachesErrorHandler(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "id must be numeric", string(body))
-}
-
-// Test_Ctx_Copy is the point of Copy: the snapshot still reads the request the
-// handler saw after the ctx has gone back to the pool and other requests have
-// reused its buffers.
-func Test_Ctx_Copy(t *testing.T) {
-	t.Parallel()
-	app := New()
-
-	var snapshot Ctx
-	app.Get("/user/:id", func(c Ctx) error {
-		if snapshot != nil {
-			// The churn requests below match this same route; only the first
-			// one is the request the snapshot has to keep.
-			return c.SendString("ok")
-		}
-		c.Locals("who", "alice")
-		snapshot = c.Copy()
-		return c.SendString("ok")
-	})
-
-	_, err := app.Test(httptest.NewRequest(MethodGet, "/user/42?q=first", http.NoBody))
-	require.NoError(t, err)
-	require.NotNil(t, snapshot)
-
-	// Drive more requests through the pooled ctx so its buffers are certainly
-	// rewritten under the snapshot.
-	for range 5 {
-		_, err := app.Test(httptest.NewRequest(MethodGet, "/user/other?q=second", http.NoBody))
-		require.NoError(t, err)
-	}
-
-	require.Equal(t, "42", snapshot.Params("id"))
-	require.Equal(t, "/user/42", snapshot.Path())
-	require.Equal(t, "first", snapshot.Query("q"))
-	require.Equal(t, MethodGet, snapshot.Method())
-	require.Equal(t, "alice", snapshot.Locals("who"))
-	require.Equal(t, "/user/:id", snapshot.Route().Path)
-}
-
-func Test_Ctx_Copy_DetachedResponse(t *testing.T) {
-	t.Parallel()
-	app := New()
-
-	fctx := &fasthttp.RequestCtx{}
-	fctx.Request.SetRequestURI("/original")
-	fctx.Request.SetBody([]byte("body"))
-	c := app.AcquireCtx(fctx)
-	t.Cleanup(func() { app.ReleaseCtx(c) })
-
-	require.NoError(t, c.SendString("original"))
-	snapshot := c.Copy()
-
-	// Writing to the snapshot leaves the live response alone.
-	require.NoError(t, snapshot.SendString("detached"))
-	snapshot.Status(StatusTeapot)
-	require.Equal(t, "detached", string(snapshot.Res().Body()))
-	require.Equal(t, "original", string(c.Res().Body()))
-	require.Equal(t, StatusOK, c.Res().StatusCode())
-
-	// The request is a deep copy, so mutating the live one does not reach it.
-	c.Request().SetBody([]byte("rewritten"))
-	require.Equal(t, "body", string(snapshot.Body()))
-	require.Equal(t, "rewritten", string(c.Body()))
-}
-
-func Test_Ctx_Copy_BodyStreamNotCopied(t *testing.T) {
-	t.Parallel()
-	app := New()
-
-	fctx := &fasthttp.RequestCtx{}
-	fctx.Request.SetBodyStream(strings.NewReader("streamed"), 8)
-	c := app.AcquireCtx(fctx)
-	t.Cleanup(func() { app.ReleaseCtx(c) })
-
-	snapshot := c.Copy()
-	require.Nil(t, snapshot.Req().BodyStream(), "an unread stream does not survive the copy")
-	require.Empty(t, snapshot.Body())
-	// The original still has it, so a handler can read it after copying.
-	require.NotNil(t, c.Req().BodyStream())
-}
-
-func Test_Ctx_Copy_IsNotPooled(t *testing.T) {
-	t.Parallel()
-	app := New()
-
-	fctx := &fasthttp.RequestCtx{}
-	fctx.Request.SetRequestURI("/keep")
-	c := app.AcquireCtx(fctx)
-
-	snapshot := c.Copy()
-	app.ReleaseCtx(c)
-
-	// Releasing the original must not have handed the snapshot back to the pool.
-	require.Equal(t, "/keep", snapshot.Path())
-	require.NotSame(t, c.RequestCtx(), snapshot.RequestCtx())
 }

--- a/ctx_helpers_test.go
+++ b/ctx_helpers_test.go
@@ -1040,6 +1040,56 @@ func Test_Req_HeaderFieldWithoutNormalizing(t *testing.T) {
 	require.Equal(t, "abc123", c.Req().Bearer())
 }
 
+func Test_Req_ConditionalHeadersWithoutNormalizing(t *testing.T) {
+	t.Parallel()
+	app := New(Config{DisableHeaderNormalizing: true})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.DisableNormalizing()
+	fctx.Request.Header.Set("if-none-match", `"a", W/"b"`)
+	fctx.Request.Header.Set("if-modified-since", "Wed, 21 Oct 2015 07:28:00 GMT")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.Equal(t, []string{`"a"`, `W/"b"`}, c.Req().IfNoneMatch())
+
+	since, err := c.Req().IfModifiedSince()
+	require.NoError(t, err)
+	require.True(t, since.Equal(time.Date(2015, time.October, 21, 7, 28, 0, 0, time.UTC)))
+}
+
+func Test_Req_IsPreflightWithoutNormalizing(t *testing.T) {
+	t.Parallel()
+	app := New(Config{DisableHeaderNormalizing: true})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.DisableNormalizing()
+	fctx.Request.Header.SetMethod(MethodOptions)
+	fctx.Request.Header.Set("origin", "https://example.com")
+	fctx.Request.Header.Set("access-control-request-method", MethodGet)
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.True(t, c.Req().IsPreflight())
+}
+
+func Test_Res_Del_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	app := New(Config{DisableHeaderNormalizing: true})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Response.Header.DisableNormalizing()
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	c.Response().Header.Set("x-token", "secret")
+	require.Equal(t, "secret", string(c.Response().Header.Peek("x-token")))
+
+	c.Res().Del(HeaderXRequestID)
+	c.Res().Del("X-Token")
+	require.Empty(t, string(c.Response().Header.Peek("x-token")), "a differently cased field is still removed")
+}
+
 func Test_Res_Cookies_UnparsableEntry(t *testing.T) {
 	t.Parallel()
 	app := New()

--- a/ctx_helpers_test.go
+++ b/ctx_helpers_test.go
@@ -18,14 +18,6 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// -----------------------------------------------------------------------------
-// Req
-// -----------------------------------------------------------------------------
-
-// Test_Req_RequestHelpersOnReq pins the helpers to Req rather than Ctx. They
-// were first written with a *DefaultCtx receiver, which kept them off the Req
-// interface: c.UserAgent() compiled but c.Req().UserAgent() did not. Every call
-// here goes through Req, so that regression cannot come back unnoticed.
 func Test_Req_RequestHelpersOnReq(t *testing.T) {
 	t.Parallel()
 	app := New()
@@ -71,7 +63,6 @@ func Test_Req_RequestHelpersOnReq(t *testing.T) {
 	require.False(t, r.IsWebSocket())
 	require.False(t, r.IsPreflight())
 
-	// Ctx keeps promoting all of them, so no caller loses an existing spelling.
 	require.Equal(t, r.FullURL(), c.FullURL())
 	require.Equal(t, r.UserAgent(), c.UserAgent())
 	require.Equal(t, r.MediaType(), c.MediaType())
@@ -106,9 +97,7 @@ func Test_Req_GetAll(t *testing.T) {
 	t.Cleanup(func() { app.ReleaseCtx(c) })
 
 	require.Equal(t, []string{"first", "second"}, c.Req().GetAll("X-Test"))
-	// Field names are case-insensitive.
 	require.Equal(t, []string{"first", "second"}, c.Req().GetAll("x-test"))
-	// Get still answers with the first line only.
 	require.Equal(t, "first", c.Req().Get("X-Test"))
 	require.Nil(t, c.Req().GetAll("X-Absent"))
 }
@@ -135,8 +124,6 @@ func Test_Req_ContentLength(t *testing.T) {
 	require.Equal(t, -1, cc.Req().ContentLength(), "chunked bodies report an unknown length")
 	require.True(t, cc.Req().HasBody(), "an unknown length still means there is a body")
 
-	// A bodyless GET reports -2, fasthttp's "Transfer-Encoding: identity"
-	// sentinel — not 0. Callers sizing a buffer from this would panic.
 	var bodyless int
 	app.Get("/", func(c Ctx) error {
 		bodyless = c.Req().ContentLength()
@@ -147,9 +134,6 @@ func Test_Req_ContentLength(t *testing.T) {
 	require.Equal(t, -2, bodyless)
 }
 
-// Test_Req_GetAll_AbsentSlottedHeaders pins that presence answers the same as
-// HasHeader. fasthttp's PeekAll appends the Content-Length and Trailer buffers
-// unconditionally, so an absent header used to come back as one empty line.
 func Test_Req_GetAll_AbsentSlottedHeaders(t *testing.T) {
 	t.Parallel()
 	app := New()
@@ -189,9 +173,6 @@ func Test_Req_ContentType(t *testing.T) {
 	require.Equal(t, MIMEApplicationJSON, c.Req().MediaType(), "MediaType drops the parameters") //nolint:testifylint // same
 	require.Equal(t, "utf-8", c.Req().Charset())
 
-	// Req and Res both define ContentType, so Ctx must resolve to the request
-	// the way it does for Get — otherwise c.ContentType() would silently report
-	// the response's default while c.Get(HeaderContentType) reports the request.
 	require.NoError(t, c.SendString("hi"))
 	c.Type("html")
 	require.Equal(t, c.Req().ContentType(), c.ContentType())
@@ -340,9 +321,6 @@ func Test_Req_CookieNames_AllCookies(t *testing.T) {
 	require.ElementsMatch(t, []string{"session", "theme"}, c.Req().CookieNames())
 	require.Equal(t, map[string]string{"session": "abc", "theme": "dark"}, c.Req().AllCookies())
 
-	// A client can shadow a cookie by sending the name twice. Cookies(name)
-	// answers with the first, so AllCookies must too: validating one value and
-	// consuming the other is the bug this pins shut.
 	shadowed := &fasthttp.RequestCtx{}
 	shadowed.Request.Header.Set(HeaderCookie, "a=first; a=second")
 	sc := app.AcquireCtx(shadowed)
@@ -371,7 +349,6 @@ func Test_Req_IfNoneMatch(t *testing.T) {
 		{name: "single", header: `"abc"`, want: []string{`"abc"`}},
 		{name: "list", header: `"a", W/"b"`, want: []string{`"a"`, `W/"b"`}},
 		{name: "wildcard", header: "*", want: []string{"*"}},
-		// etagc permits "," inside the quoted opaque-tag, so this is one tag.
 		{name: "comma inside tag", header: `"v1,v2"`, want: []string{`"v1,v2"`}},
 	}
 
@@ -432,10 +409,6 @@ func Test_Req_IfModifiedSince(t *testing.T) {
 	require.NotErrorIs(t, err, ErrHeaderNotFound, "a malformed date is not an absent header")
 }
 
-// -----------------------------------------------------------------------------
-// Res
-// -----------------------------------------------------------------------------
-
 func Test_Res_StatusCode(t *testing.T) {
 	t.Parallel()
 	app := New()
@@ -459,7 +432,6 @@ func Test_Res_Body_ResetBody_Written(t *testing.T) {
 	require.Empty(t, c.Res().Body())
 	require.False(t, c.Res().Written())
 
-	// A status alone is not a body write.
 	c.Status(StatusCreated)
 	require.False(t, c.Res().Written())
 
@@ -481,8 +453,6 @@ func Test_Res_Written_BodyStream(t *testing.T) {
 	t.Cleanup(func() { app.ReleaseCtx(c) })
 
 	require.NoError(t, c.SendStream(strings.NewReader("streamed"), 8))
-	// Written must answer without draining the stream, so the body still goes
-	// out as a stream afterwards.
 	require.True(t, c.Res().Written())
 	require.True(t, c.Response().IsBodyStream())
 }
@@ -499,17 +469,14 @@ func Test_Res_Del(t *testing.T) {
 	c.Res().Del("x-custom")
 	require.Empty(t, c.Res().Get("X-Custom"))
 
-	// Deleting an absent header is a no-op.
 	require.NotPanics(t, func() { c.Res().Del("X-Absent") })
 
-	// Every field line goes, not just the first.
 	c.Res().Add("X-Multi", "a")
 	c.Res().Add("X-Multi", "b")
 	require.Len(t, c.Response().Header.PeekAll("X-Multi"), 2)
 	c.Res().Del("X-Multi")
 	require.Empty(t, c.Response().Header.PeekAll("X-Multi"))
 
-	// Del(Set-Cookie) withdraws the cookies this response was going to set.
 	c.Cookie(&Cookie{Name: "a", Value: "1"})
 	require.NotEmpty(t, c.Res().Cookies())
 	c.Res().Del(HeaderSetCookie)
@@ -531,7 +498,6 @@ func Test_Res_Add(t *testing.T) {
 	require.Equal(t, `Basic realm="one"`, string(lines[0]))
 	require.Equal(t, `Bearer realm="two"`, string(lines[1]))
 
-	// Append folds into one line instead, which is the difference between them.
 	c.Append("X-Folded", "a")
 	c.Append("X-Folded", "b")
 	require.Len(t, c.Response().Header.PeekAll("X-Folded"), 1)
@@ -553,8 +519,6 @@ func Test_Res_ContentType_ContentLength(t *testing.T) {
 	c.Type("html")
 	require.Equal(t, MIMETextHTMLCharsetUTF8, c.Res().ContentType(), "ContentType reads back what Type set")
 
-	// Content-Length reflects the header, which fasthttp only fills in as it
-	// serializes, so it stays 0 here even though the body is not empty.
 	require.NotEmpty(t, c.Res().Body())
 	require.Equal(t, 0, c.Res().ContentLength())
 
@@ -598,7 +562,6 @@ func Test_Res_GetCookie_Cookies(t *testing.T) {
 	require.Equal(t, CookieSameSiteStrictMode, got.SameSite)
 	require.False(t, got.SessionOnly)
 
-	// A session cookie carries neither Max-Age nor Expires, and reads back as one.
 	c.Cookie(&Cookie{Name: "flash", Value: "x", SessionOnly: true})
 	flash, ok := c.Res().GetCookie("flash")
 	require.True(t, ok)
@@ -614,16 +577,12 @@ func Test_Res_GetCookie_Cookies(t *testing.T) {
 	}
 	require.ElementsMatch(t, []string{"session", "flash"}, names)
 
-	// The returned struct is a copy: editing it leaves the response alone.
 	got.Value = "tampered"
 	again, ok := c.Res().GetCookie("session")
 	require.True(t, ok)
 	require.Equal(t, "abc", again.Value)
 }
 
-// Test_Res_Cookies_RepeatedNames pins that a name written twice yields both
-// cookies. Resolving each entry by name instead of parsing it returned the
-// first cookie once per line and made the later ones unreachable.
 func Test_Res_Cookies_RepeatedNames(t *testing.T) {
 	t.Parallel()
 	app := New()
@@ -645,13 +604,10 @@ func Test_Res_Cookies_RepeatedNames(t *testing.T) {
 	}
 	require.ElementsMatch(t, []pair{{"app", "/app"}, {"admin", "/admin"}, {"z", "/"}}, got)
 
-	// GetCookie resolves by name, so it answers with the first of a repeated one.
 	first, ok := c.Res().GetCookie("sid")
 	require.True(t, ok)
 	require.Equal(t, "app", first.Value)
 
-	// And all three really do reach the client, so none of them is an artifact
-	// of how Cookies reads them back.
 	over := New()
 	over.Get("/", func(c Ctx) error {
 		c.Cookie(&Cookie{Name: "sid", Value: "app", Path: "/app"})
@@ -664,11 +620,6 @@ func Test_Res_Cookies_RepeatedNames(t *testing.T) {
 	require.Len(t, resp.Header.Values(HeaderSetCookie), 3)
 }
 
-// Test_Res_GetCookie_Deletion pins that a cookie deletion survives the
-// read-modify-write round trip. fasthttp writes a negative MaxAge as
-// "max-age=0" and parses it back as 0, which is also what an absent attribute
-// gives — so a logout cookie read and rewritten used to come back as an
-// ordinary session cookie, leaving the client logged in.
 func Test_Res_GetCookie_Deletion(t *testing.T) {
 	t.Parallel()
 	app := New()
@@ -684,7 +635,6 @@ func Test_Res_GetCookie_Deletion(t *testing.T) {
 	require.False(t, got.SessionOnly, "an explicit max-age=0 is a deletion, not a session cookie")
 	require.Negative(t, got.MaxAge)
 
-	// Rewriting an unrelated attribute must not resurrect the cookie.
 	got.Domain = "example.com"
 	c.Cookie(got)
 	require.Contains(t, string(c.Response().Header.Peek(HeaderSetCookie)), "max-age=0")
@@ -695,9 +645,6 @@ func Test_Res_GetCookie_Deletion(t *testing.T) {
 	require.Equal(t, "example.com", rewritten.Domain)
 }
 
-// Test_Res_Body_DoesNotDrainStream pins that reading the body leaves a streamed
-// response streamed. Draining it would buffer a whole SendFile into memory and
-// hang an SSE route.
 func Test_Res_Body_DoesNotDrainStream(t *testing.T) {
 	t.Parallel()
 	app := New()
@@ -711,9 +658,6 @@ func Test_Res_Body_DoesNotDrainStream(t *testing.T) {
 	require.True(t, c.Response().IsBodyStream(), "and it is still a stream afterwards")
 }
 
-// Test_Res_Add_SpecialHeaders pins fasthttp's behavior for the headers it keeps
-// in a slot of their own: Add replaces them rather than appending, which is why
-// the doc names them.
 func Test_Res_Add_SpecialHeaders(t *testing.T) {
 	t.Parallel()
 	app := New()
@@ -726,14 +670,11 @@ func Test_Res_Add_SpecialHeaders(t *testing.T) {
 	require.Equal(t, MIMETextPlain, c.Res().ContentType(), "Content-Type is replaced, not appended")
 	require.Len(t, c.Response().Header.PeekAll(HeaderContentType), 1)
 
-	// A header with no slot of its own does append, which is the documented use.
 	c.Res().Add(HeaderLink, "</a>; rel=preload")
 	c.Res().Add(HeaderLink, "</b>; rel=preload")
 	require.Len(t, c.Response().Header.PeekAll(HeaderLink), 2)
 }
 
-// Test_Res_GetCookie_RoundTrip pins the read-modify-write path GetCookie exists
-// for: middleware that rewrites a cookie an earlier handler set.
 func Test_Res_GetCookie_RoundTrip(t *testing.T) {
 	t.Parallel()
 	app := New()
@@ -792,9 +733,6 @@ func Test_Res_NoContent_OverHTTP(t *testing.T) {
 	require.Empty(t, body)
 }
 
-// Test_Res_NoContent_DiffersFromSendStatus pins the one thing NoContent adds
-// over SendStatus(204): SendStatus drops the body but keeps a Content-Type the
-// handler set, so the two are not interchangeable.
 func Test_Res_NoContent_DiffersFromSendStatus(t *testing.T) {
 	t.Parallel()
 	app := New()
@@ -818,14 +756,6 @@ func Test_Res_NoContent_DiffersFromSendStatus(t *testing.T) {
 	require.Empty(t, none.Header.Get(HeaderContentType))
 }
 
-// -----------------------------------------------------------------------------
-// Ctx
-// -----------------------------------------------------------------------------
-
-// Test_Ctx_BodyContentLengthCookiesPreferRequest pins the three names Req and
-// Res both define. Ctx has to resolve them itself or the embedded selectors are
-// ambiguous and the package stops compiling; the request wins, as it does for
-// Get, and the response stays reachable through Res().
 func Test_Ctx_BodyContentLengthCookiesPreferRequest(t *testing.T) {
 	t.Parallel()
 	app := New()
@@ -855,7 +785,6 @@ func Test_Ctx_BodyContentLengthCookiesPreferRequest(t *testing.T) {
 	require.Len(t, serverCookies, 1)
 	require.Equal(t, "server", serverCookies[0].Value)
 
-	// Every name Req and Res share has to resolve the same way on Ctx.
 	require.Equal(t, c.Req().ContentType(), c.ContentType())
 }
 
@@ -977,19 +906,15 @@ func Test_Ctx_IsFinal(t *testing.T) {
 	require.False(t, inRouteMW, "a route handler with another after it is not final")
 	require.True(t, inHandler)
 
-	// No route matched at all: there is no final handler to be.
 	c := app.AcquireCtx(&fasthttp.RequestCtx{})
 	t.Cleanup(func() { app.ReleaseCtx(c) })
 	require.False(t, c.IsFinal())
 	require.False(t, c.IsMiddleware())
 }
 
-// Test_Ctx_IsFinal_ScopedToTheRoute pins the two cases the doc calls out, so
-// nobody reads IsFinal as "the response is finished".
 func Test_Ctx_IsFinal_ScopedToTheRoute(t *testing.T) {
 	t.Parallel()
 
-	// A Use handler is never final, even when nothing runs after it.
 	terminal := New()
 	var inUse bool
 	terminal.Use(func(c Ctx) error {
@@ -1000,7 +925,6 @@ func Test_Ctx_IsFinal_ScopedToTheRoute(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, inUse, "a Use route is middleware by registration, whatever its position")
 
-	// A final handler of one route can still be followed by another route.
 	overlapping := New()
 	var inSpecific, inCatchAll bool
 	overlapping.Get("/specific", func(c Ctx) error {
@@ -1024,8 +948,6 @@ func Test_Ctx_MountPath(t *testing.T) {
 	var mounted, mountedPath string
 	micro.Get("/doe", func(c Ctx) error {
 		mounted = c.MountPath()
-		// Path aliases the pooled request buffer, which the next request
-		// overwrites; clone it to read it after the handler returns.
 		mountedPath = strings.Clone(c.Path())
 		return nil
 	})
@@ -1043,8 +965,6 @@ func Test_Ctx_MountPath(t *testing.T) {
 	_, err = app.Test(httptest.NewRequest(MethodGet, "/top", http.NoBody))
 	require.NoError(t, err)
 
-	// The same sub-app served directly is not under a mount, even though it is
-	// mounted elsewhere: MountPath answers from the route, App.MountPath does not.
 	var standalone string
 	micro.Get("/solo", func(c Ctx) error {
 		standalone = c.MountPath()

--- a/ctx_helpers_test.go
+++ b/ctx_helpers_test.go
@@ -5,6 +5,8 @@
 package fiber
 
 import (
+	"bytes"
+	"compress/gzip"
 	"io"
 	"net"
 	"net/http"
@@ -1032,7 +1034,7 @@ func Test_Req_HeaderFieldWithoutNormalizing(t *testing.T) {
 	c := app.AcquireCtx(fctx)
 	t.Cleanup(func() { app.ReleaseCtx(c) })
 
-	require.Empty(t, c.Get(HeaderOrigin), "Ctx.Get is byte-exact and misses the lower-case spelling")
+	require.Equal(t, "https://example.com", c.Get(HeaderOrigin))
 	require.Equal(t, "https://example.com", c.Req().Origin())
 
 	scheme, credentials := c.Req().Authorization()
@@ -1250,4 +1252,112 @@ func Test_Req_FreshWithoutNormalizing(t *testing.T) {
 	})
 	since.Res().Set(HeaderLastModified, "Tue, 20 Oct 2015 07:28:00 GMT")
 	require.True(t, since.Req().Fresh())
+}
+
+func Test_Req_HeaderFieldSkipsEmptyFirstLine(t *testing.T) {
+	t.Parallel()
+	app := New()
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.Add("X-Thing", "")
+	fctx.Request.Header.Add("X-Thing", "v2")
+	fctx.Request.Header.Add(HeaderAuthorization, "")
+	fctx.Request.Header.Add(HeaderAuthorization, "Bearer tok")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.True(t, c.Req().HasHeader("X-Thing"))
+	require.Equal(t, []string{"v2"}, c.Req().GetAll("X-Thing"))
+	require.Equal(t, "v2", c.Req().Get("X-Thing"))
+	require.Equal(t, "tok", c.Req().Bearer())
+}
+
+func Test_Req_GetWithoutNormalizing(t *testing.T) {
+	t.Parallel()
+	app := New(Config{DisableHeaderNormalizing: true})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.DisableNormalizing()
+	fctx.Request.Header.Set("x-api-key", "k1")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.True(t, c.Req().HasHeader("X-Api-Key"))
+	require.Equal(t, "k1", c.Req().Get("X-Api-Key"))
+	require.Equal(t, "k1", GetReqHeader[string](c, "X-Api-Key"))
+}
+
+func Test_Req_BodyContentEncodingWithoutNormalizing(t *testing.T) {
+	t.Parallel()
+	app := New(Config{DisableHeaderNormalizing: true})
+
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write([]byte("hello world"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.DisableNormalizing()
+	fctx.Request.Header.SetMethod(MethodPost)
+	fctx.Request.Header.Set("content-encoding", "gzip")
+	fctx.Request.SetBody(buf.Bytes())
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.Equal(t, []byte("hello world"), c.Req().Body())
+}
+
+func Test_Req_UpgradePredicatesWithoutNormalizing(t *testing.T) {
+	t.Parallel()
+	app := New(Config{DisableHeaderNormalizing: true})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.DisableNormalizing()
+	fctx.Request.Header.Set("connection", "Upgrade")
+	fctx.Request.Header.Set("upgrade", "websocket")
+	fctx.Request.Header.Set("x-requested-with", "XMLHttpRequest")
+	fctx.Request.Header.Set("range", "bytes=0-5")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.True(t, c.Req().IsWebSocket())
+	require.True(t, c.Req().XHR())
+
+	rg, err := c.Req().Range(100)
+	require.NoError(t, err)
+	require.Equal(t, "bytes", rg.Type)
+	require.Equal(t, []RangeSet{{Start: 0, End: 5}}, rg.Ranges)
+}
+
+func Test_Res_FormatWithoutNormalizing(t *testing.T) {
+	t.Parallel()
+	app := New(Config{DisableHeaderNormalizing: true})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.DisableNormalizing()
+	fctx.Request.Header.Set("accept", "text/html")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	err := c.Res().Format(
+		ResFmt{MediaType: "application/json", Handler: func(cc Ctx) error { return cc.SendString("json") }},
+		ResFmt{MediaType: "text/html", Handler: func(cc Ctx) error { return cc.SendString("html") }},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "html", string(c.Response().Body()))
+}
+
+func Test_Res_DelKeyCaseWithoutNormalizing(t *testing.T) {
+	t.Parallel()
+	app := New(Config{DisableHeaderNormalizing: true})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Response.Header.DisableNormalizing()
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	c.Res().Set("X-Token", "secret")
+	c.Res().Del("x-token")
+	require.Empty(t, string(c.Response().Header.Peek("X-Token")))
 }

--- a/ctx_helpers_test.go
+++ b/ctx_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1134,4 +1135,56 @@ func Test_Ctx_MountPath_NoApp(t *testing.T) {
 
 	var c DefaultCtx
 	require.NotPanics(t, func() { require.Empty(t, c.MountPath()) })
+}
+
+func Test_Req_HasHeaderWithoutNormalizing(t *testing.T) {
+	t.Parallel()
+	app := New(Config{DisableHeaderNormalizing: true})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.Header.DisableNormalizing()
+	fctx.Request.Header.Set("x-test", "yes")
+	c := app.AcquireCtx(fctx)
+	t.Cleanup(func() { app.ReleaseCtx(c) })
+
+	require.True(t, c.Req().HasHeader("X-Test"))
+	require.Equal(t, []string{"yes"}, c.Req().GetAll("X-Test"))
+	require.True(t, c.Req().HasHeader("x-test"))
+	require.False(t, c.Req().HasHeader("X-Absent"))
+}
+
+func Test_Res_SendStatus_DropsDeclaredContentLength(t *testing.T) {
+	t.Parallel()
+	app := New()
+	for _, status := range []int{StatusNoContent, StatusResetContent, StatusNotModified} {
+		app.Get("/set"+strconv.Itoa(status), func(c Ctx) error {
+			c.Set(HeaderContentLength, "42")
+			return c.SendStatus(status)
+		})
+		app.Get("/bare"+strconv.Itoa(status), func(c Ctx) error {
+			return c.SendStatus(status)
+		})
+	}
+	app.Get("/nocontent", func(c Ctx) error {
+		c.Set(HeaderContentLength, "42")
+		return c.Res().NoContent()
+	})
+
+	get := func(path string) []string {
+		resp, err := app.Test(httptest.NewRequest(MethodGet, path, http.NoBody))
+		require.NoError(t, err)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Empty(t, body, path)
+		require.NotContains(t, resp.Header.Values(HeaderContentLength), "42", path)
+		return resp.Header.Values(HeaderContentLength)
+	}
+
+	for _, status := range []int{StatusNoContent, StatusResetContent, StatusNotModified} {
+		require.Equal(t, get("/bare"+strconv.Itoa(status)), get("/set"+strconv.Itoa(status)), status)
+	}
+
+	require.Empty(t, get("/nocontent"))
+	require.Equal(t, []string{"0"}, get("/bare205"))
 }

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -66,9 +66,9 @@ type Ctx interface {
 	// and Res both carry one, so on Ctx the request wins, as it does for Get; use
 	// Res().ContentType() for the response.
 	ContentType() string
-	// Cookies returns the request cookie with the given key, or defaultValue. Req
-	// and Res both carry one, so on Ctx the request wins; use Res().Cookies() for
-	// the response. Only valid within the handler unless Immutable is set.
+	// Cookies returns the request cookie with the given key, or defaultValue. Only
+	// valid within the handler unless Immutable is set. For the cookies the response
+	// is set to send, use Res().GetCookies().
 	Cookies(key string, defaultValue ...string) string
 	// Get returns the HTTP request header specified by field.
 	// Field names are case-insensitive
@@ -558,8 +558,9 @@ type Ctx interface {
 	// (RFC 9110 Section 5.6.1.2).
 	Append(field string, values ...string)
 	// Add appends the value as a new field line, where Append folds values into one
-	// comma-separated line. It does not append for the headers fasthttp slots:
-	// Content-Type, Server and the rest are replaced, Date and TE ignored.
+	// comma-separated line. The headers fasthttp keeps in a slot of their own are
+	// the exception: Content-Type, Server and the rest are replaced and Date and TE
+	// ignored, though Set-Cookie is slotted and does append. Use Cookie for that.
 	Add(key, val string)
 	// Attachment sets the HTTP response Content-Disposition header field to attachment.
 	Attachment(filename ...string)
@@ -578,6 +579,13 @@ type Ctx interface {
 	// repeat resolves to the first. Writing the copy back through Cookie stamps
 	// Path=/ on a cookie that carried none, widening its scope — set Path first.
 	GetCookie(name string) (*Cookie, bool)
+	// GetCookies returns a copy of every cookie this response is set to send, in
+	// order, or nil when there are none. Repeated names are kept apart, and an
+	// unparsable one is skipped. For what the client sent, use Req.Cookies.
+	//
+	// Named for GetCookie beside it rather than Cookies, which would collide with
+	// Req.Cookies under a different signature and stop Ctx satisfying Res.
+	GetCookies() []*Cookie
 	// Download transfers the file from path as an attachment.
 	// Typically, browsers will prompt the user for download.
 	// By default, the Content-Disposition header filename= parameter is the filepath (this typically appears in the browser dialog).

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -318,12 +318,14 @@ type Ctx interface {
 	// DisableHeaderNormalizing a lower-case "origin:" read as absent.
 	headerField(name string) []byte
 	// AcceptLanguage returns the Accept-Language request header.
-	// Repeated field lines are combined into one comma-joined list
-	// (RFC 9110 Section 5.2), matching what AcceptsLanguages negotiates on.
+	// Repeated field lines are combined into one comma-joined list (RFC 9110
+	// Section 5.2) and the field name matches case-insensitively (Section 5.1),
+	// matching what AcceptsLanguages negotiates on.
 	AcceptLanguage() string
 	// AcceptEncoding returns the Accept-Encoding request header.
-	// Repeated field lines are combined into one comma-joined list
-	// (RFC 9110 Section 5.2), matching what AcceptsEncodings negotiates on.
+	// Repeated field lines are combined into one comma-joined list (RFC 9110
+	// Section 5.2) and the field name matches case-insensitively (Section 5.1),
+	// matching what AcceptsEncodings negotiates on.
 	AcceptEncoding() string
 	// HasHeader reports whether the request includes a header with the given key.
 	// The field name matches case-insensitively (RFC 9110 Section 5.1), so this

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"io"
 	"mime/multipart"
+	"net"
 	"time"
 
 	"github.com/valyala/fasthttp"
@@ -28,6 +29,24 @@ type Ctx interface {
 	Context() context.Context
 	// SetContext sets a context implementation by user.
 	SetContext(ctx context.Context)
+	// Copy returns a detached snapshot of the context that stays valid after the
+	// handler returns.
+	//
+	// A live Ctx is pooled and its request buffers are handed to the next request
+	// on the connection, so reading one from a goroutine that outlives the handler
+	// returns whatever arrived next. Copy deep-copies the request, the path buffers
+	// and the route parameters into a context that is never pooled, so the goroutine
+	// sees the request the handler saw. Locals come across as they are: the entries
+	// are copied, the values in them are shared.
+	//
+	// A request body that is still a stream is not copied; read it, or call Body, on
+	// the original first. The copy is for reading otherwise: its response is a
+	// detached buffer that never reaches the client, and it is always a *DefaultCtx
+	// even under a custom Ctx, so writing to it, or driving the chain again with
+	// Next or RestartRouting, changes nothing the client will see. It does not
+	// observe the request's cancellation either; when the goroutine needs that, take
+	// Context() from the original before the handler returns.
+	Copy() Ctx
 	// Deadline returns the time when work done on behalf of this context
 	// should be canceled. Ctx carries no deadline, so ok is always false.
 	//
@@ -53,6 +72,25 @@ type Ctx interface {
 	// https://godoc.org/github.com/valyala/fasthttp#Response
 	// Returns nil if the context has been released.
 	Response() *fasthttp.Response
+	// Body returns the request body, decompressing it when the request declares a
+	// Content-Encoding the app accepts.
+	//
+	// Req and Res both carry a Body, so on Ctx the request wins, as it does for
+	// Get. Use Res().Body() for what the handler has written so far.
+	Body() []byte
+	// ContentLength returns the value of the Content-Length request header.
+	//
+	// Req and Res both carry a ContentLength, so on Ctx the request wins, as it
+	// does for Get. Use Res().ContentLength() for the length of the response.
+	ContentLength() int
+	// Cookies returns the value of the request cookie with the given key, or
+	// defaultValue when the client did not send it.
+	//
+	// Req and Res both carry a Cookies, so on Ctx the request wins, as it does for
+	// Get. Use Res().Cookies() for the cookies this response will set.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
+	Cookies(key string, defaultValue ...string) string
 	// Get returns the HTTP request header specified by field.
 	// Field names are case-insensitive
 	// Returned value is only valid within the handler. Do not store any references.
@@ -87,10 +125,6 @@ type Ctx interface {
 	// Returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting to use the value outside the Handler.
 	OriginalURL() string
-	// Path returns the path part of the request URL.
-	// Optionally, you could override the path.
-	// Make copies or use the Immutable setting to use the value outside the Handler.
-	Path(override ...string) string
 	// RequestID returns the request identifier from the response header or request header.
 	RequestID() string
 	// Req returns a convenience type whose API is limited to operations
@@ -128,28 +162,80 @@ type Ctx interface {
 	Endpoint() *Route
 	// FullPath returns the matched route path, including any group prefixes.
 	FullPath() string
+	// RouteName returns the name of the route currently executing, or an empty
+	// string when the route is unnamed. Inside middleware this is the middleware's
+	// own route; use Endpoint().Name to look ahead to the route that will handle
+	// the request.
+	RouteName() string
+	// MountPath returns the prefix the sub-app owning the current route was mounted
+	// under, or an empty string when the route belongs to the top-level app.
+	//
+	// Fiber mounts by cloning a sub-app's routes into the app that serves them with
+	// the prefix already baked in, so Path inside a mounted handler is the whole
+	// requested path, not one relative to the mount. MountPath is what tells such a
+	// handler which prefix it is living under, to build links back into its own app
+	// or to strip the prefix itself.
+	//
+	// It answers from the route that is running, unlike App.MountPath, which only
+	// ever describes the app it is called on.
+	MountPath() string
 	// Matched returns true if the current request path was matched by the router.
 	Matched() bool
 	// IsMiddleware returns true if the current request handler was registered as middleware.
 	IsMiddleware() bool
-	// HasBody returns true if the request declares a body via Content-Length, Transfer-Encoding, or already buffered payload data.
-	HasBody() bool
+	// IsFinal returns true if the current request handler is the last one in the
+	// chain, meaning nothing runs after it returns. It is the complement of
+	// IsMiddleware, and false when no route matched at all.
+	IsFinal() bool
 	// OverrideParam overwrites a route parameter value by name.
 	// If the parameter name does not exist in the route, this method does nothing.
 	OverrideParam(name, value string)
-	// IsWebSocket returns true if the request includes a WebSocket upgrade handshake.
-	IsWebSocket() bool
-	// IsPreflight returns true if the request is a CORS preflight.
-	IsPreflight() bool
 	// SaveFile saves any multipart file to disk.
 	SaveFile(fileheader *multipart.FileHeader, path string) error
 	// SaveFileToStorage saves any multipart file to an external storage system.
 	SaveFileToStorage(fileheader *multipart.FileHeader, path string, storage Storage) error
-	// Secure returns whether a secure connection was established.
-	Secure() bool
+	// Error returns an *Error carrying the given status code, so a handler can
+	// reject a request in one line:
+	//
+	//	return c.Error(fiber.StatusBadRequest, "id must be numeric")
+	//
+	// The message defaults to the status text when omitted. Returning the error
+	// hands it to the app's ErrorHandler, which is what writes the response; Error
+	// itself sets nothing on the response.
+	Error(status int, message ...string) error
 	// Status sets the HTTP status for the response.
 	// This method is chainable.
 	Status(status int) Ctx
+	// ID returns the connection-unique identifier fasthttp assigned to this
+	// request. It is cheap and always present, unlike RequestID, which reads a
+	// header a client or proxy has to have set. It is not unique across processes
+	// or restarts, so it is for correlating log lines within one server run.
+	ID() uint64
+	// StartTime returns the time the server began handling this request. It is the
+	// reference point Elapsed measures from.
+	StartTime() time.Time
+	// Elapsed returns how long this request has been handled so far, measured from
+	// StartTime. Called after the handler chain has run, it is the request latency.
+	Elapsed() time.Duration
+	// LocalAddr returns the server-side address of the connection this request
+	// arrived on. IP returns the client address as a string; this is the full
+	// net.Addr, so the port, network, and unix socket path survive.
+	LocalAddr() net.Addr
+	// RemoteAddr returns the address of the immediate peer, which is the proxy
+	// rather than the client when the app sits behind one. Use IP or IPs for the
+	// client address a trusted proxy forwarded.
+	RemoteAddr() net.Addr
+	// Hijack registers a handler that takes over the connection once the current
+	// response is sent, for protocols Fiber does not speak itself. The handler runs
+	// on the connection's own goroutine, after which the connection is closed
+	// unless the server has KeepHijackedConns set.
+	//
+	// The Ctx is pooled and reused, so the hijack handler must not touch it.
+	Hijack(handler fasthttp.HijackHandler)
+	// Hijacked returns true if Hijack has been called on this request, so a later
+	// handler can tell that the connection is already spoken for and leave the
+	// response alone.
+	Hijacked() bool
 	// String returns unique string representation of the ctx.
 	//
 	// The returned value may be useful for logging.
@@ -158,9 +244,6 @@ type Ctx interface {
 	// and therefore available to all following routes that match the request. If the context
 	// has been released and c.fasthttp is nil (for example, after ReleaseCtx), Value returns nil.
 	Value(key any) any
-	// XHR returns a Boolean property, that is true, if the request's X-Requested-With header field is XMLHttpRequest,
-	// indicating that the request was issued by a client library (such as jQuery).
-	XHR() bool
 	// configDependentPaths set paths for route recognition and prepared paths for the user,
 	// here the features for caseSensitive, decoded paths, strict paths are evaluated
 	configDependentPaths()
@@ -237,12 +320,39 @@ type Ctx interface {
 	setFirstMatchIndex(index int)
 	setRoute(route *Route)
 	getPathOriginal() string
+	// Accepts checks if the specified extensions or content types are acceptable.
+	Accepts(offers ...string) string
+	// AcceptsCharsets checks if the specified charset is acceptable.
+	AcceptsCharsets(offers ...string) string
+	// AcceptsEncodings checks if the specified encoding is acceptable.
+	AcceptsEncodings(offers ...string) string
+	// AcceptsLanguages checks if the specified language is acceptable using
+	// RFC 4647 Basic Filtering.
+	AcceptsLanguages(offers ...string) string
+	// AcceptsLanguagesExtended checks if the specified language is acceptable using
+	// RFC 4647 Extended Filtering.
+	AcceptsLanguagesExtended(offers ...string) string
+	// BodyRaw contains the raw body submitted in a POST request.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
+	BodyRaw() []byte
+	//nolint:nonamedreturns // gocritic unnamedResult prefers naming decoded body, decode count, and error
+	tryDecodeBodyInOrder(originalBody *[]byte, encodings []string) (body []byte, decodesRealized uint8, err error)
+	// BodyStream returns the request body as a stream.
+	//
+	// It is only non-nil when Config.StreamRequestBody is enabled and the body has
+	// not already been buffered; IsBodyStream on the underlying request reports
+	// which of the two is in play. Reading from the returned reader consumes the
+	// body, so a later Body call will not see it.
+	BodyStream() io.Reader
 	// FullURL returns the full request URL (protocol + host + original URL).
 	FullURL() string
 	// UserAgent returns the User-Agent request header.
 	UserAgent() string
 	// Referer returns the Referer request header.
 	Referer() string
+	// Origin returns the Origin request header.
+	Origin() string
 	// AcceptLanguage returns the Accept-Language request header.
 	// Repeated field lines are combined into one comma-joined list
 	// (RFC 9110 Section 5.2), matching what AcceptsLanguages negotiates on.
@@ -271,36 +381,18 @@ type Ctx interface {
 	AcceptsXML() bool
 	// AcceptsEventStream reports whether the Accept header allows text/event-stream.
 	AcceptsEventStream() bool
-	// Accepts checks if the specified extensions or content types are acceptable.
-	Accepts(offers ...string) string
-	// AcceptsCharsets checks if the specified charset is acceptable.
-	AcceptsCharsets(offers ...string) string
-	// AcceptsEncodings checks if the specified encoding is acceptable.
-	AcceptsEncodings(offers ...string) string
-	// AcceptsLanguages checks if the specified language is acceptable using
-	// RFC 4647 Basic Filtering.
-	AcceptsLanguages(offers ...string) string
-	// AcceptsLanguagesExtended checks if the specified language is acceptable using
-	// RFC 4647 Extended Filtering.
-	AcceptsLanguagesExtended(offers ...string) string
-	// BodyRaw contains the raw body submitted in a POST request.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
-	BodyRaw() []byte
-	//nolint:nonamedreturns // gocritic unnamedResult prefers naming decoded body, decode count, and error
-	tryDecodeBodyInOrder(originalBody *[]byte, encodings []string) (body []byte, decodesRealized uint8, err error)
-	// Body contains the raw body submitted in a POST request.
-	// This method will decompress the body if the 'Content-Encoding' header is provided.
-	// It returns the original (or decompressed) body data which is valid only within the handler.
-	// Don't store direct references to the returned data.
-	// If you need to keep the body's data later, make a copy or use the Immutable option.
-	Body() []byte
-	// Cookies are used for getting a cookie value by key.
-	// Defaults to the empty string "" if the cookie doesn't exist.
-	// If a default value is given, it will return that value if the cookie doesn't exist.
-	// The returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the value outside the Handler.
-	Cookies(key string, defaultValue ...string) string
+	// CookieNames returns the names of the cookies sent with the request, in the
+	// order they appear in the Cookie header. A name repeated by the client is
+	// returned once per occurrence.
+	// Returned values are only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the values outside the Handler.
+	CookieNames() []string
+	// AllCookies returns the cookies sent with the request as a name/value map.
+	// When the client repeats a name the last value wins; use CookieNames to detect
+	// that case.
+	// Returned values are only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the values outside the Handler.
+	AllCookies() map[string]string
 	// FormFile returns the first file by key from a MultipartForm.
 	// The multipart form is parsed using the application's BodyLimit to prevent
 	// unbounded memory usage.
@@ -329,6 +421,39 @@ type Ctx interface {
 	// reload request, this module will return false to make handling these requests transparent.
 	// https://github.com/jshttp/fresh/blob/master/index.js#L33
 	Fresh() bool
+	// IfNoneMatch returns the entity tags listed in the If-None-Match request
+	// header. Repeated field lines are combined into one list (RFC 9110
+	// Section 5.2), and a comma inside a quoted opaque-tag does not split it, so
+	// `"v1,v2"` stays one tag. A wildcard header returns a single "*" element.
+	// Tags are returned verbatim, weak "W/" prefix included, and are not validated.
+	// Fresh already applies these tags to the response ETag; reach for this only to
+	// implement a comparison of your own.
+	IfNoneMatch() []string
+	// IfModifiedSince returns the time carried by the If-Modified-Since request
+	// header. It returns ErrHeaderNotFound when the header is absent, and a parse
+	// error when the value is none of the three HTTP-date formats RFC 9110
+	// Section 5.6.7 requires recipients to accept.
+	IfModifiedSince() (time.Time, error)
+	// GetAll returns every field line of the request header specified by key.
+	// Field names are case-insensitive.
+	//
+	// A header repeated across field lines is semantically one comma-joined list
+	// (RFC 9110 Section 5.2). GetAll keeps the lines apart so a caller can inspect
+	// them individually, where Get returns only the first and GetHeaders builds a
+	// map of the whole header block.
+	// Returned values are only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
+	GetAll(key string) []string
+	// Authorization splits the Authorization request header into its auth-scheme
+	// and the credentials that follow (RFC 9110 Section 11.6.2). Both are empty
+	// when the header is absent. The credentials are returned verbatim — token68 or
+	// auth-param list — and are neither decoded nor validated.
+	Authorization() (scheme, credentials string)
+	// Bearer returns the credentials of a Bearer Authorization header
+	// (RFC 6750 Section 2.1), or an empty string when the header is absent or names
+	// a different auth-scheme. The token is returned verbatim: it is not validated,
+	// decoded, or verified, so it still has to be authenticated before it is trusted.
+	Bearer() string
 	// Host contains the host derived from the X-Forwarded-Host or Host HTTP header.
 	// Returned value is only valid within the handler. Do not store any references.
 	// In a network context, `Host` refers to the combination of a hostname and potentially a port number used for connecting,
@@ -370,6 +495,17 @@ type Ctx interface {
 	// Is returns the matching content type,
 	// if the incoming request's Content-Type HTTP header field matches the MIME type specified by the type parameter
 	Is(extension string) bool
+	// HasBody returns true if the request declares a body via Content-Length, Transfer-Encoding, or already buffered payload data.
+	HasBody() bool
+	// IsWebSocket returns true if the request includes a WebSocket upgrade handshake.
+	IsWebSocket() bool
+	// IsPreflight returns true if the request is a CORS preflight.
+	IsPreflight() bool
+	// Secure returns whether a secure connection was established.
+	Secure() bool
+	// XHR returns a Boolean property, that is true, if the request's X-Requested-With header field is XMLHttpRequest,
+	// indicating that the request was issued by a client library (such as jQuery).
+	XHR() bool
 	// Locals makes it possible to pass any values under keys scoped to the request
 	// and therefore available to all following routes that match the request.
 	//
@@ -381,6 +517,13 @@ type Ctx interface {
 	// If no override is given or if the provided override is not a valid HTTP method, it returns the current method from the context.
 	// Otherwise, it updates the context's method and returns the overridden method as a string.
 	Method(override ...string) string
+	// IsSafe reports whether the request method is safe, meaning it is not expected
+	// to change server state (RFC 9110 Section 9.2.1).
+	IsSafe() bool
+	// IsIdempotent reports whether the request method is idempotent, meaning
+	// repeating it has the same intended effect as making it once (RFC 9110
+	// Section 9.2.2). Every safe method is also idempotent.
+	IsIdempotent() bool
 	// MultipartForm parse form entries from binary.
 	// This returns a map[string][]string, so given a key, the value will be a string slice.
 	//
@@ -389,6 +532,17 @@ type Ctx interface {
 	// which aliases those bytes unless Immutable is set — can change during the
 	// call. Copy it first if you need it to outlive one.
 	MultipartForm() (*multipart.Form, error)
+	// URI returns the parsed *fasthttp.URI of the request.
+	// This allows you to use all fasthttp URI methods.
+	// https://godoc.org/github.com/valyala/fasthttp#URI
+	//
+	// The returned value is owned by the request and is rewritten by a Path
+	// override, so it is only valid within the handler. Do not store any references.
+	URI() *fasthttp.URI
+	// Path returns the path part of the request URL.
+	// Optionally, you could override the path.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
+	Path(override ...string) string
 	// Params is used to get the route parameters.
 	// Defaults to empty string "" if the param doesn't exist.
 	// If a default value is given, it will return that value if the param doesn't exist.
@@ -450,6 +604,14 @@ type Ctx interface {
 	// Empty values are skipped: a sender must not generate empty list elements
 	// (RFC 9110 Section 5.6.1.2).
 	Append(field string, values ...string)
+	// Add appends the given value to the response header field as a new field
+	// line, leaving any existing lines untouched.
+	//
+	// This differs from Append, which folds values into a single comma-separated
+	// line: headers whose values may themselves contain commas — Set-Cookie,
+	// WWW-Authenticate, Link — have to be sent as separate lines to stay
+	// unambiguous (RFC 9110 Section 5.3).
+	Add(key, val string)
 	// Attachment sets the HTTP response Content-Disposition header field to attachment.
 	Attachment(filename ...string)
 	// ClearCookie expires a specific cookie by key on the client side.
@@ -462,6 +624,13 @@ type Ctx interface {
 	// Partitioned) happens on a local copy, so a caller may reuse the same *Cookie
 	// template across requests.
 	Cookie(cookie *Cookie)
+	// GetCookie reads back a cookie this response is already set to send, so a
+	// later handler or middleware can inspect or re-emit what an earlier one wrote.
+	// The second result is false when no cookie of that name has been set.
+	//
+	// The returned Cookie is a copy: changing it does not change the response.
+	// Pass it to Cookie to write the change back.
+	GetCookie(name string) (*Cookie, bool)
 	// Download transfers the file from path as an attachment.
 	// Typically, browsers will prompt the user for download.
 	// By default, the Content-Disposition header filename= parameter is the filepath (this typically appears in the browser dialog).
@@ -481,6 +650,23 @@ type Ctx interface {
 	// For more flexible content negotiation, use Format.
 	// If the header is not specified or there is no proper format, text/plain is used.
 	AutoFormat(body any) error
+	// ContentType returns the Content-Type response header, parameters included.
+	// It is the read side of Type, and of the content type Fiber sets for you when
+	// a JSON, XML, or SendFile response goes out.
+	//
+	// When nothing has set one it reports fasthttp's default, "text/plain;
+	// charset=utf-8", which is what would be sent — not an empty string.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
+	ContentType() string
+	// Del removes every field line of the response header specified by key.
+	// Field names are case-insensitive. Deleting a header that was never set is a
+	// no-op.
+	//
+	// Del(HeaderSetCookie) withdraws every cookie this response was going to set,
+	// which is not what ClearCookie does: ClearCookie adds a Set-Cookie that
+	// expires the cookie already in the client's jar.
+	Del(key string)
 	// JSON converts any interface or string to JSON.
 	// Array and slice values encode as JSON arrays,
 	// except that []byte encodes as a base64-encoded string,
@@ -524,6 +710,17 @@ type Ctx interface {
 	// Render a template with data and sends a text/html response.
 	// We support the following engines: https://github.com/gofiber/template
 	Render(name string, bind any, layouts ...string) error
+	// ResetBody discards the response body, keeping the status and headers.
+	// Use it before replacing a partially written body — an error page over a
+	// half-rendered view, a cached body over a fresh one.
+	ResetBody()
+	// Written reports whether anything has been written to the response body yet,
+	// so middleware can tell a handler that produced a response from one that left
+	// it untouched. A streamed body counts as written without draining the stream.
+	//
+	// Status and headers are not body writes: a handler that only called Status
+	// leaves this false.
+	Written() bool
 	// Send sets the HTTP response body without copying it.
 	// From this point onward the body argument must not be changed.
 	Send(body []byte) error
@@ -543,6 +740,12 @@ type Ctx interface {
 	// The Content-Type response HTTP header field is set based on the file's extension.
 	// If the file extension is missing or invalid, the Content-Type is detected from the file's format.
 	SendFile(file string, config ...SendFile) error
+	// NoContent replies 204 No Content: it sets the status, discards any body
+	// already written, and drops the Content-Type a handler had set, since
+	// RFC 9110 Section 6.4.1 gives a 204 no content to describe. fasthttp omits
+	// Content-Type from a 204 on the wire either way; dropping it here keeps the
+	// response consistent if something later moves it off 204.
+	NoContent() error
 	// SendStatus sets the HTTP status code and if the response body is empty,
 	// it sets the correct status message in the body.
 	SendStatus(status int) error
@@ -556,6 +759,12 @@ type Ctx interface {
 	// Set sets the response's HTTP header field to the specified key, value.
 	Set(key, val string)
 	setCanonical(key, val string)
+	// StatusCode returns the status code currently set on the response. It is the
+	// read side of Status, and reports 200 until something sets another code.
+	//
+	// Called after Next it is the status the chain settled on, which is what
+	// logging, metrics, and caching middleware key off.
+	StatusCode() int
 	// Type sets the Content-Type HTTP header to the MIME type specified by the file extension.
 	Type(extension string, charset ...string) Ctx
 	// Vary adds the given header field to the Vary response header.

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -153,9 +153,9 @@ type Ctx interface {
 	Matched() bool
 	// IsMiddleware returns true if the current request handler was registered as middleware.
 	IsMiddleware() bool
-	// IsFinal reports whether no further handler of the current route runs after
-	// this one, the exact complement of IsMiddleware. It describes the route, not
-	// the request: another route can still match, and a Use route is never final.
+	// IsFinal reports whether this is the last handler of a matched non-middleware
+	// route, so nothing further on that route runs. It describes the route, not the
+	// request: another route can still match, and a Use route is never final.
 	IsFinal() bool
 	// OverrideParam overwrites a route parameter value by name.
 	// If the parameter name does not exist in the route, this method does nothing.
@@ -386,8 +386,8 @@ type Ctx interface {
 	// one. Fresh already compares them. Only valid within the handler.
 	IfNoneMatch() []string
 	// IfModifiedSince returns the time carried by the If-Modified-Since request
-	// header, ErrHeaderNotFound when it is absent, and a parse error when it is none
-	// of the three HTTP-date formats RFC 9110 Section 5.6.7 requires.
+	// header, ErrHeaderNotFound when it is absent or empty, and a parse error when
+	// it is none of the HTTP-date formats RFC 9110 Section 5.6.7 requires.
 	IfModifiedSince() (time.Time, error)
 	// GetAll returns every field line stored under key, where Get returns only the
 	// first, or nil when the header is absent. Empty lines are skipped, so its
@@ -566,7 +566,8 @@ type Ctx interface {
 	Cookie(cookie *Cookie)
 	// GetCookie reads back a cookie this response is set to send, false when the
 	// name is unset or its value does not parse. Names are case-sensitive and a
-	// repeat resolves to the first. The copy is written back through Cookie.
+	// repeat resolves to the first. Writing the copy back through Cookie stamps
+	// Path=/ on a cookie that carried none, widening its scope — set Path first.
 	GetCookie(name string) (*Cookie, bool)
 	// Download transfers the file from path as an attachment.
 	// Typically, browsers will prompt the user for download.
@@ -587,9 +588,9 @@ type Ctx interface {
 	// For more flexible content negotiation, use Format.
 	// If the header is not specified or there is no proper format, text/plain is used.
 	AutoFormat(body any) error
-	// Del removes every field line stored under key, case-insensitively, and is a
-	// no-op for a header that was never set. Del(HeaderSetCookie) withdraws the
-	// pending cookies, where ClearCookie expires one already in the client's jar.
+	// Del removes every field line stored under key, whatever case it is spelled in,
+	// and is a no-op for a header that was never set. Del(HeaderSetCookie) withdraws
+	// the pending cookies, where ClearCookie expires one in the client's jar.
 	Del(key string)
 	// JSON converts any interface or string to JSON.
 	// Array and slice values encode as JSON arrays,

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -55,28 +55,20 @@ type Ctx interface {
 	// Returns nil if the context has been released.
 	Response() *fasthttp.Response
 	// Body returns the request body, decompressing it when the request declares a
-	// Content-Encoding the app accepts.
-	//
-	// Req and Res both carry a Body, so on Ctx the request wins, as it does for
-	// Get. Use Res().Body() for what the handler has written so far.
+	// Content-Encoding the app accepts. Req and Res both carry a Body, so on Ctx
+	// the request wins, as it does for Get; use Res().Body() for the response.
 	Body() []byte
-	// ContentLength returns the value of the Content-Length request header.
-	//
-	// Req and Res both carry a ContentLength, so on Ctx the request wins, as it
-	// does for Get. Use Res().ContentLength() for the length of the response.
+	// ContentLength returns the value of the Content-Length request header. Req and
+	// Res both carry one, so on Ctx the request wins, as it does for Get; use
+	// Res().ContentLength() for the response.
 	ContentLength() int
-	// ContentType returns the Content-Type request header, parameters included.
-	//
-	// Req and Res both carry a ContentType, so on Ctx the request wins, as it does
-	// for Get. Use Res().ContentType() for the type the response will send.
+	// ContentType returns the Content-Type request header, parameters included. Req
+	// and Res both carry one, so on Ctx the request wins, as it does for Get; use
+	// Res().ContentType() for the response.
 	ContentType() string
-	// Cookies returns the value of the request cookie with the given key, or
-	// defaultValue when the client did not send it.
-	//
-	// Req and Res both carry a Cookies, so on Ctx the request wins, as it does for
-	// Get. Use Res().Cookies() for the cookies this response will set.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the value outside the Handler.
+	// Cookies returns the request cookie with the given key, or defaultValue. Req
+	// and Res both carry one, so on Ctx the request wins; use Res().Cookies() for
+	// the response. Only valid within the handler unless Immutable is set.
 	Cookies(key string, defaultValue ...string) string
 	// Get returns the HTTP request header specified by field.
 	// Field names are case-insensitive
@@ -149,43 +141,21 @@ type Ctx interface {
 	Endpoint() *Route
 	// FullPath returns the matched route path, including any group prefixes.
 	FullPath() string
-	// RouteName returns the name of the route currently executing, or an empty
-	// string when the route is unnamed. Inside middleware this is the middleware's
-	// own route; use Endpoint().Name to look ahead to the route that will handle
-	// the request.
+	// RouteName returns the name of the route currently executing, or "" when it is
+	// unnamed. Inside middleware that is the middleware's own route; use
+	// Endpoint().Name to look ahead to the one that will handle the request.
 	RouteName() string
 	// MountPath returns the prefix the sub-app owning the current route was mounted
-	// under, or an empty string when the route belongs to the top-level app.
-	//
-	// Fiber mounts by cloning a sub-app's routes into the app that serves them with
-	// the prefix already baked in, so Path inside a mounted handler is the whole
-	// requested path, not one relative to the mount. MountPath is what tells such a
-	// handler which prefix it is living under, to build links back into its own app
-	// or to strip the prefix itself.
-	//
-	// It answers from the route that is running, unlike App.MountPath, which
-	// describes the app it is called on however that app is being served: a sub-app
-	// that is mounted and also listened on directly reports its mount prefix there
-	// even for its own traffic, where this reports "".
-	//
-	// The prefix is the owning app's, so mounting one *App at two prefixes reports
-	// the one it was mounted at last — the same limitation App.MountPath has, since
-	// that is where the prefix is recorded. Mount separate instances when each needs
-	// to know its own prefix.
+	// under, or "" for a top-level route. Path is not relative to it. One *App
+	// mounted twice reports its last prefix, as App.MountPath does.
 	MountPath() string
 	// Matched returns true if the current request path was matched by the router.
 	Matched() bool
 	// IsMiddleware returns true if the current request handler was registered as middleware.
 	IsMiddleware() bool
-	// IsFinal returns true if no further handler of the current route runs after
-	// this one. It is the exact complement of IsMiddleware, and false when no route
-	// matched at all.
-	//
-	// It describes this route, not the whole request: a route registered with Use is
-	// never final even when it is the last thing that runs, and another route can
-	// still match after a final handler calls Next — a specific path followed by a
-	// catch-all is the ordinary case. So this does not promise that the response is
-	// finished; use it to tell an endpoint handler from a middleware one.
+	// IsFinal reports whether no further handler of the current route runs after
+	// this one, the exact complement of IsMiddleware. It describes the route, not
+	// the request: another route can still match, and a Use route is never final.
 	IsFinal() bool
 	// OverrideParam overwrites a route parameter value by name.
 	// If the parameter name does not exist in the route, this method does nothing.
@@ -194,22 +164,16 @@ type Ctx interface {
 	SaveFile(fileheader *multipart.FileHeader, path string) error
 	// SaveFileToStorage saves any multipart file to an external storage system.
 	SaveFileToStorage(fileheader *multipart.FileHeader, path string, storage Storage) error
-	// Error returns an *Error carrying the given status code, so a handler can
-	// reject a request in one line:
-	//
-	//	return c.Error(fiber.StatusBadRequest, "id must be numeric")
-	//
-	// The message defaults to the status text when omitted. Returning the error
-	// hands it to the app's ErrorHandler, which is what writes the response; Error
-	// itself sets nothing on the response.
+	// Error returns an *Error carrying the given status code, defaulting the message
+	// to the status text. Returning it hands it to the app's ErrorHandler, which
+	// writes the response; Error itself sets nothing.
 	Error(status int, message ...string) error
 	// Status sets the HTTP status for the response.
 	// This method is chainable.
 	Status(status int) Ctx
-	// ID returns the connection-unique identifier fasthttp assigned to this
-	// request. It is cheap and always present, unlike RequestID, which reads a
-	// header a client or proxy has to have set. It is not unique across processes
-	// or restarts, so it is for correlating log lines within one server run.
+	// ID returns the connection-unique identifier fasthttp assigned to this request,
+	// unlike RequestID, which reads a header. It is not unique across processes or
+	// restarts, so use it to correlate log lines within one server run.
 	ID() uint64
 	// StartTime returns the time the server began handling this request. It is the
 	// reference point Elapsed measures from.
@@ -225,12 +189,9 @@ type Ctx interface {
 	// rather than the client when the app sits behind one. Use IP or IPs for the
 	// client address a trusted proxy forwarded.
 	RemoteAddr() net.Addr
-	// Hijack registers a handler that takes over the connection once the current
-	// response is sent, for protocols Fiber does not speak itself. The handler runs
-	// on the connection's own goroutine, after which the connection is closed
-	// unless the server has KeepHijackedConns set.
-	//
-	// The Ctx is pooled and reused, so the hijack handler must not touch it.
+	// Hijack registers a handler that takes over the connection once the response is
+	// sent, for protocols Fiber does not speak. The connection then closes unless
+	// KeepHijackedConns is set, and the handler must not touch the pooled Ctx.
 	Hijack(handler fasthttp.HijackHandler)
 	// Hijacked returns true if Hijack has been called on this request, so a later
 	// handler can tell that the connection is already spoken for and leave the
@@ -338,12 +299,9 @@ type Ctx interface {
 	BodyRaw() []byte
 	//nolint:nonamedreturns // gocritic unnamedResult prefers naming decoded body, decode count, and error
 	tryDecodeBodyInOrder(originalBody *[]byte, encodings []string) (body []byte, decodesRealized uint8, err error)
-	// BodyStream returns the request body as a stream.
-	//
-	// It is only non-nil when Config.StreamRequestBody is enabled and the body has
-	// not already been buffered; IsBodyStream on the underlying request reports
-	// which of the two is in play. Reading from the returned reader consumes the
-	// body, so a later Body call will not see it.
+	// BodyStream returns the request body as a stream, non-nil only when
+	// Config.StreamRequestBody is enabled and the body is not already buffered.
+	// Reading it consumes the body, so a later Body call will not see it.
 	BodyStream() io.Reader
 	// FullURL returns the full request URL (protocol + host + original URL).
 	FullURL() string
@@ -356,14 +314,8 @@ type Ctx interface {
 	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Origin() string
 	// headerField returns a request header's field value, matching the field name
-	// the way a recipient must (RFC 9110 Section 5.1).
-	//
-	// fasthttp's Peek is byte-exact, which resolves every spelling only while it
-	// canonicalizes the key; under DisableHeaderNormalizing the store keeps what the
-	// peer sent, which for HTTP/2 and 3 is lower case. That is the bug the CSRF
-	// middleware was fixed for: a lower-case "origin:" read as absent and the
-	// same-origin check found nothing to verify. The byte-exact read stays the fast
-	// path, and the walk runs only for the config that needs it.
+	// case-insensitively (RFC 9110 Section 5.1). Peek is byte-exact, so under
+	// DisableHeaderNormalizing a lower-case "origin:" read as absent.
 	headerField(name string) []byte
 	// AcceptLanguage returns the Accept-Language request header.
 	// Repeated field lines are combined into one comma-joined list
@@ -393,25 +345,13 @@ type Ctx interface {
 	AcceptsXML() bool
 	// AcceptsEventStream reports whether the Accept header allows text/event-stream.
 	AcceptsEventStream() bool
-	// CookieNames returns the names of the cookies sent with the request, in the
-	// order they appear in the Cookie header, or nil when the client sent none. A
-	// name the client repeated is returned once per occurrence, which is how a
-	// caller detects the shadowing AllCookies collapses.
-	//
-	// Unlike Cookies, the returned strings are copies rather than views into the
-	// request buffer, so they stay valid past the handler.
+	// CookieNames returns the request cookie names in header order, or nil when
+	// there are none. A repeated name appears once per occurrence, which is how the
+	// shadowing AllCookies collapses is detected. The strings are copies.
 	CookieNames() []string
-	// AllCookies returns the cookies sent with the request as a name/value map, or
-	// nil when the client sent none. A repeated name resolves to its first
-	// occurrence, which is the one Cookies answers with too — the two must agree,
-	// because a client can shadow a cookie by sending the name twice and code that
-	// validated one value while consuming the other would validate the wrong one.
-	// Use CookieNames to see that a name was repeated at all.
-	//
-	// The keys and values are copies rather than views into the request buffer:
-	// fasthttp rewrites those bytes in place when a handler edits a request cookie,
-	// which would not merely stale the map but rehash it into one whose own keys no
-	// longer find their entries.
+	// AllCookies returns the request cookies as a name/value map, or nil when there
+	// are none. A repeated name resolves to its first occurrence, as Cookies does,
+	// so a shadowed cookie cannot be validated in one and consumed in the other.
 	AllCookies() map[string]string
 	// FormFile returns the first file by key from a MultipartForm.
 	// The multipart form is parsed using the application's BodyLimit to prevent
@@ -441,58 +381,25 @@ type Ctx interface {
 	// reload request, this module will return false to make handling these requests transparent.
 	// https://github.com/jshttp/fresh/blob/master/index.js#L33
 	Fresh() bool
-	// IfNoneMatch returns the entity tags listed in the If-None-Match request
-	// header. Repeated field lines are combined into one list (RFC 9110
-	// Section 5.2), and a comma inside a quoted opaque-tag does not split it, so
-	// `"v1,v2"` stays one tag. A wildcard header returns a single "*" element.
-	// Tags are returned verbatim, weak "W/" prefix included, and are not validated;
-	// empty list elements are dropped, as RFC 9110 Section 5.6.1 requires, so a
-	// trailing comma is not an extra tag. Fresh already applies these tags to the
-	// response ETag; reach for this only to implement a comparison of your own.
-	// Returned values are only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
+	// IfNoneMatch returns the entity tags in the If-None-Match request header,
+	// verbatim and unvalidated; a comma inside a quoted opaque-tag does not split
+	// one. Fresh already compares them. Only valid within the handler.
 	IfNoneMatch() []string
 	// IfModifiedSince returns the time carried by the If-Modified-Since request
-	// header. It returns ErrHeaderNotFound when the header is absent, and a parse
-	// error when the value is none of the three HTTP-date formats RFC 9110
-	// Section 5.6.7 requires recipients to accept.
+	// header, ErrHeaderNotFound when it is absent, and a parse error when it is none
+	// of the three HTTP-date formats RFC 9110 Section 5.6.7 requires.
 	IfModifiedSince() (time.Time, error)
-	// GetAll returns every field line of the request header specified by key.
-	// Field names are case-insensitive.
-	//
-	// A header repeated across field lines is semantically one comma-joined list
-	// (RFC 9110 Section 5.2). GetAll keeps the lines apart so a caller can inspect
-	// them individually, where Get returns only the first and GetHeaders builds a
-	// map of the whole header block. It returns nil when the header is absent.
-	//
-	// Empty field lines are skipped, so len(GetAll(k)) > 0 answers the same question
-	// as HasHeader(k). Without that, the headers fasthttp keeps in a slot of their
-	// own report one empty line when they are not present at all, and a
-	// request-smuggling guard testing for Content-Length would fire on every request
-	// that has none.
-	// Returned values are only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
+	// GetAll returns every field line stored under key, where Get returns only the
+	// first, or nil when the header is absent. Empty lines are skipped, so its
+	// presence answers as HasHeader does. Only valid within the handler.
 	GetAll(key string) []string
-	// Authorization splits the Authorization request header into its auth-scheme
-	// and the credentials that follow (RFC 9110 Section 11.6.2). Both are empty
-	// when the header is absent. The credentials are returned verbatim — token68 or
-	// auth-param list — and are neither decoded nor validated.
-	//
-	// Returned values are only valid within the handler. Do not store any
-	// references: they view the request buffer, which the next request on the
-	// connection overwrites, so a credential cached past the handler silently
-	// becomes another request's. Make copies or use the Immutable setting instead.
+	// Authorization splits the Authorization header into auth-scheme and credentials
+	// (RFC 9110 Section 11.6.2), neither decoded nor validated. They view the request
+	// buffer: a credential kept past the handler becomes another request's.
 	Authorization() (scheme, credentials string)
-	// Bearer returns the credentials of a Bearer Authorization header
-	// (RFC 6750 Section 2.1), or an empty string when the header is absent or names
-	// a different auth-scheme. The token is returned verbatim: it is not validated,
-	// decoded, or verified, so it still has to be authenticated before it is trusted.
-	//
-	// Returned value is only valid within the handler. Do not store any references:
-	// it views the request buffer, which the next request on the connection
-	// overwrites, so a token cached past the handler — or used as a key in a shared
-	// map — silently becomes another request's. Make copies or use the Immutable
-	// setting instead.
+	// Bearer returns the credentials of a Bearer Authorization header (RFC 6750
+	// Section 2.1), unverified, or "" for another scheme. It views the request
+	// buffer: a token kept past the handler becomes another request's.
 	Bearer() string
 	// Host contains the host derived from the X-Forwarded-Host or Host HTTP header.
 	// Returned value is only valid within the handler. Do not store any references.
@@ -572,12 +479,9 @@ type Ctx interface {
 	// which aliases those bytes unless Immutable is set — can change during the
 	// call. Copy it first if you need it to outlive one.
 	MultipartForm() (*multipart.Form, error)
-	// URI returns the parsed *fasthttp.URI of the request.
-	// This allows you to use all fasthttp URI methods.
-	// https://godoc.org/github.com/valyala/fasthttp#URI
-	//
-	// The returned value is owned by the request and is rewritten by a Path
-	// override, so it is only valid within the handler. Do not store any references.
+	// URI returns the parsed *fasthttp.URI of the request, giving access to all
+	// fasthttp URI methods. It is owned by the request and rewritten by a Path
+	// override, so it is only valid within the handler.
 	URI() *fasthttp.URI
 	// Path returns the path part of the request URL.
 	// Optionally, you could override the path.
@@ -644,18 +548,9 @@ type Ctx interface {
 	// Empty values are skipped: a sender must not generate empty list elements
 	// (RFC 9110 Section 5.6.1.2).
 	Append(field string, values ...string)
-	// Add appends the given value to the response header field as a new field
-	// line, leaving any existing lines untouched.
-	//
-	// This differs from Append, which folds values into a single comma-separated
-	// line: headers whose values may themselves contain commas — Set-Cookie,
-	// WWW-Authenticate, Link — have to be sent as separate lines to stay
-	// unambiguous (RFC 9110 Section 5.3).
-	//
-	// The headers fasthttp stores in a slot of their own cannot repeat, and Add
-	// does not append for them: Content-Type, Content-Encoding, Content-Length,
-	// Connection, Server and Trailer are replaced, and Transfer-Encoding and Date
-	// are ignored because fasthttp writes them itself. Use Set for those.
+	// Add appends the value as a new field line, where Append folds values into one
+	// comma-separated line. It does not append for the headers fasthttp slots:
+	// Content-Type, Server and the rest are replaced, Date and TE ignored.
 	Add(key, val string)
 	// Attachment sets the HTTP response Content-Disposition header field to attachment.
 	Attachment(filename ...string)
@@ -669,16 +564,9 @@ type Ctx interface {
 	// Partitioned) happens on a local copy, so a caller may reuse the same *Cookie
 	// template across requests.
 	Cookie(cookie *Cookie)
-	// GetCookie reads back a cookie this response is already set to send, so a
-	// later handler or middleware can inspect or re-emit what an earlier one wrote.
-	// The second result is false when no cookie of that name has been set, or when
-	// its Set-Cookie field value does not parse.
-	//
-	// Cookie names are case-sensitive (RFC 6265 Section 4.1.1). A name written more
-	// than once resolves to the first occurrence; use Cookies to see them all.
-	//
-	// The returned Cookie is a copy: changing it does not change the response.
-	// Pass it to Cookie to write the change back.
+	// GetCookie reads back a cookie this response is set to send, false when the
+	// name is unset or its value does not parse. Names are case-sensitive and a
+	// repeat resolves to the first. The copy is written back through Cookie.
 	GetCookie(name string) (*Cookie, bool)
 	// Download transfers the file from path as an attachment.
 	// Typically, browsers will prompt the user for download.
@@ -699,13 +587,9 @@ type Ctx interface {
 	// For more flexible content negotiation, use Format.
 	// If the header is not specified or there is no proper format, text/plain is used.
 	AutoFormat(body any) error
-	// Del removes every field line of the response header specified by key.
-	// Field names are case-insensitive. Deleting a header that was never set is a
-	// no-op.
-	//
-	// Del(HeaderSetCookie) withdraws every cookie this response was going to set,
-	// which is not what ClearCookie does: ClearCookie adds a Set-Cookie that
-	// expires the cookie already in the client's jar.
+	// Del removes every field line stored under key, case-insensitively, and is a
+	// no-op for a header that was never set. Del(HeaderSetCookie) withdraws the
+	// pending cookies, where ClearCookie expires one already in the client's jar.
 	Del(key string)
 	// JSON converts any interface or string to JSON.
 	// Array and slice values encode as JSON arrays,
@@ -754,13 +638,9 @@ type Ctx interface {
 	// Use it before replacing a partially written body — an error page over a
 	// half-rendered view, a cached body over a fresh one.
 	ResetBody()
-	// Written reports whether anything has been written to the response body yet,
-	// so middleware can tell a handler that produced a response from one that left
-	// it untouched. A streamed body counts as written without draining the stream,
-	// which is the case Body deliberately answers nil for.
-	//
-	// Status and headers are not body writes: a handler that only called Status
-	// leaves this false.
+	// Written reports whether anything has been written to the response body, so a
+	// handler that produced one can be told from a handler that did not. A stream
+	// counts without being drained; a status or header alone does not.
 	Written() bool
 	// Send sets the HTTP response body without copying it.
 	// From this point onward the body argument must not be changed.
@@ -781,12 +661,9 @@ type Ctx interface {
 	// The Content-Type response HTTP header field is set based on the file's extension.
 	// If the file extension is missing or invalid, the Content-Type is detected from the file's format.
 	SendFile(file string, config ...SendFile) error
-	// NoContent replies 204 No Content. SendStatus already discards the body for
-	// every status statusDisallowsBody names; this drops the Content-Type as well,
-	// since RFC 9110 Section 6.4.1 gives a 204 no content to describe.
-	//
-	// SendStatus(StatusNoContent) leaves a Content-Type a handler had set, so the
-	// two are not interchangeable: this is the one that sends nothing about content.
+	// NoContent replies 204 No Content. SendStatus already discards the body; this
+	// drops the Content-Type too, since RFC 9110 Section 6.4.1 gives a 204 no
+	// content to describe. SendStatus(204) keeps it, so the two differ.
 	NoContent() error
 	// SendStatus sets the HTTP status code and if the response body is empty,
 	// it sets the correct status message in the body.
@@ -801,11 +678,9 @@ type Ctx interface {
 	// Set sets the response's HTTP header field to the specified key, value.
 	Set(key, val string)
 	setCanonical(key, val string)
-	// StatusCode returns the status code currently set on the response. It is the
-	// read side of Status, and reports 200 until something sets another code.
-	//
-	// Called after Next it is the status the chain settled on, which is what
-	// logging, metrics, and caching middleware key off.
+	// StatusCode returns the status code set on the response, the read side of
+	// Status, and reports 200 until something sets another. After Next it is the
+	// status the chain settled on.
 	StatusCode() int
 	// Type sets the Content-Type HTTP header to the MIME type specified by the file extension.
 	Type(extension string, charset ...string) Ctx

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -29,24 +29,6 @@ type Ctx interface {
 	Context() context.Context
 	// SetContext sets a context implementation by user.
 	SetContext(ctx context.Context)
-	// Copy returns a detached snapshot of the context that stays valid after the
-	// handler returns.
-	//
-	// A live Ctx is pooled and its request buffers are handed to the next request
-	// on the connection, so reading one from a goroutine that outlives the handler
-	// returns whatever arrived next. Copy deep-copies the request, the path buffers
-	// and the route parameters into a context that is never pooled, so the goroutine
-	// sees the request the handler saw. Locals come across as they are: the entries
-	// are copied, the values in them are shared.
-	//
-	// A request body that is still a stream is not copied; read it, or call Body, on
-	// the original first. The copy is for reading otherwise: its response is a
-	// detached buffer that never reaches the client, and it is always a *DefaultCtx
-	// even under a custom Ctx, so writing to it, or driving the chain again with
-	// Next or RestartRouting, changes nothing the client will see. It does not
-	// observe the request's cancellation either; when the goroutine needs that, take
-	// Context() from the original before the handler returns.
-	Copy() Ctx
 	// Deadline returns the time when work done on behalf of this context
 	// should be canceled. Ctx carries no deadline, so ok is always false.
 	//
@@ -83,6 +65,11 @@ type Ctx interface {
 	// Req and Res both carry a ContentLength, so on Ctx the request wins, as it
 	// does for Get. Use Res().ContentLength() for the length of the response.
 	ContentLength() int
+	// ContentType returns the Content-Type request header, parameters included.
+	//
+	// Req and Res both carry a ContentType, so on Ctx the request wins, as it does
+	// for Get. Use Res().ContentType() for the type the response will send.
+	ContentType() string
 	// Cookies returns the value of the request cookie with the given key, or
 	// defaultValue when the client did not send it.
 	//
@@ -176,16 +163,29 @@ type Ctx interface {
 	// handler which prefix it is living under, to build links back into its own app
 	// or to strip the prefix itself.
 	//
-	// It answers from the route that is running, unlike App.MountPath, which only
-	// ever describes the app it is called on.
+	// It answers from the route that is running, unlike App.MountPath, which
+	// describes the app it is called on however that app is being served: a sub-app
+	// that is mounted and also listened on directly reports its mount prefix there
+	// even for its own traffic, where this reports "".
+	//
+	// The prefix is the owning app's, so mounting one *App at two prefixes reports
+	// the one it was mounted at last — the same limitation App.MountPath has, since
+	// that is where the prefix is recorded. Mount separate instances when each needs
+	// to know its own prefix.
 	MountPath() string
 	// Matched returns true if the current request path was matched by the router.
 	Matched() bool
 	// IsMiddleware returns true if the current request handler was registered as middleware.
 	IsMiddleware() bool
-	// IsFinal returns true if the current request handler is the last one in the
-	// chain, meaning nothing runs after it returns. It is the complement of
-	// IsMiddleware, and false when no route matched at all.
+	// IsFinal returns true if no further handler of the current route runs after
+	// this one. It is the exact complement of IsMiddleware, and false when no route
+	// matched at all.
+	//
+	// It describes this route, not the whole request: a route registered with Use is
+	// never final even when it is the last thing that runs, and another route can
+	// still match after a final handler calls Next — a specific path followed by a
+	// catch-all is the ordinary case. So this does not promise that the response is
+	// finished; use it to tell an endpoint handler from a middleware one.
 	IsFinal() bool
 	// OverrideParam overwrites a route parameter value by name.
 	// If the parameter name does not exist in the route, this method does nothing.
@@ -352,7 +352,19 @@ type Ctx interface {
 	// Referer returns the Referer request header.
 	Referer() string
 	// Origin returns the Origin request header.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Origin() string
+	// headerField returns a request header's field value, matching the field name
+	// the way a recipient must (RFC 9110 Section 5.1).
+	//
+	// fasthttp's Peek is byte-exact, which resolves every spelling only while it
+	// canonicalizes the key; under DisableHeaderNormalizing the store keeps what the
+	// peer sent, which for HTTP/2 and 3 is lower case. That is the bug the CSRF
+	// middleware was fixed for: a lower-case "origin:" read as absent and the
+	// same-origin check found nothing to verify. The byte-exact read stays the fast
+	// path, and the walk runs only for the config that needs it.
+	headerField(name string) []byte
 	// AcceptLanguage returns the Accept-Language request header.
 	// Repeated field lines are combined into one comma-joined list
 	// (RFC 9110 Section 5.2), matching what AcceptsLanguages negotiates on.
@@ -382,16 +394,24 @@ type Ctx interface {
 	// AcceptsEventStream reports whether the Accept header allows text/event-stream.
 	AcceptsEventStream() bool
 	// CookieNames returns the names of the cookies sent with the request, in the
-	// order they appear in the Cookie header. A name repeated by the client is
-	// returned once per occurrence.
-	// Returned values are only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the values outside the Handler.
+	// order they appear in the Cookie header, or nil when the client sent none. A
+	// name the client repeated is returned once per occurrence, which is how a
+	// caller detects the shadowing AllCookies collapses.
+	//
+	// Unlike Cookies, the returned strings are copies rather than views into the
+	// request buffer, so they stay valid past the handler.
 	CookieNames() []string
-	// AllCookies returns the cookies sent with the request as a name/value map.
-	// When the client repeats a name the last value wins; use CookieNames to detect
-	// that case.
-	// Returned values are only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the values outside the Handler.
+	// AllCookies returns the cookies sent with the request as a name/value map, or
+	// nil when the client sent none. A repeated name resolves to its first
+	// occurrence, which is the one Cookies answers with too — the two must agree,
+	// because a client can shadow a cookie by sending the name twice and code that
+	// validated one value while consuming the other would validate the wrong one.
+	// Use CookieNames to see that a name was repeated at all.
+	//
+	// The keys and values are copies rather than views into the request buffer:
+	// fasthttp rewrites those bytes in place when a handler edits a request cookie,
+	// which would not merely stale the map but rehash it into one whose own keys no
+	// longer find their entries.
 	AllCookies() map[string]string
 	// FormFile returns the first file by key from a MultipartForm.
 	// The multipart form is parsed using the application's BodyLimit to prevent
@@ -425,9 +445,12 @@ type Ctx interface {
 	// header. Repeated field lines are combined into one list (RFC 9110
 	// Section 5.2), and a comma inside a quoted opaque-tag does not split it, so
 	// `"v1,v2"` stays one tag. A wildcard header returns a single "*" element.
-	// Tags are returned verbatim, weak "W/" prefix included, and are not validated.
-	// Fresh already applies these tags to the response ETag; reach for this only to
-	// implement a comparison of your own.
+	// Tags are returned verbatim, weak "W/" prefix included, and are not validated;
+	// empty list elements are dropped, as RFC 9110 Section 5.6.1 requires, so a
+	// trailing comma is not an extra tag. Fresh already applies these tags to the
+	// response ETag; reach for this only to implement a comparison of your own.
+	// Returned values are only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
 	IfNoneMatch() []string
 	// IfModifiedSince returns the time carried by the If-Modified-Since request
 	// header. It returns ErrHeaderNotFound when the header is absent, and a parse
@@ -440,7 +463,13 @@ type Ctx interface {
 	// A header repeated across field lines is semantically one comma-joined list
 	// (RFC 9110 Section 5.2). GetAll keeps the lines apart so a caller can inspect
 	// them individually, where Get returns only the first and GetHeaders builds a
-	// map of the whole header block.
+	// map of the whole header block. It returns nil when the header is absent.
+	//
+	// Empty field lines are skipped, so len(GetAll(k)) > 0 answers the same question
+	// as HasHeader(k). Without that, the headers fasthttp keeps in a slot of their
+	// own report one empty line when they are not present at all, and a
+	// request-smuggling guard testing for Content-Length would fire on every request
+	// that has none.
 	// Returned values are only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting instead.
 	GetAll(key string) []string
@@ -448,11 +477,22 @@ type Ctx interface {
 	// and the credentials that follow (RFC 9110 Section 11.6.2). Both are empty
 	// when the header is absent. The credentials are returned verbatim — token68 or
 	// auth-param list — and are neither decoded nor validated.
+	//
+	// Returned values are only valid within the handler. Do not store any
+	// references: they view the request buffer, which the next request on the
+	// connection overwrites, so a credential cached past the handler silently
+	// becomes another request's. Make copies or use the Immutable setting instead.
 	Authorization() (scheme, credentials string)
 	// Bearer returns the credentials of a Bearer Authorization header
 	// (RFC 6750 Section 2.1), or an empty string when the header is absent or names
 	// a different auth-scheme. The token is returned verbatim: it is not validated,
 	// decoded, or verified, so it still has to be authenticated before it is trusted.
+	//
+	// Returned value is only valid within the handler. Do not store any references:
+	// it views the request buffer, which the next request on the connection
+	// overwrites, so a token cached past the handler — or used as a key in a shared
+	// map — silently becomes another request's. Make copies or use the Immutable
+	// setting instead.
 	Bearer() string
 	// Host contains the host derived from the X-Forwarded-Host or Host HTTP header.
 	// Returned value is only valid within the handler. Do not store any references.
@@ -611,6 +651,11 @@ type Ctx interface {
 	// line: headers whose values may themselves contain commas — Set-Cookie,
 	// WWW-Authenticate, Link — have to be sent as separate lines to stay
 	// unambiguous (RFC 9110 Section 5.3).
+	//
+	// The headers fasthttp stores in a slot of their own cannot repeat, and Add
+	// does not append for them: Content-Type, Content-Encoding, Content-Length,
+	// Connection, Server and Trailer are replaced, and Transfer-Encoding and Date
+	// are ignored because fasthttp writes them itself. Use Set for those.
 	Add(key, val string)
 	// Attachment sets the HTTP response Content-Disposition header field to attachment.
 	Attachment(filename ...string)
@@ -626,7 +671,11 @@ type Ctx interface {
 	Cookie(cookie *Cookie)
 	// GetCookie reads back a cookie this response is already set to send, so a
 	// later handler or middleware can inspect or re-emit what an earlier one wrote.
-	// The second result is false when no cookie of that name has been set.
+	// The second result is false when no cookie of that name has been set, or when
+	// its Set-Cookie field value does not parse.
+	//
+	// Cookie names are case-sensitive (RFC 6265 Section 4.1.1). A name written more
+	// than once resolves to the first occurrence; use Cookies to see them all.
 	//
 	// The returned Cookie is a copy: changing it does not change the response.
 	// Pass it to Cookie to write the change back.
@@ -650,15 +699,6 @@ type Ctx interface {
 	// For more flexible content negotiation, use Format.
 	// If the header is not specified or there is no proper format, text/plain is used.
 	AutoFormat(body any) error
-	// ContentType returns the Content-Type response header, parameters included.
-	// It is the read side of Type, and of the content type Fiber sets for you when
-	// a JSON, XML, or SendFile response goes out.
-	//
-	// When nothing has set one it reports fasthttp's default, "text/plain;
-	// charset=utf-8", which is what would be sent — not an empty string.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
-	ContentType() string
 	// Del removes every field line of the response header specified by key.
 	// Field names are case-insensitive. Deleting a header that was never set is a
 	// no-op.
@@ -716,7 +756,8 @@ type Ctx interface {
 	ResetBody()
 	// Written reports whether anything has been written to the response body yet,
 	// so middleware can tell a handler that produced a response from one that left
-	// it untouched. A streamed body counts as written without draining the stream.
+	// it untouched. A streamed body counts as written without draining the stream,
+	// which is the case Body deliberately answers nil for.
 	//
 	// Status and headers are not body writes: a handler that only called Status
 	// leaves this false.
@@ -740,11 +781,12 @@ type Ctx interface {
 	// The Content-Type response HTTP header field is set based on the file's extension.
 	// If the file extension is missing or invalid, the Content-Type is detected from the file's format.
 	SendFile(file string, config ...SendFile) error
-	// NoContent replies 204 No Content: it sets the status, discards any body
-	// already written, and drops the Content-Type a handler had set, since
-	// RFC 9110 Section 6.4.1 gives a 204 no content to describe. fasthttp omits
-	// Content-Type from a 204 on the wire either way; dropping it here keeps the
-	// response consistent if something later moves it off 204.
+	// NoContent replies 204 No Content. SendStatus already discards the body for
+	// every status statusDisallowsBody names; this drops the Content-Type as well,
+	// since RFC 9110 Section 6.4.1 gives a 204 no content to describe.
+	//
+	// SendStatus(StatusNoContent) leaves a Content-Type a handler had set, so the
+	// two are not interchangeable: this is the one that sends nothing about content.
 	NoContent() error
 	// SendStatus sets the HTTP status code and if the response body is empty,
 	// it sets the correct status message in the body.

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -313,9 +313,10 @@ type Ctx interface {
 	// Returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Origin() string
-	// headerField returns a request header's field value, matching the field name
-	// case-insensitively (RFC 9110 Section 5.1). Peek is byte-exact, so under
-	// DisableHeaderNormalizing a lower-case "origin:" read as absent.
+	// headerField returns a request header's first non-empty field value, matching
+	// the field name case-insensitively (RFC 9110 Section 5.1). fieldname.First
+	// also steps over a present-but-empty first line, so a value on a later line
+	// is found and this agrees with GetAll on whether the field is there.
 	headerField(name string) []byte
 	// AcceptLanguage returns the Accept-Language request header.
 	// Repeated field lines are combined into one comma-joined list (RFC 9110
@@ -401,6 +402,10 @@ type Ctx interface {
 	// (RFC 9110 Section 11.6.2), neither decoded nor validated. They view the request
 	// buffer: a credential kept past the handler becomes another request's.
 	Authorization() (scheme, credentials string)
+	// authorizationParts splits the Authorization header at the first space or tab
+	// (RFC 9110 Section 11.4), on raw bytes so each caller materializes only the
+	// strings it needs. A lone token is a scheme without credentials.
+	authorizationParts() (scheme, credentials []byte)
 	// Bearer returns the credentials of a Bearer Authorization header (RFC 6750
 	// Section 2.1), unverified, or "" for another scheme. It views the request
 	// buffer: a token kept past the handler becomes another request's.

--- a/ctx_interface_gen.go
+++ b/ctx_interface_gen.go
@@ -326,6 +326,8 @@ type Ctx interface {
 	// (RFC 9110 Section 5.2), matching what AcceptsEncodings negotiates on.
 	AcceptEncoding() string
 	// HasHeader reports whether the request includes a header with the given key.
+	// The field name matches case-insensitively (RFC 9110 Section 5.1), so this
+	// agrees with GetAll on whether the field is there.
 	HasHeader(key string) bool
 	// MediaType returns the MIME type from the Content-Type header without parameters.
 	MediaType() string

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/gofiber/utils/v2"
+	utilsstrings "github.com/gofiber/utils/v2/strings"
 	"github.com/shamaton/msgpack/v3"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/bytebufferpool"
@@ -9826,6 +9827,157 @@ func Benchmark_Ctx_XHR(b *testing.B) {
 		equal = c.XHR()
 	}
 	require.True(b, equal)
+}
+
+// headerReadBenchCtx builds the request a browser sends, eight field lines, for
+// the header reads below. Names are stored the way the peer spelled them, so the
+// non-normalizing case exercises the case-insensitive walk rather than a store
+// fasthttp has already canonicalized.
+//
+//nolint:revive // flag-parameter: this selects which header store shape is measured
+func headerReadBenchCtx(b *testing.B, disableNormalizing bool) Ctx {
+	b.Helper()
+
+	app := New(Config{DisableHeaderNormalizing: disableNormalizing})
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	fields := [][2]string{
+		{HeaderUserAgent, "Mozilla/5.0"},
+		{HeaderAccept, "text/html,application/xhtml+xml"},
+		{HeaderAcceptLanguage, "en-US,en;q=0.9"},
+		{HeaderAcceptEncoding, "gzip, deflate, br"},
+		{HeaderConnection, "keep-alive"},
+		{HeaderCacheControl, "max-age=0"},
+		{"Sec-Fetch-Site", "same-origin"},
+		{HeaderXRequestID, "3f0c1a"},
+	}
+	if disableNormalizing {
+		c.Request().Header.DisableNormalizing()
+		for _, f := range fields {
+			c.Request().Header.Set(utilsstrings.ToLower(f[0]), f[1])
+		}
+		return c
+	}
+
+	for _, f := range fields {
+		c.Request().Header.Set(f[0], f[1])
+	}
+	return c
+}
+
+func benchHeaderReadModes(b *testing.B, f func(b *testing.B, c Ctx)) {
+	b.Helper()
+
+	b.Run("Normalizing", func(b *testing.B) {
+		c := headerReadBenchCtx(b, false)
+		b.ReportAllocs()
+		f(b, c)
+	})
+	b.Run("WithoutNormalizing", func(b *testing.B) {
+		c := headerReadBenchCtx(b, true)
+		b.ReportAllocs()
+		f(b, c)
+	})
+}
+
+// go test -v -run=^$ -bench=Benchmark_Ctx_Get_Header -benchmem -count=4
+func Benchmark_Ctx_Get_Header(b *testing.B) {
+	benchHeaderReadModes(b, func(b *testing.B, c Ctx) {
+		b.Helper()
+		var v string
+		for b.Loop() {
+			v = c.Get(HeaderXRequestID)
+		}
+		require.Equal(b, "3f0c1a", v)
+	})
+}
+
+// go test -v -run=^$ -bench=Benchmark_Ctx_Get_HeaderAbsent -benchmem -count=4
+func Benchmark_Ctx_Get_HeaderAbsent(b *testing.B) {
+	benchHeaderReadModes(b, func(b *testing.B, c Ctx) {
+		b.Helper()
+		var v string
+		for b.Loop() {
+			v = c.Get("X-Not-Sent")
+		}
+		require.Empty(b, v)
+	})
+}
+
+// go test -v -run=^$ -bench=Benchmark_Ctx_HasHeader -benchmem -count=4
+func Benchmark_Ctx_HasHeader(b *testing.B) {
+	benchHeaderReadModes(b, func(b *testing.B, c Ctx) {
+		b.Helper()
+		var ok bool
+		for b.Loop() {
+			ok = c.HasHeader(HeaderXRequestID)
+		}
+		require.True(b, ok)
+	})
+}
+
+// go test -v -run=^$ -bench=Benchmark_Ctx_HasHeaderAbsent -benchmem -count=4
+func Benchmark_Ctx_HasHeaderAbsent(b *testing.B) {
+	benchHeaderReadModes(b, func(b *testing.B, c Ctx) {
+		b.Helper()
+		var ok bool
+		for b.Loop() {
+			ok = c.HasHeader("X-Not-Sent")
+		}
+		require.False(b, ok)
+	})
+}
+
+// go test -v -run=^$ -bench=Benchmark_Ctx_GetReqHeader -benchmem -count=4
+func Benchmark_Ctx_GetReqHeader(b *testing.B) {
+	benchHeaderReadModes(b, func(b *testing.B, c Ctx) {
+		b.Helper()
+		var v string
+		for b.Loop() {
+			v = GetReqHeader[string](c, HeaderXRequestID)
+		}
+		require.Equal(b, "3f0c1a", v)
+	})
+}
+
+// go test -v -run=^$ -bench=Benchmark_Ctx_IsWebSocket -benchmem -count=4
+//
+// Covered under both settings because the two paths differ in kind, not degree:
+// the canonical one peeks, while the case-insensitive one walks the store and
+// collects the field lines, which allocates.
+func Benchmark_Ctx_IsWebSocket(b *testing.B) {
+	for _, tc := range []struct {
+		name               string
+		disableNormalizing bool
+		handshake          bool
+	}{
+		{"Normalizing/handshake", false, true},
+		{"Normalizing/no-upgrade", false, false},
+		{"WithoutNormalizing/handshake", true, true},
+		{"WithoutNormalizing/no-upgrade", true, false},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			app := New(Config{DisableHeaderNormalizing: tc.disableNormalizing})
+			c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+			connection, upgrade := HeaderConnection, HeaderUpgrade
+			if tc.disableNormalizing {
+				c.Request().Header.DisableNormalizing()
+				connection, upgrade = utilsstrings.ToLower(connection), utilsstrings.ToLower(upgrade)
+			}
+			c.Request().Header.Set(connection, "upgrade")
+			if tc.handshake {
+				c.Request().Header.Set(upgrade, "websocket")
+			}
+
+			b.ReportAllocs()
+			var got bool
+			for b.Loop() {
+				got = c.IsWebSocket()
+			}
+			require.Equal(b, tc.handshake, got)
+		})
+	}
 }
 
 // go test -v  -run=^$ -bench=Benchmark_Ctx_SendString_B -benchmem -count=4

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -404,7 +404,7 @@ app.Use(func(c fiber.Ctx) error {
 
 ### IsFinal
 
-Returns `true` if no further handler of the **current route** runs after this one. It is the exact complement of [`IsMiddleware`](#ismiddleware), and `false` when no route matched at all.
+Returns `true` only for the last handler of a matched, non-middleware route, so nothing further on that route runs. It is `false` when no route matched at all — as [`IsMiddleware`](#ismiddleware) also is, so the two are not exact complements.
 
 :::caution
 This describes the route, not the whole request. A route registered with `Use` is never final even when it is the last thing that runs, and another route can still match after a final handler calls [`Next`](#next) — a specific path followed by a catch-all is the ordinary case. Use it to tell an endpoint handler from a middleware one, not to decide that the response is finished.
@@ -3222,6 +3222,10 @@ Cookie names are case-sensitive (RFC 6265, Section 4.1.1). A name written more t
 
 :::note
 The returned `Cookie` is a copy: changing it does not change the response. Pass it to [`Cookie`](#cookie) to write the change back.
+:::
+
+:::caution
+A `Set-Cookie` that carried no `Path` comes back with `Path` empty, and [`Cookie`](#cookie) writes an empty `Path` as `/`. Re-emitting such a cookie therefore widens it from the browser's RFC 6265 default-path — the directory of the request URI — to the whole origin. Set `Path` explicitly before writing one back. Cookies written through [`Cookie`](#cookie) always carry a `Path`, so this only arises for a `Set-Cookie` added with [`Add`](#add) or copied from an upstream response.
 :::
 
 ```go title="Signature"

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -146,6 +146,35 @@ app.Get("/", func(c fiber.Ctx) error {
 })
 ```
 
+### Copy
+
+Returns a detached snapshot of the context that stays valid after the handler returns.
+
+A live `Ctx` is pooled and its request buffers are handed to the next request on the connection, so reading one from a goroutine that outlives the handler returns whatever arrived next. `Copy` deep-copies the request, the path buffers and the route parameters into a context that is never pooled, so the goroutine sees the request the handler saw. `Locals` come across as they are: the entries are copied, the values in them are shared.
+
+:::caution
+A request body that is still a stream is not copied; read it, or call [`Body`](#body), on the original first.
+
+The copy is for reading otherwise. Its response is a detached buffer that never reaches the client, and it is always a `*DefaultCtx` even under a custom `Ctx`: writing to it, or driving the chain again with `Next` or `RestartRouting`, changes nothing the client will see. It does not observe the request's cancellation either — take `Context()` from the original before the handler returns when the goroutine needs that.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) Copy() fiber.Ctx
+```
+
+```go title="Example"
+app.Post("/orders/:id", func(c fiber.Ctx) error {
+  snapshot := c.Copy()
+
+  go func() {
+    // Still the request this handler saw, long after it returned.
+    audit(snapshot.Params("id"), snapshot.IP(), snapshot.Get(fiber.HeaderUserAgent))
+  }()
+
+  return c.SendStatus(fiber.StatusAccepted)
+})
+```
+
 ### Drop
 
 Terminates the client connection silently without sending any HTTP headers or response body.
@@ -164,6 +193,22 @@ app.Get("/", func(c fiber.Ctx) error {
   }
 
   return c.SendString("Hello World!")
+})
+```
+
+### Elapsed
+
+Returns how long this request has been handled so far, measured from [`StartTime`](#starttime). Called after the handler chain has run, it is the request latency.
+
+```go title="Signature"
+func (c fiber.Ctx) Elapsed() time.Duration
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  err := c.Next()
+  metrics.Observe(c.Route().Path, c.Elapsed())
+  return err
 })
 ```
 
@@ -197,6 +242,31 @@ Mounted sub-apps report the flattened, prefixed route. The result is the route t
 
 It scans the remaining routes in the request's tree bucket, so calling it from global middleware costs a second router scan per request. That is cheap for routes spread over many prefixes and noticeable when a hundred or more share one, as with everything under `/api/v1`.
 :::
+
+### Error
+
+Returns an [`*fiber.Error`](./fiber.md#newerror) carrying the given status code, so a handler can reject a request in one line. The message defaults to the status text when omitted.
+
+Returning the error hands it to the app's `ErrorHandler`, which is what writes the response; `Error` itself sets nothing on the response.
+
+```go title="Signature"
+func (c fiber.Ctx) Error(status int, message ...string) error
+```
+
+```go title="Example"
+app.Get("/user/:id", func(c fiber.Ctx) error {
+  id, err := strconv.Atoi(c.Params("id"))
+  if err != nil {
+    return c.Error(fiber.StatusBadRequest, "id must be numeric")
+  }
+
+  if !exists(id) {
+    return c.Error(fiber.StatusNotFound) // => "Not Found"
+  }
+
+  return c.JSON(load(id))
+})
+```
 
 ### FullPath
 
@@ -318,20 +388,87 @@ from the request, escape them with [`url.PathEscape`](https://pkg.go.dev/net/url
 if the route expects one segment per parameter.
 :::
 
-### HasBody
+### Hijack
 
-Returns `true` if the incoming request contains a body or a `Content-Length` header greater than zero.
+Registers a handler that takes over the connection once the current response is sent, for protocols Fiber does not speak itself. The handler runs on the connection's own goroutine, after which the connection is closed unless the server has `KeepHijackedConns` set.
+
+:::caution
+The `Ctx` is pooled and reused, so the hijack handler must not touch it.
+:::
 
 ```go title="Signature"
-func (c fiber.Ctx) HasBody() bool
+func (c fiber.Ctx) Hijack(handler fasthttp.HijackHandler)
 ```
 
 ```go title="Example"
-app.Post("/", func(c fiber.Ctx) error {
-  if !c.HasBody() {
-    return c.SendStatus(fiber.StatusBadRequest)
+app.Get("/raw", func(c fiber.Ctx) error {
+  c.Hijack(func(conn net.Conn) {
+    _, _ = conn.Write([]byte("speaking something else now"))
+  })
+
+  return c.SendStatus(fiber.StatusSwitchingProtocols)
+})
+```
+
+### Hijacked
+
+Returns `true` if [`Hijack`](#hijack) has been called on this request, so a later handler can tell that the connection is already spoken for and leave the response alone.
+
+```go title="Signature"
+func (c fiber.Ctx) Hijacked() bool
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  if err := c.Next(); err != nil {
+    return err
   }
-  return c.SendString("OK")
+
+  if c.Hijacked() {
+    return nil // Nothing to add to a hijacked connection.
+  }
+
+  c.Set("X-Served-By", "fiber")
+  return nil
+})
+```
+
+### ID
+
+Returns the connection-unique identifier assigned to this request. It is cheap and always present, unlike [`RequestID`](#requestid), which reads a header a client or proxy has to have set.
+
+:::note
+The value is not unique across processes or restarts, so it is for correlating log lines within one server run.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) ID() uint64
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  log.Printf("[%d] %s %s", c.ID(), c.Method(), c.Path())
+  return c.Next()
+})
+```
+
+### IsFinal
+
+Returns `true` if the current request handler is the last one in the chain, meaning nothing runs after it returns. It is the complement of [`IsMiddleware`](#ismiddleware), and `false` when no route matched at all.
+
+```go title="Signature"
+func (c fiber.Ctx) IsFinal() bool
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  c.IsFinal() // => false, there is always a c.Next() from here
+  return c.Next()
+})
+
+app.Get("/", func(c fiber.Ctx) error {
+  c.IsFinal() // => true
+  return nil
 })
 ```
 
@@ -353,37 +490,19 @@ app.Get("/route", func(c fiber.Ctx) error {
 })
 ```
 
-### IsPreflight
+### LocalAddr
 
-Returns `true` if the request is a CORS preflight (`OPTIONS` + `Access-Control-Request-Method` + `Origin`).
-
-```go title="Signature"
-func (c fiber.Ctx) IsPreflight() bool
-```
-
-```go title="Example"
-app.Use(func(c fiber.Ctx) error {
-  if c.IsPreflight() {
-    return c.SendStatus(fiber.StatusNoContent)
-  }
-  return c.Next()
-})
-```
-
-### IsWebSocket
-
-Returns `true` if the request includes a WebSocket upgrade handshake.
+Returns the server-side address of the connection this request arrived on. [`IP`](#ip) returns the client address as a string; this is the full `net.Addr`, so the port, network, and unix socket path survive.
 
 ```go title="Signature"
-func (c fiber.Ctx) IsWebSocket() bool
+func (c fiber.Ctx) LocalAddr() net.Addr
 ```
 
 ```go title="Example"
 app.Get("/", func(c fiber.Ctx) error {
-  if c.IsWebSocket() {
-    // handle websocket
-  }
-  return c.Next()
+  c.LocalAddr().String() // => "127.0.0.1:3000"
+
+  // ...
 })
 ```
 
@@ -463,6 +582,33 @@ app.Use(func(c fiber.Ctx) error {
   }
   return c.Status(fiber.StatusNotFound).SendString("Not Found")
 })
+```
+
+### MountPath
+
+Returns the prefix the sub-app owning the current route was mounted under, or an empty string when the route belongs to the top-level app.
+
+Fiber mounts by cloning a sub-app's routes into the app that serves them with the prefix already baked in, so [`Path`](#path) inside a mounted handler is the whole requested path, not one relative to the mount. `MountPath` is what tells such a handler which prefix it is living under, to build links back into its own app or to strip the prefix itself.
+
+:::note
+It answers from the route that is running, unlike [`App.MountPath`](./app.md#mountpath), which only ever describes the app it is called on.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) MountPath() string
+```
+
+```go title="Example"
+micro := fiber.New()
+micro.Get("/doe", func(c fiber.Ctx) error {
+  c.MountPath() // => "/john"
+  c.Path()      // => "/john/doe"
+
+  // ...
+})
+
+app := fiber.New()
+app.Use("/john", micro)
 ```
 
 ### Next
@@ -551,6 +697,22 @@ app.Get("/coffee", func(c fiber.Ctx) error {
 
 app.Get("/teapot", func(c fiber.Ctx) error {
     return c.Status(fiber.StatusTeapot).Send("🍵 short and stout 🍵")
+})
+```
+
+### RemoteAddr
+
+Returns the address of the immediate peer, which is the proxy rather than the client when the app sits behind one. Use [`IP`](#ip) or [`IPs`](#ips) for the client address a trusted proxy forwarded.
+
+```go title="Signature"
+func (c fiber.Ctx) RemoteAddr() net.Addr
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  c.RemoteAddr().String() // => "192.168.1.10:54321"
+
+  // ...
 })
 ```
 
@@ -669,6 +831,22 @@ func MyMiddleware() fiber.Handler {
 }
 ```
 
+### RouteName
+
+Returns the name of the route currently executing, or an empty string when the route is unnamed. Inside middleware this is the middleware's own route; use `Endpoint().Name` to look ahead to the route that will handle the request.
+
+```go title="Signature"
+func (c fiber.Ctx) RouteName() string
+```
+
+```go title="Example"
+app.Get("/home", func(c fiber.Ctx) error {
+  c.RouteName() // => "home"
+
+  // ...
+}).Name("home")
+```
+
 ### SetContext
 
 Sets the base `context.Context` used by [`Context`](#context). Use this to
@@ -684,6 +862,22 @@ app.Get("/", func(c fiber.Ctx) error {
   ctx := c.Context()
   go doWork(ctx)
   return nil
+})
+```
+
+### StartTime
+
+Returns the time the server began handling this request. It is the reference point [`Elapsed`](#elapsed) measures from.
+
+```go title="Signature"
+func (c fiber.Ctx) StartTime() time.Time
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  deadline := c.StartTime().Add(2 * time.Second)
+
+  // ...
 })
 ```
 
@@ -930,6 +1124,50 @@ app.Get("/", func(c fiber.Ctx) error {
 })
 ```
 
+### AllCookies
+
+Returns the cookies sent with the request as a name/value map. When the client repeats a name the last value wins; use [`CookieNames`](#cookienames) to detect that case.
+
+:::caution
+Returned values are only valid within the handler. Do not store any references. Make copies or use the [**`Immutable`**](./fiber.md#config) setting to use the values outside the handler.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) AllCookies() map[string]string
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  // Cookie: session=abc; theme=dark
+  c.AllCookies() // => map[session:abc theme:dark]
+
+  // ...
+})
+```
+
+### Authorization
+
+Splits the `Authorization` request header into its auth-scheme and the credentials that follow (RFC 9110, Section 11.6.2). Both are empty when the header is absent.
+
+:::caution
+The credentials are returned verbatim — `token68` or an `auth-param` list — and are neither decoded nor validated.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) Authorization() (scheme, credentials string)
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  // Authorization: Basic dXNlcjpwYXNz
+  scheme, credentials := c.Authorization()
+  // scheme      => "Basic"
+  // credentials => "dXNlcjpwYXNz"
+
+  // ...
+})
+```
+
 ### BaseURL
 
 Returns the base URL (**protocol** + **host**) as a `string`.
@@ -943,6 +1181,30 @@ func (c fiber.Ctx) BaseURL() string
 
 app.Get("/", func(c fiber.Ctx) error {
   c.BaseURL() // "https://example.com"
+  // ...
+})
+```
+
+### Bearer
+
+Returns the credentials of a `Bearer` `Authorization` header (RFC 6750, Section 2.1), or an empty string when the header is absent or names a different auth-scheme.
+
+:::caution
+The token is returned verbatim: it is not validated, decoded, or verified, so it still has to be authenticated before it is trusted. Use the [keyauth](../middleware/keyauth.md) middleware when you want that done for you.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) Bearer() string
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  // Authorization: Bearer abc123
+  c.Bearer() // => "abc123"
+
+  // Authorization: Basic dXNlcjpwYXNz
+  c.Bearer() // => ""
+
   // ...
 })
 ```
@@ -991,6 +1253,36 @@ The returned value is valid only within the handler. Do not store references.
 Make copies or use the [**`Immutable`**](./fiber.md#immutable) setting instead. [Read more...](../#zero-allocation)
 :::
 
+### BodyStream
+
+Returns the request body as a stream. It is only non-`nil` when [`StreamRequestBody`](./fiber.md#config) is enabled and the body has not already been buffered.
+
+:::caution
+Reading from the returned reader consumes the body, so a later [`Body`](#body) call will not see it.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) BodyStream() io.Reader
+```
+
+```go title="Example"
+app := fiber.New(fiber.Config{StreamRequestBody: true})
+
+app.Post("/upload", func(c fiber.Ctx) error {
+  stream := c.BodyStream()
+  if stream == nil {
+    return c.Send(c.Body()) // Already buffered.
+  }
+
+  written, err := io.Copy(dst, stream)
+  if err != nil {
+    return err
+  }
+
+  return c.JSON(fiber.Map{"written": written})
+})
+```
+
 ### Charset
 
 Returns the `charset` parameter from the `Content-Type` header.
@@ -1021,6 +1313,51 @@ func (c fiber.Ctx) ClientHelloInfo() *tls.ClientHelloInfo
 // GET http://example.com/hello
 app.Get("/hello", func(c fiber.Ctx) error {
   chi := c.ClientHelloInfo()
+  // ...
+})
+```
+
+### ContentLength
+
+Returns the value of the `Content-Length` request header.
+
+A negative result means the length is not known up front rather than that the body is empty: `-1` is reported for a chunked body and `-2` for one terminated by closing the connection. Use [`HasBody`](#hasbody) to test only for the presence of a body.
+
+:::note
+`Req` and `Res` both carry a `ContentLength`, so on `Ctx` the request wins, as it does for [`Get`](#get). Use `c.Res().ContentLength()` for the length of the response.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) ContentLength() int
+```
+
+```go title="Example"
+app.Post("/", func(c fiber.Ctx) error {
+  if c.ContentLength() > maxUpload {
+    return c.Error(fiber.StatusRequestEntityTooLarge)
+  }
+
+  // ...
+})
+```
+
+### CookieNames
+
+Returns the names of the cookies sent with the request, in the order they appear in the `Cookie` header. A name repeated by the client is returned once per occurrence.
+
+:::caution
+Returned values are only valid within the handler. Do not store any references. Make copies or use the [**`Immutable`**](./fiber.md#config) setting to use the values outside the handler.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) CookieNames() []string
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  // Cookie: session=abc; theme=dark
+  c.CookieNames() // => ["session", "theme"]
+
   // ...
 })
 ```
@@ -1156,6 +1493,48 @@ The returned value is valid only within the handler. Do not store references.
 Make copies or use the [**`Immutable`**](./fiber.md#immutable) setting instead. [Read more...](../#zero-allocation)
 :::
 
+### GetAll
+
+Returns every field line of the request header specified by `key`. Field names are case-insensitive.
+
+A header repeated across field lines is semantically one comma-joined list (RFC 9110, Section 5.2). `GetAll` keeps the lines apart so a caller can inspect them individually, where [`Get`](#get) returns only the first and [`GetReqHeaders`](#getreqheaders) builds a map of the whole header block.
+
+:::caution
+Returned values are only valid within the handler. Do not store any references. Make copies or use the [**`Immutable`**](./fiber.md#config) setting instead.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) GetAll(key string) []string
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  // X-Forwarded-For: 10.0.0.1
+  // X-Forwarded-For: 10.0.0.2
+  c.GetAll("X-Forwarded-For") // => ["10.0.0.1", "10.0.0.2"]
+  c.Get("X-Forwarded-For")    // => "10.0.0.1"
+
+  // ...
+})
+```
+
+### HasBody
+
+Returns `true` if the incoming request contains a body or a `Content-Length` header greater than zero.
+
+```go title="Signature"
+func (c fiber.Ctx) HasBody() bool
+```
+
+```go title="Example"
+app.Post("/", func(c fiber.Ctx) error {
+  if !c.HasBody() {
+    return c.SendStatus(fiber.StatusBadRequest)
+  }
+  return c.SendString("OK")
+})
+```
+
 ### HasHeader
 
 Reports whether the request includes a header with the given key.
@@ -1219,6 +1598,51 @@ app.Get("/", func(c fiber.Ctx) error {
 The returned value is valid only within the handler. Do not store references.
 Make copies or use the [**`Immutable`**](./fiber.md#immutable) setting instead. [Read more...](../#zero-allocation)
 :::
+
+### IfModifiedSince
+
+Returns the time carried by the `If-Modified-Since` request header. It returns `fiber.ErrHeaderNotFound` when the header is absent, and a parse error when the value is none of the three HTTP-date formats RFC 9110, Section 5.6.7 requires recipients to accept.
+
+```go title="Signature"
+func (c fiber.Ctx) IfModifiedSince() (time.Time, error)
+```
+
+```go title="Example"
+app.Get("/report", func(c fiber.Ctx) error {
+  since, err := c.IfModifiedSince()
+  switch {
+  case errors.Is(err, fiber.ErrHeaderNotFound):
+    // Unconditional request.
+  case err != nil:
+    return c.Error(fiber.StatusBadRequest, "malformed If-Modified-Since")
+  case !report.ModTime().After(since):
+    return c.SendStatus(fiber.StatusNotModified)
+  }
+
+  return c.JSON(report)
+})
+```
+
+### IfNoneMatch
+
+Returns the entity tags listed in the `If-None-Match` request header. Repeated field lines are combined into one list (RFC 9110, Section 5.2), and a comma inside a quoted opaque-tag does not split it, so `"v1,v2"` stays one tag. A wildcard header returns a single `*` element.
+
+:::note
+Tags are returned verbatim, weak `W/` prefix included, and are not validated. [`Fresh`](#fresh) already applies these tags to the response `ETag`; reach for this only to implement a comparison of your own.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) IfNoneMatch() []string
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  // If-None-Match: W/"a", "b,c"
+  c.IfNoneMatch() // => [`W/"a"`, `"b,c"`]
+
+  // ...
+})
+```
 
 ### IP
 
@@ -1376,6 +1800,26 @@ app.Get("/", func(c fiber.Ctx) error {
 })
 ```
 
+### IsIdempotent
+
+Reports whether the request method is idempotent, meaning repeating it has the same intended effect as making it once (RFC 9110, Section 9.2.2). Every safe method is also idempotent.
+
+```go title="Signature"
+func (c fiber.Ctx) IsIdempotent() bool
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  // GET, HEAD, OPTIONS, TRACE, PUT, DELETE => true
+  // POST, PATCH                            => false
+  if c.IsIdempotent() {
+    return retryable(c)
+  }
+
+  return c.Next()
+})
+```
+
 ### IsJSON
 
 Reports whether the `Content-Type` header is JSON.
@@ -1410,6 +1854,23 @@ app.Post("/", func(c fiber.Ctx) error {
 })
 ```
 
+### IsPreflight
+
+Returns `true` if the request is a CORS preflight (`OPTIONS` + `Access-Control-Request-Method` + `Origin`).
+
+```go title="Signature"
+func (c fiber.Ctx) IsPreflight() bool
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  if c.IsPreflight() {
+    return c.SendStatus(fiber.StatusNoContent)
+  }
+  return c.Next()
+})
+```
+
 ### IsProxyTrusted
 
 Checks the trustworthiness of the remote IP.
@@ -1438,6 +1899,43 @@ app.Get("/", func(c fiber.Ctx) error {
   c.IsProxyTrusted()
 
   // ...
+})
+```
+
+### IsSafe
+
+Reports whether the request method is safe, meaning it is not expected to change server state (RFC 9110, Section 9.2.1).
+
+```go title="Signature"
+func (c fiber.Ctx) IsSafe() bool
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  // GET, HEAD, OPTIONS, TRACE => true
+  // POST, PUT, PATCH, DELETE  => false
+  if !c.IsSafe() {
+    return requireCSRFToken(c)
+  }
+
+  return c.Next()
+})
+```
+
+### IsWebSocket
+
+Returns `true` if the request includes a WebSocket upgrade handshake.
+
+```go title="Signature"
+func (c fiber.Ctx) IsWebSocket() bool
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  if c.IsWebSocket() {
+    // handle websocket
+  }
+  return c.Next()
 })
 ```
 
@@ -1529,6 +2027,23 @@ app.Post("/", func(c fiber.Ctx) error {
   }
 
   return nil
+})
+```
+
+### Origin
+
+Returns the `Origin` request header.
+
+```go title="Signature"
+func (c fiber.Ctx) Origin() string
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  // Origin: https://example.com
+  c.Origin() // => "https://example.com"
+
+  // ...
 })
 ```
 
@@ -2044,6 +2559,29 @@ app.Get("/", func(c fiber.Ctx) error {
 })
 ```
 
+### URI
+
+Returns the parsed [`*fasthttp.URI`](https://pkg.go.dev/github.com/valyala/fasthttp#URI) of the request, which gives access to every fasthttp URI method.
+
+:::caution
+The returned value is owned by the request and is rewritten by a [`Path`](#path) override, so it is only valid within the handler. Do not store any references.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) URI() *fasthttp.URI
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  // GET http://example.com/search?q=fiber#results
+  uri := c.URI()
+  uri.QueryString() // => "q=fiber"
+  uri.Hash()        // => "results"
+
+  // ...
+})
+```
+
 ### UserAgent
 
 Returns the `User-Agent` request header.
@@ -2084,6 +2622,27 @@ Methods which modify the response object.
 :::tip
 Use `c.Res()` to limit gopls suggestions to only these methods!
 :::
+
+### Add
+
+Appends the given value to the response header field as a **new field line**, leaving any existing lines untouched.
+
+This differs from [`Append`](#append), which folds values into a single comma-separated line: headers whose values may themselves contain commas — `WWW-Authenticate`, `Link` — have to be sent as separate lines to stay unambiguous (RFC 9110, Section 5.3).
+
+```go title="Signature"
+func (c fiber.Ctx) Add(key, val string)
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  c.Add(fiber.HeaderWWWAuthenticate, `Basic realm="api"`)
+  c.Add(fiber.HeaderWWWAuthenticate, `Bearer realm="api"`)
+  // => WWW-Authenticate: Basic realm="api"
+  // => WWW-Authenticate: Bearer realm="api"
+
+  return c.SendStatus(fiber.StatusUnauthorized)
+})
+```
 
 ### Append
 
@@ -2193,6 +2752,33 @@ app.Get("/", func(c fiber.Ctx) error {
   c.AutoFormat(user)
   // => <User><Name>John Doe</Name></User>
   // ..
+})
+```
+
+### Body (Res)
+
+Returns the response body buffered so far, which lets middleware inspect or checksum what a handler produced before it is written out.
+
+Reached through `c.Res()`: `Req` and `Res` both carry a `Body`, so `c.Body()` is the **request** body.
+
+:::caution
+The returned value is only valid within the handler and is invalidated by the next write to the response. Do not store any references; copy it instead.
+
+On a streamed response this drains the stream into a buffer to answer, which changes how the body is sent. Guard with [`Written`](#written) when the response may be a stream.
+:::
+
+```go title="Signature"
+func (r fiber.Res) Body() []byte
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  if err := c.Next(); err != nil {
+    return err
+  }
+
+  c.Set(fiber.HeaderETag, etag.Generate(c.Res().Body()))
+  return nil
 })
 ```
 
@@ -2313,6 +2899,57 @@ app.Get("/logout", func(c fiber.Ctx) error {
 })
 ```
 
+### ContentLength (Res)
+
+Returns the value of the `Content-Length` response header.
+
+Reached through `c.Res()`: `Req` and `Res` both carry a `ContentLength`, so `c.ContentLength()` is the **request** header.
+
+:::note
+It reports what the header declares, not what has been buffered: fasthttp fills `Content-Length` in as it serializes the response, so inside a handler this is `0` unless something set it explicitly, and `-1` once the body is a stream of unknown length. Use `len(c.Res().Body())` for the bytes buffered so far.
+:::
+
+```go title="Signature"
+func (r fiber.Res) ContentLength() int
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  if err := c.Next(); err != nil {
+    return err
+  }
+
+  log.Printf("declared %d bytes, buffered %d", c.Res().ContentLength(), len(c.Res().Body()))
+  return nil
+})
+```
+
+### ContentType
+
+Returns the `Content-Type` response header, parameters included. It is the read side of [`Type`](#type), and of the content type Fiber sets for you when a `JSON`, `XML`, or `SendFile` response goes out.
+
+:::note
+When nothing has set one it reports fasthttp's default, `text/plain; charset=utf-8`, which is what would be sent — not an empty string.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) ContentType() string
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  if err := c.Next(); err != nil {
+    return err
+  }
+
+  if strings.HasPrefix(c.ContentType(), fiber.MIMEApplicationJSON) {
+    c.Set("X-Content-Type-Options", "nosniff")
+  }
+
+  return nil
+})
+```
+
 ### Cookie
 
 Sets a cookie.
@@ -2376,6 +3013,53 @@ app.Get("/", func(c fiber.Ctx) error {
   // Set the cookie in the response
   c.Cookie(cookie)
   return c.SendString("Partitioned cookie set")
+})
+```
+
+### Cookies (Res)
+
+Returns a copy of every cookie this response is set to send, in the order they were added. It returns `nil` when none have been set.
+
+Reached through `c.Res()`: `Req` and `Res` both carry a `Cookies`, so `c.Cookies(key)` reads what the **client** sent.
+
+```go title="Signature"
+func (r fiber.Res) Cookies() []*fiber.Cookie
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  if err := c.Next(); err != nil {
+    return err
+  }
+
+  for _, cookie := range c.Res().Cookies() {
+    log.Printf("setting %s on %s", cookie.Name, cookie.Path)
+  }
+
+  return nil
+})
+```
+
+### Del
+
+Removes every field line of the response header specified by `key`. Field names are case-insensitive. Deleting a header that was never set is a no-op.
+
+:::caution
+`Del(fiber.HeaderSetCookie)` withdraws every cookie this response was going to set, which is not what [`ClearCookie`](#clearcookie) does: `ClearCookie` adds a `Set-Cookie` that expires the cookie already in the client's jar.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) Del(key string)
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  if err := c.Next(); err != nil {
+    return err
+  }
+
+  c.Del("X-Powered-By")
+  return nil
 })
 ```
 
@@ -2517,6 +3201,34 @@ app.Get("/default", func(c fiber.Ctx) error {
   }
 
   return c.Format(handlers...)
+})
+```
+
+### GetCookie
+
+Reads back a cookie this response is already set to send, so a later handler or middleware can inspect or re-emit what an earlier one wrote. The second result is `false` when no cookie of that name has been set.
+
+:::note
+The returned `Cookie` is a copy: changing it does not change the response. Pass it to [`Cookie`](#cookie) to write the change back.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) GetCookie(name string) (*fiber.Cookie, bool)
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  if err := c.Next(); err != nil {
+    return err
+  }
+
+  // Encrypt a session cookie an inner handler set, keeping its attributes.
+  if cookie, ok := c.GetCookie("session"); ok {
+    cookie.Value = encrypt(cookie.Value)
+    c.Cookie(cookie)
+  }
+
+  return nil
 })
 ```
 
@@ -2700,12 +3412,49 @@ app.Get("/msgpack", func(c fiber.Ctx) error {
 // 85 A4 74 79 70 65 D9 27 68 74 74 70 73 3A 2F 2F 65 78 61 6D 70 6C 65 2E 63 6F 6D 2F 70 72 6F 62 73 2F 6F 75 74 2D 6F 66 2D 63 72 65 64 69 74 A5 74 69 74 6C 65 BE 59 6F 75 20 64 6F 20 6E 6F 74 20 68 61 76 65 20 65 6E 6F 75 67 68 20 63 72 65 64 69 74 2E A6 73 74 61 74 75 73 CD 01 93 A6 64 65 74 61 69 6C D9 2E 59 6F 75 72 20 63 75 72 72 65 6E 74 20 62 61 6C 61 6E 63 65 20 69 73 20 33 30 2C 20 62 75 74 20 74 68 61 74 20 63 6F 73 74 73 20 35 30 2E A8 69 6E 73 74 61 6E 63 65 B7 2F 61 63 63 6F 75 6E 74 2F 31 32 33 34 35 2F 6D 73 67 73 2F 61 62 63
 ```
 
+### NoContent
+
+Replies `204 No Content`: it sets the status, discards any body already written, and drops the `Content-Type` a handler had set, since RFC 9110, Section 6.4.1 gives a `204` no content to describe.
+
+```go title="Signature"
+func (c fiber.Ctx) NoContent() error
+```
+
+```go title="Example"
+app.Delete("/item/:id", func(c fiber.Ctx) error {
+  if err := delete(c.Params("id")); err != nil {
+    return err
+  }
+
+  return c.NoContent() // => 204, no body
+})
+```
+
 ### Render
 
 Renders a view with data and sends a `text/html` response. By default, `Render` uses the default [**Go Template engine**](https://pkg.go.dev/html/template/). If you want to use another view engine, please take a look at our [**Template middleware**](https://docs.gofiber.io/template).
 
 ```go title="Signature"
 func (c fiber.Ctx) Render(name string, bind any, layouts ...string) error
+```
+
+### ResetBody
+
+Discards the response body, keeping the status and headers. Use it before replacing a partially written body — an error page over a half-rendered view, a cached body over a fresh one.
+
+```go title="Signature"
+func (c fiber.Ctx) ResetBody()
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  if err := c.Next(); err == nil {
+    return nil
+  }
+
+  c.ResetBody() // Drop whatever the handler managed to write.
+  return c.Status(fiber.StatusInternalServerError).SendString("something went wrong")
+})
 ```
 
 ### Send
@@ -3088,6 +3837,28 @@ app.Get("/world", func(c fiber.Ctx) error {
 })
 ```
 
+### StatusCode
+
+Returns the status code currently set on the response. It is the read side of [`Status`](#status), and reports `200` until something sets another code.
+
+Called after [`Next`](#next) it is the status the chain settled on, which is what logging, metrics, and caching middleware key off.
+
+```go title="Signature"
+func (c fiber.Ctx) StatusCode() int
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  err := c.Next()
+
+  if c.StatusCode() >= fiber.StatusInternalServerError {
+    alert(c.Route().Path, c.StatusCode())
+  }
+
+  return err
+})
+```
+
 ### Type
 
 Sets the [Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) HTTP header to the MIME type listed [in the Nginx MIME types configuration](https://github.com/nginx/nginx/blob/master/conf/mime.types) specified by the file **extension**.
@@ -3186,6 +3957,32 @@ func (c fiber.Ctx) WriteString(s string) (n int, err error)
 app.Get("/", func(c fiber.Ctx) error {
   return c.WriteString("Hello, World!")
   // => "Hello, World!"
+})
+```
+
+### Written
+
+Reports whether anything has been written to the response body yet, so middleware can tell a handler that produced a response from one that left it untouched. A streamed body counts as written without draining the stream.
+
+:::note
+Status and headers are not body writes: a handler that only called [`Status`](#status) leaves this `false`.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) Written() bool
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  if err := c.Next(); err != nil {
+    return err
+  }
+
+  if !c.Written() {
+    return c.NoContent()
+  }
+
+  return nil
 })
 ```
 

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -3107,6 +3107,27 @@ app.Get("/non-ascii", func(c fiber.Ctx) error {
 })
 ```
 
+### Drop
+
+Terminates the client connection silently without sending any HTTP headers or response body.
+
+This can be used for scenarios where you want to block certain requests without notifying the client, such as mitigating
+DDoS attacks or protecting sensitive endpoints from unauthorized access.
+
+```go title="Signature"
+func (c fiber.Ctx) Drop() error
+```
+
+```go title="Example"
+app.Get("/", func(c fiber.Ctx) error {
+  if c.IP() == "192.168.1.1" {
+    return c.Drop()
+  }
+
+  return c.SendString("Hello World!")
+})
+```
+
 ### End
 
 End immediately flushes the current response and closes the underlying connection.

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -1870,7 +1870,7 @@ app.Use(func(c fiber.Ctx) error {
 ### IsProxyTrusted
 
 Checks the trustworthiness of the remote IP.
-If [`TrustProxy`](fiber.md#trustproxy) is `false`, it returns `true`.
+If [`TrustProxy`](fiber.md#trustproxy) is `false`, it returns `false`.
 `IsProxyTrusted` can check the remote IP by proxy ranges and IP map.
 
 ```go title="Signature"

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -885,12 +885,17 @@ Methods which operate on the incoming request.
 Use `c.Req()` to limit gopls suggestions to only these methods!
 :::
 
+Each entry lists both forms it can be called in. `DefaultCtx` embeds `DefaultReq`, so the method is promoted: `c.UserAgent()` and `c.Req().UserAgent()` are the same call, and the second is what the `Req` interface exposes on its own.
+
+Four entries here are request-related but live on `Ctx` alone and so list only the `fiber.Ctx` form: [`ClientHelloInfo`](#clienthelloinfo), [`RequestID`](#requestid), [`SaveFile`](#savefile) and [`SaveFileToStorage`](#savefiletostorage).
+
 ### AcceptEncoding
 
 Returns the `Accept-Encoding` request header.
 
 ```go title="Signature"
 func (c fiber.Ctx) AcceptEncoding() string
+func (r fiber.Req) AcceptEncoding() string
 ```
 
 ```go title="Example"
@@ -906,6 +911,7 @@ Returns the `Accept-Language` request header.
 
 ```go title="Signature"
 func (c fiber.Ctx) AcceptLanguage() string
+func (r fiber.Req) AcceptLanguage() string
 ```
 
 ```go title="Example"
@@ -929,6 +935,11 @@ func (c fiber.Ctx) AcceptsCharsets(offers ...string) string
 func (c fiber.Ctx) AcceptsEncodings(offers ...string) string
 func (c fiber.Ctx) AcceptsLanguages(offers ...string) string
 func (c fiber.Ctx) AcceptsLanguagesExtended(offers ...string) string
+func (r fiber.Req) Accepts(offers ...string) string
+func (r fiber.Req) AcceptsCharsets(offers ...string) string
+func (r fiber.Req) AcceptsEncodings(offers ...string) string
+func (r fiber.Req) AcceptsLanguages(offers ...string) string
+func (r fiber.Req) AcceptsLanguagesExtended(offers ...string) string
 ```
 
 ```go title="Example"
@@ -1020,6 +1031,7 @@ Returns `true` when the `Accept` header allows `text/event-stream`.
 
 ```go title="Signature"
 func (c fiber.Ctx) AcceptsEventStream() bool
+func (r fiber.Req) AcceptsEventStream() bool
 ```
 
 ```go title="Example"
@@ -1037,6 +1049,7 @@ Returns `true` when the `Accept` header allows HTML.
 
 ```go title="Signature"
 func (c fiber.Ctx) AcceptsHTML() bool
+func (r fiber.Req) AcceptsHTML() bool
 ```
 
 ```go title="Example"
@@ -1054,6 +1067,7 @@ Returns `true` when the `Accept` header allows JSON.
 
 ```go title="Signature"
 func (c fiber.Ctx) AcceptsJSON() bool
+func (r fiber.Req) AcceptsJSON() bool
 ```
 
 ```go title="Example"
@@ -1071,6 +1085,7 @@ Returns `true` when the `Accept` header allows XML.
 
 ```go title="Signature"
 func (c fiber.Ctx) AcceptsXML() bool
+func (r fiber.Req) AcceptsXML() bool
 ```
 
 ```go title="Example"
@@ -1094,6 +1109,7 @@ The keys and values are copies rather than views into the request buffer, so the
 
 ```go title="Signature"
 func (c fiber.Ctx) AllCookies() map[string]string
+func (r fiber.Req) AllCookies() map[string]string
 ```
 
 ```go title="Example"
@@ -1117,6 +1133,7 @@ Returned values are only valid within the handler. Do not store any references: 
 
 ```go title="Signature"
 func (c fiber.Ctx) Authorization() (scheme, credentials string)
+func (r fiber.Req) Authorization() (scheme, credentials string)
 ```
 
 ```go title="Example"
@@ -1136,6 +1153,7 @@ Returns the base URL (**protocol** + **host**) as a `string`.
 
 ```go title="Signature"
 func (c fiber.Ctx) BaseURL() string
+func (r fiber.Req) BaseURL() string
 ```
 
 ```go title="Example"
@@ -1159,6 +1177,7 @@ Returned value is only valid within the handler. Do not store any references: it
 
 ```go title="Signature"
 func (c fiber.Ctx) Bearer() string
+func (r fiber.Req) Bearer() string
 ```
 
 ```go title="Example"
@@ -1179,6 +1198,7 @@ As per the header `Content-Encoding`, this method will try to perform a file dec
 
 ```go title="Signature"
 func (c fiber.Ctx) Body() []byte
+func (r fiber.Req) Body() []byte
 ```
 
 ```go title="Example"
@@ -1201,6 +1221,7 @@ Returns the raw request **body**.
 
 ```go title="Signature"
 func (c fiber.Ctx) BodyRaw() []byte
+func (r fiber.Req) BodyRaw() []byte
 ```
 
 ```go title="Example"
@@ -1227,6 +1248,7 @@ Reading from the returned reader consumes the body, so a later [`Body`](#body) c
 
 ```go title="Signature"
 func (c fiber.Ctx) BodyStream() io.Reader
+func (r fiber.Req) BodyStream() io.Reader
 ```
 
 ```go title="Example"
@@ -1253,6 +1275,7 @@ Returns the `charset` parameter from the `Content-Type` header.
 
 ```go title="Signature"
 func (c fiber.Ctx) Charset() string
+func (r fiber.Req) Charset() string
 ```
 
 ```go title="Example"
@@ -1293,6 +1316,7 @@ A negative result is **not a length**: `-1` is reported for a chunked body and `
 
 ```go title="Signature"
 func (c fiber.Ctx) ContentLength() int
+func (r fiber.Req) ContentLength() int
 ```
 
 ```go title="Example"
@@ -1319,6 +1343,7 @@ Returned value is only valid within the handler. Do not store any references. Ma
 
 ```go title="Signature"
 func (c fiber.Ctx) ContentType() string
+func (r fiber.Req) ContentType() string
 ```
 
 ```go title="Example"
@@ -1341,6 +1366,7 @@ Unlike [`Cookies`](#cookies), the returned strings are copies rather than views 
 
 ```go title="Signature"
 func (c fiber.Ctx) CookieNames() []string
+func (r fiber.Req) CookieNames() []string
 ```
 
 ```go title="Example"
@@ -1358,6 +1384,7 @@ Gets a cookie value by key. You can pass an optional default value that will be 
 
 ```go title="Signature"
 func (c fiber.Ctx) Cookies(key string, defaultValue ...string) string
+func (r fiber.Req) Cookies(key string, defaultValue ...string) string
 ```
 
 ```go title="Example"
@@ -1380,6 +1407,7 @@ MultipartForm files can be retrieved by name, the **first** file from the given 
 
 ```go title="Signature"
 func (c fiber.Ctx) FormFile(key string) (*multipart.FileHeader, error)
+func (r fiber.Req) FormFile(key string) (*multipart.FileHeader, error)
 ```
 
 ```go title="Example"
@@ -1407,6 +1435,7 @@ change during the call. Copy it first if you need it to outlive one.
 
 ```go title="Signature"
 func (c fiber.Ctx) FormValue(key string, defaultValue ...string) string
+func (r fiber.Req) FormValue(key string, defaultValue ...string) string
 ```
 
 ```go title="Example"
@@ -1438,6 +1467,7 @@ Read more on [https://expressjs.com/en/4x/api.html\#req.fresh](https://expressjs
 
 ```go title="Signature"
 func (c fiber.Ctx) Fresh() bool
+func (r fiber.Req) Fresh() bool
 ```
 
 ### FullURL
@@ -1446,6 +1476,7 @@ Returns the full request URL (protocol + host + original URL).
 
 ```go title="Signature"
 func (c fiber.Ctx) FullURL() string
+func (r fiber.Req) FullURL() string
 ```
 
 ```go title="Example"
@@ -1467,6 +1498,7 @@ The match is **case-insensitive**.
 
 ```go title="Signature"
 func (c fiber.Ctx) Get(key string, defaultValue ...string) string
+func (r fiber.Req) Get(key string, defaultValue ...string) string
 ```
 
 ```go title="Example"
@@ -1499,6 +1531,7 @@ Returned values are only valid within the handler. Do not store any references. 
 
 ```go title="Signature"
 func (c fiber.Ctx) GetAll(key string) []string
+func (r fiber.Req) GetAll(key string) []string
 ```
 
 ```go title="Example"
@@ -1518,6 +1551,7 @@ Returns `true` if the incoming request contains a body or a `Content-Length` hea
 
 ```go title="Signature"
 func (c fiber.Ctx) HasBody() bool
+func (r fiber.Req) HasBody() bool
 ```
 
 ```go title="Example"
@@ -1535,6 +1569,7 @@ Reports whether the request includes a header with the given key.
 
 ```go title="Signature"
 func (c fiber.Ctx) HasHeader(key string) bool
+func (r fiber.Req) HasHeader(key string) bool
 ```
 
 ```go title="Example"
@@ -1552,6 +1587,7 @@ In a network context, [`Host`](#host) refers to the combination of a hostname an
 
 ```go title="Signature"
 func (c fiber.Ctx) Host() string
+func (r fiber.Req) Host() string
 ```
 
 ```go title="Example"
@@ -1576,6 +1612,7 @@ Returns the hostname derived from the [Host](https://developer.mozilla.org/en-US
 
 ```go title="Signature"
 func (c fiber.Ctx) Hostname() string
+func (r fiber.Req) Hostname() string
 ```
 
 ```go title="Example"
@@ -1599,6 +1636,7 @@ Returns the time carried by the `If-Modified-Since` request header. It returns `
 
 ```go title="Signature"
 func (c fiber.Ctx) IfModifiedSince() (time.Time, error)
+func (r fiber.Req) IfModifiedSince() (time.Time, error)
 ```
 
 ```go title="Example"
@@ -1629,6 +1667,7 @@ Returned values are only valid within the handler. Do not store any references.
 
 ```go title="Signature"
 func (c fiber.Ctx) IfNoneMatch() []string
+func (r fiber.Req) IfNoneMatch() []string
 ```
 
 ```go title="Example"
@@ -1646,6 +1685,7 @@ Returns the remote IP address of the request.
 
 ```go title="Signature"
 func (c fiber.Ctx) IP() string
+func (r fiber.Req) IP() string
 ```
 
 ```go title="Example"
@@ -1705,6 +1745,7 @@ Returns an array of IP addresses specified in the [X-Forwarded-For](https://deve
 
 ```go title="Signature"
 func (c fiber.Ctx) IPs() []string
+func (r fiber.Req) IPs() []string
 ```
 
 ```go title="Example"
@@ -1731,6 +1772,7 @@ If the request has **no** body, it returns **false**.
 
 ```go title="Signature"
 func (c fiber.Ctx) Is(extension string) bool
+func (r fiber.Req) Is(extension string) bool
 ```
 
 ```go title="Example"
@@ -1751,6 +1793,7 @@ Reports whether the `Content-Type` header is form-encoded.
 
 ```go title="Signature"
 func (c fiber.Ctx) IsForm() bool
+func (r fiber.Req) IsForm() bool
 ```
 
 ```go title="Example"
@@ -1768,6 +1811,7 @@ Returns `true` if the request came from localhost.
 
 ```go title="Signature"
 func (c fiber.Ctx) IsFromLocal() bool
+func (r fiber.Req) IsFromLocal() bool
 ```
 
 ```go title="Example"
@@ -1785,6 +1829,7 @@ Returns `true` if the request came in over a Unix domain socket.
 
 ```go title="Signature"
 func (c fiber.Ctx) IsFromUnixSocket() bool
+func (r fiber.Req) IsFromUnixSocket() bool
 ```
 
 ```go title="Example"
@@ -1802,6 +1847,7 @@ Reports whether the request method is idempotent, meaning repeating it has the s
 
 ```go title="Signature"
 func (c fiber.Ctx) IsIdempotent() bool
+func (r fiber.Req) IsIdempotent() bool
 ```
 
 ```go title="Example"
@@ -1822,6 +1868,7 @@ Reports whether the `Content-Type` header is JSON.
 
 ```go title="Signature"
 func (c fiber.Ctx) IsJSON() bool
+func (r fiber.Req) IsJSON() bool
 ```
 
 ```go title="Example"
@@ -1839,6 +1886,7 @@ Reports whether the `Content-Type` header is multipart form data.
 
 ```go title="Signature"
 func (c fiber.Ctx) IsMultipart() bool
+func (r fiber.Req) IsMultipart() bool
 ```
 
 ```go title="Example"
@@ -1856,6 +1904,7 @@ Returns `true` if the request is a CORS preflight (`OPTIONS` + `Access-Control-R
 
 ```go title="Signature"
 func (c fiber.Ctx) IsPreflight() bool
+func (r fiber.Req) IsPreflight() bool
 ```
 
 ```go title="Example"
@@ -1875,6 +1924,7 @@ If [`TrustProxy`](fiber.md#trustproxy) is `false`, it returns `false`.
 
 ```go title="Signature"
 func (c fiber.Ctx) IsProxyTrusted() bool
+func (r fiber.Req) IsProxyTrusted() bool
 ```
 
 ```go title="Example"
@@ -1904,6 +1954,7 @@ Reports whether the request method is safe, meaning it is not expected to change
 
 ```go title="Signature"
 func (c fiber.Ctx) IsSafe() bool
+func (r fiber.Req) IsSafe() bool
 ```
 
 ```go title="Example"
@@ -1924,6 +1975,7 @@ Returns `true` if the request includes a WebSocket upgrade handshake.
 
 ```go title="Signature"
 func (c fiber.Ctx) IsWebSocket() bool
+func (r fiber.Req) IsWebSocket() bool
 ```
 
 ```go title="Example"
@@ -1941,6 +1993,7 @@ Returns the MIME type from the `Content-Type` header without parameters.
 
 ```go title="Signature"
 func (c fiber.Ctx) MediaType() string
+func (r fiber.Req) MediaType() string
 ```
 
 ```go title="Example"
@@ -1965,6 +2018,7 @@ Route registration (`app.Get`, `app.Add`, …) uppercases method names before va
 
 ```go title="Signature"
 func (c fiber.Ctx) Method(override ...string) string
+func (r fiber.Req) Method(override ...string) string
 ```
 
 ```go title="Example"
@@ -1993,6 +2047,7 @@ change during the call. Copy it first if you need it to outlive one.
 
 ```go title="Signature"
 func (c fiber.Ctx) MultipartForm() (*multipart.Form, error)
+func (r fiber.Req) MultipartForm() (*multipart.Form, error)
 ```
 
 ```go title="Example"
@@ -2036,6 +2091,7 @@ Returned value is only valid within the handler. Do not store any references. Ma
 
 ```go title="Signature"
 func (c fiber.Ctx) Origin() string
+func (r fiber.Req) Origin() string
 ```
 
 ```go title="Example"
@@ -2053,6 +2109,7 @@ Returns the original request URL.
 
 ```go title="Signature"
 func (c fiber.Ctx) OriginalURL() string
+func (r fiber.Req) OriginalURL() string
 ```
 
 ```go title="Example"
@@ -2080,6 +2137,7 @@ Defaults to an empty string \(`""`\) if the param **doesn't** exist.
 
 ```go title="Signature"
 func (c fiber.Ctx) Params(key string, defaultValue ...string) string
+func (r fiber.Req) Params(key string, defaultValue ...string) string
 ```
 
 ```go title="Example"
@@ -2154,6 +2212,7 @@ Contains the path part of the request URL. Optionally, you can override the path
 
 ```go title="Signature"
 func (c fiber.Ctx) Path(override ...string) string
+func (r fiber.Req) Path(override ...string) string
 ```
 
 ```go title="Example"
@@ -2175,6 +2234,7 @@ Returns the remote port of the request.
 
 ```go title="Signature"
 func (c fiber.Ctx) Port() string
+func (r fiber.Req) Port() string
 ```
 
 ```go title="Example"
@@ -2197,6 +2257,7 @@ To get the request scheme (`http` or `https`), use [`Scheme`](#scheme) instead.
 
 ```go title="Signature"
 func (c fiber.Ctx) Protocol() string
+func (r fiber.Req) Protocol() string
 ```
 
 ```go title="Example"
@@ -2215,6 +2276,7 @@ app.Get("/", func(c fiber.Ctx) error {
 
 ```go title="Signature"
 func (c fiber.Ctx) Queries() map[string]string
+func (r fiber.Req) Queries() map[string]string
 ```
 
 ```go title="Example"
@@ -2283,6 +2345,7 @@ If there is **no** query string, it returns an **empty string**.
 
 ```go title="Signature"
 func (c fiber.Ctx) Query(key string, defaultValue ...string) string
+func (r fiber.Req) Query(key string, defaultValue ...string) string
 ```
 
 ```go title="Example"
@@ -2355,6 +2418,7 @@ populates the `Content-Range` header with the current representation size.
 
 ```go title="Signature"
 func (c fiber.Ctx) Range(size int64) (Range, error)
+func (r fiber.Req) Range(size int64) (Range, error)
 ```
 
 ```go title="Example"
@@ -2376,6 +2440,7 @@ Returns the `Referer` request header.
 
 ```go title="Signature"
 func (c fiber.Ctx) Referer() string
+func (r fiber.Req) Referer() string
 ```
 
 ```go title="Example"
@@ -2489,6 +2554,7 @@ scheme the client used to reach it.
 
 ```go title="Signature"
 func (c fiber.Ctx) Scheme() string
+func (r fiber.Req) Scheme() string
 ```
 
 ```go title="Example"
@@ -2507,6 +2573,7 @@ A boolean property that is `true` if a **TLS** connection is established.
 
 ```go title="Signature"
 func (c fiber.Ctx) Secure() bool
+func (r fiber.Req) Secure() bool
 ```
 
 ```go title="Example"
@@ -2524,6 +2591,7 @@ representation is still valid.
 
 ```go title="Signature"
 func (c fiber.Ctx) Stale() bool
+func (r fiber.Req) Stale() bool
 ```
 
 ### Subdomains
@@ -2569,6 +2637,7 @@ The returned value is owned by the request and is rewritten by a [`Path`](#path)
 
 ```go title="Signature"
 func (c fiber.Ctx) URI() *fasthttp.URI
+func (r fiber.Req) URI() *fasthttp.URI
 ```
 
 ```go title="Example"
@@ -2588,6 +2657,7 @@ Returns the `User-Agent` request header.
 
 ```go title="Signature"
 func (c fiber.Ctx) UserAgent() string
+func (r fiber.Req) UserAgent() string
 ```
 
 ```go title="Example"
@@ -2603,6 +2673,7 @@ A boolean property that is `true` if the request’s [X-Requested-With](https://
 
 ```go title="Signature"
 func (c fiber.Ctx) XHR() bool
+func (r fiber.Req) XHR() bool
 ```
 
 ```go title="Example"
@@ -2623,6 +2694,12 @@ Methods which modify the response object.
 Use `c.Res()` to limit gopls suggestions to only these methods!
 :::
 
+Each entry lists both forms it can be called in. `DefaultCtx` embeds `DefaultRes`, so the method is promoted: `c.Del(key)` and `c.Res().Del(key)` are the same call.
+
+:::caution
+Four names are defined on both `Req` and `Res`: `Body`, `ContentLength`, `ContentType` and `Cookies`. On `Ctx` the **request wins**, the way [`Get`](#get) already does, so `c.Body()` reads the request body. The response counterparts are listed below as [`Body (Res)`](#body-res), [`ContentLength (Res)`](#contentlength-res), [`ContentType (Res)`](#contenttype-res) and [`Cookies (Res)`](#cookies-res), and are reachable only through `c.Res()` — which is why they list a single `fiber.Res` signature.
+:::
+
 ### Add
 
 Appends the given value to the response header field as a **new field line**, leaving any existing lines untouched.
@@ -2635,6 +2712,7 @@ The headers fasthttp stores in a slot of their own cannot repeat, and `Add` does
 
 ```go title="Signature"
 func (c fiber.Ctx) Add(key, val string)
+func (r fiber.Res) Add(key, val string)
 ```
 
 ```go title="Example"
@@ -2660,6 +2738,7 @@ Empty values are skipped, since a sender must not generate empty list elements (
 
 ```go title="Signature"
 func (c fiber.Ctx) Append(field string, values ...string)
+func (r fiber.Res) Append(field string, values ...string)
 ```
 
 ```go title="Example"
@@ -2680,6 +2759,7 @@ Sets the HTTP response [Content-Disposition](https://developer.mozilla.org/en-US
 
 ```go title="Signature"
 func (c fiber.Ctx) Attachment(filename ...string)
+func (r fiber.Res) Attachment(filename ...string)
 ```
 
 ```go title="Example"
@@ -2723,6 +2803,7 @@ If the header is **not** specified or there is **no** proper format, **text/plai
 
 ```go title="Signature"
 func (c fiber.Ctx) AutoFormat(body any) error
+func (r fiber.Res) AutoFormat(body any) error
 ```
 
 ```go title="Example"
@@ -2800,6 +2881,7 @@ CBOR also sets the content header to the `ctype` parameter. If no `ctype` is pas
 
 ```go title="Signature"
 func (c fiber.Ctx) CBOR(data any, ctype ...string) error
+func (r fiber.Res) CBOR(data any, ctype ...string) error
 ```
 
 ```go title="Example"
@@ -2844,6 +2926,7 @@ Expires a client cookie (or all cookies if left empty).
 
 ```go title="Signature"
 func (c fiber.Ctx) ClearCookie(key ...string)
+func (r fiber.Res) ClearCookie(key ...string)
 ```
 
 ```go title="Example"
@@ -2964,6 +3047,7 @@ Sets a cookie.
 
 ```go title="Signature"
 func (c fiber.Ctx) Cookie(cookie *Cookie)
+func (r fiber.Res) Cookie(cookie *Cookie)
 ```
 
 ```go
@@ -3060,6 +3144,7 @@ Removes every field line of the response header specified by `key`. Field names 
 
 ```go title="Signature"
 func (c fiber.Ctx) Del(key string)
+func (r fiber.Res) Del(key string)
 ```
 
 ```go title="Example"
@@ -3082,6 +3167,7 @@ Override this default with the `filename` parameter.
 
 ```go title="Signature"
 func (c fiber.Ctx) Download(file string, filename ...string) error
+func (r fiber.Res) Download(file string, filename ...string) error
 ```
 
 ```go title="Example"
@@ -3116,6 +3202,7 @@ DDoS attacks or protecting sensitive endpoints from unauthorized access.
 
 ```go title="Signature"
 func (c fiber.Ctx) Drop() error
+func (r fiber.Res) Drop() error
 ```
 
 ```go title="Example"
@@ -3134,6 +3221,7 @@ End immediately flushes the current response and closes the underlying connectio
 
 ```go title="Signature"
 func (c fiber.Ctx) End() error
+func (r fiber.Res) End() error
 ```
 
 ```go title="Example"
@@ -3192,6 +3280,7 @@ If the Accept header is **not** specified, the first handler with a real media t
 
 ```go title="Signature"
 func (c fiber.Ctx) Format(handlers ...ResFmt) error
+func (r fiber.Res) Format(handlers ...ResFmt) error
 ```
 
 ```go title="Example"
@@ -3251,6 +3340,7 @@ A `Set-Cookie` that carried no `Path` comes back with `Path` empty, and [`Cookie
 
 ```go title="Signature"
 func (c fiber.Ctx) GetCookie(name string) (*fiber.Cookie, bool)
+func (r fiber.Res) GetCookie(name string) (*fiber.Cookie, bool)
 ```
 
 ```go title="Example"
@@ -3279,6 +3369,7 @@ JSON also sets the content header to the `ctype` parameter. If no `ctype` is pas
 
 ```go title="Signature"
 func (c fiber.Ctx) JSON(data any, ctype ...string) error
+func (r fiber.Res) JSON(data any, ctype ...string) error
 ```
 
 ```go title="Example"
@@ -3333,6 +3424,7 @@ The callback name is reduced to a JavaScript member expression: every character 
 
 ```go title="Signature"
 func (c fiber.Ctx) JSONP(data any, callback ...string) error
+func (r fiber.Res) JSONP(data any, callback ...string) error
 ```
 
 ```go title="Example"
@@ -3363,6 +3455,7 @@ Quotes and backslashes in the `rel` value are escaped so the emitted quoted-stri
 
 ```go title="Signature"
 func (c fiber.Ctx) Links(link ...string)
+func (r fiber.Res) Links(link ...string)
 ```
 
 ```go title="Example"
@@ -3384,6 +3477,7 @@ Sets the response [Location](https://developer.mozilla.org/en-US/docs/Web/HTTP/H
 
 ```go title="Signature"
 func (c fiber.Ctx) Location(path string)
+func (r fiber.Res) Location(path string)
 ```
 
 ```go title="Example"
@@ -3410,6 +3504,7 @@ MsgPack also sets the content header to the `ctype` parameter. If no `ctype` is 
 
 ```go title="Signature"
 func (c fiber.Ctx) MsgPack(data any, ctype ...string) error
+func (r fiber.Res) MsgPack(data any, ctype ...string) error
 ```
 
 ```go title="Example"
@@ -3459,6 +3554,7 @@ Replies `204 No Content`. [`SendStatus`](#sendstatus) already discards the body 
 
 ```go title="Signature"
 func (c fiber.Ctx) NoContent() error
+func (r fiber.Res) NoContent() error
 ```
 
 ```go title="Example"
@@ -3477,6 +3573,7 @@ Renders a view with data and sends a `text/html` response. By default, `Render` 
 
 ```go title="Signature"
 func (c fiber.Ctx) Render(name string, bind any, layouts ...string) error
+func (r fiber.Res) Render(name string, bind any, layouts ...string) error
 ```
 
 ### ResetBody
@@ -3485,6 +3582,7 @@ Discards the response body, keeping the status and headers. Use it before replac
 
 ```go title="Signature"
 func (c fiber.Ctx) ResetBody()
+func (r fiber.Res) ResetBody()
 ```
 
 ```go title="Example"
@@ -3504,6 +3602,7 @@ Sets the HTTP response body.
 
 ```go title="Signature"
 func (c fiber.Ctx) Send(body []byte) error
+func (r fiber.Res) Send(body []byte) error
 ```
 
 ```go title="Example"
@@ -3521,6 +3620,8 @@ Use this if you **don't need** type assertion, recommended for **faster** perfor
 ```go title="Signature"
 func (c fiber.Ctx) SendString(body string) error
 func (c fiber.Ctx) SendStream(stream io.Reader, size ...int) error
+func (r fiber.Res) SendString(body string) error
+func (r fiber.Res) SendStream(stream io.Reader, size ...int) error
 ```
 
 ```go title="Example"
@@ -3559,6 +3660,7 @@ still delivered on the final response.
 
 ```go title="Signature"
 func (c fiber.Ctx) SendEarlyHints(hints []string) error
+func (r fiber.Res) SendEarlyHints(hints []string) error
 ```
 
 ```go title="Example"
@@ -3618,6 +3720,7 @@ type SendFile struct {
 
 ```go title="Signature" title="Signature"
 func (c fiber.Ctx) SendFile(file string, config ...SendFile) error
+func (r fiber.Res) SendFile(file string, config ...SendFile) error
 ```
 
 ```go title="Example"
@@ -3695,6 +3798,7 @@ You can find all used status codes and messages [in the Fiber source code](https
 
 ```go title="Signature"
 func (c fiber.Ctx) SendStatus(status int) error
+func (r fiber.Res) SendStatus(status int) error
 ```
 
 ```go title="Example"
@@ -3714,6 +3818,7 @@ Sets the response body to a stream of data and adds an optional body size.
 
 ```go title="Signature"
 func (c fiber.Ctx) SendStream(stream io.Reader, size ...int) error
+func (r fiber.Res) SendStream(stream io.Reader, size ...int) error
 ```
 
 :::info
@@ -3769,7 +3874,8 @@ the response body using a buffered stream writer.
 :::
 
 ```go title="Signature"
-func (c Ctx) SendStreamWriter(streamWriter func(*bufio.Writer)) error
+func (c fiber.Ctx) SendStreamWriter(streamWriter func(*bufio.Writer)) error
+func (r fiber.Res) SendStreamWriter(streamWriter func(*bufio.Writer)) error
 ```
 
 ```go title="Example"
@@ -3825,6 +3931,7 @@ Sets the response body to a string.
 
 ```go title="Signature"
 func (c fiber.Ctx) SendString(body string) error
+func (r fiber.Res) SendString(body string) error
 ```
 
 ```go title="Example"
@@ -3840,6 +3947,7 @@ Sets the response’s HTTP header field to the specified `key`, `value`.
 
 ```go title="Signature"
 func (c fiber.Ctx) Set(key string, val string)
+func (r fiber.Res) Set(key string, val string)
 ```
 
 ```go title="Example"
@@ -3861,6 +3969,7 @@ This method is **chainable**.
 
 ```go title="Signature"
 func (c fiber.Ctx) Status(status int) fiber.Ctx
+func (r fiber.Res) Status(status int) fiber.Ctx
 ```
 
 ```go title="Example"
@@ -3886,6 +3995,7 @@ Called after [`Next`](#next) it is the status the chain settled on, which is wha
 
 ```go title="Signature"
 func (c fiber.Ctx) StatusCode() int
+func (r fiber.Res) StatusCode() int
 ```
 
 ```go title="Example"
@@ -3910,6 +4020,7 @@ This method is **chainable**.
 
 ```go title="Signature"
 func (c fiber.Ctx) Type(ext string, charset ...string) fiber.Ctx
+func (r fiber.Res) Type(ext string, charset ...string) fiber.Ctx
 ```
 
 ```go title="Example"
@@ -3934,6 +4045,7 @@ Multiple fields are **allowed**. Per RFC 9110, the wildcard `"*"` is only meanin
 
 ```go title="Signature"
 func (c fiber.Ctx) Vary(fields ...string)
+func (r fiber.Res) Vary(fields ...string)
 ```
 
 ```go title="Example"
@@ -3959,6 +4071,7 @@ Adopts the `Writer` interface.
 
 ```go title="Signature"
 func (c fiber.Ctx) Write(p []byte) (n int, err error)
+func (r fiber.Res) Write(p []byte) (n int, err error)
 ```
 
 ```go title="Example"
@@ -3975,6 +4088,7 @@ Writes a formatted string using a format specifier.
 
 ```go title="Signature"
 func (c fiber.Ctx) Writef(format string, a ...any) (n int, err error)
+func (r fiber.Res) Writef(format string, a ...any) (n int, err error)
 ```
 
 ```go title="Example"
@@ -3992,6 +4106,7 @@ Writes a string to the response body.
 
 ```go title="Signature"
 func (c fiber.Ctx) WriteString(s string) (n int, err error)
+func (r fiber.Res) WriteString(s string) (n int, err error)
 ```
 
 ```go title="Example"
@@ -4011,6 +4126,7 @@ Status and headers are not body writes: a handler that only called [`Status`](#s
 
 ```go title="Signature"
 func (c fiber.Ctx) Written() bool
+func (r fiber.Res) Written() bool
 ```
 
 ```go title="Example"
@@ -4037,6 +4153,7 @@ XML also sets the content header to `application/xml; charset=utf-8`.
 
 ```go title="Signature"
 func (c fiber.Ctx) XML(data any) error
+func (r fiber.Res) XML(data any) error
 ```
 
 ```go title="Example"

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -146,56 +146,6 @@ app.Get("/", func(c fiber.Ctx) error {
 })
 ```
 
-### Copy
-
-Returns a detached snapshot of the context that stays valid after the handler returns.
-
-A live `Ctx` is pooled and its request buffers are handed to the next request on the connection, so reading one from a goroutine that outlives the handler returns whatever arrived next. `Copy` deep-copies the request, the path buffers and the route parameters into a context that is never pooled, so the goroutine sees the request the handler saw. `Locals` come across as they are: the entries are copied, the values in them are shared.
-
-:::caution
-A request body that is still a stream is not copied; read it, or call [`Body`](#body), on the original first.
-
-The copy is for reading otherwise. Its response is a detached buffer that never reaches the client, and it is always a `*DefaultCtx` even under a custom `Ctx`: writing to it, or driving the chain again with `Next` or `RestartRouting`, changes nothing the client will see. It does not observe the request's cancellation either — take `Context()` from the original before the handler returns when the goroutine needs that.
-:::
-
-```go title="Signature"
-func (c fiber.Ctx) Copy() fiber.Ctx
-```
-
-```go title="Example"
-app.Post("/orders/:id", func(c fiber.Ctx) error {
-  snapshot := c.Copy()
-
-  go func() {
-    // Still the request this handler saw, long after it returned.
-    audit(snapshot.Params("id"), snapshot.IP(), snapshot.Get(fiber.HeaderUserAgent))
-  }()
-
-  return c.SendStatus(fiber.StatusAccepted)
-})
-```
-
-### Drop
-
-Terminates the client connection silently without sending any HTTP headers or response body.
-
-This can be used for scenarios where you want to block certain requests without notifying the client, such as mitigating
-DDoS attacks or protecting sensitive endpoints from unauthorized access.
-
-```go title="Signature"
-func (c fiber.Ctx) Drop() error
-```
-
-```go title="Example"
-app.Get("/", func(c fiber.Ctx) error {
-  if c.IP() == "192.168.1.1" {
-    return c.Drop()
-  }
-
-  return c.SendString("Hello World!")
-})
-```
-
 ### Elapsed
 
 Returns how long this request has been handled so far, measured from [`StartTime`](#starttime). Called after the handler chain has run, it is the request latency.
@@ -454,7 +404,11 @@ app.Use(func(c fiber.Ctx) error {
 
 ### IsFinal
 
-Returns `true` if the current request handler is the last one in the chain, meaning nothing runs after it returns. It is the complement of [`IsMiddleware`](#ismiddleware), and `false` when no route matched at all.
+Returns `true` if no further handler of the **current route** runs after this one. It is the exact complement of [`IsMiddleware`](#ismiddleware), and `false` when no route matched at all.
+
+:::caution
+This describes the route, not the whole request. A route registered with `Use` is never final even when it is the last thing that runs, and another route can still match after a final handler calls [`Next`](#next) — a specific path followed by a catch-all is the ordinary case. Use it to tell an endpoint handler from a middleware one, not to decide that the response is finished.
+:::
 
 ```go title="Signature"
 func (c fiber.Ctx) IsFinal() bool
@@ -591,7 +545,11 @@ Returns the prefix the sub-app owning the current route was mounted under, or an
 Fiber mounts by cloning a sub-app's routes into the app that serves them with the prefix already baked in, so [`Path`](#path) inside a mounted handler is the whole requested path, not one relative to the mount. `MountPath` is what tells such a handler which prefix it is living under, to build links back into its own app or to strip the prefix itself.
 
 :::note
-It answers from the route that is running, unlike [`App.MountPath`](./app.md#mountpath), which only ever describes the app it is called on.
+It answers from the route that is running, unlike [`App.MountPath`](./app.md#mountpath), which describes the app it is called on however that app is being served — a sub-app that is mounted *and* listened on directly reports its mount prefix there even for its own traffic, where this reports `""`.
+:::
+
+:::caution
+The prefix is the owning app's, so mounting one `*fiber.App` at two prefixes reports the one it was mounted at last — the same limitation `App.MountPath` has, since that is where the prefix is recorded. Mount separate instances when each needs to know its own prefix.
 :::
 
 ```go title="Signature"
@@ -1126,10 +1084,12 @@ app.Get("/", func(c fiber.Ctx) error {
 
 ### AllCookies
 
-Returns the cookies sent with the request as a name/value map. When the client repeats a name the last value wins; use [`CookieNames`](#cookienames) to detect that case.
+Returns the cookies sent with the request as a name/value map, or `nil` when the client sent none.
 
-:::caution
-Returned values are only valid within the handler. Do not store any references. Make copies or use the [**`Immutable`**](./fiber.md#config) setting to use the values outside the handler.
+A repeated name resolves to its **first** occurrence, which is the one [`Cookies`](#cookies) answers with too. The two have to agree: a client can shadow a cookie by sending the name twice, and code that validated one value while consuming the other would validate the wrong one. Use [`CookieNames`](#cookienames) to see that a name was repeated at all.
+
+:::note
+The keys and values are copies rather than views into the request buffer, so they stay valid past the handler. fasthttp rewrites those bytes in place when a handler edits a request cookie, which would not merely stale the map but rehash it into one whose own keys no longer find their entries.
 :::
 
 ```go title="Signature"
@@ -1151,6 +1111,8 @@ Splits the `Authorization` request header into its auth-scheme and the credentia
 
 :::caution
 The credentials are returned verbatim — `token68` or an `auth-param` list — and are neither decoded nor validated.
+
+Returned values are only valid within the handler. Do not store any references: they view the request buffer, which the next request on the connection overwrites, so a credential cached past the handler silently becomes another request's. Make copies or use the [**`Immutable`**](./fiber.md#config) setting instead.
 :::
 
 ```go title="Signature"
@@ -1191,6 +1153,8 @@ Returns the credentials of a `Bearer` `Authorization` header (RFC 6750, Section 
 
 :::caution
 The token is returned verbatim: it is not validated, decoded, or verified, so it still has to be authenticated before it is trusted. Use the [keyauth](../middleware/keyauth.md) middleware when you want that done for you.
+
+Returned value is only valid within the handler. Do not store any references: it views the request buffer, which the next request on the connection overwrites, so a token cached past the handler — or used as a key in a shared map — silently becomes another request's.
 :::
 
 ```go title="Signature"
@@ -1321,7 +1285,7 @@ app.Get("/hello", func(c fiber.Ctx) error {
 
 Returns the value of the `Content-Length` request header.
 
-A negative result means the length is not known up front rather than that the body is empty: `-1` is reported for a chunked body and `-2` for one terminated by closing the connection. Use [`HasBody`](#hasbody) to test only for the presence of a body.
+A negative result is **not a length**: `-1` is reported for a chunked body and `-2` for `Transfer-Encoding: identity`, which is also what an ordinary `GET` with no body reports. So `-2`, not `0`, is the common case for a bodyless request — use [`HasBody`](#hasbody) to test whether there is a body at all, and read this only to find out how large a declared one is.
 
 :::note
 `Req` and `Res` both carry a `ContentLength`, so on `Ctx` the request wins, as it does for [`Get`](#get). Use `c.Res().ContentLength()` for the length of the response.
@@ -1341,12 +1305,38 @@ app.Post("/", func(c fiber.Ctx) error {
 })
 ```
 
-### CookieNames
+### ContentType
 
-Returns the names of the cookies sent with the request, in the order they appear in the `Cookie` header. A name repeated by the client is returned once per occurrence.
+Returns the `Content-Type` request header, parameters included. [`MediaType`](#mediatype) returns the same header with the parameters stripped, and [`Charset`](#charset) returns just the charset one.
+
+:::note
+`Req` and `Res` both carry a `ContentType`, so on `Ctx` the request wins, as it does for [`Get`](#get). Use `c.Res().ContentType()` for the type the response will send.
+:::
 
 :::caution
-Returned values are only valid within the handler. Do not store any references. Make copies or use the [**`Immutable`**](./fiber.md#config) setting to use the values outside the handler.
+Returned value is only valid within the handler. Do not store any references. Make copies or use the [**`Immutable`**](./fiber.md#config) setting to use the value outside the handler.
+:::
+
+```go title="Signature"
+func (c fiber.Ctx) ContentType() string
+```
+
+```go title="Example"
+app.Post("/", func(c fiber.Ctx) error {
+  // Content-Type: application/json; charset=utf-8
+  c.ContentType() // => "application/json; charset=utf-8"
+  c.MediaType()   // => "application/json"
+
+  // ...
+})
+```
+
+### CookieNames
+
+Returns the names of the cookies sent with the request, in the order they appear in the `Cookie` header, or `nil` when the client sent none. A name the client repeated is returned once per occurrence, which is how a caller detects the shadowing [`AllCookies`](#allcookies) collapses.
+
+:::note
+Unlike [`Cookies`](#cookies), the returned strings are copies rather than views into the request buffer, so they stay valid past the handler.
 :::
 
 ```go title="Signature"
@@ -1497,7 +1487,11 @@ Make copies or use the [**`Immutable`**](./fiber.md#immutable) setting instead. 
 
 Returns every field line of the request header specified by `key`. Field names are case-insensitive.
 
-A header repeated across field lines is semantically one comma-joined list (RFC 9110, Section 5.2). `GetAll` keeps the lines apart so a caller can inspect them individually, where [`Get`](#get) returns only the first and [`GetReqHeaders`](#getreqheaders) builds a map of the whole header block.
+A header repeated across field lines is semantically one comma-joined list (RFC 9110, Section 5.2). `GetAll` keeps the lines apart so a caller can inspect them individually, where [`Get`](#get) returns only the first and [`GetReqHeaders`](#getreqheaders) builds a map of the whole header block. It returns `nil` when the header is absent.
+
+:::note
+Empty field lines are skipped, so `len(c.GetAll(k)) > 0` answers the same question as [`HasHeader`](#hasheader). Without that, the headers fasthttp keeps in a slot of their own (`Content-Length`, `Trailer`) report one empty line when they are not present at all.
+:::
 
 :::caution
 Returned values are only valid within the handler. Do not store any references. Make copies or use the [**`Immutable`**](./fiber.md#config) setting instead.
@@ -1628,7 +1622,9 @@ app.Get("/report", func(c fiber.Ctx) error {
 Returns the entity tags listed in the `If-None-Match` request header. Repeated field lines are combined into one list (RFC 9110, Section 5.2), and a comma inside a quoted opaque-tag does not split it, so `"v1,v2"` stays one tag. A wildcard header returns a single `*` element.
 
 :::note
-Tags are returned verbatim, weak `W/` prefix included, and are not validated. [`Fresh`](#fresh) already applies these tags to the response `ETag`; reach for this only to implement a comparison of your own.
+Tags are returned verbatim, weak `W/` prefix included, and are not validated; empty list elements are dropped as RFC 9110, Section 5.6.1 requires, so a trailing comma is not an extra tag. [`Fresh`](#fresh) already applies these tags to the response `ETag`; reach for this only to implement a comparison of your own.
+
+Returned values are only valid within the handler. Do not store any references.
 :::
 
 ```go title="Signature"
@@ -2033,6 +2029,10 @@ app.Post("/", func(c fiber.Ctx) error {
 ### Origin
 
 Returns the `Origin` request header.
+
+:::caution
+Returned value is only valid within the handler. Do not store any references. Make copies or use the [**`Immutable`**](./fiber.md#config) setting to use the value outside the handler.
+:::
 
 ```go title="Signature"
 func (c fiber.Ctx) Origin() string
@@ -2629,6 +2629,10 @@ Appends the given value to the response header field as a **new field line**, le
 
 This differs from [`Append`](#append), which folds values into a single comma-separated line: headers whose values may themselves contain commas — `WWW-Authenticate`, `Link` — have to be sent as separate lines to stay unambiguous (RFC 9110, Section 5.3).
 
+:::caution
+The headers fasthttp stores in a slot of their own cannot repeat, and `Add` does not append for them: `Content-Type`, `Content-Encoding`, `Content-Length`, `Connection`, `Server` and `Trailer` are **replaced**, and `Transfer-Encoding` and `Date` are **ignored** because fasthttp writes them itself. Use [`Set`](#set) for those.
+:::
+
 ```go title="Signature"
 func (c fiber.Ctx) Add(key, val string)
 ```
@@ -2761,10 +2765,12 @@ Returns the response body buffered so far, which lets middleware inspect or chec
 
 Reached through `c.Res()`: `Req` and `Res` both carry a `Body`, so `c.Body()` is the **request** body.
 
+:::note
+A streamed body returns `nil` rather than being drained. Reading it would pull the whole stream into memory and turn the response into a buffered one, which would hang an SSE route and defeat a large [`SendFile`](#sendfile). Use [`Written`](#written) to tell a streaming response from one that produced nothing, and the underlying `c.Response().Body()` if you really do want to materialize the stream.
+:::
+
 :::caution
 The returned value is only valid within the handler and is invalidated by the next write to the response. Do not store any references; copy it instead.
-
-On a streamed response this drains the stream into a buffer to answer, which changes how the body is sent. Guard with [`Written`](#written) when the response may be a stream.
 :::
 
 ```go title="Signature"
@@ -2924,16 +2930,18 @@ app.Use(func(c fiber.Ctx) error {
 })
 ```
 
-### ContentType
+### ContentType (Res)
 
 Returns the `Content-Type` response header, parameters included. It is the read side of [`Type`](#type), and of the content type Fiber sets for you when a `JSON`, `XML`, or `SendFile` response goes out.
 
 :::note
-When nothing has set one it reports fasthttp's default, `text/plain; charset=utf-8`, which is what would be sent — not an empty string.
+When nothing has set one it reports what would be sent: fasthttp's default, `text/plain; charset=utf-8`, or an empty string under [`DisableDefaultContentType`](./fiber.md#config).
+
+`Req` and `Res` both carry a `ContentType`, so on `Ctx` the request wins, as it does for [`Get`](#get). This section is the response side, reached through `c.Res()`.
 :::
 
 ```go title="Signature"
-func (c fiber.Ctx) ContentType() string
+func (r fiber.Res) ContentType() string
 ```
 
 ```go title="Example"
@@ -2942,7 +2950,7 @@ app.Use(func(c fiber.Ctx) error {
     return err
   }
 
-  if strings.HasPrefix(c.ContentType(), fiber.MIMEApplicationJSON) {
+  if strings.HasPrefix(c.Res().ContentType(), fiber.MIMEApplicationJSON) {
     c.Set("X-Content-Type-Options", "nosniff")
   }
 
@@ -3019,6 +3027,8 @@ app.Get("/", func(c fiber.Ctx) error {
 ### Cookies (Res)
 
 Returns a copy of every cookie this response is set to send, in the order they were added. It returns `nil` when none have been set.
+
+Repeated names are kept apart, so a response that sets one name at two paths yields both. A `Set-Cookie` whose field value does not parse is skipped.
 
 Reached through `c.Res()`: `Req` and `Res` both carry a `Cookies`, so `c.Cookies(key)` reads what the **client** sent.
 
@@ -3206,7 +3216,9 @@ app.Get("/default", func(c fiber.Ctx) error {
 
 ### GetCookie
 
-Reads back a cookie this response is already set to send, so a later handler or middleware can inspect or re-emit what an earlier one wrote. The second result is `false` when no cookie of that name has been set.
+Reads back a cookie this response is already set to send, so a later handler or middleware can inspect or re-emit what an earlier one wrote. The second result is `false` when no cookie of that name has been set, or when its `Set-Cookie` field value does not parse.
+
+Cookie names are case-sensitive (RFC 6265, Section 4.1.1). A name written more than once resolves to the **first** occurrence; use [`Cookies`](#cookies-res) to see them all.
 
 :::note
 The returned `Cookie` is a copy: changing it does not change the response. Pass it to [`Cookie`](#cookie) to write the change back.
@@ -3414,7 +3426,11 @@ app.Get("/msgpack", func(c fiber.Ctx) error {
 
 ### NoContent
 
-Replies `204 No Content`: it sets the status, discards any body already written, and drops the `Content-Type` a handler had set, since RFC 9110, Section 6.4.1 gives a `204` no content to describe.
+Replies `204 No Content`. [`SendStatus`](#sendstatus) already discards the body for every status that disallows one; this drops the `Content-Type` as well, since RFC 9110, Section 6.4.1 gives a `204` no content to describe.
+
+:::note
+`c.SendStatus(fiber.StatusNoContent)` leaves a `Content-Type` a handler had set, so the two are not interchangeable — this is the one that sends nothing about content.
+:::
 
 ```go title="Signature"
 func (c fiber.Ctx) NoContent() error
@@ -3962,7 +3978,7 @@ app.Get("/", func(c fiber.Ctx) error {
 
 ### Written
 
-Reports whether anything has been written to the response body yet, so middleware can tell a handler that produced a response from one that left it untouched. A streamed body counts as written without draining the stream.
+Reports whether anything has been written to the response body yet, so middleware can tell a handler that produced a response from one that left it untouched. A streamed body counts as written without draining the stream, which is the case [`Body`](#body-res) deliberately answers `nil` for.
 
 :::note
 Status and headers are not body writes: a handler that only called [`Status`](#status) leaves this `false`.

--- a/docs/api/ctx.md
+++ b/docs/api/ctx.md
@@ -2697,7 +2697,7 @@ Use `c.Res()` to limit gopls suggestions to only these methods!
 Each entry lists both forms it can be called in. `DefaultCtx` embeds `DefaultRes`, so the method is promoted: `c.Del(key)` and `c.Res().Del(key)` are the same call.
 
 :::caution
-Four names are defined on both `Req` and `Res`: `Body`, `ContentLength`, `ContentType` and `Cookies`. On `Ctx` the **request wins**, the way [`Get`](#get) already does, so `c.Body()` reads the request body. The response counterparts are listed below as [`Body (Res)`](#body-res), [`ContentLength (Res)`](#contentlength-res), [`ContentType (Res)`](#contenttype-res) and [`Cookies (Res)`](#cookies-res), and are reachable only through `c.Res()` — which is why they list a single `fiber.Res` signature.
+Three names are defined on both `Req` and `Res`: `Body`, `ContentLength` and `ContentType`. On `Ctx` the **request wins**, the way [`Get`](#get) already does, so `c.Body()` reads the request body. The response counterparts are listed below as [`Body (Res)`](#body-res), [`ContentLength (Res)`](#contentlength-res) and [`ContentType (Res)`](#contenttype-res), and are reachable only through `c.Res()` — which is why they list a single `fiber.Res` signature. The response cookies are [`GetCookies`](#getcookies): named apart from `Req.Cookies` so that a `Ctx` still satisfies `fiber.Res`, which a same-name/different-signature pair would prevent.
 :::
 
 ### Add
@@ -2707,7 +2707,7 @@ Appends the given value to the response header field as a **new field line**, le
 This differs from [`Append`](#append), which folds values into a single comma-separated line: headers whose values may themselves contain commas — `WWW-Authenticate`, `Link` — have to be sent as separate lines to stay unambiguous (RFC 9110, Section 5.3).
 
 :::caution
-The headers fasthttp stores in a slot of their own cannot repeat, and `Add` does not append for them: `Content-Type`, `Content-Encoding`, `Content-Length`, `Connection`, `Server` and `Trailer` are **replaced**, and `Transfer-Encoding` and `Date` are **ignored** because fasthttp writes them itself. Use [`Set`](#set) for those.
+`Add` does not append for most of the headers fasthttp stores in a slot of their own: `Content-Type`, `Content-Encoding`, `Content-Length`, `Connection`, `Server` and `Trailer` are **replaced**, and `Transfer-Encoding` and `Date` are **ignored** because fasthttp writes them itself. Use [`Set`](#set) for those. `Set-Cookie` is slotted too but does repeat, so `Add` appends a line — prefer [`Cookie`](#cookie), which builds the field value for you.
 :::
 
 ```go title="Signature"
@@ -2851,7 +2851,7 @@ A streamed body returns `nil` rather than being drained. Reading it would pull t
 :::
 
 :::caution
-The returned value is only valid within the handler and is invalidated by the next write to the response. Do not store any references; copy it instead.
+The returned slice is the response's live buffer, not a copy — writing through it writes to the response, as it does for the request-side [`Body`](#body). It is only valid within the handler and is invalidated by the next write to the response. Do not store any references; copy it instead.
 :::
 
 ```go title="Signature"
@@ -2995,7 +2995,7 @@ Returns the value of the `Content-Length` response header.
 Reached through `c.Res()`: `Req` and `Res` both carry a `ContentLength`, so `c.ContentLength()` is the **request** header.
 
 :::note
-It reports what the header declares, not what has been buffered: fasthttp fills `Content-Length` in as it serializes the response, so inside a handler this is `0` unless something set it explicitly, and `-1` once the body is a stream of unknown length. Use `len(c.Res().Body())` for the bytes buffered so far.
+It reports what the header **declares** — a length a handler, middleware or upstream response set, and `-1` once the body is a stream of unknown length. It is not a count of buffered bytes: fasthttp fills `Content-Length` in as it serializes the response, so this is `0` inside a handler unless something set it explicitly. Use `len(c.Res().Body())` for the bytes buffered so far.
 :::
 
 ```go title="Signature"
@@ -3105,32 +3105,6 @@ app.Get("/", func(c fiber.Ctx) error {
   // Set the cookie in the response
   c.Cookie(cookie)
   return c.SendString("Partitioned cookie set")
-})
-```
-
-### Cookies (Res)
-
-Returns a copy of every cookie this response is set to send, in the order they were added. It returns `nil` when none have been set.
-
-Repeated names are kept apart, so a response that sets one name at two paths yields both. A `Set-Cookie` whose field value does not parse is skipped.
-
-Reached through `c.Res()`: `Req` and `Res` both carry a `Cookies`, so `c.Cookies(key)` reads what the **client** sent.
-
-```go title="Signature"
-func (r fiber.Res) Cookies() []*fiber.Cookie
-```
-
-```go title="Example"
-app.Use(func(c fiber.Ctx) error {
-  if err := c.Next(); err != nil {
-    return err
-  }
-
-  for _, cookie := range c.Res().Cookies() {
-    log.Printf("setting %s on %s", cookie.Name, cookie.Path)
-  }
-
-  return nil
 })
 ```
 
@@ -3328,7 +3302,7 @@ app.Get("/default", func(c fiber.Ctx) error {
 
 Reads back a cookie this response is already set to send, so a later handler or middleware can inspect or re-emit what an earlier one wrote. The second result is `false` when no cookie of that name has been set, or when its `Set-Cookie` field value does not parse.
 
-Cookie names are case-sensitive (RFC 6265, Section 4.1.1). A name written more than once resolves to the **first** occurrence; use [`Cookies`](#cookies-res) to see them all.
+Cookie names are case-sensitive (RFC 6265, Section 4.1.1). A name written more than once resolves to the **first** occurrence; use [`GetCookies`](#getcookies) to see them all.
 
 :::note
 The returned `Cookie` is a copy: changing it does not change the response. Pass it to [`Cookie`](#cookie) to write the change back.
@@ -3353,6 +3327,33 @@ app.Use(func(c fiber.Ctx) error {
   if cookie, ok := c.GetCookie("session"); ok {
     cookie.Value = encrypt(cookie.Value)
     c.Cookie(cookie)
+  }
+
+  return nil
+})
+```
+
+### GetCookies
+
+Returns a copy of every cookie this response is set to send, in the order they were added. It returns `nil` when none have been set.
+
+Repeated names are kept apart, so a response that sets one name at two paths yields both. A `Set-Cookie` whose field value does not parse is skipped.
+
+Named to sit beside [`GetCookie`](#getcookie) rather than mirroring `Req.Cookies`: the same name under a different signature would stop `fiber.Ctx` satisfying `fiber.Res`. `c.Cookies(key)` reads what the **client** sent.
+
+```go title="Signature"
+func (c fiber.Ctx) GetCookies() []*fiber.Cookie
+func (r fiber.Res) GetCookies() []*fiber.Cookie
+```
+
+```go title="Example"
+app.Use(func(c fiber.Ctx) error {
+  if err := c.Next(); err != nil {
+    return err
+  }
+
+  for _, cookie := range c.Res().GetCookies() {
+    log.Printf("setting %s on %s", cookie.Name, cookie.Path)
   }
 
   return nil

--- a/docs/middleware/logger.md
+++ b/docs/middleware/logger.md
@@ -327,6 +327,10 @@ Logger provides predefined formats that you can use by name or directly by speci
 `${bytesSent}` returns the value of the `Content-Length` response header. If the header is missing or the response is streaming (e.g., chunked encoding), the value will be `-1`. Fiber does not calculate the actual response body size for performance reasons.
 :::
 
+:::tip
+`${resBody}` logs nothing for a streamed response (`SendStream`, `SendStreamWriter`, and `SendFile` for a large file). Reading such a body would pull the whole stream into memory and turn the response into a buffered one — an SSE route would deliver nothing until its writer finished — so logging leaves it alone.
+:::
+
 ## The `${ips}` tag
 
 `${ips}` logs the chain the framework parsed, `Ctx.IPs()`, joined with `,`.

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -704,6 +704,42 @@ The `TypeConstraint` type, `Constraint.ID`, and `Constraint.RegexCompiler` field
 - **OverrideParam**: Overwrites the value of an existing route parameter, or does nothing if the parameter does not exist
 - **IsWebSocket**: Reports if the request attempts a WebSocket upgrade.
 - **IsPreflight**: Identifies CORS preflight requests before handlers run.
+- **Copy**: Returns a detached snapshot of the context that stays valid in a goroutine after the handler returns.
+- **ID**: Returns the connection-unique identifier of the request, without depending on a header.
+- **StartTime** / **Elapsed**: Report when the server began handling the request and how long it has taken so far.
+- **LocalAddr** / **RemoteAddr**: Return the connection's addresses as `net.Addr`, where `IP` returns a string.
+- **Hijack** / **Hijacked**: Take over the connection after the response is sent, and report whether that has happened.
+- **RouteName**: Returns the name of the route currently executing.
+- **IsFinal**: Reports whether the current handler is the last one in the chain, the complement of `IsMiddleware`.
+- **MountPath**: Returns the prefix the sub-app owning the current route was mounted under.
+- **Error**: Builds a `*fiber.Error` with the given status code, so a handler can reject a request in one line.
+- **GetAll**: Returns every field line of a request header, where `Get` returns only the first.
+- **Authorization** / **Bearer**: Split the `Authorization` header into scheme and credentials, and read a `Bearer` token.
+- **Origin**: Returns the `Origin` request header.
+- **ContentLength**: Returns the value of the `Content-Length` request header; `Res` carries one for the response.
+- **BodyStream**: Returns the request body as a stream when `StreamRequestBody` is enabled.
+- **URI**: Returns the parsed `*fasthttp.URI` of the request.
+- **CookieNames** / **AllCookies**: Enumerate the cookies the client sent.
+- **IfNoneMatch** / **IfModifiedSince**: Read the conditional-request headers, parsed.
+- **IsSafe** / **IsIdempotent**: Classify the request method per RFC 9110.
+- **Add**: Appends a response header as a new field line, where `Append` folds values into one.
+- **Del**: Removes a response header.
+- **StatusCode**: Returns the status code set on the response, the read side of `Status`.
+- **Body** (on `Res`): Returns the response body buffered so far.
+- **ResetBody**: Discards the response body, keeping the status and headers.
+- **Written**: Reports whether anything has been written to the response body yet.
+- **ContentType**: Returns the `Content-Type` response header, the read side of `Type`.
+- **GetCookie** / **Cookies** (on `Res`): Read back the cookies the response is set to send.
+- **NoContent**: Replies `204 No Content`, discarding any body and the `Content-Type`.
+
+### Req and Res Method Placement
+
+The request helpers listed above are defined on `Req`, so they are reachable both as `c.UserAgent()` and as
+`c.Req().UserAgent()`. This also applies to `Path`, `Secure`, `XHR`, `HasBody`, `IsWebSocket`, `IsPreflight`
+and the `Accept`/`Content-Type` helpers, which are request methods and are now on `Req` as well.
+
+`Req` and `Res` each define a `Body`, `ContentLength` and `Cookies`. On `Ctx` these resolve to the **request**,
+as `Get` already did; use `c.Res().Body()`, `c.Res().ContentLength()` and `c.Res().Cookies()` for the response.
 
 ### Removed Methods
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -738,9 +738,10 @@ The request helpers listed above are defined on `Req`, so they are reachable bot
 `c.Req().UserAgent()`. This also applies to `Path`, `Secure`, `XHR`, `HasBody`, `IsWebSocket`, `IsPreflight`
 and the `Accept`/`Content-Type` helpers, which are request methods and are now on `Req` as well.
 
-`Req` and `Res` each define a `Body`, `ContentLength`, `ContentType` and `Cookies`. On `Ctx` these resolve to the
-**request**, as `Get` already did; use `c.Res().Body()`, `c.Res().ContentLength()`, `c.Res().ContentType()` and
-`c.Res().Cookies()` for the response.
+`Req` and `Res` each define a `Body`, `ContentLength` and `ContentType`. On `Ctx` these resolve to the
+**request**, as `Get` already did; use `c.Res().Body()`, `c.Res().ContentLength()` and `c.Res().ContentType()`
+for the response. The response cookies are `c.Res().GetCookies()`, named apart from `Req.Cookies` so that a
+`Ctx` keeps satisfying `fiber.Res`.
 
 ### Removed Methods
 
@@ -772,6 +773,21 @@ and the `Accept`/`Content-Type` helpers, which are request methods and are now o
   `filename="report 2024.txt"` (previously `filename="report+2024.txt"`), with
   quotes and backslashes escaped as quoted-pairs, so browsers save files under
   their real names.
+- **Get, GetReqHeader and the request header helpers**: Field names are now matched case-insensitively, as
+  [RFC 9110, Section 5.1](https://www.rfc-editor.org/rfc/rfc9110#section-5.1) requires. This is only observable
+  under `DisableHeaderNormalizing: true`, where the store keeps the spelling the peer sent: with a
+  `x-test: yes` line, `c.Get("X-Test")` returned `""` in v2 and returns `"yes"` now. The default configuration
+  is unchanged, because fasthttp canonicalizes the names on the way in.
+- **Fresh()**: `If-None-Match`, `If-Modified-Since` and `Cache-Control` are read case-insensitively for the
+  same reason, so `c.Fresh()` can now return `true` where it returned `false` under `DisableHeaderNormalizing`.
+  That changes which requests are answered `304 Not Modified`.
+- **SendStatus()**: For a status that disallows a body — `1xx`, `204` and `304` — the response body and any
+  `Content-Length` already set are now dropped, per
+  [RFC 9110, Section 8.6](https://www.rfc-editor.org/rfc/rfc9110#section-8.6). `c.Set(fiber.HeaderContentLength, "42")`
+  followed by `c.SendStatus(204)` previously put `Content-Length: 42` on the wire, along with a `Content-Type`
+  fasthttp emits for a declared length; neither line is sent now. `205 Reset Content` still sends
+  `Content-Length: 0`, which [Section 15.3.6](https://www.rfc-editor.org/rfc/rfc9110#section-15.3.6) requires.
+  Unlike the two above, this applies under the default configuration.
 - **Context()**: Renamed to `RequestCtx()` to access the underlying `fasthttp.RequestCtx`.
 - **IP()**: When `EnableIPValidation` is `true` and `TrustProxyConfig` is set, `c.IP()` now walks the `X-Forwarded-For` chain from right to left and returns the first non-trusted IP, instead of the leftmost syntactically valid IP. This closes an IP-spoofing vector where an attacker could prepend a fake address and have it returned by `c.IP()`. Apps with `EnableIPValidation = false` (the default) are unaffected. See [`Ctx.IP`](./api/ctx.md#ip) and the [reverse proxy guide](./guide/reverse-proxy.md#getting-the-real-client-ip-address) for details.
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -704,7 +704,6 @@ The `TypeConstraint` type, `Constraint.ID`, and `Constraint.RegexCompiler` field
 - **OverrideParam**: Overwrites the value of an existing route parameter, or does nothing if the parameter does not exist
 - **IsWebSocket**: Reports if the request attempts a WebSocket upgrade.
 - **IsPreflight**: Identifies CORS preflight requests before handlers run.
-- **Copy**: Returns a detached snapshot of the context that stays valid in a goroutine after the handler returns.
 - **ID**: Returns the connection-unique identifier of the request, without depending on a header.
 - **StartTime** / **Elapsed**: Report when the server began handling the request and how long it has taken so far.
 - **LocalAddr** / **RemoteAddr**: Return the connection's addresses as `net.Addr`, where `IP` returns a string.
@@ -717,6 +716,7 @@ The `TypeConstraint` type, `Constraint.ID`, and `Constraint.RegexCompiler` field
 - **Authorization** / **Bearer**: Split the `Authorization` header into scheme and credentials, and read a `Bearer` token.
 - **Origin**: Returns the `Origin` request header.
 - **ContentLength**: Returns the value of the `Content-Length` request header; `Res` carries one for the response.
+- **ContentType**: Returns the `Content-Type` request header with its parameters; `Res` carries one for the response.
 - **BodyStream**: Returns the request body as a stream when `StreamRequestBody` is enabled.
 - **URI**: Returns the parsed `*fasthttp.URI` of the request.
 - **CookieNames** / **AllCookies**: Enumerate the cookies the client sent.
@@ -738,8 +738,9 @@ The request helpers listed above are defined on `Req`, so they are reachable bot
 `c.Req().UserAgent()`. This also applies to `Path`, `Secure`, `XHR`, `HasBody`, `IsWebSocket`, `IsPreflight`
 and the `Accept`/`Content-Type` helpers, which are request methods and are now on `Req` as well.
 
-`Req` and `Res` each define a `Body`, `ContentLength` and `Cookies`. On `Ctx` these resolve to the **request**,
-as `Get` already did; use `c.Res().Body()`, `c.Res().ContentLength()` and `c.Res().Cookies()` for the response.
+`Req` and `Res` each define a `Body`, `ContentLength`, `ContentType` and `Cookies`. On `Ctx` these resolve to the
+**request**, as `Get` already did; use `c.Res().Body()`, `c.Res().ContentLength()`, `c.Res().ContentType()` and
+`c.Res().Cookies()` for the response.
 
 ### Removed Methods
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -709,7 +709,7 @@ The `TypeConstraint` type, `Constraint.ID`, and `Constraint.RegexCompiler` field
 - **LocalAddr** / **RemoteAddr**: Return the connection's addresses as `net.Addr`, where `IP` returns a string.
 - **Hijack** / **Hijacked**: Take over the connection after the response is sent, and report whether that has happened.
 - **RouteName**: Returns the name of the route currently executing.
-- **IsFinal**: Reports whether the current handler is the last one in the chain, the complement of `IsMiddleware`.
+- **IsFinal**: Reports whether the current handler is the last one of a matched, non-middleware route.
 - **MountPath**: Returns the prefix the sub-app owning the current route was mounted under.
 - **Error**: Builds a `*fiber.Error` with the given status code, so a handler can reject a request in one line.
 - **GetAll**: Returns every field line of a request header, where `Get` returns only the first.

--- a/error.go
+++ b/error.go
@@ -104,3 +104,10 @@ var (
 	ErrFileRead      = errors.New("file: failed to read file")
 	ErrFileStore     = errors.New("file: failed to store file")
 )
+
+// Header errors
+var (
+	// ErrHeaderNotFound is returned by request header accessors that parse a
+	// value, to tell an absent header apart from one that failed to parse.
+	ErrHeaderNotFound = errors.New("header: field not present in the request")
+)

--- a/internal/cookie/samesite.go
+++ b/internal/cookie/samesite.go
@@ -57,10 +57,9 @@ func ParseSameSite(value string) (SameSite, bool) {
 	}
 }
 
-// FormatSameSite names the Fiber SameSite mode a fasthttp cookie carries. It
-// inverts ParseSameSite for every mode Fiber writes. A cookie set outside
-// Fiber can also carry fasthttp's default mode, which emits the attribute with
-// no value and has no Fiber name, so that returns an empty string.
+// FormatSameSite names the Fiber SameSite mode a fasthttp cookie carries,
+// inverting ParseSameSite for every mode Fiber writes. fasthttp's default mode
+// has no Fiber name and returns an empty string.
 func FormatSameSite(mode fasthttp.CookieSameSite) string {
 	switch mode {
 	case fasthttp.CookieSameSiteDisabled:

--- a/internal/cookie/samesite.go
+++ b/internal/cookie/samesite.go
@@ -56,3 +56,24 @@ func ParseSameSite(value string) (SameSite, bool) {
 		}, false
 	}
 }
+
+// FormatSameSite names the Fiber SameSite mode a fasthttp cookie carries. It
+// inverts ParseSameSite for every mode Fiber writes. A cookie set outside
+// Fiber can also carry fasthttp's default mode, which emits the attribute with
+// no value and has no Fiber name, so that returns an empty string.
+func FormatSameSite(mode fasthttp.CookieSameSite) string {
+	switch mode {
+	case fasthttp.CookieSameSiteDisabled:
+		return SameSiteDisabled
+	case fasthttp.CookieSameSiteLaxMode:
+		return SameSiteLax
+	case fasthttp.CookieSameSiteStrictMode:
+		return SameSiteStrict
+	case fasthttp.CookieSameSiteNoneMode:
+		return SameSiteNone
+	default:
+		// fasthttp's default mode lands here: it emits the attribute with no
+		// value, which is not one of the modes Fiber names.
+		return ""
+	}
+}

--- a/internal/cookie/samesite_test.go
+++ b/internal/cookie/samesite_test.go
@@ -102,7 +102,6 @@ func Test_FormatSameSite(t *testing.T) {
 			got := FormatSameSite(tc.mode)
 			require.Equal(t, tc.want, got)
 
-			// Every named mode round-trips back to the same fasthttp mode.
 			if got == "" {
 				return
 			}

--- a/internal/cookie/samesite_test.go
+++ b/internal/cookie/samesite_test.go
@@ -78,8 +78,6 @@ func Test_ParseSameSite(t *testing.T) {
 	}
 }
 
-// Test_FormatSameSite covers the inverse of ParseSameSite, including the
-// fasthttp default mode that has no Fiber name.
 func Test_FormatSameSite(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cookie/samesite_test.go
+++ b/internal/cookie/samesite_test.go
@@ -77,3 +77,38 @@ func Test_ParseSameSite(t *testing.T) {
 		})
 	}
 }
+
+// Test_FormatSameSite covers the inverse of ParseSameSite, including the
+// fasthttp default mode that has no Fiber name.
+func Test_FormatSameSite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want string
+		mode fasthttp.CookieSameSite
+	}{
+		{name: "disabled", mode: fasthttp.CookieSameSiteDisabled, want: SameSiteDisabled},
+		{name: "lax", mode: fasthttp.CookieSameSiteLaxMode, want: SameSiteLax},
+		{name: "strict", mode: fasthttp.CookieSameSiteStrictMode, want: SameSiteStrict},
+		{name: "none", mode: fasthttp.CookieSameSiteNoneMode, want: SameSiteNone},
+		{name: "fasthttp default has no Fiber name", mode: fasthttp.CookieSameSiteDefaultMode, want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := FormatSameSite(tc.mode)
+			require.Equal(t, tc.want, got)
+
+			// Every named mode round-trips back to the same fasthttp mode.
+			if got == "" {
+				return
+			}
+			parsed, ok := ParseSameSite(got)
+			require.True(t, ok)
+			require.Equal(t, tc.mode, parsed.FastHTTPMode)
+		})
+	}
+}

--- a/internal/etag/etag.go
+++ b/internal/etag/etag.go
@@ -55,67 +55,102 @@ func MatchStrong(s, etag string) bool {
 	return n1 == n2
 }
 
-// Tags iterates the entity tags in a raw If-None-Match or If-Match field
-// value. Commas that sit inside a DQUOTE-delimited opaque-tag do not split the
-// list: etagc permits "," inside the quoted tag (RFC 9110 Section 8.8.3), so
-// `"v1,v2"` is a single entity tag, not two list elements. Elements are yielded
-// with surrounding whitespace trimmed and are not validated; pass each to Parse
-// to reject malformed ones. An empty field value yields nothing.
+// cutTag splits the first entity tag off a raw If-None-Match or If-Match field
+// value, returning it and the remainder of the list. ok is false only when
+// there is nothing left to split.
+//
+// A comma inside a DQUOTE-delimited opaque-tag does not end an element: etagc
+// permits "," inside the quoted tag (RFC 9110 Section 8.8.3), so `"v1,v2"` is a
+// single entity tag rather than two list elements.
+//
+// Written as a stepper rather than a closure so AnyMatch, which runs on the
+// conditional-request path, shares the rule without paying for an iterator.
+func cutTag(header string) (tag, rest string, ok bool) { //nolint:nonamedreturns // gocritic unnamedResult requires naming the three parts
+	if header == "" {
+		return "", "", false
+	}
+
+	// Only '"' and ',' affect the split, so jump between them instead of
+	// visiting every byte.
+	inQuotes := false
+	for i := 0; i < len(header); {
+		j := utils.IndexAny2(header[i:], '"', ',')
+		if j == -1 {
+			break
+		}
+		i += j
+		if header[i] == '"' {
+			inQuotes = !inQuotes
+		} else if !inQuotes {
+			return utils.TrimSpace(header[:i]), header[i+1:], true
+		}
+		i++
+	}
+
+	return utils.TrimSpace(header), "", true
+}
+
+// Tags iterates the entity tags in a raw If-None-Match or If-Match field value.
+// Elements are yielded with surrounding whitespace trimmed and are not
+// validated; pass each to Parse to reject malformed ones.
+//
+// Empty list elements are skipped rather than yielded as empty strings, because
+// RFC 9110 Section 5.6.1 requires a recipient to parse and ignore them: a
+// trailing comma is not an extra tag. An empty field value yields nothing.
 func Tags(header string) iter.Seq[string] {
 	return func(yield func(string) bool) {
-		header = utils.TrimSpace(header)
-		if header == "" {
-			return
-		}
-
-		// Only '"' and ',' affect the split, so jump between them instead of
-		// visiting every byte.
-		start := 0
-		pos := 0
-		inQuotes := false
-		for {
-			i := utils.IndexAny2(header[pos:], '"', ',')
-			if i == -1 {
-				break
+		rest := utils.TrimSpace(header)
+		for rest != "" {
+			tag, next, ok := cutTag(rest)
+			if !ok {
+				return
 			}
-			i += pos
-			pos = i + 1
-			if header[i] == '"' {
-				inQuotes = !inQuotes
-			} else if !inQuotes {
-				if !yield(utils.TrimSpace(header[start:i])) {
-					return
-				}
-				start = i + 1
+			if tag != "" && !yield(tag) {
+				return
 			}
+			rest = next
 		}
-
-		yield(utils.TrimSpace(header[start:]))
 	}
 }
 
 // Split returns the entity tags in a raw If-None-Match or If-Match field value.
-// It collects Tags, so the same quoted-comma rules apply. An empty field value
-// returns nil.
+// It collects Tags, so the same quoted-comma and empty-element rules apply. A
+// field value carrying no tags returns nil.
 func Split(header string) []string {
-	return slices.Collect(Tags(header))
+	header = utils.TrimSpace(header)
+	if header == "" {
+		return nil
+	}
+
+	// One more than the commas is an upper bound: a comma inside a quoted
+	// opaque-tag only over-estimates, never under.
+	tags := slices.AppendSeq(make([]string, 0, strings.Count(header, ",")+1), Tags(header))
+	if len(tags) == 0 {
+		return nil
+	}
+	return tags
 }
 
 // AnyMatch reports whether any entity tag in the raw If-None-Match field value
 // matches etag. Comparison is weak as defined by RFC 9110 Section 8.8.3.2, and
 // "*" matches every entity tag. An empty field value matches nothing.
 func AnyMatch(header, etag string) bool {
-	header = utils.TrimSpace(header)
+	rest := utils.TrimSpace(header)
 
 	// Short-circuit the wildcard case: "*" matches any entity tag.
-	if header == "*" {
+	if rest == "*" {
 		return true
 	}
 
-	for tag := range Tags(header) {
-		if Match(tag, etag) {
+	for rest != "" {
+		tag, next, ok := cutTag(rest)
+		if !ok {
+			return false
+		}
+		if tag != "" && Match(tag, etag) {
 			return true
 		}
+		rest = next
 	}
 
 	return false

--- a/internal/etag/etag.go
+++ b/internal/etag/etag.go
@@ -5,6 +5,8 @@
 package etag
 
 import (
+	"iter"
+	"slices"
 	"strings"
 
 	"github.com/gofiber/utils/v2"
@@ -53,6 +55,52 @@ func MatchStrong(s, etag string) bool {
 	return n1 == n2
 }
 
+// Tags iterates the entity tags in a raw If-None-Match or If-Match field
+// value. Commas that sit inside a DQUOTE-delimited opaque-tag do not split the
+// list: etagc permits "," inside the quoted tag (RFC 9110 Section 8.8.3), so
+// `"v1,v2"` is a single entity tag, not two list elements. Elements are yielded
+// with surrounding whitespace trimmed and are not validated; pass each to Parse
+// to reject malformed ones. An empty field value yields nothing.
+func Tags(header string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		header = utils.TrimSpace(header)
+		if header == "" {
+			return
+		}
+
+		// Only '"' and ',' affect the split, so jump between them instead of
+		// visiting every byte.
+		start := 0
+		pos := 0
+		inQuotes := false
+		for {
+			i := utils.IndexAny2(header[pos:], '"', ',')
+			if i == -1 {
+				break
+			}
+			i += pos
+			pos = i + 1
+			if header[i] == '"' {
+				inQuotes = !inQuotes
+			} else if !inQuotes {
+				if !yield(utils.TrimSpace(header[start:i])) {
+					return
+				}
+				start = i + 1
+			}
+		}
+
+		yield(utils.TrimSpace(header[start:]))
+	}
+}
+
+// Split returns the entity tags in a raw If-None-Match or If-Match field value.
+// It collects Tags, so the same quoted-comma rules apply. An empty field value
+// returns nil.
+func Split(header string) []string {
+	return slices.Collect(Tags(header))
+}
+
 // AnyMatch reports whether any entity tag in the raw If-None-Match field value
 // matches etag. Comparison is weak as defined by RFC 9110 Section 8.8.3.2, and
 // "*" matches every entity tag. An empty field value matches nothing.
@@ -64,29 +112,11 @@ func AnyMatch(header, etag string) bool {
 		return true
 	}
 
-	// Split the header on commas that sit outside DQUOTE-delimited opaque-tags:
-	// etagc permits "," inside the quoted tag (RFC 9110 Section 8.8.3), so
-	// `"v1,v2"` is a single entity tag, not two list elements. Only '"' and ','
-	// affect the split, so jump between them instead of visiting every byte.
-	start := 0
-	pos := 0
-	inQuotes := false
-	for {
-		i := utils.IndexAny2(header[pos:], '"', ',')
-		if i == -1 {
-			break
-		}
-		i += pos
-		pos = i + 1
-		if header[i] == '"' {
-			inQuotes = !inQuotes
-		} else if !inQuotes {
-			if Match(utils.TrimSpace(header[start:i]), etag) {
-				return true
-			}
-			start = i + 1
+	for tag := range Tags(header) {
+		if Match(tag, etag) {
+			return true
 		}
 	}
 
-	return Match(utils.TrimSpace(header[start:]), etag)
+	return false
 }

--- a/internal/etag/etag.go
+++ b/internal/etag/etag.go
@@ -55,16 +55,9 @@ func MatchStrong(s, etag string) bool {
 	return n1 == n2
 }
 
-// cutTag splits the first entity tag off a raw If-None-Match or If-Match field
-// value, returning it and the remainder of the list. ok is false only when
-// there is nothing left to split.
-//
-// A comma inside a DQUOTE-delimited opaque-tag does not end an element: etagc
-// permits "," inside the quoted tag (RFC 9110 Section 8.8.3), so `"v1,v2"` is a
-// single entity tag rather than two list elements.
-//
-// Written as a stepper rather than a closure so AnyMatch, which runs on the
-// conditional-request path, shares the rule without paying for an iterator.
+// cutTag splits the first entity tag off a raw If-None-Match or If-Match value,
+// returning it and the rest. A comma inside a quoted opaque-tag does not end an
+// element (RFC 9110 Section 8.8.3), so `"v1,v2"` is one tag.
 func cutTag(header string) (tag, rest string, ok bool) { //nolint:nonamedreturns // gocritic unnamedResult requires naming the three parts
 	if header == "" {
 		return "", "", false
@@ -90,13 +83,9 @@ func cutTag(header string) (tag, rest string, ok bool) { //nolint:nonamedreturns
 	return utils.TrimSpace(header), "", true
 }
 
-// Tags iterates the entity tags in a raw If-None-Match or If-Match field value.
-// Elements are yielded with surrounding whitespace trimmed and are not
-// validated; pass each to Parse to reject malformed ones.
-//
-// Empty list elements are skipped rather than yielded as empty strings, because
-// RFC 9110 Section 5.6.1 requires a recipient to parse and ignore them: a
-// trailing comma is not an extra tag. An empty field value yields nothing.
+// Tags iterates the entity tags in a raw If-None-Match or If-Match value,
+// trimmed and unvalidated. Empty list elements are skipped, as RFC 9110
+// Section 5.6.1 requires, so a trailing comma is not an extra tag.
 func Tags(header string) iter.Seq[string] {
 	return func(yield func(string) bool) {
 		rest := utils.TrimSpace(header)

--- a/internal/etag/etag_test.go
+++ b/internal/etag/etag_test.go
@@ -122,15 +122,10 @@ func Test_Split(t *testing.T) {
 		{name: "list", header: `"a", "b"`, want: []string{`"a"`, `"b"`}},
 		{name: "weak", header: `W/"a", "b"`, want: []string{`W/"a"`, `"b"`}},
 		{name: "wildcard", header: "*", want: []string{"*"}},
-		// etagc permits "," inside the quoted opaque-tag, so this is one tag.
 		{name: "comma inside tag", header: `"v1,v2"`, want: []string{`"v1,v2"`}},
 		{name: "comma inside and after", header: `"v1,v2", "v3"`, want: []string{`"v1,v2"`, `"v3"`}},
 		{name: "untrimmed", header: `  "a" ,  "b"  `, want: []string{`"a"`, `"b"`}},
-		// Malformed input is returned verbatim rather than dropped; Parse is
-		// what rejects it.
 		{name: "unquoted", header: `abc`, want: []string{"abc"}},
-		// RFC 9110 Section 5.6.1 requires empty list elements to be ignored, so
-		// a trailing comma is not an extra tag.
 		{name: "trailing comma", header: `"a",`, want: []string{`"a"`}},
 		{name: "trailing comma and space", header: `"a", `, want: []string{`"a"`}},
 		{name: "leading comma", header: `,"a"`, want: []string{`"a"`}},
@@ -147,8 +142,6 @@ func Test_Split(t *testing.T) {
 	}
 }
 
-// Test_Tags_EarlyStop covers the yield-returns-false path, which Split alone
-// never exercises.
 func Test_Tags_EarlyStop(t *testing.T) {
 	t.Parallel()
 
@@ -162,8 +155,6 @@ func Test_Tags_EarlyStop(t *testing.T) {
 	require.Equal(t, []string{`"a"`, `"b"`}, seen)
 }
 
-// Test_AnyMatch_IgnoresEmptyElements pins that the empty-element rule reaches
-// AnyMatch too, so the two entry points cannot drift apart again.
 func Test_AnyMatch_IgnoresEmptyElements(t *testing.T) {
 	t.Parallel()
 
@@ -171,7 +162,6 @@ func Test_AnyMatch_IgnoresEmptyElements(t *testing.T) {
 	require.True(t, AnyMatch(`,"a"`, `"a"`))
 	require.True(t, AnyMatch(`"a",,"b"`, `"b"`))
 	require.False(t, AnyMatch(`,,`, `"a"`))
-	// An empty stored ETag must not be matched by an empty list element.
 	require.False(t, AnyMatch(`"a",`, ""))
 	require.False(t, AnyMatch(`,`, ""))
 }

--- a/internal/etag/etag_test.go
+++ b/internal/etag/etag_test.go
@@ -107,3 +107,49 @@ func Test_AnyMatch(t *testing.T) {
 		})
 	}
 }
+
+func Test_Split(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		header string
+		want   []string
+	}{
+		{name: "empty", header: ""},
+		{name: "whitespace only", header: "   "},
+		{name: "single", header: `"abc"`, want: []string{`"abc"`}},
+		{name: "list", header: `"a", "b"`, want: []string{`"a"`, `"b"`}},
+		{name: "weak", header: `W/"a", "b"`, want: []string{`W/"a"`, `"b"`}},
+		{name: "wildcard", header: "*", want: []string{"*"}},
+		// etagc permits "," inside the quoted opaque-tag, so this is one tag.
+		{name: "comma inside tag", header: `"v1,v2"`, want: []string{`"v1,v2"`}},
+		{name: "comma inside and after", header: `"v1,v2", "v3"`, want: []string{`"v1,v2"`, `"v3"`}},
+		{name: "untrimmed", header: `  "a" ,  "b"  `, want: []string{`"a"`, `"b"`}},
+		// Malformed input is returned verbatim rather than dropped; Parse is
+		// what rejects it.
+		{name: "unquoted", header: `abc`, want: []string{"abc"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, Split(tc.header))
+		})
+	}
+}
+
+// Test_Tags_EarlyStop covers the yield-returns-false path, which Split alone
+// never exercises.
+func Test_Tags_EarlyStop(t *testing.T) {
+	t.Parallel()
+
+	var seen []string
+	for tag := range Tags(`"a", "b", "c"`) {
+		seen = append(seen, tag)
+		if len(seen) == 2 {
+			break
+		}
+	}
+	require.Equal(t, []string{`"a"`, `"b"`}, seen)
+}

--- a/internal/etag/etag_test.go
+++ b/internal/etag/etag_test.go
@@ -129,6 +129,14 @@ func Test_Split(t *testing.T) {
 		// Malformed input is returned verbatim rather than dropped; Parse is
 		// what rejects it.
 		{name: "unquoted", header: `abc`, want: []string{"abc"}},
+		// RFC 9110 Section 5.6.1 requires empty list elements to be ignored, so
+		// a trailing comma is not an extra tag.
+		{name: "trailing comma", header: `"a",`, want: []string{`"a"`}},
+		{name: "trailing comma and space", header: `"a", `, want: []string{`"a"`}},
+		{name: "leading comma", header: `,"a"`, want: []string{`"a"`}},
+		{name: "doubled comma", header: `"a",,"b"`, want: []string{`"a"`, `"b"`}},
+		{name: "only commas", header: `,,`},
+		{name: "only a comma", header: `,`},
 	}
 
 	for _, tc := range tests {
@@ -152,4 +160,48 @@ func Test_Tags_EarlyStop(t *testing.T) {
 		}
 	}
 	require.Equal(t, []string{`"a"`, `"b"`}, seen)
+}
+
+// Test_AnyMatch_IgnoresEmptyElements pins that the empty-element rule reaches
+// AnyMatch too, so the two entry points cannot drift apart again.
+func Test_AnyMatch_IgnoresEmptyElements(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, AnyMatch(`"a",`, `"a"`))
+	require.True(t, AnyMatch(`,"a"`, `"a"`))
+	require.True(t, AnyMatch(`"a",,"b"`, `"b"`))
+	require.False(t, AnyMatch(`,,`, `"a"`))
+	// An empty stored ETag must not be matched by an empty list element.
+	require.False(t, AnyMatch(`"a",`, ""))
+	require.False(t, AnyMatch(`,`, ""))
+}
+
+func Benchmark_AnyMatch(b *testing.B) {
+	benchmarks := []struct {
+		name   string
+		header string
+		etag   string
+	}{
+		{name: "hit", header: `"abc123"`, etag: `"abc123"`},
+		{name: "miss", header: `"abc123"`, etag: `"xyz789"`},
+		{name: "list_miss", header: `"a", "b", "c", "d", "e"`, etag: `"z"`},
+		{name: "weak", header: `W/"abcdefghijklmnop"`, etag: `W/"abcdefghijklmnop"`},
+		{name: "empty", header: "", etag: `"a"`},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = AnyMatch(bm.header, bm.etag)
+			}
+		})
+	}
+}
+
+func Benchmark_Split(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = Split(`"a", "b", "c"`)
+	}
 }

--- a/internal/fieldname/fieldname.go
+++ b/internal/fieldname/fieldname.go
@@ -110,12 +110,16 @@ func First(h Peeker, name string, canonical bool) []byte {
 // firstFold answers First for a store whose field names are spelled however the
 // peer sent them.
 func firstFold(h Peeker, name string) []byte {
-	for k, v := range h.All() {
-		if len(v) > 0 && utils.EqualFold(utils.UnsafeString(k), name) {
-			return v
+	// Walked rather than ranged, for the reason Lines gives: All builds a
+	// heap-allocated iterator per call. Scanning past the match costs less than
+	// the early exit ranging would buy.
+	var found []byte
+	h.VisitAll(func(k, v []byte) {
+		if found == nil && len(v) > 0 && utils.EqualFold(utils.UnsafeString(k), name) {
+			found = v
 		}
-	}
-	return nil
+	})
+	return found
 }
 
 // Canonical reports whether every field name in h is spelled the way fasthttp
@@ -165,21 +169,21 @@ func Del(h Deleter, name string, canonical bool) {
 		return
 	}
 
-	// Restart after each removal rather than deleting while ranging over the
-	// store being modified. A field arrives under one spelling essentially
-	// always, so this repeats only for a peer that sent several.
-	for {
-		other := ""
-		for k := range h.All() {
-			if utils.EqualFold(utils.UnsafeString(k), name) {
-				other = string(k)
-				break
-			}
+	// Collected before deleting, like DelOthers, rather than rescanning after
+	// each removal: ResponseHeader.All reports a default Content-Type whenever
+	// the slot is empty, so a rescan would keep finding the name it just
+	// deleted. A name stored non-canonically in a normalizing store is the same
+	// shape, since Del normalizes the key before matching and so cannot remove
+	// it at all.
+	var others []string
+	for k := range h.All() {
+		if utils.EqualFold(utils.UnsafeString(k), name) {
+			others = append(others, string(k))
 		}
-		if other == "" {
-			return
-		}
-		h.Del(other)
+	}
+
+	for _, k := range others {
+		h.Del(k)
 	}
 }
 

--- a/internal/fieldname/fieldname_test.go
+++ b/internal/fieldname/fieldname_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
@@ -111,4 +112,57 @@ func Test_First_EmptyLineDoesNotHideTheValue(t *testing.T) {
 			require.Equal(t, tc.want, string(First(h, fasthttp.HeaderOrigin, tc.canonical)))
 		})
 	}
+}
+
+func Test_Del_TerminatesOnSynthesizedContentType(t *testing.T) {
+	t.Parallel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h := &fasthttp.ResponseHeader{}
+		Del(h, fasthttp.HeaderContentType, false)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Del did not return: ResponseHeader.All reports a default Content-Type once the slot is empty")
+	}
+}
+
+func Test_Del_TerminatesOnNonCanonicalNameInNormalizingStore(t *testing.T) {
+	t.Parallel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h := &fasthttp.ResponseHeader{}
+		h.SetNoDefaultContentType(true)
+		h.SetCanonical([]byte("x-session-id"), []byte("v"))
+		Del(h, "X-Session-Id", false)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Del did not return: the store normalizes the key it is given, so it never matches the stored spelling")
+	}
+}
+
+func Test_Del_RemovesEverySpelling(t *testing.T) {
+	t.Parallel()
+
+	h := &fasthttp.ResponseHeader{}
+	h.SetNoDefaultContentType(true)
+	h.DisableNormalizing()
+	h.Add("x-trace", "a")
+	h.Add("X-Trace", "b")
+	h.Add("X-TRACE", "c")
+	h.Add("X-Keep", "k")
+
+	Del(h, "X-Trace", false)
+
+	require.Empty(t, Lines(h, "X-Trace", false))
+	require.Equal(t, "k", string(First(h, "X-Keep", false)))
 }

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -711,7 +711,7 @@ func New(config ...Config) fiber.Handler {
 		sharedCacheMode := !hasAuthorization || isSharedCacheAllowed
 
 		// Don't cache response if status code is not cacheable
-		if _, ok := cacheableStatusCodes[c.Response().StatusCode()]; !ok {
+		if _, ok := cacheableStatusCodes[c.Res().StatusCode()]; !ok {
 			markUnreachable()
 			return nil
 		}
@@ -830,7 +830,7 @@ func New(config ...Config) fiber.Handler {
 		e = manager.acquire()
 		// Cache response
 		e.body = utils.CopyBytes(c.Response().Body())
-		e.status = c.Response().StatusCode()
+		e.status = c.Res().StatusCode()
 		e.ctype = utils.CopyBytes(c.Response().Header.ContentType())
 		e.cencoding = utils.CopyBytes(c.Response().Header.Peek(fiber.HeaderContentEncoding))
 		e.private = false

--- a/middleware/cache/keygen.go
+++ b/middleware/cache/keygen.go
@@ -81,7 +81,7 @@ func appendDefaultKey(dst []byte, c fiber.Ctx, cfg *Config) []byte {
 
 	if !cfg.DisableQueryKeys {
 		dst = append(dst, '|', 'q', '=')
-		dst = appendCanonicalQueryString(dst, c.Request().URI())
+		dst = appendCanonicalQueryString(dst, c.Req().URI())
 	}
 
 	if len(cfg.KeyHeaders) > 0 {

--- a/middleware/compress/compress.go
+++ b/middleware/compress/compress.go
@@ -23,7 +23,7 @@ func shouldSkip(c fiber.Ctx) bool {
 		return true
 	}
 
-	status := c.Response().StatusCode()
+	status := c.Res().StatusCode()
 	if status < 200 ||
 		status == fiber.StatusNoContent ||
 		status == fiber.StatusResetContent ||
@@ -35,8 +35,9 @@ func shouldSkip(c fiber.Ctx) bool {
 		return true
 	}
 
-	// Skip body length check for streaming responses to avoid materializing the stream
-	if !c.Response().IsBodyStream() && len(c.Response().Body()) == 0 {
+	// Written counts a stream without draining it, so a streaming response is
+	// never mistaken for an empty one.
+	if !c.Res().Written() {
 		return true
 	}
 

--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/gofiber/fiber/v3/internal/fieldname"
 	"github.com/gofiber/fiber/v3/internal/headerlookup"
 	"github.com/gofiber/fiber/v3/log"
 	"github.com/gofiber/utils/v2"
@@ -112,8 +111,6 @@ func New(config ...Config) fiber.Handler {
 		// Every request header here is read case-insensitively, as csrf already
 		// does: Ctx.Get is byte-exact, so under DisableHeaderNormalizing the
 		// lower-case names HTTP/2 sends read as absent and CORS never applied.
-		canonical := headerlookup.Canonical(c)
-
 		// Origin, with the original case kept for the response.
 		originHeaderRaw, _ := headerlookup.Value(c, fiber.HeaderOrigin)
 		originHeader := utilsstrings.ToLower(originHeaderRaw)
@@ -203,7 +200,9 @@ func New(config ...Config) fiber.Handler {
 		if len(cfg.AllowHeaders) > 0 {
 			c.Set(fiber.HeaderAccessControlAllowHeaders, strings.Join(cfg.AllowHeaders, ", "))
 		} else {
-			h := string(fieldname.First(&c.Request().Header, fiber.HeaderAccessControlRequestHeaders, canonical))
+			// Combined, not Value: this one is a list field, so a peer may
+			// legally split it over two lines and both name headers to allow.
+			h := headerlookup.Combined(c, fiber.HeaderAccessControlRequestHeaders)
 			if h != "" {
 				c.Set(fiber.HeaderAccessControlAllowHeaders, h)
 			}

--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -107,8 +107,11 @@ func New(config ...Config) fiber.Handler {
 			return c.Next()
 		}
 
-		// Get origin header preserving the original case for the response
-		originHeaderRaw := c.Get(fiber.HeaderOrigin)
+		// Get origin header preserving the original case for the response.
+		// Req.Origin matches the field name case-insensitively (RFC 9110 §5.1),
+		// where Ctx.Get is byte-exact: under DisableHeaderNormalizing a
+		// lower-case "origin:" read as absent and CORS did not apply at all.
+		originHeaderRaw := c.Req().Origin()
 		originHeader := utilsstrings.ToLower(originHeaderRaw)
 
 		// If the request does not have Origin header, the request is outside the scope of CORS

--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -107,10 +107,9 @@ func New(config ...Config) fiber.Handler {
 			return c.Next()
 		}
 
-		// Get origin header preserving the original case for the response.
-		// Req.Origin matches the field name case-insensitively (RFC 9110 §5.1),
-		// where Ctx.Get is byte-exact: under DisableHeaderNormalizing a
-		// lower-case "origin:" read as absent and CORS did not apply at all.
+		// Origin, with the original case kept for the response. Req.Origin matches
+		// the field name case-insensitively, where Ctx.Get is byte-exact: a
+		// lower-case "origin:" read as absent under DisableHeaderNormalizing.
 		originHeaderRaw := c.Req().Origin()
 		originHeader := utilsstrings.ToLower(originHeaderRaw)
 

--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -126,8 +126,12 @@ func New(config ...Config) fiber.Handler {
 			return c.Next()
 		}
 
-		// If it's a preflight request and doesn't have Access-Control-Request-Method header, it's outside the scope of CORS
-		requestMethod, _ := headerlookup.Value(c, fiber.HeaderAccessControlRequestMethod)
+		// If it's a preflight request and doesn't have Access-Control-Request-Method header, it's outside the scope of CORS.
+		// The header is read only for OPTIONS, so plain cross-origin requests skip the lookup.
+		requestMethod := ""
+		if c.Method() == fiber.MethodOptions {
+			requestMethod, _ = headerlookup.Value(c, fiber.HeaderAccessControlRequestMethod)
+		}
 		if c.Method() == fiber.MethodOptions && requestMethod == "" {
 			// Response to OPTIONS request should not be cached but,
 			// some caching can be configured to cache such responses.
@@ -183,8 +187,14 @@ func New(config ...Config) fiber.Handler {
 		// To avoid poisoning the cache, we include the Vary header
 		// of preflight responses, set in a single variadic Vary call
 		// per branch since every Vary call scans all response headers.
-		privateNetwork, _ := headerlookup.Value(c, fiber.HeaderAccessControlRequestPrivateNetwork)
-		if cfg.AllowPrivateNetwork && privateNetwork == "true" {
+		privateNetworkRequested := false
+		if cfg.AllowPrivateNetwork {
+			// Read only when the feature is on: with the default config the
+			// header's value is discarded, so the lookup would be pure cost.
+			privateNetwork, _ := headerlookup.Value(c, fiber.HeaderAccessControlRequestPrivateNetwork)
+			privateNetworkRequested = privateNetwork == "true"
+		}
+		if privateNetworkRequested {
 			c.Vary(fiber.HeaderAccessControlRequestMethod, fiber.HeaderAccessControlRequestHeaders, fiber.HeaderAccessControlRequestPrivateNetwork, fiber.HeaderOrigin)
 			c.Set(fiber.HeaderAccessControlAllowPrivateNetwork, "true")
 		} else {

--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/internal/fieldname"
+	"github.com/gofiber/fiber/v3/internal/headerlookup"
 	"github.com/gofiber/fiber/v3/log"
 	"github.com/gofiber/utils/v2"
 	utilsstrings "github.com/gofiber/utils/v2/strings"
@@ -107,10 +109,13 @@ func New(config ...Config) fiber.Handler {
 			return c.Next()
 		}
 
-		// Origin, with the original case kept for the response. Req.Origin matches
-		// the field name case-insensitively, where Ctx.Get is byte-exact: a
-		// lower-case "origin:" read as absent under DisableHeaderNormalizing.
-		originHeaderRaw := c.Req().Origin()
+		// Every request header here is read case-insensitively, as csrf already
+		// does: Ctx.Get is byte-exact, so under DisableHeaderNormalizing the
+		// lower-case names HTTP/2 sends read as absent and CORS never applied.
+		canonical := headerlookup.Canonical(c)
+
+		// Origin, with the original case kept for the response.
+		originHeaderRaw, _ := headerlookup.Value(c, fiber.HeaderOrigin)
 		originHeader := utilsstrings.ToLower(originHeaderRaw)
 
 		// If the request does not have Origin header, the request is outside the scope of CORS
@@ -125,7 +130,8 @@ func New(config ...Config) fiber.Handler {
 		}
 
 		// If it's a preflight request and doesn't have Access-Control-Request-Method header, it's outside the scope of CORS
-		if c.Method() == fiber.MethodOptions && c.Get(fiber.HeaderAccessControlRequestMethod) == "" {
+		requestMethod, _ := headerlookup.Value(c, fiber.HeaderAccessControlRequestMethod)
+		if c.Method() == fiber.MethodOptions && requestMethod == "" {
 			// Response to OPTIONS request should not be cached but,
 			// some caching can be configured to cache such responses.
 			// To Avoid poisoning the cache, we include the Vary header
@@ -180,7 +186,8 @@ func New(config ...Config) fiber.Handler {
 		// To avoid poisoning the cache, we include the Vary header
 		// of preflight responses, set in a single variadic Vary call
 		// per branch since every Vary call scans all response headers.
-		if cfg.AllowPrivateNetwork && c.Get(fiber.HeaderAccessControlRequestPrivateNetwork) == "true" {
+		privateNetwork, _ := headerlookup.Value(c, fiber.HeaderAccessControlRequestPrivateNetwork)
+		if cfg.AllowPrivateNetwork && privateNetwork == "true" {
 			c.Vary(fiber.HeaderAccessControlRequestMethod, fiber.HeaderAccessControlRequestHeaders, fiber.HeaderAccessControlRequestPrivateNetwork, fiber.HeaderOrigin)
 			c.Set(fiber.HeaderAccessControlAllowPrivateNetwork, "true")
 		} else {
@@ -196,7 +203,7 @@ func New(config ...Config) fiber.Handler {
 		if len(cfg.AllowHeaders) > 0 {
 			c.Set(fiber.HeaderAccessControlAllowHeaders, strings.Join(cfg.AllowHeaders, ", "))
 		} else {
-			h := c.Get(fiber.HeaderAccessControlRequestHeaders)
+			h := string(fieldname.First(&c.Request().Header, fiber.HeaderAccessControlRequestHeaders, canonical))
 			if h != "" {
 				c.Set(fiber.HeaderAccessControlAllowHeaders, h)
 			}

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -1904,12 +1904,9 @@ func Test_CORS_OriginWithoutHeaderNormalizing(t *testing.T) {
 	lower := do("origin: http://example.com")
 	require.Equal(t, "http://example.com", string(lower.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
 
-	// The canonical spelling behaves the same, so the lookup did not trade one
-	// case for the other.
 	canonical := do("Origin: http://example.com")
 	require.Equal(t, "http://example.com", string(canonical.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
 
-	// A disallowed origin is still refused, whatever the field name looks like.
 	other := do("origin: http://evil.example")
 	require.Empty(t, string(other.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
 }

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -1910,3 +1910,35 @@ func Test_CORS_OriginWithoutHeaderNormalizing(t *testing.T) {
 	other := do("origin: http://evil.example")
 	require.Empty(t, string(other.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
 }
+
+func Test_CORS_PreflightWithoutHeaderNormalizing(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New(fiber.Config{DisableHeaderNormalizing: true})
+	app.Use(New(Config{
+		AllowOrigins: []string{"http://example.com"},
+		AllowMethods: []string{fiber.MethodGet, fiber.MethodPut},
+	}))
+	app.Put("/", func(c fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	raw := "OPTIONS / HTTP/1.1\r\nHost: example.com\r\n" +
+		"origin: http://example.com\r\n" +
+		"access-control-request-method: PUT\r\n" +
+		"access-control-request-headers: X-Custom\r\n\r\n"
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	req.Header.DisableNormalizing()
+	require.NoError(t, req.Read(bufio.NewReader(strings.NewReader(raw))))
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Init(req, nil, nil)
+	app.Handler()(fctx)
+
+	require.Equal(t, fiber.StatusNoContent, fctx.Response.StatusCode())
+	require.Equal(t, "http://example.com", string(fctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
+	require.Contains(t, string(fctx.Response.Header.Peek(fiber.HeaderAccessControlAllowMethods)), fiber.MethodPut)
+	require.Equal(t, "X-Custom", string(fctx.Response.Header.Peek(fiber.HeaderAccessControlAllowHeaders)))
+}

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -1,6 +1,7 @@
 package cors
 
 import (
+	"bufio"
 	"bytes"
 	"net/http"
 	"net/http/httptest"
@@ -1871,4 +1872,44 @@ func Test_CORS_Security_NoOriginReflectionForDisallowed(t *testing.T) {
 	got := resp.Header.Get(fiber.HeaderAccessControlAllowOrigin)
 	require.Empty(t, got)
 	require.NotEqual(t, "https://attacker.example.net", got)
+}
+
+// Test_CORS_OriginWithoutHeaderNormalizing covers the field-name lookup. Ctx.Get
+// is byte-exact, so with DisableHeaderNormalizing a lower-case "origin:" — what
+// HTTP/2 and 3 send — read as absent and the request fell outside CORS
+// altogether: no Access-Control-Allow-Origin, and no Vary either.
+func Test_CORS_OriginWithoutHeaderNormalizing(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New(fiber.Config{DisableHeaderNormalizing: true})
+	app.Use(New(Config{AllowOrigins: []string{"http://example.com"}}))
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	do := func(header string) *fasthttp.RequestCtx {
+		raw := "GET / HTTP/1.1\r\nHost: example.com\r\n" + header + "\r\n\r\n"
+
+		req := fasthttp.AcquireRequest()
+		defer fasthttp.ReleaseRequest(req)
+		req.Header.DisableNormalizing()
+		require.NoError(t, req.Read(bufio.NewReader(strings.NewReader(raw))))
+
+		fctx := &fasthttp.RequestCtx{}
+		fctx.Init(req, nil, nil)
+		app.Handler()(fctx)
+		return fctx
+	}
+
+	lower := do("origin: http://example.com")
+	require.Equal(t, "http://example.com", string(lower.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
+
+	// The canonical spelling behaves the same, so the lookup did not trade one
+	// case for the other.
+	canonical := do("Origin: http://example.com")
+	require.Equal(t, "http://example.com", string(canonical.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
+
+	// A disallowed origin is still refused, whatever the field name looks like.
+	other := do("origin: http://evil.example")
+	require.Empty(t, string(other.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
 }

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -1874,10 +1874,6 @@ func Test_CORS_Security_NoOriginReflectionForDisallowed(t *testing.T) {
 	require.NotEqual(t, "https://attacker.example.net", got)
 }
 
-// Test_CORS_OriginWithoutHeaderNormalizing covers the field-name lookup. Ctx.Get
-// is byte-exact, so with DisableHeaderNormalizing a lower-case "origin:" — what
-// HTTP/2 and 3 send — read as absent and the request fell outside CORS
-// altogether: no Access-Control-Allow-Origin, and no Vary either.
 func Test_CORS_OriginWithoutHeaderNormalizing(t *testing.T) {
 	t.Parallel()
 
@@ -1941,4 +1937,34 @@ func Test_CORS_PreflightWithoutHeaderNormalizing(t *testing.T) {
 	require.Equal(t, "http://example.com", string(fctx.Response.Header.Peek(fiber.HeaderAccessControlAllowOrigin)))
 	require.Contains(t, string(fctx.Response.Header.Peek(fiber.HeaderAccessControlAllowMethods)), fiber.MethodPut)
 	require.Equal(t, "X-Custom", string(fctx.Response.Header.Peek(fiber.HeaderAccessControlAllowHeaders)))
+}
+
+func Test_CORS_PreflightSplitRequestHeaders(t *testing.T) {
+	t.Parallel()
+
+	app := fiber.New()
+	app.Use(New(Config{
+		AllowOrigins: []string{"http://example.com"},
+		AllowMethods: []string{fiber.MethodGet, fiber.MethodPut},
+	}))
+	app.Put("/", func(c fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	raw := "OPTIONS / HTTP/1.1\r\nHost: example.com\r\n" +
+		"Origin: http://example.com\r\n" +
+		"Access-Control-Request-Method: PUT\r\n" +
+		"Access-Control-Request-Headers: X-One\r\n" +
+		"Access-Control-Request-Headers: X-Two\r\n\r\n"
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	require.NoError(t, req.Read(bufio.NewReader(strings.NewReader(raw))))
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Init(req, nil, nil)
+	app.Handler()(fctx)
+
+	require.Equal(t, fiber.StatusNoContent, fctx.Response.StatusCode())
+	require.Equal(t, "X-One, X-Two", string(fctx.Response.Header.Peek(fiber.HeaderAccessControlAllowHeaders)))
 }

--- a/middleware/earlydata/config.go
+++ b/middleware/earlydata/config.go
@@ -39,7 +39,7 @@ var ConfigDefault = Config{
 	},
 
 	AllowEarlyData: func(c fiber.Ctx) bool {
-		return fiber.IsMethodSafe(c.Method())
+		return c.IsSafe()
 	},
 
 	Error: fiber.ErrTooEarly,

--- a/middleware/etag/etag.go
+++ b/middleware/etag/etag.go
@@ -68,7 +68,7 @@ func New(config ...Config) fiber.Handler {
 		}
 
 		// Don't generate ETags for invalid responses
-		if c.Response().StatusCode() != fiber.StatusOK {
+		if c.Res().StatusCode() != fiber.StatusOK {
 			return nil
 		}
 		body := c.Response().Body()
@@ -102,7 +102,7 @@ func New(config ...Config) fiber.Handler {
 		// Both slices are only read for the duration of the comparison and
 		// neither is retained, so the unsafe views cannot outlive them.
 		if internaletag.AnyMatch(utils.UnsafeString(clientEtag), utils.UnsafeString(etag)) {
-			c.RequestCtx().ResetBody()
+			c.Res().ResetBody()
 
 			return c.SendStatus(fiber.StatusNotModified)
 		}

--- a/middleware/etag/etag.go
+++ b/middleware/etag/etag.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	internaletag "github.com/gofiber/fiber/v3/internal/etag"
+	"github.com/gofiber/fiber/v3/internal/fieldname"
+	"github.com/gofiber/fiber/v3/internal/headerlist"
+	"github.com/gofiber/fiber/v3/internal/headerlookup"
 	"github.com/gofiber/utils/v2"
 	"github.com/valyala/bytebufferpool"
 )
@@ -76,8 +79,11 @@ func New(config ...Config) fiber.Handler {
 		if len(body) == 0 {
 			return nil
 		}
-		// Skip ETag if header is already present
-		if c.Response().Header.PeekBytes(normalizedHeaderETag) != nil {
+		// Skip ETag if any field line is already present, whatever case the
+		// handler spelled the name in — a second line would be a conflicting
+		// validator (RFC 9110 Section 8.8.3).
+		respHeader := &c.Response().Header
+		if len(fieldname.Lines(respHeader, fiber.HeaderETag, fieldname.Canonical(respHeader))) > 0 {
 			return nil
 		}
 
@@ -96,8 +102,10 @@ func New(config ...Config) fiber.Handler {
 		// The ETag header is sent on both 200 and 304 responses (RFC 9110 §15.4.5).
 		c.Response().Header.SetCanonical(normalizedHeaderETag, etag)
 
-		// Get ETag header from request
-		clientEtag := c.Request().Header.Peek(fiber.HeaderIfNoneMatch)
+		// Get ETag header from request. If-None-Match is a list field: repeated
+		// lines are one combined list (RFC 9110 Section 5.2) and the name
+		// matches case-insensitively, agreeing with the core Fresh path.
+		clientEtag := headerlist.Join(fieldname.Lines(&c.Request().Header, fiber.HeaderIfNoneMatch, headerlookup.Canonical(c)))
 
 		// Both slices are only read for the duration of the comparison and
 		// neither is retained, so the unsafe views cannot outlive them.

--- a/middleware/etag/etag.go
+++ b/middleware/etag/etag.go
@@ -82,8 +82,12 @@ func New(config ...Config) fiber.Handler {
 		// Skip ETag if any field line is already present, whatever case the
 		// handler spelled the name in — a second line would be a conflicting
 		// validator (RFC 9110 Section 8.8.3).
+		//
+		// Both halves of the guard are needed: fasthttp canonicalizes ETag to
+		// "Etag", so a store of canonical names still holds a spelling the
+		// byte-exact PeekAll(fiber.HeaderETag) misses while normalizing is off.
 		respHeader := &c.Response().Header
-		if len(fieldname.Lines(respHeader, fiber.HeaderETag, fieldname.Canonical(respHeader))) > 0 {
+		if len(fieldname.Lines(respHeader, fiber.HeaderETag, headerlookup.Canonical(c) && fieldname.Canonical(respHeader))) > 0 {
 			return nil
 		}
 

--- a/middleware/etag/etag_test.go
+++ b/middleware/etag/etag_test.go
@@ -402,6 +402,37 @@ func Test_ETag_SplitIfNoneMatch(t *testing.T) {
 	require.Equal(t, fiber.StatusNotModified, resp.StatusCode)
 }
 
+func Test_ETag_HandlerETagSpellingsWithoutNormalizing(t *testing.T) {
+	t.Parallel()
+
+	for _, spelling := range []string{"ETag", "Etag", "etag", "ETAG", "eTaG"} {
+		t.Run(spelling, func(t *testing.T) {
+			t.Parallel()
+			app := fiber.New(fiber.Config{DisableHeaderNormalizing: true})
+			app.Use(New())
+			app.Get("/", func(c fiber.Ctx) error {
+				c.Response().Header.Set(spelling, `"upstream"`)
+				return c.SendString("Hello, World!")
+			})
+
+			fctx := &fasthttp.RequestCtx{}
+			fctx.Request.SetRequestURI("/")
+			fctx.Request.Header.SetMethod(fiber.MethodGet)
+			fctx.Request.Header.DisableNormalizing()
+			fctx.Response.Header.DisableNormalizing()
+			app.Handler()(fctx)
+
+			var lines []string
+			for k, v := range fctx.Response.Header.All() {
+				if utils.EqualFold(string(k), fiber.HeaderETag) {
+					lines = append(lines, string(v))
+				}
+			}
+			require.Equal(t, []string{`"upstream"`}, lines)
+		})
+	}
+}
+
 func Test_ETag_HandlerETagWithoutNormalizing(t *testing.T) {
 	t.Parallel()
 	app := fiber.New(fiber.Config{DisableHeaderNormalizing: true})

--- a/middleware/etag/etag_test.go
+++ b/middleware/etag/etag_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/utils/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 )
@@ -378,4 +379,50 @@ func Test_ETag_WeakComparison(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_ETag_SplitIfNoneMatch(t *testing.T) {
+	t.Parallel()
+	app := fiber.New()
+	app.Use(New())
+	app.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("Hello, World!")
+	})
+
+	resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/", http.NoBody))
+	require.NoError(t, err)
+	generated := resp.Header.Get(fiber.HeaderETag)
+	require.NotEmpty(t, generated)
+
+	req := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Header.Add(fiber.HeaderIfNoneMatch, `"other"`)
+	req.Header.Add(fiber.HeaderIfNoneMatch, generated)
+	resp, err = app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusNotModified, resp.StatusCode)
+}
+
+func Test_ETag_HandlerETagWithoutNormalizing(t *testing.T) {
+	t.Parallel()
+	app := fiber.New(fiber.Config{DisableHeaderNormalizing: true})
+	app.Use(New())
+	app.Get("/", func(c fiber.Ctx) error {
+		c.Set("ETag", `"custom"`)
+		return c.SendString("Hello, World!")
+	})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.SetRequestURI("/")
+	fctx.Request.Header.SetMethod(fiber.MethodGet)
+	fctx.Request.Header.DisableNormalizing()
+	fctx.Response.Header.DisableNormalizing()
+	app.Handler()(fctx)
+
+	var lines []string
+	for k, v := range fctx.Response.Header.All() {
+		if utils.EqualFold(string(k), fiber.HeaderETag) {
+			lines = append(lines, string(v))
+		}
+	}
+	require.Equal(t, []string{`"custom"`}, lines)
 }

--- a/middleware/idempotency/config.go
+++ b/middleware/idempotency/config.go
@@ -58,7 +58,7 @@ type Config struct {
 var ConfigDefault = Config{
 	Next: func(c fiber.Ctx) bool {
 		// Skip middleware if the request was done using a safe HTTP method
-		return fiber.IsMethodSafe(c.Method())
+		return c.IsSafe()
 	},
 
 	Lifetime: 30 * time.Minute,

--- a/middleware/idempotency/idempotency.go
+++ b/middleware/idempotency/idempotency.go
@@ -146,7 +146,7 @@ func New(config ...Config) fiber.Handler {
 
 		// Construct response
 		res := &response{
-			StatusCode: c.Response().StatusCode(),
+			StatusCode: c.Res().StatusCode(),
 			Body:       c.Response().Body(),
 		}
 		{

--- a/middleware/keyauth/keyauth.go
+++ b/middleware/keyauth/keyauth.go
@@ -101,7 +101,7 @@ func New(config ...Config) fiber.Handler {
 		// Execute the error handler first
 		handlerErr := cfg.ErrorHandler(c, err)
 
-		status := c.Response().StatusCode()
+		status := c.Res().StatusCode()
 		if status == fiber.StatusUnauthorized || status == fiber.StatusProxyAuthRequired {
 			header := fiber.HeaderWWWAuthenticate
 			if status == fiber.StatusProxyAuthRequired {

--- a/middleware/limiter/limiter.go
+++ b/middleware/limiter/limiter.go
@@ -32,7 +32,7 @@ func New(config ...Config) fiber.Handler {
 // getEffectiveStatusCode returns the actual status code, considering both the error and response status
 func getEffectiveStatusCode(c fiber.Ctx, err error) int {
 	if nilerror.IsNil(err) {
-		return c.Response().StatusCode()
+		return c.Res().StatusCode()
 	}
 
 	// If there's an error and it's a *fiber.Error, use its status code
@@ -42,5 +42,5 @@ func getEffectiveStatusCode(c fiber.Ctx, err error) int {
 	}
 
 	// Otherwise, use the response status code
-	return c.Response().StatusCode()
+	return c.Res().StatusCode()
 }

--- a/middleware/limiter/limiter_fixed.go
+++ b/middleware/limiter/limiter_fixed.go
@@ -100,7 +100,7 @@ func (FixedWindow) New(cfg *Config) fiber.Handler {
 			return cfg.LimitReached(c)
 		}
 
-		// Continue stack for reaching c.Response().StatusCode()
+		// Continue stack for reaching c.Res().StatusCode()
 		// Store err for returning
 		err = c.Next()
 

--- a/middleware/limiter/limiter_sliding.go
+++ b/middleware/limiter/limiter_sliding.go
@@ -108,7 +108,7 @@ func (SlidingWindow) New(cfg *Config) fiber.Handler {
 			return cfg.LimitReached(c)
 		}
 
-		// Continue stack for reaching c.Response().StatusCode()
+		// Continue stack for reaching c.Res().StatusCode()
 		// Store err for returning
 		err = c.Next()
 

--- a/middleware/logger/default_logger.go
+++ b/middleware/logger/default_logger.go
@@ -53,7 +53,7 @@ func defaultLoggerInstance(c fiber.Ctx, data *Data, cfg *Config) error {
 				buf,
 				"%s |%s %3d %s| %13v | %15s |%s %-7s %s| %-"+data.ErrPaddingStr+"s %s\n",
 				data.Timestamp,
-				statusColor(c.Response().StatusCode(), &colors), c.Response().StatusCode(), colors.Reset,
+				statusColor(c.Res().StatusCode(), &colors), c.Res().StatusCode(), colors.Reset,
 				data.Stop.Sub(data.Start),
 				sanitizeLogValue(c.IP()),
 				methodColor(c.Method(), &colors), c.Method(), colors.Reset,
@@ -86,7 +86,7 @@ func defaultLoggerInstance(c fiber.Ctx, data *Data, cfg *Config) error {
 
 			// Status Code with 3 fixed width, right aligned; appended digit-wise
 			// to avoid the per-request Itoa string.
-			appendIntPadded(buf, c.Response().StatusCode(), 3)
+			appendIntPadded(buf, c.Res().StatusCode(), 3)
 			buf.WriteString(" | ")
 
 			// Duration with 13 fixed width, right aligned

--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -2262,7 +2262,6 @@ func Test_Logger_ResBody_DoesNotDrainStream(t *testing.T) {
 	require.True(t, fctx.Response.IsBodyStream(), "logging must leave a streamed response streamed")
 	require.Equal(t, "[]", logged.String(), "and it logs nothing rather than the buffered stream")
 
-	// A buffered response is still logged, so the tag did not simply go quiet.
 	logged.Reset()
 	buffered := fiber.New()
 	buffered.Use(New(Config{Format: "[${resBody}]", Stream: &logged}))

--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -2231,3 +2231,49 @@ func Test_TagIPs_PropagatesWriteErrors(t *testing.T) {
 		require.Equal(t, len("1.1.1.1,"), n)
 	})
 }
+
+// Test_Logger_ResBody_DoesNotDrainStream covers a side effect logging must not
+// have. The ${resBody} tag read the response through fasthttp's Response.Body,
+// which materializes a body stream into a buffer and closes it — so merely
+// logging an SSE or SendFile route turned a streamed response into a buffered
+// one, holding the whole payload in memory and delaying every event until the
+// writer finished. Res.Body answers nil for a stream instead.
+func Test_Logger_ResBody_DoesNotDrainStream(t *testing.T) {
+	t.Parallel()
+
+	var logged bytes.Buffer
+	app := fiber.New()
+	app.Use(New(Config{
+		Format: "[${resBody}]",
+		Stream: &logged,
+	}))
+	app.Get("/events", func(c fiber.Ctx) error {
+		return c.SendStreamWriter(func(w *bufio.Writer) {
+			w.WriteString("data: one\n\n") //nolint:errcheck // nothing to do with a stream-writer error here
+			w.Flush()                      //nolint:errcheck // same
+		})
+	})
+
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.SetRequestURI("/events")
+	fctx.Request.Header.SetMethod(fiber.MethodGet)
+	app.Handler()(fctx)
+
+	require.True(t, fctx.Response.IsBodyStream(), "logging must leave a streamed response streamed")
+	require.Equal(t, "[]", logged.String(), "and it logs nothing rather than the buffered stream")
+
+	// A buffered response is still logged, so the tag did not simply go quiet.
+	logged.Reset()
+	buffered := fiber.New()
+	buffered.Use(New(Config{Format: "[${resBody}]", Stream: &logged}))
+	buffered.Get("/", func(c fiber.Ctx) error {
+		return c.SendString("hello")
+	})
+
+	bctx := &fasthttp.RequestCtx{}
+	bctx.Request.SetRequestURI("/")
+	bctx.Request.Header.SetMethod(fiber.MethodGet)
+	buffered.Handler()(bctx)
+
+	require.Equal(t, "[hello]", logged.String())
+}

--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -2232,12 +2232,6 @@ func Test_TagIPs_PropagatesWriteErrors(t *testing.T) {
 	})
 }
 
-// Test_Logger_ResBody_DoesNotDrainStream covers a side effect logging must not
-// have. The ${resBody} tag read the response through fasthttp's Response.Body,
-// which materializes a body stream into a buffer and closes it — so merely
-// logging an SSE or SendFile route turned a streamed response into a buffered
-// one, holding the whole payload in memory and delaying every event until the
-// writer finished. Res.Body answers nil for a stream instead.
 func Test_Logger_ResBody_DoesNotDrainStream(t *testing.T) {
 	t.Parallel()
 

--- a/middleware/logger/tags.go
+++ b/middleware/logger/tags.go
@@ -145,10 +145,10 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			return writeSanitized(output, c.Body())
 		},
 		TagBytesReceived: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return appendInt(output, c.Request().Header.ContentLength())
+			return appendInt(output, c.Req().ContentLength())
 		},
 		TagBytesSent: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return appendInt(output, c.Response().Header.ContentLength())
+			return appendInt(output, c.Res().ContentLength())
 		},
 		TagRoute: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
 			// Normally the registered pattern, but Ctx.Route falls back to a
@@ -157,7 +157,10 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			return writeSanitizedString(output, c.Route().Path)
 		},
 		TagResBody: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return writeSanitized(output, c.Response().Body())
+			// Res.Body answers nil for a streamed response rather than draining
+			// it, so logging cannot buffer an SSE or SendFile body it was only
+			// meant to observe.
+			return writeSanitized(output, c.Res().Body())
 		},
 		TagReqHeaders: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
 			out := make(map[string][]string)
@@ -172,7 +175,7 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 			return writeSanitizedString(output, strings.Join(reqHeaders, "&"))
 		},
 		TagQueryStringParams: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
-			return writeSanitizedString(output, c.Request().URI().QueryArgs().String())
+			return writeSanitizedString(output, c.Req().URI().QueryArgs().String())
 		},
 
 		TagBlack: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
@@ -244,9 +247,9 @@ func createTagMap(cfg *Config) map[string]LogFunc {
 		TagStatus: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
 			if cfg.areColorsEnabled {
 				colors := c.App().Config().ColorScheme
-				return fmt.Fprintf(output, "%s%3d%s", statusColor(c.Response().StatusCode(), &colors), c.Response().StatusCode(), colors.Reset)
+				return fmt.Fprintf(output, "%s%3d%s", statusColor(c.Res().StatusCode(), &colors), c.Res().StatusCode(), colors.Reset)
 			}
-			return appendInt(output, c.Response().StatusCode())
+			return appendInt(output, c.Res().StatusCode())
 		},
 		TagMethod: func(output Buffer, c fiber.Ctx, _ *Data, _ string) (int, error) {
 			if cfg.areColorsEnabled {

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -524,7 +524,7 @@ func (s *Session) delSession() {
 		switch ext.Source {
 		case extractors.SourceHeader:
 			s.ctx.Request().Header.Del(ext.Key)
-			s.ctx.Response().Header.Del(ext.Key)
+			s.ctx.Res().Del(ext.Key)
 		case extractors.SourceCookie:
 			s.ctx.Request().Header.DelCookie(ext.Key)
 			s.ctx.Response().Header.DelCookie(ext.Key)

--- a/middleware/timeout/timeout.go
+++ b/middleware/timeout/timeout.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"runtime/debug"
 
+	"github.com/valyala/fasthttp"
+
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/log"
 )
@@ -119,12 +121,14 @@ func handleTimeout(
 		timeoutErr = invokeOnTimeout(ctx, cfg)
 
 		// If the response is still the default 200/empty, ensure a sensible timeout
-		// response is captured for fasthttp to send.
-		// Written is stream-safe: Response().Body() would materialize a body
-		// stream the timed-out handler may still be writing, blocking forever.
-		if ctx.Res().StatusCode() == fiber.StatusOK && !ctx.Res().Written() {
-			ctx.Response().SetStatusCode(fiber.StatusRequestTimeout)
-			ctx.Response().SetBodyString(fiber.ErrRequestTimeout.Message)
+		// response is captured for fasthttp to send. ResetBody closes a body
+		// stream rather than draining it, so a reader the timed-out handler never
+		// finishes writing cannot block this path.
+		resp := ctx.Response()
+		if resp.StatusCode() == fiber.StatusOK && timeoutResponseUnwritten(resp) {
+			resp.ResetBody()
+			resp.SetStatusCode(fiber.StatusRequestTimeout)
+			resp.SetBodyString(fiber.ErrRequestTimeout.Message)
 		}
 
 		// Tell fasthttp to not recycle the RequestCtx - it will acquire a new one
@@ -163,6 +167,13 @@ func handleTimeout(
 	}()
 
 	return timeoutErr
+}
+
+// timeoutResponseUnwritten reports whether the response still carries nothing a
+// client could use. A stream counts as unwritten, since Response.CopyTo does not
+// carry one over, and is checked first because Body would drain it.
+func timeoutResponseUnwritten(resp *fasthttp.Response) bool {
+	return resp.IsBodyStream() || len(resp.Body()) == 0
 }
 
 // invokeOnTimeout calls the OnTimeout handler if configured

--- a/middleware/timeout/timeout.go
+++ b/middleware/timeout/timeout.go
@@ -120,7 +120,7 @@ func handleTimeout(
 
 		// If the response is still the default 200/empty, ensure a sensible timeout
 		// response is captured for fasthttp to send.
-		if ctx.Response().StatusCode() == fiber.StatusOK && len(ctx.Response().Body()) == 0 {
+		if ctx.Res().StatusCode() == fiber.StatusOK && len(ctx.Response().Body()) == 0 {
 			ctx.Response().SetStatusCode(fiber.StatusRequestTimeout)
 			ctx.Response().SetBodyString(fiber.ErrRequestTimeout.Message)
 		}

--- a/middleware/timeout/timeout.go
+++ b/middleware/timeout/timeout.go
@@ -120,7 +120,9 @@ func handleTimeout(
 
 		// If the response is still the default 200/empty, ensure a sensible timeout
 		// response is captured for fasthttp to send.
-		if ctx.Res().StatusCode() == fiber.StatusOK && len(ctx.Response().Body()) == 0 {
+		// Written is stream-safe: Response().Body() would materialize a body
+		// stream the timed-out handler may still be writing, blocking forever.
+		if ctx.Res().StatusCode() == fiber.StatusOK && !ctx.Res().Written() {
 			ctx.Response().SetStatusCode(fiber.StatusRequestTimeout)
 			ctx.Response().SetBodyString(fiber.ErrRequestTimeout.Message)
 		}

--- a/middleware/timeout/timeout_test.go
+++ b/middleware/timeout/timeout_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -653,4 +654,77 @@ func TestTimeout_AbandonWithoutReclaimNotPooled(t *testing.T) {
 	ctx.Abandon()
 	app.ReleaseCtx(ctx)
 	require.True(t, ctx.IsAbandoned(), "abandoned, un-armed context must not be auto-reclaimed")
+}
+
+type neverReturningReader struct{}
+
+func (neverReturningReader) Read(_ []byte) (int, error) { select {} }
+
+// Test_Timeout_ResponseUnwritten covers the OnTimeout fallback's decision on its
+// own. Driving it through a served request would mean reading the response while
+// the timed-out handler still writes to it, which is a race this middleware has
+// either way: the handler is abandoned by design and keeps running.
+func Test_Timeout_ResponseUnwritten(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		setup func(resp *fasthttp.Response)
+		name  string
+		want  bool
+	}{
+		{
+			name:  "nothing written",
+			setup: func(_ *fasthttp.Response) {},
+			want:  true,
+		},
+		{
+			name:  "stream with a payload",
+			setup: func(resp *fasthttp.Response) { resp.SetBodyStream(strings.NewReader("streamed"), -1) },
+			want:  true,
+		},
+		{
+			name:  "stream that yields nothing",
+			setup: func(resp *fasthttp.Response) { resp.SetBodyStream(strings.NewReader(""), -1) },
+			want:  true,
+		},
+		{
+			name:  "reader that never returns",
+			setup: func(resp *fasthttp.Response) { resp.SetBodyStream(neverReturningReader{}, -1) },
+			want:  true,
+		},
+		{
+			name:  "buffered body the handler already wrote",
+			setup: func(resp *fasthttp.Response) { resp.SetBodyString("handler-body") },
+			want:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &fasthttp.Response{}
+			tc.setup(resp)
+			require.Equal(t, tc.want, timeoutResponseUnwritten(resp))
+		})
+	}
+}
+
+func Test_Timeout_OnTimeout_ResetsBodyStream(t *testing.T) {
+	t.Parallel()
+
+	resp := &fasthttp.Response{}
+	resp.SetBodyStream(neverReturningReader{}, -1)
+
+	require.True(t, timeoutResponseUnwritten(resp))
+
+	// What handleTimeout does once the check passes. ResetBody closes the stream
+	// instead of draining it, so this returns rather than blocking on the reader.
+	resp.ResetBody()
+	resp.SetStatusCode(fiber.StatusRequestTimeout)
+	resp.SetBodyString(fiber.ErrRequestTimeout.Message)
+
+	require.False(t, resp.IsBodyStream())
+	require.Equal(t, fiber.StatusRequestTimeout, resp.StatusCode())
+	require.Equal(t, fiber.ErrRequestTimeout.Message, string(resp.Body()))
 }

--- a/req.go
+++ b/req.go
@@ -287,8 +287,10 @@ func (r *DefaultReq) AcceptEncoding() string {
 }
 
 // HasHeader reports whether the request includes a header with the given key.
+// The field name matches case-insensitively (RFC 9110 Section 5.1), so this
+// agrees with GetAll on whether the field is there.
 func (r *DefaultReq) HasHeader(key string) bool {
-	return len(r.c.fasthttp.Request.Header.Peek(key)) > 0
+	return len(r.headerField(key)) > 0
 }
 
 // ContentType returns the Content-Type request header, parameters included;

--- a/req.go
+++ b/req.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/net/idna"
 
 	etagpkg "github.com/gofiber/fiber/v3/internal/etag"
+	"github.com/gofiber/fiber/v3/internal/fieldname"
 	"github.com/gofiber/fiber/v3/internal/mediatype"
 )
 
@@ -218,10 +219,11 @@ func (r *DefaultReq) BodyStream() io.Reader {
 
 // ContentLength returns the value of the Content-Length request header.
 //
-// A negative result means the length is not known up front rather than that the
-// body is empty: fasthttp reports -1 for a chunked body and -2 for one
-// terminated by closing the connection. Use HasBody to test only for the
-// presence of a body.
+// A negative result is not a length. fasthttp reports -1 for a chunked body and
+// -2 for "Transfer-Encoding: identity", which is also what an ordinary GET with
+// no body reports — so -2, not 0, is the common case for a bodyless request.
+// Use HasBody to test whether there is a body at all, and read this only to
+// find out how large a declared one is.
 func (r *DefaultReq) ContentLength() int {
 	return r.c.fasthttp.Request.Header.ContentLength()
 }
@@ -256,8 +258,30 @@ func (r *DefaultReq) Referer() string {
 }
 
 // Origin returns the Origin request header.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting to use the value outside the Handler.
 func (r *DefaultReq) Origin() string {
-	return r.c.app.toString(r.c.fasthttp.Request.Header.Peek(HeaderOrigin))
+	return r.c.app.toString(r.headerField(HeaderOrigin))
+}
+
+// headerField returns a request header's field value, matching the field name
+// the way a recipient must (RFC 9110 Section 5.1).
+//
+// fasthttp's Peek is byte-exact, which resolves every spelling only while it
+// canonicalizes the key; under DisableHeaderNormalizing the store keeps what the
+// peer sent, which for HTTP/2 and 3 is lower case. That is the bug the CSRF
+// middleware was fixed for: a lower-case "origin:" read as absent and the
+// same-origin check found nothing to verify. The byte-exact read stays the fast
+// path, and the walk runs only for the config that needs it.
+func (r *DefaultReq) headerField(name string) []byte {
+	if v := r.c.fasthttp.Request.Header.Peek(name); len(v) > 0 {
+		return v
+	}
+	if !r.c.app.config.DisableHeaderNormalizing {
+		return nil
+	}
+
+	return fieldname.First(&r.c.fasthttp.Request.Header, name, false)
 }
 
 // AcceptLanguage returns the Accept-Language request header.
@@ -277,6 +301,18 @@ func (r *DefaultReq) AcceptEncoding() string {
 // HasHeader reports whether the request includes a header with the given key.
 func (r *DefaultReq) HasHeader(key string) bool {
 	return len(r.c.fasthttp.Request.Header.Peek(key)) > 0
+}
+
+// ContentType returns the Content-Type request header, parameters included.
+// MediaType returns the same header with the parameters stripped, and Charset
+// returns just the charset one.
+//
+// Req and Res both carry a ContentType, so on Ctx the request wins, as it does
+// for Get. Use Res().ContentType() for the type the response will send.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting to use the value outside the Handler.
+func (r *DefaultReq) ContentType() string {
+	return r.c.app.toString(r.c.fasthttp.Request.Header.ContentType())
 }
 
 // MediaType returns the MIME type from the Content-Type header without parameters.
@@ -416,29 +452,42 @@ func (r *DefaultReq) Cookies(key string, defaultValue ...string) string {
 }
 
 // CookieNames returns the names of the cookies sent with the request, in the
-// order they appear in the Cookie header. A name repeated by the client is
-// returned once per occurrence.
-// Returned values are only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting to use the values outside the Handler.
+// order they appear in the Cookie header, or nil when the client sent none. A
+// name the client repeated is returned once per occurrence, which is how a
+// caller detects the shadowing AllCookies collapses.
+//
+// Unlike Cookies, the returned strings are copies rather than views into the
+// request buffer, so they stay valid past the handler.
 func (r *DefaultReq) CookieNames() []string {
-	app := r.c.app
-	names := make([]string, 0, 8)
+	var names []string
 	for key := range r.c.fasthttp.Request.Header.Cookies() {
-		names = append(names, app.toString(key))
+		names = append(names, string(key))
 	}
 	return names
 }
 
-// AllCookies returns the cookies sent with the request as a name/value map.
-// When the client repeats a name the last value wins; use CookieNames to detect
-// that case.
-// Returned values are only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting to use the values outside the Handler.
+// AllCookies returns the cookies sent with the request as a name/value map, or
+// nil when the client sent none. A repeated name resolves to its first
+// occurrence, which is the one Cookies answers with too — the two must agree,
+// because a client can shadow a cookie by sending the name twice and code that
+// validated one value while consuming the other would validate the wrong one.
+// Use CookieNames to see that a name was repeated at all.
+//
+// The keys and values are copies rather than views into the request buffer:
+// fasthttp rewrites those bytes in place when a handler edits a request cookie,
+// which would not merely stale the map but rehash it into one whose own keys no
+// longer find their entries.
 func (r *DefaultReq) AllCookies() map[string]string {
-	app := r.c.app
-	cookies := make(map[string]string)
+	var cookies map[string]string
 	for key, value := range r.c.fasthttp.Request.Header.Cookies() {
-		cookies[app.toString(key)] = app.toString(value)
+		name := string(key)
+		if _, seen := cookies[name]; seen {
+			continue
+		}
+		if cookies == nil {
+			cookies = make(map[string]string)
+		}
+		cookies[name] = string(value)
 	}
 	return cookies
 }
@@ -614,9 +663,12 @@ func parseHTTPDate(date []byte) (time.Time, error) {
 // header. Repeated field lines are combined into one list (RFC 9110
 // Section 5.2), and a comma inside a quoted opaque-tag does not split it, so
 // `"v1,v2"` stays one tag. A wildcard header returns a single "*" element.
-// Tags are returned verbatim, weak "W/" prefix included, and are not validated.
-// Fresh already applies these tags to the response ETag; reach for this only to
-// implement a comparison of your own.
+// Tags are returned verbatim, weak "W/" prefix included, and are not validated;
+// empty list elements are dropped, as RFC 9110 Section 5.6.1 requires, so a
+// trailing comma is not an extra tag. Fresh already applies these tags to the
+// response ETag; reach for this only to implement a comparison of your own.
+// Returned values are only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting instead.
 func (r *DefaultReq) IfNoneMatch() []string {
 	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderIfNoneMatch))
 	if len(header) == 0 {
@@ -663,18 +715,25 @@ func GetReqHeader[V GenericType](c Ctx, key string, defaultValue ...V) V {
 // A header repeated across field lines is semantically one comma-joined list
 // (RFC 9110 Section 5.2). GetAll keeps the lines apart so a caller can inspect
 // them individually, where Get returns only the first and GetHeaders builds a
-// map of the whole header block.
+// map of the whole header block. It returns nil when the header is absent.
+//
+// Empty field lines are skipped, so len(GetAll(k)) > 0 answers the same question
+// as HasHeader(k). Without that, the headers fasthttp keeps in a slot of their
+// own report one empty line when they are not present at all, and a
+// request-smuggling guard testing for Content-Length would fire on every request
+// that has none.
 // Returned values are only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting instead.
 func (r *DefaultReq) GetAll(key string) []string {
-	lines := r.c.fasthttp.Request.Header.PeekAll(key)
-	if len(lines) == 0 {
-		return nil
-	}
 	app := r.c.app
-	values := make([]string, len(lines))
-	for i, line := range lines {
-		values[i] = app.toString(line)
+	lines := fieldname.Lines(&r.c.fasthttp.Request.Header, key, !app.config.DisableHeaderNormalizing)
+
+	var values []string
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		values = append(values, app.toString(line))
 	}
 	return values
 }
@@ -683,13 +742,18 @@ func (r *DefaultReq) GetAll(key string) []string {
 // and the credentials that follow (RFC 9110 Section 11.6.2). Both are empty
 // when the header is absent. The credentials are returned verbatim — token68 or
 // auth-param list — and are neither decoded nor validated.
+//
+// Returned values are only valid within the handler. Do not store any
+// references: they view the request buffer, which the next request on the
+// connection overwrites, so a credential cached past the handler silently
+// becomes another request's. Make copies or use the Immutable setting instead.
 func (r *DefaultReq) Authorization() (scheme, credentials string) { //nolint:nonamedreturns // gocritic unnamedResult requires naming the two halves for clarity
-	raw := utils.TrimSpace(r.c.fasthttp.Request.Header.Peek(HeaderAuthorization))
+	raw := utils.TrimSpace(r.headerField(HeaderAuthorization))
 	if len(raw) == 0 {
 		return "", ""
 	}
 	app := r.c.app
-	i := bytes.IndexAny(raw, " \t")
+	i := utils.IndexAny2(raw, ' ', '\t')
 	if i < 0 {
 		// A lone token is a scheme without credentials, not credentials without
 		// a scheme: RFC 9110 Section 11.4 makes the scheme the mandatory half.
@@ -702,12 +766,22 @@ func (r *DefaultReq) Authorization() (scheme, credentials string) { //nolint:non
 // (RFC 6750 Section 2.1), or an empty string when the header is absent or names
 // a different auth-scheme. The token is returned verbatim: it is not validated,
 // decoded, or verified, so it still has to be authenticated before it is trusted.
+//
+// Returned value is only valid within the handler. Do not store any references:
+// it views the request buffer, which the next request on the connection
+// overwrites, so a token cached past the handler — or used as a key in a shared
+// map — silently becomes another request's. Make copies or use the Immutable
+// setting instead.
 func (r *DefaultReq) Bearer() string {
-	scheme, credentials := r.Authorization()
-	if !utils.EqualFold(scheme, "Bearer") {
+	raw := utils.TrimSpace(r.headerField(HeaderAuthorization))
+	i := utils.IndexAny2(raw, ' ', '\t')
+	// The scheme is compared on the raw bytes rather than through Authorization,
+	// so a header naming another scheme costs no string at all and a Bearer one
+	// materializes only the token.
+	if i < 0 || !utils.EqualFold(utils.UnsafeString(raw[:i]), "Bearer") {
 		return ""
 	}
-	return credentials
+	return r.c.app.toString(utils.TrimSpace(raw[i+1:]))
 }
 
 // GetHeaders (a.k.a GetReqHeaders) returns the HTTP request headers.

--- a/req.go
+++ b/req.go
@@ -53,33 +53,33 @@ type DefaultReq struct {
 
 // Accepts checks if the specified extensions or content types are acceptable.
 func (r *DefaultReq) Accepts(offers ...string) string {
-	header := headerlist.Join(r.c.fasthttp.Request.Header.PeekAll(HeaderAccept))
+	header := peekJoinedRequestHeader(&r.c.fasthttp.Request.Header, HeaderAccept)
 	return getOffer(header, acceptsOfferType, offers...)
 }
 
 // AcceptsCharsets checks if the specified charset is acceptable.
 func (r *DefaultReq) AcceptsCharsets(offers ...string) string {
-	header := headerlist.Join(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptCharset))
+	header := peekJoinedRequestHeader(&r.c.fasthttp.Request.Header, HeaderAcceptCharset)
 	return getOffer(header, acceptsOffer, offers...)
 }
 
 // AcceptsEncodings checks if the specified encoding is acceptable.
 func (r *DefaultReq) AcceptsEncodings(offers ...string) string {
-	header := headerlist.Join(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptEncoding))
+	header := peekJoinedRequestHeader(&r.c.fasthttp.Request.Header, HeaderAcceptEncoding)
 	return getOffer(header, acceptsOffer, offers...)
 }
 
 // AcceptsLanguages checks if the specified language is acceptable using
 // RFC 4647 Basic Filtering.
 func (r *DefaultReq) AcceptsLanguages(offers ...string) string {
-	header := headerlist.Join(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage))
+	header := peekJoinedRequestHeader(&r.c.fasthttp.Request.Header, HeaderAcceptLanguage)
 	return getOffer(header, acceptsLanguageOfferBasic, offers...)
 }
 
 // AcceptsLanguagesExtended checks if the specified language is acceptable using
 // RFC 4647 Extended Filtering.
 func (r *DefaultReq) AcceptsLanguagesExtended(offers ...string) string {
-	header := headerlist.Join(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage))
+	header := peekJoinedRequestHeader(&r.c.fasthttp.Request.Header, HeaderAcceptLanguage)
 	return getOffer(header, acceptsLanguageOfferExtended, offers...)
 }
 
@@ -273,17 +273,19 @@ func (r *DefaultReq) headerField(name string) []byte {
 }
 
 // AcceptLanguage returns the Accept-Language request header.
-// Repeated field lines are combined into one comma-joined list
-// (RFC 9110 Section 5.2), matching what AcceptsLanguages negotiates on.
+// Repeated field lines are combined into one comma-joined list (RFC 9110
+// Section 5.2) and the field name matches case-insensitively (Section 5.1),
+// matching what AcceptsLanguages negotiates on.
 func (r *DefaultReq) AcceptLanguage() string {
-	return r.c.app.toString(headerlist.Join(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage)))
+	return r.c.app.toString(peekJoinedRequestHeader(&r.c.fasthttp.Request.Header, HeaderAcceptLanguage))
 }
 
 // AcceptEncoding returns the Accept-Encoding request header.
-// Repeated field lines are combined into one comma-joined list
-// (RFC 9110 Section 5.2), matching what AcceptsEncodings negotiates on.
+// Repeated field lines are combined into one comma-joined list (RFC 9110
+// Section 5.2) and the field name matches case-insensitively (Section 5.1),
+// matching what AcceptsEncodings negotiates on.
 func (r *DefaultReq) AcceptEncoding() string {
-	return r.c.app.toString(headerlist.Join(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptEncoding)))
+	return r.c.app.toString(peekJoinedRequestHeader(&r.c.fasthttp.Request.Header, HeaderAcceptEncoding))
 }
 
 // HasHeader reports whether the request includes a header with the given key.
@@ -553,9 +555,11 @@ func (r *DefaultReq) Fresh() bool {
 
 	// fields
 	// List-based fields may be split across multiple field lines, which are
-	// semantically one comma-joined list (RFC 9110 Section 5.2).
-	modifiedSince := header.Peek(HeaderIfModifiedSince)
-	noneMatch := headerlist.Join(header.PeekAll(HeaderIfNoneMatch))
+	// semantically one comma-joined list (RFC 9110 Section 5.2). Field names
+	// match case-insensitively, so the lower-case spellings HTTP/2 and 3 send
+	// are not read as an unconditional request.
+	modifiedSince := r.headerField(HeaderIfModifiedSince)
+	noneMatch := peekJoinedRequestHeader(header, HeaderIfNoneMatch)
 
 	// unconditional request
 	if len(modifiedSince) == 0 && len(noneMatch) == 0 {
@@ -565,7 +569,7 @@ func (r *DefaultReq) Fresh() bool {
 	// Always return stale when Cache-Control: no-cache
 	// to support end-to-end reload requests
 	// https://www.rfc-editor.org/rfc/rfc9111#section-5.2.1.4
-	cacheControl := headerlist.Join(header.PeekAll(HeaderCacheControl))
+	cacheControl := peekJoinedRequestHeader(header, HeaderCacheControl)
 	if len(cacheControl) > 0 && isNoCache(utils.UnsafeString(cacheControl)) {
 		return false
 	}
@@ -636,9 +640,7 @@ func parseHTTPDate(date []byte) (time.Time, error) {
 // verbatim and unvalidated; a comma inside a quoted opaque-tag does not split
 // one. Fresh already compares them. Only valid within the handler.
 func (r *DefaultReq) IfNoneMatch() []string {
-	app := r.c.app
-	lines := fieldname.Lines(&r.c.fasthttp.Request.Header, HeaderIfNoneMatch, !app.config.DisableHeaderNormalizing)
-	header := headerlist.Join(lines)
+	header := peekJoinedRequestHeader(&r.c.fasthttp.Request.Header, HeaderIfNoneMatch)
 	if len(header) == 0 {
 		return nil
 	}

--- a/req.go
+++ b/req.go
@@ -207,23 +207,16 @@ func (r *DefaultReq) Body() []byte {
 	return r.c.app.GetBytes(body)
 }
 
-// BodyStream returns the request body as a stream.
-//
-// It is only non-nil when Config.StreamRequestBody is enabled and the body has
-// not already been buffered; IsBodyStream on the underlying request reports
-// which of the two is in play. Reading from the returned reader consumes the
-// body, so a later Body call will not see it.
+// BodyStream returns the request body as a stream, non-nil only when
+// Config.StreamRequestBody is enabled and the body is not already buffered.
+// Reading it consumes the body, so a later Body call will not see it.
 func (r *DefaultReq) BodyStream() io.Reader {
 	return r.c.fasthttp.Request.BodyStream()
 }
 
-// ContentLength returns the value of the Content-Length request header.
-//
-// A negative result is not a length. fasthttp reports -1 for a chunked body and
-// -2 for "Transfer-Encoding: identity", which is also what an ordinary GET with
-// no body reports — so -2, not 0, is the common case for a bodyless request.
-// Use HasBody to test whether there is a body at all, and read this only to
-// find out how large a declared one is.
+// ContentLength returns the value of the Content-Length request header. A
+// negative result is not a length: -1 is chunked and -2 is identity, which is
+// what a bodyless GET reports. Use HasBody to test for a body at all.
 func (r *DefaultReq) ContentLength() int {
 	return r.c.fasthttp.Request.Header.ContentLength()
 }
@@ -265,14 +258,8 @@ func (r *DefaultReq) Origin() string {
 }
 
 // headerField returns a request header's field value, matching the field name
-// the way a recipient must (RFC 9110 Section 5.1).
-//
-// fasthttp's Peek is byte-exact, which resolves every spelling only while it
-// canonicalizes the key; under DisableHeaderNormalizing the store keeps what the
-// peer sent, which for HTTP/2 and 3 is lower case. That is the bug the CSRF
-// middleware was fixed for: a lower-case "origin:" read as absent and the
-// same-origin check found nothing to verify. The byte-exact read stays the fast
-// path, and the walk runs only for the config that needs it.
+// case-insensitively (RFC 9110 Section 5.1). Peek is byte-exact, so under
+// DisableHeaderNormalizing a lower-case "origin:" read as absent.
 func (r *DefaultReq) headerField(name string) []byte {
 	if v := r.c.fasthttp.Request.Header.Peek(name); len(v) > 0 {
 		return v
@@ -303,14 +290,9 @@ func (r *DefaultReq) HasHeader(key string) bool {
 	return len(r.c.fasthttp.Request.Header.Peek(key)) > 0
 }
 
-// ContentType returns the Content-Type request header, parameters included.
-// MediaType returns the same header with the parameters stripped, and Charset
-// returns just the charset one.
-//
-// Req and Res both carry a ContentType, so on Ctx the request wins, as it does
-// for Get. Use Res().ContentType() for the type the response will send.
-// Returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting to use the value outside the Handler.
+// ContentType returns the Content-Type request header, parameters included;
+// MediaType strips them and Charset returns just the charset. On Ctx the request
+// wins over Res. Only valid within the handler unless Immutable is set.
 func (r *DefaultReq) ContentType() string {
 	return r.c.app.toString(r.c.fasthttp.Request.Header.ContentType())
 }
@@ -451,13 +433,9 @@ func (r *DefaultReq) Cookies(key string, defaultValue ...string) string {
 	return defaultString(r.c.app.toString(r.c.fasthttp.Request.Header.Cookie(key)), defaultValue)
 }
 
-// CookieNames returns the names of the cookies sent with the request, in the
-// order they appear in the Cookie header, or nil when the client sent none. A
-// name the client repeated is returned once per occurrence, which is how a
-// caller detects the shadowing AllCookies collapses.
-//
-// Unlike Cookies, the returned strings are copies rather than views into the
-// request buffer, so they stay valid past the handler.
+// CookieNames returns the request cookie names in header order, or nil when
+// there are none. A repeated name appears once per occurrence, which is how the
+// shadowing AllCookies collapses is detected. The strings are copies.
 func (r *DefaultReq) CookieNames() []string {
 	var names []string
 	for key := range r.c.fasthttp.Request.Header.Cookies() {
@@ -466,17 +444,9 @@ func (r *DefaultReq) CookieNames() []string {
 	return names
 }
 
-// AllCookies returns the cookies sent with the request as a name/value map, or
-// nil when the client sent none. A repeated name resolves to its first
-// occurrence, which is the one Cookies answers with too — the two must agree,
-// because a client can shadow a cookie by sending the name twice and code that
-// validated one value while consuming the other would validate the wrong one.
-// Use CookieNames to see that a name was repeated at all.
-//
-// The keys and values are copies rather than views into the request buffer:
-// fasthttp rewrites those bytes in place when a handler edits a request cookie,
-// which would not merely stale the map but rehash it into one whose own keys no
-// longer find their entries.
+// AllCookies returns the request cookies as a name/value map, or nil when there
+// are none. A repeated name resolves to its first occurrence, as Cookies does,
+// so a shadowed cookie cannot be validated in one and consumed in the other.
 func (r *DefaultReq) AllCookies() map[string]string {
 	var cookies map[string]string
 	for key, value := range r.c.fasthttp.Request.Header.Cookies() {
@@ -659,16 +629,9 @@ func parseHTTPDate(date []byte) (time.Time, error) {
 	return t, nil
 }
 
-// IfNoneMatch returns the entity tags listed in the If-None-Match request
-// header. Repeated field lines are combined into one list (RFC 9110
-// Section 5.2), and a comma inside a quoted opaque-tag does not split it, so
-// `"v1,v2"` stays one tag. A wildcard header returns a single "*" element.
-// Tags are returned verbatim, weak "W/" prefix included, and are not validated;
-// empty list elements are dropped, as RFC 9110 Section 5.6.1 requires, so a
-// trailing comma is not an extra tag. Fresh already applies these tags to the
-// response ETag; reach for this only to implement a comparison of your own.
-// Returned values are only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting instead.
+// IfNoneMatch returns the entity tags in the If-None-Match request header,
+// verbatim and unvalidated; a comma inside a quoted opaque-tag does not split
+// one. Fresh already compares them. Only valid within the handler.
 func (r *DefaultReq) IfNoneMatch() []string {
 	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderIfNoneMatch))
 	if len(header) == 0 {
@@ -678,9 +641,8 @@ func (r *DefaultReq) IfNoneMatch() []string {
 }
 
 // IfModifiedSince returns the time carried by the If-Modified-Since request
-// header. It returns ErrHeaderNotFound when the header is absent, and a parse
-// error when the value is none of the three HTTP-date formats RFC 9110
-// Section 5.6.7 requires recipients to accept.
+// header, ErrHeaderNotFound when it is absent, and a parse error when it is none
+// of the three HTTP-date formats RFC 9110 Section 5.6.7 requires.
 func (r *DefaultReq) IfModifiedSince() (time.Time, error) {
 	value := r.c.fasthttp.Request.Header.Peek(HeaderIfModifiedSince)
 	if len(value) == 0 {
@@ -709,21 +671,9 @@ func GetReqHeader[V GenericType](c Ctx, key string, defaultValue ...V) V {
 	return v
 }
 
-// GetAll returns every field line of the request header specified by key.
-// Field names are case-insensitive.
-//
-// A header repeated across field lines is semantically one comma-joined list
-// (RFC 9110 Section 5.2). GetAll keeps the lines apart so a caller can inspect
-// them individually, where Get returns only the first and GetHeaders builds a
-// map of the whole header block. It returns nil when the header is absent.
-//
-// Empty field lines are skipped, so len(GetAll(k)) > 0 answers the same question
-// as HasHeader(k). Without that, the headers fasthttp keeps in a slot of their
-// own report one empty line when they are not present at all, and a
-// request-smuggling guard testing for Content-Length would fire on every request
-// that has none.
-// Returned values are only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting instead.
+// GetAll returns every field line stored under key, where Get returns only the
+// first, or nil when the header is absent. Empty lines are skipped, so its
+// presence answers as HasHeader does. Only valid within the handler.
 func (r *DefaultReq) GetAll(key string) []string {
 	app := r.c.app
 	lines := fieldname.Lines(&r.c.fasthttp.Request.Header, key, !app.config.DisableHeaderNormalizing)
@@ -738,15 +688,9 @@ func (r *DefaultReq) GetAll(key string) []string {
 	return values
 }
 
-// Authorization splits the Authorization request header into its auth-scheme
-// and the credentials that follow (RFC 9110 Section 11.6.2). Both are empty
-// when the header is absent. The credentials are returned verbatim — token68 or
-// auth-param list — and are neither decoded nor validated.
-//
-// Returned values are only valid within the handler. Do not store any
-// references: they view the request buffer, which the next request on the
-// connection overwrites, so a credential cached past the handler silently
-// becomes another request's. Make copies or use the Immutable setting instead.
+// Authorization splits the Authorization header into auth-scheme and credentials
+// (RFC 9110 Section 11.6.2), neither decoded nor validated. They view the request
+// buffer: a credential kept past the handler becomes another request's.
 func (r *DefaultReq) Authorization() (scheme, credentials string) { //nolint:nonamedreturns // gocritic unnamedResult requires naming the two halves for clarity
 	raw := utils.TrimSpace(r.headerField(HeaderAuthorization))
 	if len(raw) == 0 {
@@ -762,16 +706,9 @@ func (r *DefaultReq) Authorization() (scheme, credentials string) { //nolint:non
 	return app.toString(raw[:i]), app.toString(utils.TrimSpace(raw[i+1:]))
 }
 
-// Bearer returns the credentials of a Bearer Authorization header
-// (RFC 6750 Section 2.1), or an empty string when the header is absent or names
-// a different auth-scheme. The token is returned verbatim: it is not validated,
-// decoded, or verified, so it still has to be authenticated before it is trusted.
-//
-// Returned value is only valid within the handler. Do not store any references:
-// it views the request buffer, which the next request on the connection
-// overwrites, so a token cached past the handler — or used as a key in a shared
-// map — silently becomes another request's. Make copies or use the Immutable
-// setting instead.
+// Bearer returns the credentials of a Bearer Authorization header (RFC 6750
+// Section 2.1), unverified, or "" for another scheme. It views the request
+// buffer: a token kept past the handler becomes another request's.
 func (r *DefaultReq) Bearer() string {
 	raw := utils.TrimSpace(r.headerField(HeaderAuthorization))
 	i := utils.IndexAny2(raw, ' ', '\t')
@@ -1339,12 +1276,9 @@ func (r *DefaultReq) OriginalURL() string {
 	return r.c.app.toString(r.c.fasthttp.Request.Header.RequestURI())
 }
 
-// URI returns the parsed *fasthttp.URI of the request.
-// This allows you to use all fasthttp URI methods.
-// https://godoc.org/github.com/valyala/fasthttp#URI
-//
-// The returned value is owned by the request and is rewritten by a Path
-// override, so it is only valid within the handler. Do not store any references.
+// URI returns the parsed *fasthttp.URI of the request, giving access to all
+// fasthttp URI methods. It is owned by the request and rewritten by a Path
+// override, so it is only valid within the handler.
 func (r *DefaultReq) URI() *fasthttp.URI {
 	return r.c.fasthttp.Request.URI()
 }

--- a/req.go
+++ b/req.go
@@ -161,11 +161,13 @@ func (r *DefaultReq) Body() []byte {
 
 	request := &r.c.fasthttp.Request
 
-	// Fast path: no Content-Encoding header at all. ContentEncoding uses the
-	// pre-normalized key constant, so absence costs a single cheap lookup.
+	// Fast path: no Content-Encoding header at all. ContentEncoding peeks the
+	// stored key byte-exactly, which is decisive only while fasthttp normalized
+	// the names on the way in — under DisableHeaderNormalizing a lower-case
+	// spelling would read as absent here and skip decompression entirely.
 	// An empty value is still a present field line and must be joined with
 	// duplicates below before RFC 9110 empty-list elements are ignored.
-	if request.Header.ContentEncoding() == nil {
+	if !r.c.app.config.DisableHeaderNormalizing && request.Header.ContentEncoding() == nil {
 		return r.getBody()
 	}
 
@@ -258,18 +260,12 @@ func (r *DefaultReq) Origin() string {
 	return r.c.app.toString(r.headerField(HeaderOrigin))
 }
 
-// headerField returns a request header's field value, matching the field name
-// case-insensitively (RFC 9110 Section 5.1). Peek is byte-exact, so under
-// DisableHeaderNormalizing a lower-case "origin:" read as absent.
+// headerField returns a request header's first non-empty field value, matching
+// the field name case-insensitively (RFC 9110 Section 5.1). fieldname.First
+// also steps over a present-but-empty first line, so a value on a later line
+// is found and this agrees with GetAll on whether the field is there.
 func (r *DefaultReq) headerField(name string) []byte {
-	if v := r.c.fasthttp.Request.Header.Peek(name); len(v) > 0 {
-		return v
-	}
-	if !r.c.app.config.DisableHeaderNormalizing {
-		return nil
-	}
-
-	return fieldname.First(&r.c.fasthttp.Request.Header, name, false)
+	return fieldname.First(&r.c.fasthttp.Request.Header, name, !r.c.app.config.DisableHeaderNormalizing)
 }
 
 // AcceptLanguage returns the Accept-Language request header.
@@ -671,7 +667,7 @@ func (r *DefaultReq) Get(key string, defaultValue ...string) string {
 // If the generic type cannot be matched to a supported type, the function
 // returns the default value (if provided) or the zero value of type V.
 func GetReqHeader[V GenericType](c Ctx, key string, defaultValue ...V) V {
-	v, err := genericParseType[V](c.App().toString(c.Request().Header.Peek(key)))
+	v, err := genericParseType[V](c.App().toString(c.Req().headerField(key)))
 	if err != nil && len(defaultValue) > 0 {
 		return defaultValue[0]
 	}
@@ -699,33 +695,38 @@ func (r *DefaultReq) GetAll(key string) []string {
 // (RFC 9110 Section 11.6.2), neither decoded nor validated. They view the request
 // buffer: a credential kept past the handler becomes another request's.
 func (r *DefaultReq) Authorization() (scheme, credentials string) { //nolint:nonamedreturns // gocritic unnamedResult requires naming the two halves for clarity
+	rawScheme, rawCredentials := r.authorizationParts()
+	app := r.c.app
+	return app.toString(rawScheme), app.toString(rawCredentials)
+}
+
+// authorizationParts splits the Authorization header at the first space or tab
+// (RFC 9110 Section 11.4), on raw bytes so each caller materializes only the
+// strings it needs. A lone token is a scheme without credentials.
+func (r *DefaultReq) authorizationParts() (scheme, credentials []byte) { //nolint:nonamedreturns // the two halves need naming for clarity
 	raw := utils.TrimSpace(r.headerField(HeaderAuthorization))
 	if len(raw) == 0 {
-		return "", ""
+		return nil, nil
 	}
-	app := r.c.app
 	i := utils.IndexAny2(raw, ' ', '\t')
 	if i < 0 {
-		// A lone token is a scheme without credentials, not credentials without
-		// a scheme: RFC 9110 Section 11.4 makes the scheme the mandatory half.
-		return app.toString(raw), ""
+		return raw, nil
 	}
-	return app.toString(raw[:i]), app.toString(utils.TrimSpace(raw[i+1:]))
+	return raw[:i], utils.TrimSpace(raw[i+1:])
 }
 
 // Bearer returns the credentials of a Bearer Authorization header (RFC 6750
 // Section 2.1), unverified, or "" for another scheme. It views the request
 // buffer: a token kept past the handler becomes another request's.
 func (r *DefaultReq) Bearer() string {
-	raw := utils.TrimSpace(r.headerField(HeaderAuthorization))
-	i := utils.IndexAny2(raw, ' ', '\t')
 	// The scheme is compared on the raw bytes rather than through Authorization,
 	// so a header naming another scheme costs no string at all and a Bearer one
 	// materializes only the token.
-	if i < 0 || !utils.EqualFold(utils.UnsafeString(raw[:i]), "Bearer") {
+	scheme, credentials := r.authorizationParts()
+	if len(credentials) == 0 || !utils.EqualFold(utils.UnsafeString(scheme), "Bearer") {
 		return ""
 	}
-	return r.c.app.toString(utils.TrimSpace(raw[i+1:]))
+	return r.c.app.toString(credentials)
 }
 
 // GetHeaders (a.k.a GetReqHeaders) returns the HTTP request headers.
@@ -1095,12 +1096,14 @@ func (r *DefaultReq) IsWebSocket() bool {
 	// Repeated field lines are equivalent to one combined comma-separated
 	// list (RFC 9110 Section 5.2), so inspect every Connection and Upgrade
 	// field line, not just the first.
-	if !headerListContainsToken(r.c.fasthttp.Request.Header.PeekAll(HeaderConnection), "upgrade") {
+	hdr := &r.c.fasthttp.Request.Header
+	canonical := !r.c.app.config.DisableHeaderNormalizing
+	if !headerListContainsToken(fieldname.Lines(hdr, HeaderConnection, canonical), "upgrade") {
 		return false
 	}
 	// Upgrade is a list of protocols, each optionally carrying a "/version"
 	// suffix (RFC 9110 Section 7.8), e.g. "Upgrade: websocket, h2c".
-	return headerListContainsToken(r.c.fasthttp.Request.Header.PeekAll(HeaderUpgrade), "websocket")
+	return headerListContainsToken(fieldname.Lines(hdr, HeaderUpgrade, canonical), "websocket")
 }
 
 // headerListContainsToken reports whether any comma-separated element across
@@ -1144,7 +1147,7 @@ var xmlHTTPRequestBytes = []byte("xmlhttprequest")
 // XHR returns a Boolean property, that is true, if the request's X-Requested-With header field is XMLHttpRequest,
 // indicating that the request was issued by a client library (such as jQuery).
 func (r *DefaultReq) XHR() bool {
-	return utils.EqualFold(r.c.fasthttp.Request.Header.Peek(HeaderXRequestedWith), xmlHTTPRequestBytes)
+	return utils.EqualFold(r.headerField(HeaderXRequestedWith), xmlHTTPRequestBytes)
 }
 
 // Locals makes it possible to pass any values under keys scoped to the request

--- a/req.go
+++ b/req.go
@@ -3,6 +3,7 @@ package fiber
 import (
 	"bytes"
 	"errors"
+	"io"
 	"math"
 	"mime/multipart"
 	"net"
@@ -15,6 +16,7 @@ import (
 	"github.com/valyala/fasthttp"
 	"golang.org/x/net/idna"
 
+	etagpkg "github.com/gofiber/fiber/v3/internal/etag"
 	"github.com/gofiber/fiber/v3/internal/mediatype"
 )
 
@@ -204,6 +206,26 @@ func (r *DefaultReq) Body() []byte {
 	return r.c.app.GetBytes(body)
 }
 
+// BodyStream returns the request body as a stream.
+//
+// It is only non-nil when Config.StreamRequestBody is enabled and the body has
+// not already been buffered; IsBodyStream on the underlying request reports
+// which of the two is in play. Reading from the returned reader consumes the
+// body, so a later Body call will not see it.
+func (r *DefaultReq) BodyStream() io.Reader {
+	return r.c.fasthttp.Request.BodyStream()
+}
+
+// ContentLength returns the value of the Content-Length request header.
+//
+// A negative result means the length is not known up front rather than that the
+// body is empty: fasthttp reports -1 for a chunked body and -2 for one
+// terminated by closing the connection. Use HasBody to test only for the
+// presence of a body.
+func (r *DefaultReq) ContentLength() int {
+	return r.c.fasthttp.Request.Header.ContentLength()
+}
+
 // RequestCtx returns *fasthttp.RequestCtx that carries a deadline
 // a cancellation signal, and other values across API boundaries.
 func (r *DefaultReq) RequestCtx() *fasthttp.RequestCtx {
@@ -211,50 +233,55 @@ func (r *DefaultReq) RequestCtx() *fasthttp.RequestCtx {
 }
 
 // FullURL returns the full request URL (protocol + host + original URL).
-func (c *DefaultCtx) FullURL() string {
+func (r *DefaultReq) FullURL() string {
 	buf := bytebufferpool.Get()
 	defer bytebufferpool.Put(buf)
 
-	buf.WriteString(c.Scheme())
+	buf.WriteString(r.Scheme())
 	buf.WriteString("://")
-	buf.WriteString(c.Host())
-	buf.WriteString(c.OriginalURL())
+	buf.WriteString(r.Host())
+	buf.WriteString(r.OriginalURL())
 
 	return buf.String()
 }
 
 // UserAgent returns the User-Agent request header.
-func (c *DefaultCtx) UserAgent() string {
-	return c.app.toString(c.fasthttp.Request.Header.UserAgent())
+func (r *DefaultReq) UserAgent() string {
+	return r.c.app.toString(r.c.fasthttp.Request.Header.UserAgent())
 }
 
 // Referer returns the Referer request header.
-func (c *DefaultCtx) Referer() string {
-	return c.app.toString(c.fasthttp.Request.Header.Referer())
+func (r *DefaultReq) Referer() string {
+	return r.c.app.toString(r.c.fasthttp.Request.Header.Referer())
+}
+
+// Origin returns the Origin request header.
+func (r *DefaultReq) Origin() string {
+	return r.c.app.toString(r.c.fasthttp.Request.Header.Peek(HeaderOrigin))
 }
 
 // AcceptLanguage returns the Accept-Language request header.
 // Repeated field lines are combined into one comma-joined list
 // (RFC 9110 Section 5.2), matching what AcceptsLanguages negotiates on.
-func (c *DefaultCtx) AcceptLanguage() string {
-	return c.app.toString(joinHeaderValues(c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage)))
+func (r *DefaultReq) AcceptLanguage() string {
+	return r.c.app.toString(joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptLanguage)))
 }
 
 // AcceptEncoding returns the Accept-Encoding request header.
 // Repeated field lines are combined into one comma-joined list
 // (RFC 9110 Section 5.2), matching what AcceptsEncodings negotiates on.
-func (c *DefaultCtx) AcceptEncoding() string {
-	return c.app.toString(joinHeaderValues(c.fasthttp.Request.Header.PeekAll(HeaderAcceptEncoding)))
+func (r *DefaultReq) AcceptEncoding() string {
+	return r.c.app.toString(joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderAcceptEncoding)))
 }
 
 // HasHeader reports whether the request includes a header with the given key.
-func (c *DefaultCtx) HasHeader(key string) bool {
-	return len(c.fasthttp.Request.Header.Peek(key)) > 0
+func (r *DefaultReq) HasHeader(key string) bool {
+	return len(r.c.fasthttp.Request.Header.Peek(key)) > 0
 }
 
 // MediaType returns the MIME type from the Content-Type header without parameters.
-func (c *DefaultCtx) MediaType() string {
-	contentType := utils.TrimSpace(c.fasthttp.Request.Header.ContentType())
+func (r *DefaultReq) MediaType() string {
+	contentType := utils.TrimSpace(r.c.fasthttp.Request.Header.ContentType())
 	if len(contentType) == 0 {
 		return ""
 	}
@@ -262,12 +289,12 @@ func (c *DefaultCtx) MediaType() string {
 		contentType = contentType[:idx]
 	}
 	contentType = utils.TrimSpace(contentType)
-	return c.app.toString(contentType)
+	return r.c.app.toString(contentType)
 }
 
 // Charset returns the charset parameter from the Content-Type header.
-func (c *DefaultCtx) Charset() string {
-	contentType := c.fasthttp.Request.Header.ContentType()
+func (r *DefaultReq) Charset() string {
+	contentType := r.c.fasthttp.Request.Header.ContentType()
 	_, params, ok := bytes.Cut(contentType, []byte{';'})
 	if !ok {
 		return ""
@@ -339,44 +366,44 @@ func (c *DefaultCtx) Charset() string {
 			// charset parameter later in the header can still be found.
 			continue
 		}
-		return c.app.toString(v)
+		return r.c.app.toString(v)
 	}
 	return ""
 }
 
 // IsJSON reports whether the Content-Type header is JSON.
-func (c *DefaultCtx) IsJSON() bool {
-	return utils.EqualFold(c.MediaType(), MIMEApplicationJSON)
+func (r *DefaultReq) IsJSON() bool {
+	return utils.EqualFold(r.MediaType(), MIMEApplicationJSON)
 }
 
 // IsForm reports whether the Content-Type header is form-encoded.
-func (c *DefaultCtx) IsForm() bool {
-	return utils.EqualFold(c.MediaType(), MIMEApplicationForm)
+func (r *DefaultReq) IsForm() bool {
+	return utils.EqualFold(r.MediaType(), MIMEApplicationForm)
 }
 
 // IsMultipart reports whether the Content-Type header is multipart form data.
-func (c *DefaultCtx) IsMultipart() bool {
-	return utils.EqualFold(c.MediaType(), MIMEMultipartForm)
+func (r *DefaultReq) IsMultipart() bool {
+	return utils.EqualFold(r.MediaType(), MIMEMultipartForm)
 }
 
 // AcceptsJSON reports whether the Accept header allows JSON.
-func (c *DefaultCtx) AcceptsJSON() bool {
-	return c.Accepts(MIMEApplicationJSON) != ""
+func (r *DefaultReq) AcceptsJSON() bool {
+	return r.Accepts(MIMEApplicationJSON) != ""
 }
 
 // AcceptsHTML reports whether the Accept header allows HTML.
-func (c *DefaultCtx) AcceptsHTML() bool {
-	return c.Accepts(MIMETextHTML) != ""
+func (r *DefaultReq) AcceptsHTML() bool {
+	return r.Accepts(MIMETextHTML) != ""
 }
 
 // AcceptsXML reports whether the Accept header allows XML.
-func (c *DefaultCtx) AcceptsXML() bool {
-	return c.Accepts(MIMEApplicationXML, MIMETextXML) != ""
+func (r *DefaultReq) AcceptsXML() bool {
+	return r.Accepts(MIMEApplicationXML, MIMETextXML) != ""
 }
 
 // AcceptsEventStream reports whether the Accept header allows text/event-stream.
-func (c *DefaultCtx) AcceptsEventStream() bool {
-	return c.Accepts(MIMETextEventStream) != ""
+func (r *DefaultReq) AcceptsEventStream() bool {
+	return r.Accepts(MIMETextEventStream) != ""
 }
 
 // Cookies are used for getting a cookie value by key.
@@ -386,6 +413,34 @@ func (c *DefaultCtx) AcceptsEventStream() bool {
 // Make copies or use the Immutable setting to use the value outside the Handler.
 func (r *DefaultReq) Cookies(key string, defaultValue ...string) string {
 	return defaultString(r.c.app.toString(r.c.fasthttp.Request.Header.Cookie(key)), defaultValue)
+}
+
+// CookieNames returns the names of the cookies sent with the request, in the
+// order they appear in the Cookie header. A name repeated by the client is
+// returned once per occurrence.
+// Returned values are only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting to use the values outside the Handler.
+func (r *DefaultReq) CookieNames() []string {
+	app := r.c.app
+	names := make([]string, 0, 8)
+	for key := range r.c.fasthttp.Request.Header.Cookies() {
+		names = append(names, app.toString(key))
+	}
+	return names
+}
+
+// AllCookies returns the cookies sent with the request as a name/value map.
+// When the client repeats a name the last value wins; use CookieNames to detect
+// that case.
+// Returned values are only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting to use the values outside the Handler.
+func (r *DefaultReq) AllCookies() map[string]string {
+	app := r.c.app
+	cookies := make(map[string]string)
+	for key, value := range r.c.fasthttp.Request.Header.Cookies() {
+		cookies[app.toString(key)] = app.toString(value)
+	}
+	return cookies
 }
 
 // Request return the *fasthttp.Request object
@@ -555,6 +610,33 @@ func parseHTTPDate(date []byte) (time.Time, error) {
 	return t, nil
 }
 
+// IfNoneMatch returns the entity tags listed in the If-None-Match request
+// header. Repeated field lines are combined into one list (RFC 9110
+// Section 5.2), and a comma inside a quoted opaque-tag does not split it, so
+// `"v1,v2"` stays one tag. A wildcard header returns a single "*" element.
+// Tags are returned verbatim, weak "W/" prefix included, and are not validated.
+// Fresh already applies these tags to the response ETag; reach for this only to
+// implement a comparison of your own.
+func (r *DefaultReq) IfNoneMatch() []string {
+	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderIfNoneMatch))
+	if len(header) == 0 {
+		return nil
+	}
+	return etagpkg.Split(r.c.app.toString(header))
+}
+
+// IfModifiedSince returns the time carried by the If-Modified-Since request
+// header. It returns ErrHeaderNotFound when the header is absent, and a parse
+// error when the value is none of the three HTTP-date formats RFC 9110
+// Section 5.6.7 requires recipients to accept.
+func (r *DefaultReq) IfModifiedSince() (time.Time, error) {
+	value := r.c.fasthttp.Request.Header.Peek(HeaderIfModifiedSince)
+	if len(value) == 0 {
+		return time.Time{}, ErrHeaderNotFound
+	}
+	return parseHTTPDate(value)
+}
+
 // Get returns the HTTP request header specified by field.
 // Field names are case-insensitive
 // Returned value is only valid within the handler. Do not store any references.
@@ -573,6 +655,59 @@ func GetReqHeader[V GenericType](c Ctx, key string, defaultValue ...V) V {
 		return defaultValue[0]
 	}
 	return v
+}
+
+// GetAll returns every field line of the request header specified by key.
+// Field names are case-insensitive.
+//
+// A header repeated across field lines is semantically one comma-joined list
+// (RFC 9110 Section 5.2). GetAll keeps the lines apart so a caller can inspect
+// them individually, where Get returns only the first and GetHeaders builds a
+// map of the whole header block.
+// Returned values are only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting instead.
+func (r *DefaultReq) GetAll(key string) []string {
+	lines := r.c.fasthttp.Request.Header.PeekAll(key)
+	if len(lines) == 0 {
+		return nil
+	}
+	app := r.c.app
+	values := make([]string, len(lines))
+	for i, line := range lines {
+		values[i] = app.toString(line)
+	}
+	return values
+}
+
+// Authorization splits the Authorization request header into its auth-scheme
+// and the credentials that follow (RFC 9110 Section 11.6.2). Both are empty
+// when the header is absent. The credentials are returned verbatim — token68 or
+// auth-param list — and are neither decoded nor validated.
+func (r *DefaultReq) Authorization() (scheme, credentials string) { //nolint:nonamedreturns // gocritic unnamedResult requires naming the two halves for clarity
+	raw := utils.TrimSpace(r.c.fasthttp.Request.Header.Peek(HeaderAuthorization))
+	if len(raw) == 0 {
+		return "", ""
+	}
+	app := r.c.app
+	i := bytes.IndexAny(raw, " \t")
+	if i < 0 {
+		// A lone token is a scheme without credentials, not credentials without
+		// a scheme: RFC 9110 Section 11.4 makes the scheme the mandatory half.
+		return app.toString(raw), ""
+	}
+	return app.toString(raw[:i]), app.toString(utils.TrimSpace(raw[i+1:]))
+}
+
+// Bearer returns the credentials of a Bearer Authorization header
+// (RFC 6750 Section 2.1), or an empty string when the header is absent or names
+// a different auth-scheme. The token is returned verbatim: it is not validated,
+// decoded, or verified, so it still has to be authenticated before it is trusted.
+func (r *DefaultReq) Bearer() string {
+	scheme, credentials := r.Authorization()
+	if !utils.EqualFold(scheme, "Bearer") {
+		return ""
+	}
+	return credentials
 }
 
 // GetHeaders (a.k.a GetReqHeaders) returns the HTTP request headers.
@@ -876,6 +1011,131 @@ func (r *DefaultReq) Is(extension string) bool {
 	return utils.EqualFold(ct, extensionHeader)
 }
 
+// HasBody returns true if the request declares a body via Content-Length, Transfer-Encoding, or already buffered payload data.
+func (r *DefaultReq) HasBody() bool {
+	hdr := &r.c.fasthttp.Request.Header
+
+	switch cl := hdr.ContentLength(); {
+	case cl > 0:
+		return true
+	case cl == -1:
+		// fasthttp reports -1 for Transfer-Encoding: chunked bodies.
+		return true
+	case cl == 0:
+		if hasTransferEncodingBody(hdr) {
+			return true
+		}
+	}
+
+	return len(r.c.fasthttp.Request.Body()) > 0
+}
+
+func hasTransferEncodingBody(hdr *fasthttp.RequestHeader) bool {
+	// Repeated field lines form one combined list (RFC 9110 Section 5.2),
+	// so every Transfer-Encoding line must be inspected, not just the first.
+	if lines := hdr.PeekAll(HeaderTransferEncoding); len(lines) > 0 {
+		for _, line := range lines {
+			if transferEncodingLineHasBody(utils.UnsafeString(line)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Fallback scan for non-normalized header keys.
+	for key, value := range hdr.All() {
+		if !utils.EqualFold(utils.UnsafeString(key), HeaderTransferEncoding) {
+			continue
+		}
+		if transferEncodingLineHasBody(utils.UnsafeString(value)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// transferEncodingLineHasBody reports whether a single Transfer-Encoding
+// field line contains a transfer coding other than "identity".
+func transferEncodingLineHasBody(te string) bool {
+	for raw := range strings.SplitSeq(te, ",") {
+		token := utils.TrimSpace(raw)
+		if token == "" {
+			continue
+		}
+		if idx := strings.IndexByte(token, ';'); idx >= 0 {
+			token = utils.TrimSpace(token[:idx])
+		}
+		if token == "" {
+			continue
+		}
+		if utils.EqualFold(token, "identity") {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// IsWebSocket returns true if the request includes a WebSocket upgrade handshake.
+func (r *DefaultReq) IsWebSocket() bool {
+	// Repeated field lines are equivalent to one combined comma-separated
+	// list (RFC 9110 Section 5.2), so inspect every Connection and Upgrade
+	// field line, not just the first.
+	if !headerListContainsToken(r.c.fasthttp.Request.Header.PeekAll(HeaderConnection), "upgrade") {
+		return false
+	}
+	// Upgrade is a list of protocols, each optionally carrying a "/version"
+	// suffix (RFC 9110 Section 7.8), e.g. "Upgrade: websocket, h2c".
+	return headerListContainsToken(r.c.fasthttp.Request.Header.PeekAll(HeaderUpgrade), "websocket")
+}
+
+// headerListContainsToken reports whether any comma-separated element across
+// the given field lines equals token case-insensitively. An optional
+// "/version" suffix (Upgrade protocol syntax, RFC 9110 Section 7.8) is
+// ignored when comparing; valid Connection members never contain "/", so
+// this is safe for both headers.
+func headerListContainsToken(lines [][]byte, token string) bool {
+	for _, line := range lines {
+		for v := range strings.SplitSeq(utils.UnsafeString(line), ",") {
+			element := utils.TrimSpace(v)
+			if i := strings.IndexByte(element, '/'); i >= 0 {
+				element = element[:i]
+			}
+			if utils.EqualFold(element, token) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsPreflight returns true if the request is a CORS preflight.
+func (r *DefaultReq) IsPreflight() bool {
+	if r.Method() != MethodOptions {
+		return false
+	}
+	hdr := &r.c.fasthttp.Request.Header
+	if len(hdr.Peek(HeaderAccessControlRequestMethod)) == 0 {
+		return false
+	}
+	return len(hdr.Peek(HeaderOrigin)) > 0
+}
+
+// Secure returns whether a secure connection was established.
+func (r *DefaultReq) Secure() bool {
+	return r.Scheme() == schemeHTTPS
+}
+
+// xmlHTTPRequestBytes is precomputed for XHR detection
+var xmlHTTPRequestBytes = []byte("xmlhttprequest")
+
+// XHR returns a Boolean property, that is true, if the request's X-Requested-With header field is XMLHttpRequest,
+// indicating that the request was issued by a client library (such as jQuery).
+func (r *DefaultReq) XHR() bool {
+	return utils.EqualFold(r.c.fasthttp.Request.Header.Peek(HeaderXRequestedWith), xmlHTTPRequestBytes)
+}
+
 // Locals makes it possible to pass any values under keys scoped to the request
 // and therefore available to all following routes that match the request.
 //
@@ -967,6 +1227,19 @@ func currentMethod(c *DefaultCtx) string {
 	return string(c.fasthttp.Request.Header.Method())
 }
 
+// IsSafe reports whether the request method is safe, meaning it is not expected
+// to change server state (RFC 9110 Section 9.2.1).
+func (r *DefaultReq) IsSafe() bool {
+	return IsMethodSafe(r.Method())
+}
+
+// IsIdempotent reports whether the request method is idempotent, meaning
+// repeating it has the same intended effect as making it once (RFC 9110
+// Section 9.2.2). Every safe method is also idempotent.
+func (r *DefaultReq) IsIdempotent() bool {
+	return IsMethodIdempotent(r.Method())
+}
+
 // MultipartForm parse form entries from binary.
 // This returns a map[string][]string, so given a key, the value will be a string slice.
 //
@@ -990,6 +1263,34 @@ func (r *DefaultReq) MultipartForm() (*multipart.Form, error) {
 // Make copies or use the Immutable setting to use the value outside the Handler.
 func (r *DefaultReq) OriginalURL() string {
 	return r.c.app.toString(r.c.fasthttp.Request.Header.RequestURI())
+}
+
+// URI returns the parsed *fasthttp.URI of the request.
+// This allows you to use all fasthttp URI methods.
+// https://godoc.org/github.com/valyala/fasthttp#URI
+//
+// The returned value is owned by the request and is rewritten by a Path
+// override, so it is only valid within the handler. Do not store any references.
+func (r *DefaultReq) URI() *fasthttp.URI {
+	return r.c.fasthttp.Request.URI()
+}
+
+// Path returns the path part of the request URL.
+// Optionally, you could override the path.
+// Make copies or use the Immutable setting to use the value outside the Handler.
+func (r *DefaultReq) Path(override ...string) string {
+	if len(override) != 0 && string(r.c.path) != override[0] {
+		// Set new path to context
+		r.c.pathOriginal = override[0]
+
+		// Set new path to request context
+		r.c.fasthttp.Request.URI().SetPath(r.c.pathOriginal)
+		// Prettify path
+		r.c.configDependentPaths()
+		// The detection path/tree hash changed; invalidate the lookahead index.
+		r.c.firstMatchIndex = -1
+	}
+	return r.c.app.toString(r.c.path)
 }
 
 // Params is used to get the route parameters.

--- a/req.go
+++ b/req.go
@@ -633,7 +633,9 @@ func parseHTTPDate(date []byte) (time.Time, error) {
 // verbatim and unvalidated; a comma inside a quoted opaque-tag does not split
 // one. Fresh already compares them. Only valid within the handler.
 func (r *DefaultReq) IfNoneMatch() []string {
-	header := joinHeaderValues(r.c.fasthttp.Request.Header.PeekAll(HeaderIfNoneMatch))
+	app := r.c.app
+	lines := fieldname.Lines(&r.c.fasthttp.Request.Header, HeaderIfNoneMatch, !app.config.DisableHeaderNormalizing)
+	header := joinHeaderValues(lines)
 	if len(header) == 0 {
 		return nil
 	}
@@ -641,10 +643,10 @@ func (r *DefaultReq) IfNoneMatch() []string {
 }
 
 // IfModifiedSince returns the time carried by the If-Modified-Since request
-// header, ErrHeaderNotFound when it is absent, and a parse error when it is none
-// of the three HTTP-date formats RFC 9110 Section 5.6.7 requires.
+// header, ErrHeaderNotFound when it is absent or empty, and a parse error when
+// it is none of the HTTP-date formats RFC 9110 Section 5.6.7 requires.
 func (r *DefaultReq) IfModifiedSince() (time.Time, error) {
-	value := r.c.fasthttp.Request.Header.Peek(HeaderIfModifiedSince)
+	value := r.headerField(HeaderIfModifiedSince)
 	if len(value) == 0 {
 		return time.Time{}, ErrHeaderNotFound
 	}
@@ -1126,11 +1128,10 @@ func (r *DefaultReq) IsPreflight() bool {
 	if r.Method() != MethodOptions {
 		return false
 	}
-	hdr := &r.c.fasthttp.Request.Header
-	if len(hdr.Peek(HeaderAccessControlRequestMethod)) == 0 {
+	if len(r.headerField(HeaderAccessControlRequestMethod)) == 0 {
 		return false
 	}
-	return len(hdr.Peek(HeaderOrigin)) > 0
+	return len(r.headerField(HeaderOrigin)) > 0
 }
 
 // Secure returns whether a secure connection was established.

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -3,7 +3,9 @@
 package fiber
 
 import (
+	"io"
 	"mime/multipart"
+	"time"
 
 	"github.com/valyala/fasthttp"
 )
@@ -38,15 +40,77 @@ type Req interface {
 	// Don't store direct references to the returned data.
 	// If you need to keep the body's data later, make a copy or use the Immutable option.
 	Body() []byte
+	// BodyStream returns the request body as a stream.
+	//
+	// It is only non-nil when Config.StreamRequestBody is enabled and the body has
+	// not already been buffered; IsBodyStream on the underlying request reports
+	// which of the two is in play. Reading from the returned reader consumes the
+	// body, so a later Body call will not see it.
+	BodyStream() io.Reader
+	// ContentLength returns the value of the Content-Length request header.
+	//
+	// A negative result means the length is not known up front rather than that the
+	// body is empty: fasthttp reports -1 for a chunked body and -2 for one
+	// terminated by closing the connection. Use HasBody to test only for the
+	// presence of a body.
+	ContentLength() int
 	// RequestCtx returns *fasthttp.RequestCtx that carries a deadline
 	// a cancellation signal, and other values across API boundaries.
 	RequestCtx() *fasthttp.RequestCtx
+	// FullURL returns the full request URL (protocol + host + original URL).
+	FullURL() string
+	// UserAgent returns the User-Agent request header.
+	UserAgent() string
+	// Referer returns the Referer request header.
+	Referer() string
+	// Origin returns the Origin request header.
+	Origin() string
+	// AcceptLanguage returns the Accept-Language request header.
+	// Repeated field lines are combined into one comma-joined list
+	// (RFC 9110 Section 5.2), matching what AcceptsLanguages negotiates on.
+	AcceptLanguage() string
+	// AcceptEncoding returns the Accept-Encoding request header.
+	// Repeated field lines are combined into one comma-joined list
+	// (RFC 9110 Section 5.2), matching what AcceptsEncodings negotiates on.
+	AcceptEncoding() string
+	// HasHeader reports whether the request includes a header with the given key.
+	HasHeader(key string) bool
+	// MediaType returns the MIME type from the Content-Type header without parameters.
+	MediaType() string
+	// Charset returns the charset parameter from the Content-Type header.
+	Charset() string
+	// IsJSON reports whether the Content-Type header is JSON.
+	IsJSON() bool
+	// IsForm reports whether the Content-Type header is form-encoded.
+	IsForm() bool
+	// IsMultipart reports whether the Content-Type header is multipart form data.
+	IsMultipart() bool
+	// AcceptsJSON reports whether the Accept header allows JSON.
+	AcceptsJSON() bool
+	// AcceptsHTML reports whether the Accept header allows HTML.
+	AcceptsHTML() bool
+	// AcceptsXML reports whether the Accept header allows XML.
+	AcceptsXML() bool
+	// AcceptsEventStream reports whether the Accept header allows text/event-stream.
+	AcceptsEventStream() bool
 	// Cookies are used for getting a cookie value by key.
 	// Defaults to the empty string "" if the cookie doesn't exist.
 	// If a default value is given, it will return that value if the cookie doesn't exist.
 	// The returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Cookies(key string, defaultValue ...string) string
+	// CookieNames returns the names of the cookies sent with the request, in the
+	// order they appear in the Cookie header. A name repeated by the client is
+	// returned once per occurrence.
+	// Returned values are only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the values outside the Handler.
+	CookieNames() []string
+	// AllCookies returns the cookies sent with the request as a name/value map.
+	// When the client repeats a name the last value wins; use CookieNames to detect
+	// that case.
+	// Returned values are only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the values outside the Handler.
+	AllCookies() map[string]string
 	// Request return the *fasthttp.Request object
 	// This allows you to use all fasthttp request methods
 	// https://godoc.org/github.com/valyala/fasthttp#Request
@@ -79,11 +143,44 @@ type Req interface {
 	// reload request, this module will return false to make handling these requests transparent.
 	// https://github.com/jshttp/fresh/blob/master/index.js#L33
 	Fresh() bool
+	// IfNoneMatch returns the entity tags listed in the If-None-Match request
+	// header. Repeated field lines are combined into one list (RFC 9110
+	// Section 5.2), and a comma inside a quoted opaque-tag does not split it, so
+	// `"v1,v2"` stays one tag. A wildcard header returns a single "*" element.
+	// Tags are returned verbatim, weak "W/" prefix included, and are not validated.
+	// Fresh already applies these tags to the response ETag; reach for this only to
+	// implement a comparison of your own.
+	IfNoneMatch() []string
+	// IfModifiedSince returns the time carried by the If-Modified-Since request
+	// header. It returns ErrHeaderNotFound when the header is absent, and a parse
+	// error when the value is none of the three HTTP-date formats RFC 9110
+	// Section 5.6.7 requires recipients to accept.
+	IfModifiedSince() (time.Time, error)
 	// Get returns the HTTP request header specified by field.
 	// Field names are case-insensitive
 	// Returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting instead.
 	Get(key string, defaultValue ...string) string
+	// GetAll returns every field line of the request header specified by key.
+	// Field names are case-insensitive.
+	//
+	// A header repeated across field lines is semantically one comma-joined list
+	// (RFC 9110 Section 5.2). GetAll keeps the lines apart so a caller can inspect
+	// them individually, where Get returns only the first and GetHeaders builds a
+	// map of the whole header block.
+	// Returned values are only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
+	GetAll(key string) []string
+	// Authorization splits the Authorization request header into its auth-scheme
+	// and the credentials that follow (RFC 9110 Section 11.6.2). Both are empty
+	// when the header is absent. The credentials are returned verbatim — token68 or
+	// auth-param list — and are neither decoded nor validated.
+	Authorization() (scheme, credentials string)
+	// Bearer returns the credentials of a Bearer Authorization header
+	// (RFC 6750 Section 2.1), or an empty string when the header is absent or names
+	// a different auth-scheme. The token is returned verbatim: it is not validated,
+	// decoded, or verified, so it still has to be authenticated before it is trusted.
+	Bearer() string
 	// GetHeaders (a.k.a GetReqHeaders) returns the HTTP request headers.
 	// Returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting instead.
@@ -129,6 +226,17 @@ type Req interface {
 	// Is returns the matching content type,
 	// if the incoming request's Content-Type HTTP header field matches the MIME type specified by the type parameter
 	Is(extension string) bool
+	// HasBody returns true if the request declares a body via Content-Length, Transfer-Encoding, or already buffered payload data.
+	HasBody() bool
+	// IsWebSocket returns true if the request includes a WebSocket upgrade handshake.
+	IsWebSocket() bool
+	// IsPreflight returns true if the request is a CORS preflight.
+	IsPreflight() bool
+	// Secure returns whether a secure connection was established.
+	Secure() bool
+	// XHR returns a Boolean property, that is true, if the request's X-Requested-With header field is XMLHttpRequest,
+	// indicating that the request was issued by a client library (such as jQuery).
+	XHR() bool
 	// Locals makes it possible to pass any values under keys scoped to the request
 	// and therefore available to all following routes that match the request.
 	//
@@ -140,6 +248,13 @@ type Req interface {
 	// If no override is given or if the provided override is not a valid HTTP method, it returns the current method from the context.
 	// Otherwise, it updates the context's method and returns the overridden method as a string.
 	Method(override ...string) string
+	// IsSafe reports whether the request method is safe, meaning it is not expected
+	// to change server state (RFC 9110 Section 9.2.1).
+	IsSafe() bool
+	// IsIdempotent reports whether the request method is idempotent, meaning
+	// repeating it has the same intended effect as making it once (RFC 9110
+	// Section 9.2.2). Every safe method is also idempotent.
+	IsIdempotent() bool
 	// MultipartForm parse form entries from binary.
 	// This returns a map[string][]string, so given a key, the value will be a string slice.
 	//
@@ -152,6 +267,17 @@ type Req interface {
 	// Returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting to use the value outside the Handler.
 	OriginalURL() string
+	// URI returns the parsed *fasthttp.URI of the request.
+	// This allows you to use all fasthttp URI methods.
+	// https://godoc.org/github.com/valyala/fasthttp#URI
+	//
+	// The returned value is owned by the request and is rewritten by a Path
+	// override, so it is only valid within the handler. Do not store any references.
+	URI() *fasthttp.URI
+	// Path returns the path part of the request URL.
+	// Optionally, you could override the path.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
+	Path(override ...string) string
 	// Params is used to get the route parameters.
 	// Defaults to empty string "" if the param doesn't exist.
 	// If a default value is given, it will return that value if the param doesn't exist.

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -40,20 +40,13 @@ type Req interface {
 	// Don't store direct references to the returned data.
 	// If you need to keep the body's data later, make a copy or use the Immutable option.
 	Body() []byte
-	// BodyStream returns the request body as a stream.
-	//
-	// It is only non-nil when Config.StreamRequestBody is enabled and the body has
-	// not already been buffered; IsBodyStream on the underlying request reports
-	// which of the two is in play. Reading from the returned reader consumes the
-	// body, so a later Body call will not see it.
+	// BodyStream returns the request body as a stream, non-nil only when
+	// Config.StreamRequestBody is enabled and the body is not already buffered.
+	// Reading it consumes the body, so a later Body call will not see it.
 	BodyStream() io.Reader
-	// ContentLength returns the value of the Content-Length request header.
-	//
-	// A negative result is not a length. fasthttp reports -1 for a chunked body and
-	// -2 for "Transfer-Encoding: identity", which is also what an ordinary GET with
-	// no body reports — so -2, not 0, is the common case for a bodyless request.
-	// Use HasBody to test whether there is a body at all, and read this only to
-	// find out how large a declared one is.
+	// ContentLength returns the value of the Content-Length request header. A
+	// negative result is not a length: -1 is chunked and -2 is identity, which is
+	// what a bodyless GET reports. Use HasBody to test for a body at all.
 	ContentLength() int
 	// RequestCtx returns *fasthttp.RequestCtx that carries a deadline
 	// a cancellation signal, and other values across API boundaries.
@@ -69,14 +62,8 @@ type Req interface {
 	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Origin() string
 	// headerField returns a request header's field value, matching the field name
-	// the way a recipient must (RFC 9110 Section 5.1).
-	//
-	// fasthttp's Peek is byte-exact, which resolves every spelling only while it
-	// canonicalizes the key; under DisableHeaderNormalizing the store keeps what the
-	// peer sent, which for HTTP/2 and 3 is lower case. That is the bug the CSRF
-	// middleware was fixed for: a lower-case "origin:" read as absent and the
-	// same-origin check found nothing to verify. The byte-exact read stays the fast
-	// path, and the walk runs only for the config that needs it.
+	// case-insensitively (RFC 9110 Section 5.1). Peek is byte-exact, so under
+	// DisableHeaderNormalizing a lower-case "origin:" read as absent.
 	headerField(name string) []byte
 	// AcceptLanguage returns the Accept-Language request header.
 	// Repeated field lines are combined into one comma-joined list
@@ -88,14 +75,9 @@ type Req interface {
 	AcceptEncoding() string
 	// HasHeader reports whether the request includes a header with the given key.
 	HasHeader(key string) bool
-	// ContentType returns the Content-Type request header, parameters included.
-	// MediaType returns the same header with the parameters stripped, and Charset
-	// returns just the charset one.
-	//
-	// Req and Res both carry a ContentType, so on Ctx the request wins, as it does
-	// for Get. Use Res().ContentType() for the type the response will send.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the value outside the Handler.
+	// ContentType returns the Content-Type request header, parameters included;
+	// MediaType strips them and Charset returns just the charset. On Ctx the request
+	// wins over Res. Only valid within the handler unless Immutable is set.
 	ContentType() string
 	// MediaType returns the MIME type from the Content-Type header without parameters.
 	MediaType() string
@@ -121,25 +103,13 @@ type Req interface {
 	// The returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Cookies(key string, defaultValue ...string) string
-	// CookieNames returns the names of the cookies sent with the request, in the
-	// order they appear in the Cookie header, or nil when the client sent none. A
-	// name the client repeated is returned once per occurrence, which is how a
-	// caller detects the shadowing AllCookies collapses.
-	//
-	// Unlike Cookies, the returned strings are copies rather than views into the
-	// request buffer, so they stay valid past the handler.
+	// CookieNames returns the request cookie names in header order, or nil when
+	// there are none. A repeated name appears once per occurrence, which is how the
+	// shadowing AllCookies collapses is detected. The strings are copies.
 	CookieNames() []string
-	// AllCookies returns the cookies sent with the request as a name/value map, or
-	// nil when the client sent none. A repeated name resolves to its first
-	// occurrence, which is the one Cookies answers with too — the two must agree,
-	// because a client can shadow a cookie by sending the name twice and code that
-	// validated one value while consuming the other would validate the wrong one.
-	// Use CookieNames to see that a name was repeated at all.
-	//
-	// The keys and values are copies rather than views into the request buffer:
-	// fasthttp rewrites those bytes in place when a handler edits a request cookie,
-	// which would not merely stale the map but rehash it into one whose own keys no
-	// longer find their entries.
+	// AllCookies returns the request cookies as a name/value map, or nil when there
+	// are none. A repeated name resolves to its first occurrence, as Cookies does,
+	// so a shadowed cookie cannot be validated in one and consumed in the other.
 	AllCookies() map[string]string
 	// Request return the *fasthttp.Request object
 	// This allows you to use all fasthttp request methods
@@ -173,63 +143,30 @@ type Req interface {
 	// reload request, this module will return false to make handling these requests transparent.
 	// https://github.com/jshttp/fresh/blob/master/index.js#L33
 	Fresh() bool
-	// IfNoneMatch returns the entity tags listed in the If-None-Match request
-	// header. Repeated field lines are combined into one list (RFC 9110
-	// Section 5.2), and a comma inside a quoted opaque-tag does not split it, so
-	// `"v1,v2"` stays one tag. A wildcard header returns a single "*" element.
-	// Tags are returned verbatim, weak "W/" prefix included, and are not validated;
-	// empty list elements are dropped, as RFC 9110 Section 5.6.1 requires, so a
-	// trailing comma is not an extra tag. Fresh already applies these tags to the
-	// response ETag; reach for this only to implement a comparison of your own.
-	// Returned values are only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
+	// IfNoneMatch returns the entity tags in the If-None-Match request header,
+	// verbatim and unvalidated; a comma inside a quoted opaque-tag does not split
+	// one. Fresh already compares them. Only valid within the handler.
 	IfNoneMatch() []string
 	// IfModifiedSince returns the time carried by the If-Modified-Since request
-	// header. It returns ErrHeaderNotFound when the header is absent, and a parse
-	// error when the value is none of the three HTTP-date formats RFC 9110
-	// Section 5.6.7 requires recipients to accept.
+	// header, ErrHeaderNotFound when it is absent, and a parse error when it is none
+	// of the three HTTP-date formats RFC 9110 Section 5.6.7 requires.
 	IfModifiedSince() (time.Time, error)
 	// Get returns the HTTP request header specified by field.
 	// Field names are case-insensitive
 	// Returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting instead.
 	Get(key string, defaultValue ...string) string
-	// GetAll returns every field line of the request header specified by key.
-	// Field names are case-insensitive.
-	//
-	// A header repeated across field lines is semantically one comma-joined list
-	// (RFC 9110 Section 5.2). GetAll keeps the lines apart so a caller can inspect
-	// them individually, where Get returns only the first and GetHeaders builds a
-	// map of the whole header block. It returns nil when the header is absent.
-	//
-	// Empty field lines are skipped, so len(GetAll(k)) > 0 answers the same question
-	// as HasHeader(k). Without that, the headers fasthttp keeps in a slot of their
-	// own report one empty line when they are not present at all, and a
-	// request-smuggling guard testing for Content-Length would fire on every request
-	// that has none.
-	// Returned values are only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
+	// GetAll returns every field line stored under key, where Get returns only the
+	// first, or nil when the header is absent. Empty lines are skipped, so its
+	// presence answers as HasHeader does. Only valid within the handler.
 	GetAll(key string) []string
-	// Authorization splits the Authorization request header into its auth-scheme
-	// and the credentials that follow (RFC 9110 Section 11.6.2). Both are empty
-	// when the header is absent. The credentials are returned verbatim — token68 or
-	// auth-param list — and are neither decoded nor validated.
-	//
-	// Returned values are only valid within the handler. Do not store any
-	// references: they view the request buffer, which the next request on the
-	// connection overwrites, so a credential cached past the handler silently
-	// becomes another request's. Make copies or use the Immutable setting instead.
+	// Authorization splits the Authorization header into auth-scheme and credentials
+	// (RFC 9110 Section 11.6.2), neither decoded nor validated. They view the request
+	// buffer: a credential kept past the handler becomes another request's.
 	Authorization() (scheme, credentials string)
-	// Bearer returns the credentials of a Bearer Authorization header
-	// (RFC 6750 Section 2.1), or an empty string when the header is absent or names
-	// a different auth-scheme. The token is returned verbatim: it is not validated,
-	// decoded, or verified, so it still has to be authenticated before it is trusted.
-	//
-	// Returned value is only valid within the handler. Do not store any references:
-	// it views the request buffer, which the next request on the connection
-	// overwrites, so a token cached past the handler — or used as a key in a shared
-	// map — silently becomes another request's. Make copies or use the Immutable
-	// setting instead.
+	// Bearer returns the credentials of a Bearer Authorization header (RFC 6750
+	// Section 2.1), unverified, or "" for another scheme. It views the request
+	// buffer: a token kept past the handler becomes another request's.
 	Bearer() string
 	// GetHeaders (a.k.a GetReqHeaders) returns the HTTP request headers.
 	// Returned value is only valid within the handler. Do not store any references.
@@ -317,12 +254,9 @@ type Req interface {
 	// Returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting to use the value outside the Handler.
 	OriginalURL() string
-	// URI returns the parsed *fasthttp.URI of the request.
-	// This allows you to use all fasthttp URI methods.
-	// https://godoc.org/github.com/valyala/fasthttp#URI
-	//
-	// The returned value is owned by the request and is rewritten by a Path
-	// override, so it is only valid within the handler. Do not store any references.
+	// URI returns the parsed *fasthttp.URI of the request, giving access to all
+	// fasthttp URI methods. It is owned by the request and rewritten by a Path
+	// override, so it is only valid within the handler.
 	URI() *fasthttp.URI
 	// Path returns the path part of the request URL.
 	// Optionally, you could override the path.

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -74,6 +74,8 @@ type Req interface {
 	// (RFC 9110 Section 5.2), matching what AcceptsEncodings negotiates on.
 	AcceptEncoding() string
 	// HasHeader reports whether the request includes a header with the given key.
+	// The field name matches case-insensitively (RFC 9110 Section 5.1), so this
+	// agrees with GetAll on whether the field is there.
 	HasHeader(key string) bool
 	// ContentType returns the Content-Type request header, parameters included;
 	// MediaType strips them and Charset returns just the charset. On Ctx the request

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -49,10 +49,11 @@ type Req interface {
 	BodyStream() io.Reader
 	// ContentLength returns the value of the Content-Length request header.
 	//
-	// A negative result means the length is not known up front rather than that the
-	// body is empty: fasthttp reports -1 for a chunked body and -2 for one
-	// terminated by closing the connection. Use HasBody to test only for the
-	// presence of a body.
+	// A negative result is not a length. fasthttp reports -1 for a chunked body and
+	// -2 for "Transfer-Encoding: identity", which is also what an ordinary GET with
+	// no body reports — so -2, not 0, is the common case for a bodyless request.
+	// Use HasBody to test whether there is a body at all, and read this only to
+	// find out how large a declared one is.
 	ContentLength() int
 	// RequestCtx returns *fasthttp.RequestCtx that carries a deadline
 	// a cancellation signal, and other values across API boundaries.
@@ -64,7 +65,19 @@ type Req interface {
 	// Referer returns the Referer request header.
 	Referer() string
 	// Origin returns the Origin request header.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Origin() string
+	// headerField returns a request header's field value, matching the field name
+	// the way a recipient must (RFC 9110 Section 5.1).
+	//
+	// fasthttp's Peek is byte-exact, which resolves every spelling only while it
+	// canonicalizes the key; under DisableHeaderNormalizing the store keeps what the
+	// peer sent, which for HTTP/2 and 3 is lower case. That is the bug the CSRF
+	// middleware was fixed for: a lower-case "origin:" read as absent and the
+	// same-origin check found nothing to verify. The byte-exact read stays the fast
+	// path, and the walk runs only for the config that needs it.
+	headerField(name string) []byte
 	// AcceptLanguage returns the Accept-Language request header.
 	// Repeated field lines are combined into one comma-joined list
 	// (RFC 9110 Section 5.2), matching what AcceptsLanguages negotiates on.
@@ -75,6 +88,15 @@ type Req interface {
 	AcceptEncoding() string
 	// HasHeader reports whether the request includes a header with the given key.
 	HasHeader(key string) bool
+	// ContentType returns the Content-Type request header, parameters included.
+	// MediaType returns the same header with the parameters stripped, and Charset
+	// returns just the charset one.
+	//
+	// Req and Res both carry a ContentType, so on Ctx the request wins, as it does
+	// for Get. Use Res().ContentType() for the type the response will send.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting to use the value outside the Handler.
+	ContentType() string
 	// MediaType returns the MIME type from the Content-Type header without parameters.
 	MediaType() string
 	// Charset returns the charset parameter from the Content-Type header.
@@ -100,16 +122,24 @@ type Req interface {
 	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Cookies(key string, defaultValue ...string) string
 	// CookieNames returns the names of the cookies sent with the request, in the
-	// order they appear in the Cookie header. A name repeated by the client is
-	// returned once per occurrence.
-	// Returned values are only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the values outside the Handler.
+	// order they appear in the Cookie header, or nil when the client sent none. A
+	// name the client repeated is returned once per occurrence, which is how a
+	// caller detects the shadowing AllCookies collapses.
+	//
+	// Unlike Cookies, the returned strings are copies rather than views into the
+	// request buffer, so they stay valid past the handler.
 	CookieNames() []string
-	// AllCookies returns the cookies sent with the request as a name/value map.
-	// When the client repeats a name the last value wins; use CookieNames to detect
-	// that case.
-	// Returned values are only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting to use the values outside the Handler.
+	// AllCookies returns the cookies sent with the request as a name/value map, or
+	// nil when the client sent none. A repeated name resolves to its first
+	// occurrence, which is the one Cookies answers with too — the two must agree,
+	// because a client can shadow a cookie by sending the name twice and code that
+	// validated one value while consuming the other would validate the wrong one.
+	// Use CookieNames to see that a name was repeated at all.
+	//
+	// The keys and values are copies rather than views into the request buffer:
+	// fasthttp rewrites those bytes in place when a handler edits a request cookie,
+	// which would not merely stale the map but rehash it into one whose own keys no
+	// longer find their entries.
 	AllCookies() map[string]string
 	// Request return the *fasthttp.Request object
 	// This allows you to use all fasthttp request methods
@@ -147,9 +177,12 @@ type Req interface {
 	// header. Repeated field lines are combined into one list (RFC 9110
 	// Section 5.2), and a comma inside a quoted opaque-tag does not split it, so
 	// `"v1,v2"` stays one tag. A wildcard header returns a single "*" element.
-	// Tags are returned verbatim, weak "W/" prefix included, and are not validated.
-	// Fresh already applies these tags to the response ETag; reach for this only to
-	// implement a comparison of your own.
+	// Tags are returned verbatim, weak "W/" prefix included, and are not validated;
+	// empty list elements are dropped, as RFC 9110 Section 5.6.1 requires, so a
+	// trailing comma is not an extra tag. Fresh already applies these tags to the
+	// response ETag; reach for this only to implement a comparison of your own.
+	// Returned values are only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
 	IfNoneMatch() []string
 	// IfModifiedSince returns the time carried by the If-Modified-Since request
 	// header. It returns ErrHeaderNotFound when the header is absent, and a parse
@@ -167,7 +200,13 @@ type Req interface {
 	// A header repeated across field lines is semantically one comma-joined list
 	// (RFC 9110 Section 5.2). GetAll keeps the lines apart so a caller can inspect
 	// them individually, where Get returns only the first and GetHeaders builds a
-	// map of the whole header block.
+	// map of the whole header block. It returns nil when the header is absent.
+	//
+	// Empty field lines are skipped, so len(GetAll(k)) > 0 answers the same question
+	// as HasHeader(k). Without that, the headers fasthttp keeps in a slot of their
+	// own report one empty line when they are not present at all, and a
+	// request-smuggling guard testing for Content-Length would fire on every request
+	// that has none.
 	// Returned values are only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting instead.
 	GetAll(key string) []string
@@ -175,11 +214,22 @@ type Req interface {
 	// and the credentials that follow (RFC 9110 Section 11.6.2). Both are empty
 	// when the header is absent. The credentials are returned verbatim — token68 or
 	// auth-param list — and are neither decoded nor validated.
+	//
+	// Returned values are only valid within the handler. Do not store any
+	// references: they view the request buffer, which the next request on the
+	// connection overwrites, so a credential cached past the handler silently
+	// becomes another request's. Make copies or use the Immutable setting instead.
 	Authorization() (scheme, credentials string)
 	// Bearer returns the credentials of a Bearer Authorization header
 	// (RFC 6750 Section 2.1), or an empty string when the header is absent or names
 	// a different auth-scheme. The token is returned verbatim: it is not validated,
 	// decoded, or verified, so it still has to be authenticated before it is trusted.
+	//
+	// Returned value is only valid within the handler. Do not store any references:
+	// it views the request buffer, which the next request on the connection
+	// overwrites, so a token cached past the handler — or used as a key in a shared
+	// map — silently becomes another request's. Make copies or use the Immutable
+	// setting instead.
 	Bearer() string
 	// GetHeaders (a.k.a GetReqHeaders) returns the HTTP request headers.
 	// Returned value is only valid within the handler. Do not store any references.

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -61,9 +61,10 @@ type Req interface {
 	// Returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting to use the value outside the Handler.
 	Origin() string
-	// headerField returns a request header's field value, matching the field name
-	// case-insensitively (RFC 9110 Section 5.1). Peek is byte-exact, so under
-	// DisableHeaderNormalizing a lower-case "origin:" read as absent.
+	// headerField returns a request header's first non-empty field value, matching
+	// the field name case-insensitively (RFC 9110 Section 5.1). fieldname.First
+	// also steps over a present-but-empty first line, so a value on a later line
+	// is found and this agrees with GetAll on whether the field is there.
 	headerField(name string) []byte
 	// AcceptLanguage returns the Accept-Language request header.
 	// Repeated field lines are combined into one comma-joined list (RFC 9110
@@ -168,6 +169,10 @@ type Req interface {
 	// (RFC 9110 Section 11.6.2), neither decoded nor validated. They view the request
 	// buffer: a credential kept past the handler becomes another request's.
 	Authorization() (scheme, credentials string)
+	// authorizationParts splits the Authorization header at the first space or tab
+	// (RFC 9110 Section 11.4), on raw bytes so each caller materializes only the
+	// strings it needs. A lone token is a scheme without credentials.
+	authorizationParts() (scheme, credentials []byte)
 	// Bearer returns the credentials of a Bearer Authorization header (RFC 6750
 	// Section 2.1), unverified, or "" for another scheme. It views the request
 	// buffer: a token kept past the handler becomes another request's.

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -148,8 +148,8 @@ type Req interface {
 	// one. Fresh already compares them. Only valid within the handler.
 	IfNoneMatch() []string
 	// IfModifiedSince returns the time carried by the If-Modified-Since request
-	// header, ErrHeaderNotFound when it is absent, and a parse error when it is none
-	// of the three HTTP-date formats RFC 9110 Section 5.6.7 requires.
+	// header, ErrHeaderNotFound when it is absent or empty, and a parse error when
+	// it is none of the HTTP-date formats RFC 9110 Section 5.6.7 requires.
 	IfModifiedSince() (time.Time, error)
 	// Get returns the HTTP request header specified by field.
 	// Field names are case-insensitive

--- a/req_interface_gen.go
+++ b/req_interface_gen.go
@@ -66,12 +66,14 @@ type Req interface {
 	// DisableHeaderNormalizing a lower-case "origin:" read as absent.
 	headerField(name string) []byte
 	// AcceptLanguage returns the Accept-Language request header.
-	// Repeated field lines are combined into one comma-joined list
-	// (RFC 9110 Section 5.2), matching what AcceptsLanguages negotiates on.
+	// Repeated field lines are combined into one comma-joined list (RFC 9110
+	// Section 5.2) and the field name matches case-insensitively (Section 5.1),
+	// matching what AcceptsLanguages negotiates on.
 	AcceptLanguage() string
 	// AcceptEncoding returns the Accept-Encoding request header.
-	// Repeated field lines are combined into one comma-joined list
-	// (RFC 9110 Section 5.2), matching what AcceptsEncodings negotiates on.
+	// Repeated field lines are combined into one comma-joined list (RFC 9110
+	// Section 5.2) and the field name matches case-insensitively (Section 5.1),
+	// matching what AcceptsEncodings negotiates on.
 	AcceptEncoding() string
 	// HasHeader reports whether the request includes a header with the given key.
 	// The field name matches case-insensitively (RFC 9110 Section 5.1), so this

--- a/res.go
+++ b/res.go
@@ -1342,7 +1342,12 @@ func (r *DefaultRes) SendStatus(status int) error {
 	r.Status(status)
 
 	if statusDisallowsBody(status) {
-		r.c.fasthttp.Response.ResetBody()
+		resp := &r.c.fasthttp.Response
+		resp.ResetBody()
+		// ResetBody drops the body but keeps a Content-Length the handler
+		// declared, which RFC 9110 Section 8.6 forbids here and which leaves a
+		// keep-alive peer waiting for bytes that never come.
+		resp.Header.Del(HeaderContentLength)
 		return nil
 	}
 

--- a/res.go
+++ b/res.go
@@ -414,7 +414,7 @@ func (r *DefaultRes) GetCookie(name string) (*Cookie, bool) {
 }
 
 // Cookies returns a copy of every cookie this response is set to send, in order,
-// or nil when there are none. Repeated names are kept apart, and an unparseable
+// or nil when there are none. Repeated names are kept apart, and an unparsable
 // one is skipped. For what the client sent, use Req.Cookies.
 func (r *DefaultRes) Cookies() []*Cookie {
 	header := &r.c.fasthttp.Response.Header

--- a/res.go
+++ b/res.go
@@ -272,6 +272,17 @@ func contentDispositionAttachment(fname string) string {
 	return disp
 }
 
+// Add appends the given value to the response header field as a new field
+// line, leaving any existing lines untouched.
+//
+// This differs from Append, which folds values into a single comma-separated
+// line: headers whose values may themselves contain commas — Set-Cookie,
+// WWW-Authenticate, Link — have to be sent as separate lines to stay
+// unambiguous (RFC 9110 Section 5.3).
+func (r *DefaultRes) Add(key, val string) {
+	r.c.fasthttp.Response.Header.Add(key, val)
+}
+
 // Attachment sets the HTTP response Content-Disposition header field to attachment.
 func (r *DefaultRes) Attachment(filename ...string) {
 	if len(filename) > 0 {
@@ -378,6 +389,70 @@ func (r *DefaultRes) Cookie(cookie *Cookie) {
 	// Set resp header
 	r.c.fasthttp.Response.Header.SetCookie(fcookie)
 	fasthttp.ReleaseCookie(fcookie)
+}
+
+// GetCookie reads back a cookie this response is already set to send, so a
+// later handler or middleware can inspect or re-emit what an earlier one wrote.
+// The second result is false when no cookie of that name has been set.
+//
+// The returned Cookie is a copy: changing it does not change the response.
+// Pass it to Cookie to write the change back.
+func (r *DefaultRes) GetCookie(name string) (*Cookie, bool) {
+	fcookie := fasthttp.AcquireCookie()
+	defer fasthttp.ReleaseCookie(fcookie)
+
+	fcookie.SetKey(name)
+	if !r.c.fasthttp.Response.Header.Cookie(fcookie) {
+		return nil, false
+	}
+
+	return responseCookie(fcookie), true
+}
+
+// Cookies returns a copy of every cookie this response is set to send, in the
+// order they were added. It returns nil when none have been set.
+//
+// These are the response's own Set-Cookie headers. For the cookies the client
+// sent, use Req.Cookies or Req.AllCookies.
+func (r *DefaultRes) Cookies() []*Cookie {
+	header := &r.c.fasthttp.Response.Header
+
+	fcookie := fasthttp.AcquireCookie()
+	defer fasthttp.ReleaseCookie(fcookie)
+
+	var cookies []*Cookie
+	for key := range header.Cookies() {
+		fcookie.Reset()
+		fcookie.SetKeyBytes(key)
+		if header.Cookie(fcookie) {
+			cookies = append(cookies, responseCookie(fcookie))
+		}
+	}
+
+	return cookies
+}
+
+// responseCookie converts a parsed Set-Cookie header back into the Cookie
+// struct Res.Cookie accepts, so a cookie survives a read-modify-write round
+// trip. SessionOnly is derived rather than transmitted: a cookie carrying
+// neither Max-Age nor Expires is by definition a session cookie
+// (RFC 6265 Section 4.1.2).
+func responseCookie(fcookie *fasthttp.Cookie) *Cookie {
+	cookie := &Cookie{
+		Name:        string(fcookie.Key()),
+		Value:       string(fcookie.Value()),
+		Path:        string(fcookie.Path()),
+		Domain:      string(fcookie.Domain()),
+		Expires:     fcookie.Expire(),
+		MaxAge:      fcookie.MaxAge(),
+		Secure:      fcookie.Secure(),
+		HTTPOnly:    fcookie.HTTPOnly(),
+		SameSite:    internalcookie.FormatSameSite(fcookie.SameSite()),
+		Partitioned: fcookie.Partitioned(),
+	}
+	cookie.SessionOnly = cookie.MaxAge == 0 && cookie.Expires.IsZero()
+
+	return cookie
 }
 
 // Download transfers the file from path as an attachment.
@@ -522,6 +597,39 @@ func (r *DefaultRes) AutoFormat(body any) error {
 
 	// Default case
 	return r.SendString(b)
+}
+
+// ContentLength returns the value of the Content-Length response header.
+//
+// It reports what the header declares, not what has been buffered: fasthttp
+// fills Content-Length in as it serializes the response, so inside a handler
+// this is 0 unless something set it explicitly, and -1 once the body is a
+// stream of unknown length. Use len(Res.Body()) for the bytes buffered so far.
+func (r *DefaultRes) ContentLength() int {
+	return r.c.fasthttp.Response.Header.ContentLength()
+}
+
+// ContentType returns the Content-Type response header, parameters included.
+// It is the read side of Type, and of the content type Fiber sets for you when
+// a JSON, XML, or SendFile response goes out.
+//
+// When nothing has set one it reports fasthttp's default, "text/plain;
+// charset=utf-8", which is what would be sent — not an empty string.
+// Returned value is only valid within the handler. Do not store any references.
+// Make copies or use the Immutable setting instead.
+func (r *DefaultRes) ContentType() string {
+	return r.c.app.toString(r.c.fasthttp.Response.Header.ContentType())
+}
+
+// Del removes every field line of the response header specified by key.
+// Field names are case-insensitive. Deleting a header that was never set is a
+// no-op.
+//
+// Del(HeaderSetCookie) withdraws every cookie this response was going to set,
+// which is not what ClearCookie does: ClearCookie adds a Set-Cookie that
+// expires the cookie already in the client's jar.
+func (r *DefaultRes) Del(key string) {
+	r.c.fasthttp.Response.Header.Del(key)
 }
 
 // Get (a.k.a. GetRespHeader) returns the HTTP response header specified by field.
@@ -995,6 +1103,37 @@ func (r *DefaultRes) renderExtensions(bind any) {
 	r.c.renderExtensions(bind)
 }
 
+// Body returns the response body buffered so far, which lets middleware
+// inspect or checksum what a handler produced before it is written out.
+//
+// Returned value is only valid within the handler and is invalidated by the
+// next write to the response. Do not store any references; copy it instead.
+//
+// On a streamed response this drains the stream into a buffer to answer, which
+// changes how the body is sent. Guard with Written or the underlying
+// Response.IsBodyStream when the response may be a stream.
+func (r *DefaultRes) Body() []byte {
+	return r.c.fasthttp.Response.Body()
+}
+
+// ResetBody discards the response body, keeping the status and headers.
+// Use it before replacing a partially written body — an error page over a
+// half-rendered view, a cached body over a fresh one.
+func (r *DefaultRes) ResetBody() {
+	r.c.fasthttp.Response.ResetBody()
+}
+
+// Written reports whether anything has been written to the response body yet,
+// so middleware can tell a handler that produced a response from one that left
+// it untouched. A streamed body counts as written without draining the stream.
+//
+// Status and headers are not body writes: a handler that only called Status
+// leaves this false.
+func (r *DefaultRes) Written() bool {
+	resp := &r.c.fasthttp.Response
+	return resp.IsBodyStream() || len(resp.Body()) > 0
+}
+
 // Send sets the HTTP response body without copying it.
 // From this point onward the body argument must not be changed.
 func (r *DefaultRes) Send(body []byte) error {
@@ -1216,6 +1355,19 @@ func sendFileContentLength(path string, cfg SendFile) (int64, error) {
 	return info.Size(), nil
 }
 
+// NoContent replies 204 No Content: it sets the status, discards any body
+// already written, and drops the Content-Type a handler had set, since
+// RFC 9110 Section 6.4.1 gives a 204 no content to describe. fasthttp omits
+// Content-Type from a 204 on the wire either way; dropping it here keeps the
+// response consistent if something later moves it off 204.
+func (r *DefaultRes) NoContent() error {
+	r.Status(StatusNoContent)
+	r.c.fasthttp.Response.ResetBody()
+	r.c.fasthttp.Response.Header.Del(HeaderContentType)
+
+	return nil
+}
+
 // SendStatus sets the HTTP status code and if the response body is empty,
 // it sets the correct status message in the body.
 func (r *DefaultRes) SendStatus(status int) error {
@@ -1274,6 +1426,15 @@ func (r *DefaultRes) setCanonical(key, val string) {
 func (r *DefaultRes) Status(status int) Ctx {
 	r.c.fasthttp.Response.SetStatusCode(status)
 	return r.c
+}
+
+// StatusCode returns the status code currently set on the response. It is the
+// read side of Status, and reports 200 until something sets another code.
+//
+// Called after Next it is the status the chain settled on, which is what
+// logging, metrics, and caching middleware key off.
+func (r *DefaultRes) StatusCode() int {
+	return r.c.fasthttp.Response.StatusCode()
 }
 
 func statusDisallowsBody(status int) bool {

--- a/res.go
+++ b/res.go
@@ -18,6 +18,7 @@ import (
 	"unicode/utf8"
 
 	internalcookie "github.com/gofiber/fiber/v3/internal/cookie"
+	"github.com/gofiber/fiber/v3/internal/fieldname"
 	"github.com/gofiber/fiber/v3/internal/quotedstring"
 	"github.com/gofiber/utils/v2"
 	"github.com/valyala/bytebufferpool"
@@ -390,7 +391,8 @@ func (r *DefaultRes) Cookie(cookie *Cookie) {
 
 // GetCookie reads back a cookie this response is set to send, false when the
 // name is unset or its value does not parse. Names are case-sensitive and a
-// repeat resolves to the first. The copy is written back through Cookie.
+// repeat resolves to the first. Writing the copy back through Cookie stamps
+// Path=/ on a cookie that carried none, widening its scope — set Path first.
 func (r *DefaultRes) GetCookie(name string) (*Cookie, bool) {
 	header := &r.c.fasthttp.Response.Header
 
@@ -643,11 +645,12 @@ func (r *DefaultRes) ContentType() string {
 	return r.c.app.toString(r.c.fasthttp.Response.Header.ContentType())
 }
 
-// Del removes every field line stored under key, case-insensitively, and is a
-// no-op for a header that was never set. Del(HeaderSetCookie) withdraws the
-// pending cookies, where ClearCookie expires one already in the client's jar.
+// Del removes every field line stored under key, whatever case it is spelled in,
+// and is a no-op for a header that was never set. Del(HeaderSetCookie) withdraws
+// the pending cookies, where ClearCookie expires one in the client's jar.
 func (r *DefaultRes) Del(key string) {
-	r.c.fasthttp.Response.Header.Del(key)
+	header := &r.c.fasthttp.Response.Header
+	fieldname.Del(header, key, fieldname.Canonical(header))
 }
 
 // Get (a.k.a. GetRespHeader) returns the HTTP response header specified by field.

--- a/res.go
+++ b/res.go
@@ -491,10 +491,11 @@ func (r *DefaultRes) Format(handlers ...ResFmt) error {
 	r.Vary(HeaderAccept)
 
 	// Absent means the combined Accept view (RFC 9110 Section 5.2) is empty:
-	// no field line, or a single empty one. Checked on the raw lines to skip
-	// the join allocation that multi-line headers would pay.
-	accepts := r.c.fasthttp.Request.Header.PeekAll(HeaderAccept)
-	if len(accepts) == 0 || (len(accepts) == 1 && len(accepts[0]) == 0) {
+	// no field line, or only empty ones. The joined read matches the field name
+	// case-insensitively, the same way Accepts negotiates, so the two entry
+	// points agree on whether the client stated a preference.
+	acceptRaw := peekJoinedRequestHeader(&r.c.fasthttp.Request.Header, HeaderAccept)
+	if len(acceptRaw) == 0 {
 		// Without an Accept header the client accepts any media type
 		// (RFC 9110 Section 12.5.1), so pick the first non-default handler and
 		// use its media type. The literal "default" is not a media type and
@@ -606,7 +607,11 @@ func (r *DefaultRes) ContentType() string {
 // the pending cookies, where ClearCookie expires one in the client's jar.
 func (r *DefaultRes) Del(key string) {
 	header := &r.c.fasthttp.Response.Header
-	fieldname.Del(header, key, fieldname.Canonical(header))
+	// The byte-exact fast path needs both sides canonical: the stored names (a
+	// proxied response can hold lower-case ones) and the caller's key, which
+	// fasthttp only normalizes while DisableHeaderNormalizing is off.
+	canonical := !r.c.app.config.DisableHeaderNormalizing && fieldname.Canonical(header)
+	fieldname.Del(header, key, canonical)
 }
 
 // Get (a.k.a. GetRespHeader) returns the HTTP response header specified by field.

--- a/res.go
+++ b/res.go
@@ -2,6 +2,7 @@ package fiber
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"html/template"
 	"io"
@@ -279,6 +280,11 @@ func contentDispositionAttachment(fname string) string {
 // line: headers whose values may themselves contain commas — Set-Cookie,
 // WWW-Authenticate, Link — have to be sent as separate lines to stay
 // unambiguous (RFC 9110 Section 5.3).
+//
+// The headers fasthttp stores in a slot of their own cannot repeat, and Add
+// does not append for them: Content-Type, Content-Encoding, Content-Length,
+// Connection, Server and Trailer are replaced, and Transfer-Encoding and Date
+// are ignored because fasthttp writes them itself. Use Set for those.
 func (r *DefaultRes) Add(key, val string) {
 	r.c.fasthttp.Response.Header.Add(key, val)
 }
@@ -393,24 +399,42 @@ func (r *DefaultRes) Cookie(cookie *Cookie) {
 
 // GetCookie reads back a cookie this response is already set to send, so a
 // later handler or middleware can inspect or re-emit what an earlier one wrote.
-// The second result is false when no cookie of that name has been set.
+// The second result is false when no cookie of that name has been set, or when
+// its Set-Cookie field value does not parse.
+//
+// Cookie names are case-sensitive (RFC 6265 Section 4.1.1). A name written more
+// than once resolves to the first occurrence; use Cookies to see them all.
 //
 // The returned Cookie is a copy: changing it does not change the response.
 // Pass it to Cookie to write the change back.
 func (r *DefaultRes) GetCookie(name string) (*Cookie, bool) {
+	header := &r.c.fasthttp.Response.Header
+
 	fcookie := fasthttp.AcquireCookie()
 	defer fasthttp.ReleaseCookie(fcookie)
 
-	fcookie.SetKey(name)
-	if !r.c.fasthttp.Response.Header.Cookie(fcookie) {
-		return nil, false
+	for key, value := range header.Cookies() {
+		if string(key) != name {
+			continue
+		}
+		// Parsed from the field value the iterator yields rather than looked up
+		// again by name: the lookup reports the first cookie of that name and
+		// discards the parse error, which turns a Set-Cookie whose attributes
+		// fail to parse into a cookie that silently lost its Path and flags.
+		if fcookie.ParseBytes(value) != nil {
+			return nil, false
+		}
+		return responseCookie(fcookie, value), true
 	}
 
-	return responseCookie(fcookie), true
+	return nil, false
 }
 
 // Cookies returns a copy of every cookie this response is set to send, in the
 // order they were added. It returns nil when none have been set.
+//
+// Repeated names are kept apart, so a response that sets one name at two paths
+// yields both. A Set-Cookie whose field value does not parse is skipped.
 //
 // These are the response's own Set-Cookie headers. For the cookies the client
 // sent, use Req.Cookies or Req.AllCookies.
@@ -421,23 +445,62 @@ func (r *DefaultRes) Cookies() []*Cookie {
 	defer fasthttp.ReleaseCookie(fcookie)
 
 	var cookies []*Cookie
-	for key := range header.Cookies() {
-		fcookie.Reset()
-		fcookie.SetKeyBytes(key)
-		if header.Cookie(fcookie) {
-			cookies = append(cookies, responseCookie(fcookie))
+	// The iterator yields the whole Set-Cookie field value for each entry, so
+	// each is parsed where it is found. Resolving the name against the header
+	// again would answer with the first cookie of that name once per entry,
+	// hiding every later one behind a duplicate of the first.
+	for _, value := range header.Cookies() {
+		if fcookie.ParseBytes(value) != nil {
+			continue
 		}
+		cookies = append(cookies, responseCookie(fcookie, value))
 	}
 
 	return cookies
 }
 
+// cookieAttrPresent reports whether a Set-Cookie field value carries the named
+// attribute. Attributes are separated by ";", which RFC 6265 Section 4.1.1
+// excludes from cookie-value, so splitting on it cannot cut a value in two. The
+// first element is the cookie's own name=value pair and is skipped, so a cookie
+// named after an attribute is not mistaken for one.
+func cookieAttrPresent(value []byte, attr string) bool {
+	_, rest, found := bytes.Cut(value, []byte{';'})
+	if !found {
+		return false
+	}
+
+	for len(rest) > 0 {
+		part := rest
+		if i := bytes.IndexByte(rest, ';'); i >= 0 {
+			part, rest = rest[:i], rest[i+1:]
+		} else {
+			rest = nil
+		}
+		name, _, _ := bytes.Cut(part, []byte{'='})
+		if utils.EqualFold(utils.UnsafeString(utils.TrimSpace(name)), attr) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // responseCookie converts a parsed Set-Cookie header back into the Cookie
 // struct Res.Cookie accepts, so a cookie survives a read-modify-write round
-// trip. SessionOnly is derived rather than transmitted: a cookie carrying
-// neither Max-Age nor Expires is by definition a session cookie
-// (RFC 6265 Section 4.1.2).
-func responseCookie(fcookie *fasthttp.Cookie) *Cookie {
+// trip. raw is the field value fcookie was parsed from, which two attributes
+// have to be read off directly:
+//
+// Max-Age, because fasthttp writes a deletion (a negative MaxAge) as
+// "max-age=0" and parses that back as 0 — the same value an absent attribute
+// gives. Left alone, reading a deletion and writing it back would drop the
+// attribute and turn it into an ordinary session cookie, so an explicit
+// "max-age=0" is handed back as the negative MaxAge that re-emits as one.
+//
+// SessionOnly, which is not transmitted at all: a cookie carrying neither
+// Max-Age nor Expires is by definition a session cookie (RFC 6265
+// Section 4.1.2).
+func responseCookie(fcookie *fasthttp.Cookie, raw []byte) *Cookie {
 	cookie := &Cookie{
 		Name:        string(fcookie.Key()),
 		Value:       string(fcookie.Value()),
@@ -449,6 +512,9 @@ func responseCookie(fcookie *fasthttp.Cookie) *Cookie {
 		HTTPOnly:    fcookie.HTTPOnly(),
 		SameSite:    internalcookie.FormatSameSite(fcookie.SameSite()),
 		Partitioned: fcookie.Partitioned(),
+	}
+	if cookie.MaxAge == 0 && cookieAttrPresent(raw, "max-age") {
+		cookie.MaxAge = -1
 	}
 	cookie.SessionOnly = cookie.MaxAge == 0 && cookie.Expires.IsZero()
 
@@ -613,8 +679,9 @@ func (r *DefaultRes) ContentLength() int {
 // It is the read side of Type, and of the content type Fiber sets for you when
 // a JSON, XML, or SendFile response goes out.
 //
-// When nothing has set one it reports fasthttp's default, "text/plain;
-// charset=utf-8", which is what would be sent — not an empty string.
+// When nothing has set one it reports what would be sent: fasthttp's default,
+// "text/plain; charset=utf-8", or an empty string under
+// Config.DisableDefaultContentType.
 // Returned value is only valid within the handler. Do not store any references.
 // Make copies or use the Immutable setting instead.
 func (r *DefaultRes) ContentType() string {
@@ -1106,14 +1173,20 @@ func (r *DefaultRes) renderExtensions(bind any) {
 // Body returns the response body buffered so far, which lets middleware
 // inspect or checksum what a handler produced before it is written out.
 //
+// A streamed body returns nil rather than being drained. Reading it would pull
+// the whole stream into memory and turn the response into a buffered one, which
+// would hang an SSE route and defeat a large SendFile; use Written to tell a
+// streaming response from one that produced nothing, and the underlying
+// Response.Body if you really do want to materialize the stream.
+//
 // Returned value is only valid within the handler and is invalidated by the
 // next write to the response. Do not store any references; copy it instead.
-//
-// On a streamed response this drains the stream into a buffer to answer, which
-// changes how the body is sent. Guard with Written or the underlying
-// Response.IsBodyStream when the response may be a stream.
 func (r *DefaultRes) Body() []byte {
-	return r.c.fasthttp.Response.Body()
+	resp := &r.c.fasthttp.Response
+	if resp.IsBodyStream() {
+		return nil
+	}
+	return resp.Body()
 }
 
 // ResetBody discards the response body, keeping the status and headers.
@@ -1125,7 +1198,8 @@ func (r *DefaultRes) ResetBody() {
 
 // Written reports whether anything has been written to the response body yet,
 // so middleware can tell a handler that produced a response from one that left
-// it untouched. A streamed body counts as written without draining the stream.
+// it untouched. A streamed body counts as written without draining the stream,
+// which is the case Body deliberately answers nil for.
 //
 // Status and headers are not body writes: a handler that only called Status
 // leaves this false.
@@ -1355,17 +1429,16 @@ func sendFileContentLength(path string, cfg SendFile) (int64, error) {
 	return info.Size(), nil
 }
 
-// NoContent replies 204 No Content: it sets the status, discards any body
-// already written, and drops the Content-Type a handler had set, since
-// RFC 9110 Section 6.4.1 gives a 204 no content to describe. fasthttp omits
-// Content-Type from a 204 on the wire either way; dropping it here keeps the
-// response consistent if something later moves it off 204.
+// NoContent replies 204 No Content. SendStatus already discards the body for
+// every status statusDisallowsBody names; this drops the Content-Type as well,
+// since RFC 9110 Section 6.4.1 gives a 204 no content to describe.
+//
+// SendStatus(StatusNoContent) leaves a Content-Type a handler had set, so the
+// two are not interchangeable: this is the one that sends nothing about content.
 func (r *DefaultRes) NoContent() error {
-	r.Status(StatusNoContent)
-	r.c.fasthttp.Response.ResetBody()
-	r.c.fasthttp.Response.Header.Del(HeaderContentType)
+	r.Del(HeaderContentType)
 
-	return nil
+	return r.SendStatus(StatusNoContent)
 }
 
 // SendStatus sets the HTTP status code and if the response body is empty,

--- a/res.go
+++ b/res.go
@@ -231,8 +231,9 @@ func contentDispositionAttachment(fname string) string {
 }
 
 // Add appends the value as a new field line, where Append folds values into one
-// comma-separated line. It does not append for the headers fasthttp slots:
-// Content-Type, Server and the rest are replaced, Date and TE ignored.
+// comma-separated line. The headers fasthttp keeps in a slot of their own are
+// the exception: Content-Type, Server and the rest are replaced and Date and TE
+// ignored, though Set-Cookie is slotted and does append. Use Cookie for that.
 func (r *DefaultRes) Add(key, val string) {
 	r.c.fasthttp.Response.Header.Add(key, val)
 }
@@ -371,10 +372,13 @@ func (r *DefaultRes) GetCookie(name string) (*Cookie, bool) {
 	return nil, false
 }
 
-// Cookies returns a copy of every cookie this response is set to send, in order,
-// or nil when there are none. Repeated names are kept apart, and an unparsable
-// one is skipped. For what the client sent, use Req.Cookies.
-func (r *DefaultRes) Cookies() []*Cookie {
+// GetCookies returns a copy of every cookie this response is set to send, in
+// order, or nil when there are none. Repeated names are kept apart, and an
+// unparsable one is skipped. For what the client sent, use Req.Cookies.
+//
+// Named for GetCookie beside it rather than Cookies, which would collide with
+// Req.Cookies under a different signature and stop Ctx satisfying Res.
+func (r *DefaultRes) GetCookies() []*Cookie {
 	header := &r.c.fasthttp.Response.Header
 
 	fcookie := fasthttp.AcquireCookie()
@@ -588,9 +592,9 @@ func (r *DefaultRes) AutoFormat(body any) error {
 	return r.SendString(b)
 }
 
-// ContentLength returns what the Content-Length response header declares, not
-// what is buffered: fasthttp fills it in on serialization, so inside a handler
-// it is 0 unless set explicitly. Use len(Res.Body()) for buffered bytes.
+// ContentLength returns what the Content-Length response header declares: a
+// length a handler or upstream set, -1 for an unknown-length stream, 0 when
+// none is declared. fasthttp fills it in on serialization; see also Res.Body.
 func (r *DefaultRes) ContentLength() int {
 	return r.c.fasthttp.Response.Header.ContentLength()
 }
@@ -1086,8 +1090,8 @@ func (r *DefaultRes) renderExtensions(bind any) {
 }
 
 // Body returns the response body buffered so far, or nil for a streamed one,
-// which draining would pull into memory and de-stream. Use Written to tell those
-// apart. Only valid until the next write to the response.
+// which draining would de-stream; Written tells those apart. The buffer is live,
+// so writing to it writes to the response, and the next write voids it.
 func (r *DefaultRes) Body() []byte {
 	resp := &r.c.fasthttp.Response
 	if resp.IsBodyStream() {

--- a/res.go
+++ b/res.go
@@ -273,18 +273,9 @@ func contentDispositionAttachment(fname string) string {
 	return disp
 }
 
-// Add appends the given value to the response header field as a new field
-// line, leaving any existing lines untouched.
-//
-// This differs from Append, which folds values into a single comma-separated
-// line: headers whose values may themselves contain commas — Set-Cookie,
-// WWW-Authenticate, Link — have to be sent as separate lines to stay
-// unambiguous (RFC 9110 Section 5.3).
-//
-// The headers fasthttp stores in a slot of their own cannot repeat, and Add
-// does not append for them: Content-Type, Content-Encoding, Content-Length,
-// Connection, Server and Trailer are replaced, and Transfer-Encoding and Date
-// are ignored because fasthttp writes them itself. Use Set for those.
+// Add appends the value as a new field line, where Append folds values into one
+// comma-separated line. It does not append for the headers fasthttp slots:
+// Content-Type, Server and the rest are replaced, Date and TE ignored.
 func (r *DefaultRes) Add(key, val string) {
 	r.c.fasthttp.Response.Header.Add(key, val)
 }
@@ -397,16 +388,9 @@ func (r *DefaultRes) Cookie(cookie *Cookie) {
 	fasthttp.ReleaseCookie(fcookie)
 }
 
-// GetCookie reads back a cookie this response is already set to send, so a
-// later handler or middleware can inspect or re-emit what an earlier one wrote.
-// The second result is false when no cookie of that name has been set, or when
-// its Set-Cookie field value does not parse.
-//
-// Cookie names are case-sensitive (RFC 6265 Section 4.1.1). A name written more
-// than once resolves to the first occurrence; use Cookies to see them all.
-//
-// The returned Cookie is a copy: changing it does not change the response.
-// Pass it to Cookie to write the change back.
+// GetCookie reads back a cookie this response is set to send, false when the
+// name is unset or its value does not parse. Names are case-sensitive and a
+// repeat resolves to the first. The copy is written back through Cookie.
 func (r *DefaultRes) GetCookie(name string) (*Cookie, bool) {
 	header := &r.c.fasthttp.Response.Header
 
@@ -417,10 +401,9 @@ func (r *DefaultRes) GetCookie(name string) (*Cookie, bool) {
 		if string(key) != name {
 			continue
 		}
-		// Parsed from the field value the iterator yields rather than looked up
-		// again by name: the lookup reports the first cookie of that name and
-		// discards the parse error, which turns a Set-Cookie whose attributes
-		// fail to parse into a cookie that silently lost its Path and flags.
+		// Parsed from the yielded value rather than looked up again by name: the
+		// lookup discards the parse error, turning a Set-Cookie whose attributes
+		// fail to parse into one that silently lost its Path and flags.
 		if fcookie.ParseBytes(value) != nil {
 			return nil, false
 		}
@@ -430,14 +413,9 @@ func (r *DefaultRes) GetCookie(name string) (*Cookie, bool) {
 	return nil, false
 }
 
-// Cookies returns a copy of every cookie this response is set to send, in the
-// order they were added. It returns nil when none have been set.
-//
-// Repeated names are kept apart, so a response that sets one name at two paths
-// yields both. A Set-Cookie whose field value does not parse is skipped.
-//
-// These are the response's own Set-Cookie headers. For the cookies the client
-// sent, use Req.Cookies or Req.AllCookies.
+// Cookies returns a copy of every cookie this response is set to send, in order,
+// or nil when there are none. Repeated names are kept apart, and an unparseable
+// one is skipped. For what the client sent, use Req.Cookies.
 func (r *DefaultRes) Cookies() []*Cookie {
 	header := &r.c.fasthttp.Response.Header
 
@@ -445,9 +423,8 @@ func (r *DefaultRes) Cookies() []*Cookie {
 	defer fasthttp.ReleaseCookie(fcookie)
 
 	var cookies []*Cookie
-	// The iterator yields the whole Set-Cookie field value for each entry, so
-	// each is parsed where it is found. Resolving the name against the header
-	// again would answer with the first cookie of that name once per entry,
+	// Each entry is parsed where it is found: resolving the name against the
+	// header again answers with the first cookie of that name once per entry,
 	// hiding every later one behind a duplicate of the first.
 	for _, value := range header.Cookies() {
 		if fcookie.ParseBytes(value) != nil {
@@ -459,11 +436,9 @@ func (r *DefaultRes) Cookies() []*Cookie {
 	return cookies
 }
 
-// cookieAttrPresent reports whether a Set-Cookie field value carries the named
-// attribute. Attributes are separated by ";", which RFC 6265 Section 4.1.1
-// excludes from cookie-value, so splitting on it cannot cut a value in two. The
-// first element is the cookie's own name=value pair and is skipped, so a cookie
-// named after an attribute is not mistaken for one.
+// cookieAttrPresent reports whether a Set-Cookie value carries the named
+// attribute. RFC 6265 Section 4.1.1 excludes ";" from cookie-value, so splitting
+// on it is safe; the first element is the name=value pair and is skipped.
 func cookieAttrPresent(value []byte, attr string) bool {
 	_, rest, found := bytes.Cut(value, []byte{';'})
 	if !found {
@@ -486,20 +461,9 @@ func cookieAttrPresent(value []byte, attr string) bool {
 	return false
 }
 
-// responseCookie converts a parsed Set-Cookie header back into the Cookie
-// struct Res.Cookie accepts, so a cookie survives a read-modify-write round
-// trip. raw is the field value fcookie was parsed from, which two attributes
-// have to be read off directly:
-//
-// Max-Age, because fasthttp writes a deletion (a negative MaxAge) as
-// "max-age=0" and parses that back as 0 — the same value an absent attribute
-// gives. Left alone, reading a deletion and writing it back would drop the
-// attribute and turn it into an ordinary session cookie, so an explicit
-// "max-age=0" is handed back as the negative MaxAge that re-emits as one.
-//
-// SessionOnly, which is not transmitted at all: a cookie carrying neither
-// Max-Age nor Expires is by definition a session cookie (RFC 6265
-// Section 4.1.2).
+// responseCookie converts a parsed Set-Cookie back into the Cookie Res.Cookie
+// accepts. fasthttp writes a deletion as "max-age=0" and parses it back as 0,
+// so raw is consulted to tell that from an absent attribute.
 func responseCookie(fcookie *fasthttp.Cookie, raw []byte) *Cookie {
 	cookie := &Cookie{
 		Name:        string(fcookie.Key()),
@@ -665,36 +629,23 @@ func (r *DefaultRes) AutoFormat(body any) error {
 	return r.SendString(b)
 }
 
-// ContentLength returns the value of the Content-Length response header.
-//
-// It reports what the header declares, not what has been buffered: fasthttp
-// fills Content-Length in as it serializes the response, so inside a handler
-// this is 0 unless something set it explicitly, and -1 once the body is a
-// stream of unknown length. Use len(Res.Body()) for the bytes buffered so far.
+// ContentLength returns what the Content-Length response header declares, not
+// what is buffered: fasthttp fills it in on serialization, so inside a handler
+// it is 0 unless set explicitly. Use len(Res.Body()) for buffered bytes.
 func (r *DefaultRes) ContentLength() int {
 	return r.c.fasthttp.Response.Header.ContentLength()
 }
 
-// ContentType returns the Content-Type response header, parameters included.
-// It is the read side of Type, and of the content type Fiber sets for you when
-// a JSON, XML, or SendFile response goes out.
-//
-// When nothing has set one it reports what would be sent: fasthttp's default,
-// "text/plain; charset=utf-8", or an empty string under
-// Config.DisableDefaultContentType.
-// Returned value is only valid within the handler. Do not store any references.
-// Make copies or use the Immutable setting instead.
+// ContentType returns the Content-Type response header, the read side of Type.
+// With none set it reports what would be sent: fasthttp's default, or "" under
+// Config.DisableDefaultContentType. Only valid within the handler.
 func (r *DefaultRes) ContentType() string {
 	return r.c.app.toString(r.c.fasthttp.Response.Header.ContentType())
 }
 
-// Del removes every field line of the response header specified by key.
-// Field names are case-insensitive. Deleting a header that was never set is a
-// no-op.
-//
-// Del(HeaderSetCookie) withdraws every cookie this response was going to set,
-// which is not what ClearCookie does: ClearCookie adds a Set-Cookie that
-// expires the cookie already in the client's jar.
+// Del removes every field line stored under key, case-insensitively, and is a
+// no-op for a header that was never set. Del(HeaderSetCookie) withdraws the
+// pending cookies, where ClearCookie expires one already in the client's jar.
 func (r *DefaultRes) Del(key string) {
 	r.c.fasthttp.Response.Header.Del(key)
 }
@@ -1170,17 +1121,9 @@ func (r *DefaultRes) renderExtensions(bind any) {
 	r.c.renderExtensions(bind)
 }
 
-// Body returns the response body buffered so far, which lets middleware
-// inspect or checksum what a handler produced before it is written out.
-//
-// A streamed body returns nil rather than being drained. Reading it would pull
-// the whole stream into memory and turn the response into a buffered one, which
-// would hang an SSE route and defeat a large SendFile; use Written to tell a
-// streaming response from one that produced nothing, and the underlying
-// Response.Body if you really do want to materialize the stream.
-//
-// Returned value is only valid within the handler and is invalidated by the
-// next write to the response. Do not store any references; copy it instead.
+// Body returns the response body buffered so far, or nil for a streamed one,
+// which draining would pull into memory and de-stream. Use Written to tell those
+// apart. Only valid until the next write to the response.
 func (r *DefaultRes) Body() []byte {
 	resp := &r.c.fasthttp.Response
 	if resp.IsBodyStream() {
@@ -1196,13 +1139,9 @@ func (r *DefaultRes) ResetBody() {
 	r.c.fasthttp.Response.ResetBody()
 }
 
-// Written reports whether anything has been written to the response body yet,
-// so middleware can tell a handler that produced a response from one that left
-// it untouched. A streamed body counts as written without draining the stream,
-// which is the case Body deliberately answers nil for.
-//
-// Status and headers are not body writes: a handler that only called Status
-// leaves this false.
+// Written reports whether anything has been written to the response body, so a
+// handler that produced one can be told from a handler that did not. A stream
+// counts without being drained; a status or header alone does not.
 func (r *DefaultRes) Written() bool {
 	resp := &r.c.fasthttp.Response
 	return resp.IsBodyStream() || len(resp.Body()) > 0
@@ -1429,12 +1368,9 @@ func sendFileContentLength(path string, cfg SendFile) (int64, error) {
 	return info.Size(), nil
 }
 
-// NoContent replies 204 No Content. SendStatus already discards the body for
-// every status statusDisallowsBody names; this drops the Content-Type as well,
-// since RFC 9110 Section 6.4.1 gives a 204 no content to describe.
-//
-// SendStatus(StatusNoContent) leaves a Content-Type a handler had set, so the
-// two are not interchangeable: this is the one that sends nothing about content.
+// NoContent replies 204 No Content. SendStatus already discards the body; this
+// drops the Content-Type too, since RFC 9110 Section 6.4.1 gives a 204 no
+// content to describe. SendStatus(204) keeps it, so the two differ.
 func (r *DefaultRes) NoContent() error {
 	r.Del(HeaderContentType)
 
@@ -1501,11 +1437,9 @@ func (r *DefaultRes) Status(status int) Ctx {
 	return r.c
 }
 
-// StatusCode returns the status code currently set on the response. It is the
-// read side of Status, and reports 200 until something sets another code.
-//
-// Called after Next it is the status the chain settled on, which is what
-// logging, metrics, and caching middleware key off.
+// StatusCode returns the status code set on the response, the read side of
+// Status, and reports 200 until something sets another. After Next it is the
+// status the chain settled on.
 func (r *DefaultRes) StatusCode() int {
 	return r.c.fasthttp.Response.StatusCode()
 }

--- a/res_interface_gen.go
+++ b/res_interface_gen.go
@@ -19,8 +19,9 @@ type Res interface {
 	// (RFC 9110 Section 5.6.1.2).
 	Append(field string, values ...string)
 	// Add appends the value as a new field line, where Append folds values into one
-	// comma-separated line. It does not append for the headers fasthttp slots:
-	// Content-Type, Server and the rest are replaced, Date and TE ignored.
+	// comma-separated line. The headers fasthttp keeps in a slot of their own are
+	// the exception: Content-Type, Server and the rest are replaced and Date and TE
+	// ignored, though Set-Cookie is slotted and does append. Use Cookie for that.
 	Add(key, val string)
 	// Attachment sets the HTTP response Content-Disposition header field to attachment.
 	Attachment(filename ...string)
@@ -42,10 +43,13 @@ type Res interface {
 	// repeat resolves to the first. Writing the copy back through Cookie stamps
 	// Path=/ on a cookie that carried none, widening its scope — set Path first.
 	GetCookie(name string) (*Cookie, bool)
-	// Cookies returns a copy of every cookie this response is set to send, in order,
-	// or nil when there are none. Repeated names are kept apart, and an unparsable
-	// one is skipped. For what the client sent, use Req.Cookies.
-	Cookies() []*Cookie
+	// GetCookies returns a copy of every cookie this response is set to send, in
+	// order, or nil when there are none. Repeated names are kept apart, and an
+	// unparsable one is skipped. For what the client sent, use Req.Cookies.
+	//
+	// Named for GetCookie beside it rather than Cookies, which would collide with
+	// Req.Cookies under a different signature and stop Ctx satisfying Res.
+	GetCookies() []*Cookie
 	// Download transfers the file from path as an attachment.
 	// Typically, browsers will prompt the user for download.
 	// By default, the Content-Disposition header filename= parameter is the filepath (this typically appears in the browser dialog).
@@ -69,9 +73,9 @@ type Res interface {
 	// For more flexible content negotiation, use Format.
 	// If the header is not specified or there is no proper format, text/plain is used.
 	AutoFormat(body any) error
-	// ContentLength returns what the Content-Length response header declares, not
-	// what is buffered: fasthttp fills it in on serialization, so inside a handler
-	// it is 0 unless set explicitly. Use len(Res.Body()) for buffered bytes.
+	// ContentLength returns what the Content-Length response header declares: a
+	// length a handler or upstream set, -1 for an unknown-length stream, 0 when
+	// none is declared. fasthttp fills it in on serialization; see also Res.Body.
 	ContentLength() int
 	// ContentType returns the Content-Type response header, the read side of Type.
 	// With none set it reports what would be sent: fasthttp's default, or "" under
@@ -147,8 +151,8 @@ type Res interface {
 	Render(name string, bind any, layouts ...string) error
 	renderExtensions(bind any)
 	// Body returns the response body buffered so far, or nil for a streamed one,
-	// which draining would pull into memory and de-stream. Use Written to tell those
-	// apart. Only valid until the next write to the response.
+	// which draining would de-stream; Written tells those apart. The buffer is live,
+	// so writing to it writes to the response, and the next write voids it.
 	Body() []byte
 	// ResetBody discards the response body, keeping the status and headers.
 	// Use it before replacing a partially written body — an error page over a

--- a/res_interface_gen.go
+++ b/res_interface_gen.go
@@ -18,18 +18,9 @@ type Res interface {
 	// Empty values are skipped: a sender must not generate empty list elements
 	// (RFC 9110 Section 5.6.1.2).
 	Append(field string, values ...string)
-	// Add appends the given value to the response header field as a new field
-	// line, leaving any existing lines untouched.
-	//
-	// This differs from Append, which folds values into a single comma-separated
-	// line: headers whose values may themselves contain commas — Set-Cookie,
-	// WWW-Authenticate, Link — have to be sent as separate lines to stay
-	// unambiguous (RFC 9110 Section 5.3).
-	//
-	// The headers fasthttp stores in a slot of their own cannot repeat, and Add
-	// does not append for them: Content-Type, Content-Encoding, Content-Length,
-	// Connection, Server and Trailer are replaced, and Transfer-Encoding and Date
-	// are ignored because fasthttp writes them itself. Use Set for those.
+	// Add appends the value as a new field line, where Append folds values into one
+	// comma-separated line. It does not append for the headers fasthttp slots:
+	// Content-Type, Server and the rest are replaced, Date and TE ignored.
 	Add(key, val string)
 	// Attachment sets the HTTP response Content-Disposition header field to attachment.
 	Attachment(filename ...string)
@@ -46,25 +37,13 @@ type Res interface {
 	// Partitioned) happens on a local copy, so a caller may reuse the same *Cookie
 	// template across requests.
 	Cookie(cookie *Cookie)
-	// GetCookie reads back a cookie this response is already set to send, so a
-	// later handler or middleware can inspect or re-emit what an earlier one wrote.
-	// The second result is false when no cookie of that name has been set, or when
-	// its Set-Cookie field value does not parse.
-	//
-	// Cookie names are case-sensitive (RFC 6265 Section 4.1.1). A name written more
-	// than once resolves to the first occurrence; use Cookies to see them all.
-	//
-	// The returned Cookie is a copy: changing it does not change the response.
-	// Pass it to Cookie to write the change back.
+	// GetCookie reads back a cookie this response is set to send, false when the
+	// name is unset or its value does not parse. Names are case-sensitive and a
+	// repeat resolves to the first. The copy is written back through Cookie.
 	GetCookie(name string) (*Cookie, bool)
-	// Cookies returns a copy of every cookie this response is set to send, in the
-	// order they were added. It returns nil when none have been set.
-	//
-	// Repeated names are kept apart, so a response that sets one name at two paths
-	// yields both. A Set-Cookie whose field value does not parse is skipped.
-	//
-	// These are the response's own Set-Cookie headers. For the cookies the client
-	// sent, use Req.Cookies or Req.AllCookies.
+	// Cookies returns a copy of every cookie this response is set to send, in order,
+	// or nil when there are none. Repeated names are kept apart, and an unparseable
+	// one is skipped. For what the client sent, use Req.Cookies.
 	Cookies() []*Cookie
 	// Download transfers the file from path as an attachment.
 	// Typically, browsers will prompt the user for download.
@@ -89,30 +68,17 @@ type Res interface {
 	// For more flexible content negotiation, use Format.
 	// If the header is not specified or there is no proper format, text/plain is used.
 	AutoFormat(body any) error
-	// ContentLength returns the value of the Content-Length response header.
-	//
-	// It reports what the header declares, not what has been buffered: fasthttp
-	// fills Content-Length in as it serializes the response, so inside a handler
-	// this is 0 unless something set it explicitly, and -1 once the body is a
-	// stream of unknown length. Use len(Res.Body()) for the bytes buffered so far.
+	// ContentLength returns what the Content-Length response header declares, not
+	// what is buffered: fasthttp fills it in on serialization, so inside a handler
+	// it is 0 unless set explicitly. Use len(Res.Body()) for buffered bytes.
 	ContentLength() int
-	// ContentType returns the Content-Type response header, parameters included.
-	// It is the read side of Type, and of the content type Fiber sets for you when
-	// a JSON, XML, or SendFile response goes out.
-	//
-	// When nothing has set one it reports what would be sent: fasthttp's default,
-	// "text/plain; charset=utf-8", or an empty string under
-	// Config.DisableDefaultContentType.
-	// Returned value is only valid within the handler. Do not store any references.
-	// Make copies or use the Immutable setting instead.
+	// ContentType returns the Content-Type response header, the read side of Type.
+	// With none set it reports what would be sent: fasthttp's default, or "" under
+	// Config.DisableDefaultContentType. Only valid within the handler.
 	ContentType() string
-	// Del removes every field line of the response header specified by key.
-	// Field names are case-insensitive. Deleting a header that was never set is a
-	// no-op.
-	//
-	// Del(HeaderSetCookie) withdraws every cookie this response was going to set,
-	// which is not what ClearCookie does: ClearCookie adds a Set-Cookie that
-	// expires the cookie already in the client's jar.
+	// Del removes every field line stored under key, case-insensitively, and is a
+	// no-op for a header that was never set. Del(HeaderSetCookie) withdraws the
+	// pending cookies, where ClearCookie expires one already in the client's jar.
 	Del(key string)
 	// Get (a.k.a. GetRespHeader) returns the HTTP response header specified by field.
 	// Field names are case-insensitive
@@ -179,29 +145,17 @@ type Res interface {
 	// We support the following engines: https://github.com/gofiber/template
 	Render(name string, bind any, layouts ...string) error
 	renderExtensions(bind any)
-	// Body returns the response body buffered so far, which lets middleware
-	// inspect or checksum what a handler produced before it is written out.
-	//
-	// A streamed body returns nil rather than being drained. Reading it would pull
-	// the whole stream into memory and turn the response into a buffered one, which
-	// would hang an SSE route and defeat a large SendFile; use Written to tell a
-	// streaming response from one that produced nothing, and the underlying
-	// Response.Body if you really do want to materialize the stream.
-	//
-	// Returned value is only valid within the handler and is invalidated by the
-	// next write to the response. Do not store any references; copy it instead.
+	// Body returns the response body buffered so far, or nil for a streamed one,
+	// which draining would pull into memory and de-stream. Use Written to tell those
+	// apart. Only valid until the next write to the response.
 	Body() []byte
 	// ResetBody discards the response body, keeping the status and headers.
 	// Use it before replacing a partially written body — an error page over a
 	// half-rendered view, a cached body over a fresh one.
 	ResetBody()
-	// Written reports whether anything has been written to the response body yet,
-	// so middleware can tell a handler that produced a response from one that left
-	// it untouched. A streamed body counts as written without draining the stream,
-	// which is the case Body deliberately answers nil for.
-	//
-	// Status and headers are not body writes: a handler that only called Status
-	// leaves this false.
+	// Written reports whether anything has been written to the response body, so a
+	// handler that produced one can be told from a handler that did not. A stream
+	// counts without being drained; a status or header alone does not.
 	Written() bool
 	// Send sets the HTTP response body without copying it.
 	// From this point onward the body argument must not be changed.
@@ -222,12 +176,9 @@ type Res interface {
 	// The Content-Type response HTTP header field is set based on the file's extension.
 	// If the file extension is missing or invalid, the Content-Type is detected from the file's format.
 	SendFile(file string, config ...SendFile) error
-	// NoContent replies 204 No Content. SendStatus already discards the body for
-	// every status statusDisallowsBody names; this drops the Content-Type as well,
-	// since RFC 9110 Section 6.4.1 gives a 204 no content to describe.
-	//
-	// SendStatus(StatusNoContent) leaves a Content-Type a handler had set, so the
-	// two are not interchangeable: this is the one that sends nothing about content.
+	// NoContent replies 204 No Content. SendStatus already discards the body; this
+	// drops the Content-Type too, since RFC 9110 Section 6.4.1 gives a 204 no
+	// content to describe. SendStatus(204) keeps it, so the two differ.
 	NoContent() error
 	// SendStatus sets the HTTP status code and if the response body is empty,
 	// it sets the correct status message in the body.
@@ -245,11 +196,9 @@ type Res interface {
 	// Status sets the HTTP status for the response.
 	// This method is chainable.
 	Status(status int) Ctx
-	// StatusCode returns the status code currently set on the response. It is the
-	// read side of Status, and reports 200 until something sets another code.
-	//
-	// Called after Next it is the status the chain settled on, which is what
-	// logging, metrics, and caching middleware key off.
+	// StatusCode returns the status code set on the response, the read side of
+	// Status, and reports 200 until something sets another. After Next it is the
+	// status the chain settled on.
 	StatusCode() int
 	// Type sets the Content-Type HTTP header to the MIME type specified by the file extension.
 	Type(extension string, charset ...string) Ctx

--- a/res_interface_gen.go
+++ b/res_interface_gen.go
@@ -42,7 +42,7 @@ type Res interface {
 	// repeat resolves to the first. The copy is written back through Cookie.
 	GetCookie(name string) (*Cookie, bool)
 	// Cookies returns a copy of every cookie this response is set to send, in order,
-	// or nil when there are none. Repeated names are kept apart, and an unparseable
+	// or nil when there are none. Repeated names are kept apart, and an unparsable
 	// one is skipped. For what the client sent, use Req.Cookies.
 	Cookies() []*Cookie
 	// Download transfers the file from path as an attachment.

--- a/res_interface_gen.go
+++ b/res_interface_gen.go
@@ -25,6 +25,11 @@ type Res interface {
 	// line: headers whose values may themselves contain commas — Set-Cookie,
 	// WWW-Authenticate, Link — have to be sent as separate lines to stay
 	// unambiguous (RFC 9110 Section 5.3).
+	//
+	// The headers fasthttp stores in a slot of their own cannot repeat, and Add
+	// does not append for them: Content-Type, Content-Encoding, Content-Length,
+	// Connection, Server and Trailer are replaced, and Transfer-Encoding and Date
+	// are ignored because fasthttp writes them itself. Use Set for those.
 	Add(key, val string)
 	// Attachment sets the HTTP response Content-Disposition header field to attachment.
 	Attachment(filename ...string)
@@ -43,13 +48,20 @@ type Res interface {
 	Cookie(cookie *Cookie)
 	// GetCookie reads back a cookie this response is already set to send, so a
 	// later handler or middleware can inspect or re-emit what an earlier one wrote.
-	// The second result is false when no cookie of that name has been set.
+	// The second result is false when no cookie of that name has been set, or when
+	// its Set-Cookie field value does not parse.
+	//
+	// Cookie names are case-sensitive (RFC 6265 Section 4.1.1). A name written more
+	// than once resolves to the first occurrence; use Cookies to see them all.
 	//
 	// The returned Cookie is a copy: changing it does not change the response.
 	// Pass it to Cookie to write the change back.
 	GetCookie(name string) (*Cookie, bool)
 	// Cookies returns a copy of every cookie this response is set to send, in the
 	// order they were added. It returns nil when none have been set.
+	//
+	// Repeated names are kept apart, so a response that sets one name at two paths
+	// yields both. A Set-Cookie whose field value does not parse is skipped.
 	//
 	// These are the response's own Set-Cookie headers. For the cookies the client
 	// sent, use Req.Cookies or Req.AllCookies.
@@ -88,8 +100,9 @@ type Res interface {
 	// It is the read side of Type, and of the content type Fiber sets for you when
 	// a JSON, XML, or SendFile response goes out.
 	//
-	// When nothing has set one it reports fasthttp's default, "text/plain;
-	// charset=utf-8", which is what would be sent — not an empty string.
+	// When nothing has set one it reports what would be sent: fasthttp's default,
+	// "text/plain; charset=utf-8", or an empty string under
+	// Config.DisableDefaultContentType.
 	// Returned value is only valid within the handler. Do not store any references.
 	// Make copies or use the Immutable setting instead.
 	ContentType() string
@@ -169,12 +182,14 @@ type Res interface {
 	// Body returns the response body buffered so far, which lets middleware
 	// inspect or checksum what a handler produced before it is written out.
 	//
+	// A streamed body returns nil rather than being drained. Reading it would pull
+	// the whole stream into memory and turn the response into a buffered one, which
+	// would hang an SSE route and defeat a large SendFile; use Written to tell a
+	// streaming response from one that produced nothing, and the underlying
+	// Response.Body if you really do want to materialize the stream.
+	//
 	// Returned value is only valid within the handler and is invalidated by the
 	// next write to the response. Do not store any references; copy it instead.
-	//
-	// On a streamed response this drains the stream into a buffer to answer, which
-	// changes how the body is sent. Guard with Written or the underlying
-	// Response.IsBodyStream when the response may be a stream.
 	Body() []byte
 	// ResetBody discards the response body, keeping the status and headers.
 	// Use it before replacing a partially written body — an error page over a
@@ -182,7 +197,8 @@ type Res interface {
 	ResetBody()
 	// Written reports whether anything has been written to the response body yet,
 	// so middleware can tell a handler that produced a response from one that left
-	// it untouched. A streamed body counts as written without draining the stream.
+	// it untouched. A streamed body counts as written without draining the stream,
+	// which is the case Body deliberately answers nil for.
 	//
 	// Status and headers are not body writes: a handler that only called Status
 	// leaves this false.
@@ -206,11 +222,12 @@ type Res interface {
 	// The Content-Type response HTTP header field is set based on the file's extension.
 	// If the file extension is missing or invalid, the Content-Type is detected from the file's format.
 	SendFile(file string, config ...SendFile) error
-	// NoContent replies 204 No Content: it sets the status, discards any body
-	// already written, and drops the Content-Type a handler had set, since
-	// RFC 9110 Section 6.4.1 gives a 204 no content to describe. fasthttp omits
-	// Content-Type from a 204 on the wire either way; dropping it here keeps the
-	// response consistent if something later moves it off 204.
+	// NoContent replies 204 No Content. SendStatus already discards the body for
+	// every status statusDisallowsBody names; this drops the Content-Type as well,
+	// since RFC 9110 Section 6.4.1 gives a 204 no content to describe.
+	//
+	// SendStatus(StatusNoContent) leaves a Content-Type a handler had set, so the
+	// two are not interchangeable: this is the one that sends nothing about content.
 	NoContent() error
 	// SendStatus sets the HTTP status code and if the response body is empty,
 	// it sets the correct status message in the body.

--- a/res_interface_gen.go
+++ b/res_interface_gen.go
@@ -18,6 +18,14 @@ type Res interface {
 	// Empty values are skipped: a sender must not generate empty list elements
 	// (RFC 9110 Section 5.6.1.2).
 	Append(field string, values ...string)
+	// Add appends the given value to the response header field as a new field
+	// line, leaving any existing lines untouched.
+	//
+	// This differs from Append, which folds values into a single comma-separated
+	// line: headers whose values may themselves contain commas — Set-Cookie,
+	// WWW-Authenticate, Link — have to be sent as separate lines to stay
+	// unambiguous (RFC 9110 Section 5.3).
+	Add(key, val string)
 	// Attachment sets the HTTP response Content-Disposition header field to attachment.
 	Attachment(filename ...string)
 	// ClearCookie expires a specific cookie by key on the client side.
@@ -33,6 +41,19 @@ type Res interface {
 	// Partitioned) happens on a local copy, so a caller may reuse the same *Cookie
 	// template across requests.
 	Cookie(cookie *Cookie)
+	// GetCookie reads back a cookie this response is already set to send, so a
+	// later handler or middleware can inspect or re-emit what an earlier one wrote.
+	// The second result is false when no cookie of that name has been set.
+	//
+	// The returned Cookie is a copy: changing it does not change the response.
+	// Pass it to Cookie to write the change back.
+	GetCookie(name string) (*Cookie, bool)
+	// Cookies returns a copy of every cookie this response is set to send, in the
+	// order they were added. It returns nil when none have been set.
+	//
+	// These are the response's own Set-Cookie headers. For the cookies the client
+	// sent, use Req.Cookies or Req.AllCookies.
+	Cookies() []*Cookie
 	// Download transfers the file from path as an attachment.
 	// Typically, browsers will prompt the user for download.
 	// By default, the Content-Disposition header filename= parameter is the filepath (this typically appears in the browser dialog).
@@ -56,6 +77,30 @@ type Res interface {
 	// For more flexible content negotiation, use Format.
 	// If the header is not specified or there is no proper format, text/plain is used.
 	AutoFormat(body any) error
+	// ContentLength returns the value of the Content-Length response header.
+	//
+	// It reports what the header declares, not what has been buffered: fasthttp
+	// fills Content-Length in as it serializes the response, so inside a handler
+	// this is 0 unless something set it explicitly, and -1 once the body is a
+	// stream of unknown length. Use len(Res.Body()) for the bytes buffered so far.
+	ContentLength() int
+	// ContentType returns the Content-Type response header, parameters included.
+	// It is the read side of Type, and of the content type Fiber sets for you when
+	// a JSON, XML, or SendFile response goes out.
+	//
+	// When nothing has set one it reports fasthttp's default, "text/plain;
+	// charset=utf-8", which is what would be sent — not an empty string.
+	// Returned value is only valid within the handler. Do not store any references.
+	// Make copies or use the Immutable setting instead.
+	ContentType() string
+	// Del removes every field line of the response header specified by key.
+	// Field names are case-insensitive. Deleting a header that was never set is a
+	// no-op.
+	//
+	// Del(HeaderSetCookie) withdraws every cookie this response was going to set,
+	// which is not what ClearCookie does: ClearCookie adds a Set-Cookie that
+	// expires the cookie already in the client's jar.
+	Del(key string)
 	// Get (a.k.a. GetRespHeader) returns the HTTP response header specified by field.
 	// Field names are case-insensitive
 	// Returned value is only valid within the handler. Do not store any references.
@@ -121,6 +166,27 @@ type Res interface {
 	// We support the following engines: https://github.com/gofiber/template
 	Render(name string, bind any, layouts ...string) error
 	renderExtensions(bind any)
+	// Body returns the response body buffered so far, which lets middleware
+	// inspect or checksum what a handler produced before it is written out.
+	//
+	// Returned value is only valid within the handler and is invalidated by the
+	// next write to the response. Do not store any references; copy it instead.
+	//
+	// On a streamed response this drains the stream into a buffer to answer, which
+	// changes how the body is sent. Guard with Written or the underlying
+	// Response.IsBodyStream when the response may be a stream.
+	Body() []byte
+	// ResetBody discards the response body, keeping the status and headers.
+	// Use it before replacing a partially written body — an error page over a
+	// half-rendered view, a cached body over a fresh one.
+	ResetBody()
+	// Written reports whether anything has been written to the response body yet,
+	// so middleware can tell a handler that produced a response from one that left
+	// it untouched. A streamed body counts as written without draining the stream.
+	//
+	// Status and headers are not body writes: a handler that only called Status
+	// leaves this false.
+	Written() bool
 	// Send sets the HTTP response body without copying it.
 	// From this point onward the body argument must not be changed.
 	Send(body []byte) error
@@ -140,6 +206,12 @@ type Res interface {
 	// The Content-Type response HTTP header field is set based on the file's extension.
 	// If the file extension is missing or invalid, the Content-Type is detected from the file's format.
 	SendFile(file string, config ...SendFile) error
+	// NoContent replies 204 No Content: it sets the status, discards any body
+	// already written, and drops the Content-Type a handler had set, since
+	// RFC 9110 Section 6.4.1 gives a 204 no content to describe. fasthttp omits
+	// Content-Type from a 204 on the wire either way; dropping it here keeps the
+	// response consistent if something later moves it off 204.
+	NoContent() error
 	// SendStatus sets the HTTP status code and if the response body is empty,
 	// it sets the correct status message in the body.
 	SendStatus(status int) error
@@ -156,6 +228,12 @@ type Res interface {
 	// Status sets the HTTP status for the response.
 	// This method is chainable.
 	Status(status int) Ctx
+	// StatusCode returns the status code currently set on the response. It is the
+	// read side of Status, and reports 200 until something sets another code.
+	//
+	// Called after Next it is the status the chain settled on, which is what
+	// logging, metrics, and caching middleware key off.
+	StatusCode() int
 	// Type sets the Content-Type HTTP header to the MIME type specified by the file extension.
 	Type(extension string, charset ...string) Ctx
 	// Vary adds the given header field to the Vary response header.

--- a/res_interface_gen.go
+++ b/res_interface_gen.go
@@ -39,7 +39,8 @@ type Res interface {
 	Cookie(cookie *Cookie)
 	// GetCookie reads back a cookie this response is set to send, false when the
 	// name is unset or its value does not parse. Names are case-sensitive and a
-	// repeat resolves to the first. The copy is written back through Cookie.
+	// repeat resolves to the first. Writing the copy back through Cookie stamps
+	// Path=/ on a cookie that carried none, widening its scope — set Path first.
 	GetCookie(name string) (*Cookie, bool)
 	// Cookies returns a copy of every cookie this response is set to send, in order,
 	// or nil when there are none. Repeated names are kept apart, and an unparsable
@@ -76,9 +77,9 @@ type Res interface {
 	// With none set it reports what would be sent: fasthttp's default, or "" under
 	// Config.DisableDefaultContentType. Only valid within the handler.
 	ContentType() string
-	// Del removes every field line stored under key, case-insensitively, and is a
-	// no-op for a header that was never set. Del(HeaderSetCookie) withdraws the
-	// pending cookies, where ClearCookie expires one already in the client's jar.
+	// Del removes every field line stored under key, whatever case it is spelled in,
+	// and is a no-op for a header that was never set. Del(HeaderSetCookie) withdraws
+	// the pending cookies, where ClearCookie expires one in the client's jar.
 	Del(key string)
 	// Get (a.k.a. GetRespHeader) returns the HTTP response header specified by field.
 	// Field names are case-insensitive


### PR DESCRIPTION
# Description

v3's `Req`/`Res` split gave `Ctx` a request half and a response half, but a lot of everyday work still drops through to raw fasthttp. `c.Response().StatusCode()` alone appears 15 times across eight built-in middlewares; response headers have no `Del`; and there is no way to read back a cookie the response is already set to send.

This does three things:

1. **Fixes a receiver mistake in the previous helper batch.** Fifteen request helpers (`UserAgent`, `MediaType`, `Charset`, the `Accepts*`/`Is*` predicates, …) were written with a `*DefaultCtx` receiver inside `req.go`, which kept them off the `Req` interface `ifacemaker` generates from `DefaultReq`: `c.UserAgent()` compiled, `c.Req().UserAgent()` did not. They move onto `*DefaultReq`, along with `Path`, `Secure`, `XHR`, `HasBody`, `IsWebSocket` and `IsPreflight` out of `ctx.go` — request methods on the wrong type for the same reason. `Req` goes from 39 to 74 methods.
2. **Adds 29 helpers**, mostly closing the paths where middleware in this repo escapes to fasthttp.
3. **Updates twelve middlewares** to use them, which also fixes five latent bugs.

No issue — this came out of an audit of what `ctx.go`/`req.go`/`res.go` were missing.

## Not a breaking change

`DefaultCtx` embeds `DefaultReq`, so every moved method is still promoted: `c.IsWebSocket()` and friends are untouched. Verified rather than assumed:

- Diffing the **reflected method sets** of `Ctx`, `*DefaultCtx`, `*DefaultReq` and `*DefaultRes` between `main` and this branch: **nothing removed, no signature changed**. All four are strict supersets.
- A **consumer module** exercising interface calls, method values (`f := c.HasBody`), method expressions (`(*fiber.DefaultCtx).HasBody`), concrete calls, `var _ fiber.Ctx = (*fiber.DefaultCtx)(nil)`, and a custom Ctx embedding `fiber.DefaultCtx` (including one overriding `HasBody`) compiles identically against both. The only difference is `c.Req().HasBody()`, which fails on `main` and works here.

The interfaces gained methods (`Ctx` +33, `Req` +35, `Res` +11), which normally breaks implementers — but `Ctx` already declares 31 **unexported** methods (`release()`, `getMethodInt()`, `setIndexRoute()`, …), `Req` 7, `Res` 3. Go qualifies unexported method names by package, so no type outside `package fiber` has ever been able to implement them; the documented pattern (embed `fiber.DefaultCtx`) picks new methods up for free. Confirmed by compiling a hand-written `Ctx` against released `main` — it fails there exactly as it does here.

### Risks that remain

- **Assignment, not implementation.** An earlier revision named the response cookie accessor `Res.Cookies() []*Cookie`, which collides with `Req.Cookies(key string, ...string) string`. Same name, different signature, so `Ctx` stopped satisfying `Res`: `func writeHeaders(r fiber.Res)` could no longer be handed a `c`, and `interface { fiber.Req; fiber.Res }` failed to compile. Splitting a handler into a request half and a response half is the reason the split exists, so that shape is not exotic. It is now `Res.GetCookies()`, beside the `GetCookie` it belongs with; `apidiff` reports **0 incompatible / 139 compatible** changes, and `ctx_helpers_test.go` pins `Req` and `Res` on both `Ctx` and `*DefaultCtx` so a future collision fails at compile time rather than on a user's assignment.
- **Ambiguous selector on a double embed.** `HasBody` and the other moved methods are now promoted one level deeper. A type embedding `fiber.DefaultCtx` **alongside** another type supplying the same name at exactly depth 2 goes from "DefaultCtx wins" to `ambiguous selector`. It needs a deliberate double-embed collision and fails loudly at compile time.
- **Silent shadowing on an unequal embed.** The same depth change cuts the other way when the collision is *not* at equal depth. Where a user's own method sits strictly deeper than fiber's, a name this PR adds to `Ctx` now wins where the user's used to: the same program compiles on both revisions and changes what it returns, with no diagnostic. Embedding `fiber.DefaultCtx` is the documented extension path, so this is the one change here that can be silent — it needs one of the 34 names added to `Ctx` to match a method the embedding type supplies below depth 1.

## Changes introduced

**`Req`** — `GetAll`, `Authorization`, `Bearer`, `Origin`, `ContentLength`, `ContentType`, `BodyStream`, `URI`, `CookieNames`, `AllCookies`, `IfNoneMatch`, `IfModifiedSince`, `IsSafe`, `IsIdempotent`

**`Res`** — `StatusCode`, `Body`, `Del`, `Add`, `ContentType`, `ContentLength`, `GetCookie`, `GetCookies`, `ResetBody`, `Written`, `NoContent`

**`Ctx`** — `ID`, `StartTime`, `Elapsed`, `LocalAddr`, `RemoteAddr`, `Hijack`, `Hijacked`, `RouteName`, `IsFinal`, `MountPath`, `Error`

`Req` and `Res` now both define `Body`, `ContentLength` and `ContentType`, which makes those selectors ambiguous on the embedding `DefaultCtx`. They are resolved on `Ctx` the way `Get` already is: **the request wins**, and `c.Res().X()` reaches the response. The response cookies are `GetCookies` rather than a fourth such pair, because the two signatures differ — see *Risks that remain* above.

Two internal packages grew what the helpers needed rather than carrying a second copy: `etag.Split` (collects `headerlist.AllQuoted`, the walk that knows a comma can sit inside a quoted opaque-tag, and pre-sizes for it) and `cookie.FormatSameSite` (inverts `ParseSameSite` so a response cookie survives a read-modify-write).

**Middleware adoption** — cache, etag, limiter, idempotency, keyauth, logger, compress, timeout, session, earlydata, cors. Mostly renames; three read better (`compress`'s "empty body, but not an empty-looking stream" *is* `Res.Written()`; `etag` resets the response body through `Res.ResetBody` rather than the request ctx; `earlydata`/`idempotency` ask `c.IsSafe()`).

**Behaviour fixes — six of this PR's tests fail on `main`:**

- **cors was inert on HTTP/2.** It read `Origin` with `Ctx.Get`, which is byte-exact, so under `DisableHeaderNormalizing` a lower-case `origin:` read as absent and the request fell outside CORS entirely — no `Access-Control-Allow-Origin`, no `Vary`. `Req.Origin` matches the field name the way a recipient must; this is the same fix `csrf` already carries. Every request-header read in the handler now goes through `headerlookup`.
- **cors dropped half a split `Access-Control-Request-Headers`.** It is a list field, so RFC 9110 §5.2 lets a client spread it over several lines and §5.3 combines them; the byte-exact read took only the first, failing the preflight for every header named on a later line. It now reads through `headerlist`-backed `headerlookup.Combined`. (`Origin`, `Access-Control-Request-Method` and `Access-Control-Request-Private-Network` stay on `headerlookup.Value`, which *refuses* a repeated line — each is a single-value field where a second line makes the message malformed.)
- **logger's `${resBody}` de-streamed responses.** It read through fasthttp's `Response.Body`, which materializes a body stream and closes it, so logging an SSE or `SendFile` route turned a streamed response into a buffered one. `Res.Body` returns nil for a stream.
- **etag emitted two conflicting validators.** The handler-ETag check was byte-exact, so a handler that set the field under any other spelling got a second, computed `ETag` line beside its own — two validators for one representation (RFC 9110 §8.8.3). The check now matches the field name case-insensitively, and is guarded on both halves of "the byte-exact lookup will find it": whether the app normalizes *and* whether the stored names are canonical. fasthttp canonicalizes `ETag` to `Etag`, so asking only the second question let that one spelling through.
- **etag ignored a split `If-None-Match`.** Same list-field shape as the cors fix, read through `headerlist.Join`.

**Three released APIs change behaviour**, now called out in `docs/whats_new.md`: `Get` and the request-header helpers match field names case-insensitively (visible only under `DisableHeaderNormalizing`); `Fresh()` follows, which changes 304 decisions; and `SendStatus` drops the body and any `Content-Length` for a status that disallows one, which changes wire bytes under the **default** configuration too.

**Deliberately not done, and why:**

- `Ctx.Copy()` was drafted and **withdrawn**. Built on a bare `fasthttp.RequestCtx` it has no connection, so `IP()` read `0.0.0.0`, an HTTPS request read as `http`, `ID()` was 0 and `Elapsed()` was 292 years — silently, in the audit and rate-limiting paths it exists for. Doing it right needs the connection-derived values snapshotted onto `DefaultCtx` and read there by six accessors, a change to the pooled type that deserves its own PR; and fasthttp closes `Locals` implementing `io.Closer` when the original request resets, which a copy cannot prevent.
- cache/etag/idempotency also read the response body, but there draining a stream produces a correct (if memory-hungry) result — switching them to `Res.Body` would cache and hash empty bodies. That is a streaming-policy decision per middleware, not a rename.
- `basicauth` parses `Authorization` more strictly than `Req.Authorization` (exact single-space separator, header limit, no interior whitespace), and `extractors` goes through `headerlookup`, which refuses a second `Authorization` line. Both would lose something.

**Known, pre-existing, not fixed here:**

- `encryptcookie` enumerates response cookie names and re-resolves each by name — a first-match lookup — so two cookies sharing a name get the first encrypted twice and the second never touched. Same shape as the `Res.GetCookies()` bug fixed here, but fasthttp's response cookie store is name-keyed for *writes*, so there is no clean write-back; it needs the cookie list rebuilt. Worth noting that `Res.Add(HeaderSetCookie, …)` makes that shape reachable from Fiber's own API for the first time.
- **`middleware/timeout` races with the handler it abandoned.** On the `Config.OnTimeout` path the middleware reads the response to decide whether to write a 408, while the timed-out handler goroutine — abandoned by design, and still running — may still be writing to it. `go test -race` reports it against `main` as well as this branch; it is not reachable from anything this PR changed. The fallback's decision is therefore covered by a direct test of `timeoutResponseUnwritten` rather than a served request, which would only re-report the pre-existing race.

## Merged with #4637

`internal/headerlist` landed while this was open, and it consolidates the comma-list header scanning this branch had **moved** rather than rewritten. The conflicts resolve in its direction throughout, so this branch adds no second copy of that walk:

- The quote-aware splitter this branch had factored out of `etag.AnyMatch` is **deleted** — `headerlist.AllQuoted` is exactly it, and removing the last hand-rolled one was #4637's stated goal. `etag.Split` now collects `AllQuoted`; `AnyMatch` is #4637's version untouched.
- `transferEncodingLineHasBody` and `headerListContainsToken` keep this branch's move to `req.go` and take #4637's rewrite over `headerlist.All`/`AllLines`.
- `AcceptLanguage`/`AcceptEncoding`/`IfNoneMatch` keep the `*DefaultReq` receiver and take `headerlist.Join`.

`IsPreflight` is the one place that keeps this branch's version over `main`'s: its `headerField` lookups are the fix above, not a divergence.

- [x] **Benchmarks**: dedicated `Benchmark_Ctx_Get_Header`, `_Get_HeaderAbsent`, `_HasHeader`, `_HasHeaderAbsent`, `_GetReqHeader` and `_IsWebSocket`, each under both normalizing settings, so this path is measured directly instead of being inferred from `Benchmark_Ctx_Range`/`_XHR`/`_Fresh_*`. Plus `Benchmark_AnyMatch`/`Benchmark_Split` in `internal/etag`, where a shared hot path was touched.
- [x] **Documentation Update**: 36 new sections in `docs/api/ctx.md`, inserted alphabetically within their `Request`/`Response`/`Ctx` group, with the moved pages relocated to the Request section; a `${resBody}` note in `docs/middleware/logger.md`. Every link added was checked to resolve.
- [x] **Changelog/What's New**: `docs/whats_new.md` lists the new methods, a *Req and Res Method Placement* section covering the request-wins rule, and the three behaviour changes to released APIs.
- [x] **Migration Guide**: not required — see *Not a breaking change* above.
- [x] **API Alignment with Express**: `Res.Del` ≈ `res.removeHeader`, `Res.Add` ≈ `res.append` for repeatable headers, `Res.StatusCode`/`ContentType` are the read sides Express exposes as `res.statusCode`/`res.get`, `Req.Origin`/`ContentType`/`ContentLength` mirror `req.get(...)` shortcuts.
- [x] **API Longevity**: the collision rule (`Get`'s request-wins) is applied consistently to the three shared names, so adding a `Res` method whose name `Req` already has has a known answer — and where the signatures cannot agree, the `Res` side is named apart rather than shadowing. Absence is signalled the same way as the surrounding API (`nil` for collections, `(T, bool)` for `GetCookie`).
- [ ] **Examples**: each doc section carries a `Signature` and an `Example` block; no separate example app.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing features and functionality)
- [x] Documentation update (changes to documentation)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [x] Followed the inspiration of the Express.js framework for new functionalities, making them similar in usage.
- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation in the `/docs/` directory for [Fiber's documentation](https://docs.gofiber.io/).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes — `go test ./...` and `go test -race ./...` green across all 57 packages, `golangci-lint` at the Makefile-pinned v2.12.2 reports 0 issues, `make generate` reproduces the three `*_interface_gen.go` files byte-identically.
- [x] Verified that any new dependencies are essential — none added.
- [x] Aimed for optimal performance with minimal allocations in the new code — the accessors are thin; `GetAll`, `CookieNames` and `AllCookies` allocate only when there is something to return; the `Authorization` split uses `utils.IndexAny2` and `Bearer` compares the scheme on raw bytes so a non-Bearer header materializes no string. Case-insensitive lookups are allocation-free in the default configuration; under `DisableHeaderNormalizing` they walk the store with `VisitAll` rather than ranging `All()`, whose iterator escapes to the heap.
- [x] Provided benchmarks for the new code — see *Benchmarks* above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cy2PTLcLKw87Bzq7rMtazX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy2PTLcLKw87Bzq7rMtazX)_