### PR TITLE
feat: add Bind().WithSplitting() for per-call override of EnableSplittingOnParsers

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -38,7 +38,10 @@ var bindPool = sync.Pool{
 // By default (manual mode), parsing failures are returned as *BindError; use errors.As to extract source and field details.
 // With WithAutoHandling(), parsing failures set HTTP 400 and return *Error instead.
 type Bind struct {
-	ctx                   Ctx
+	ctx Ctx
+	// overrideSplitting tri-state: nil falls back to the app's
+	// EnableSplittingOnParsers config; non-nil forces the value for this chain.
+	overrideSplitting     *bool
 	shouldSkipErrHandling bool
 	shouldSkipValidation  bool
 }
@@ -130,6 +133,7 @@ func (b *Bind) release() {
 	b.ctx = nil
 	b.shouldSkipErrHandling = true
 	b.shouldSkipValidation = false
+	b.overrideSplitting = nil
 }
 
 // WithoutAutoHandling If you want to handle binder errors manually, you can use `WithoutAutoHandling`.
@@ -154,6 +158,27 @@ func (b *Bind) SkipValidation(skip bool) *Bind {
 	b.shouldSkipValidation = skip
 
 	return b
+}
+
+// WithSplitting overrides the app's EnableSplittingOnParsers config for the
+// current bind chain. When enabled, comma-separated values are split into
+// individual elements for fields whose target type is a slice.
+// Pass true to force splitting on, false to force it off; the override applies
+// until the Bind instance is released back to the pool.
+func (b *Bind) WithSplitting(enable bool) *Bind {
+	b.overrideSplitting = &enable
+
+	return b
+}
+
+// splittingEnabled reports the effective comma-splitting setting for this bind
+// chain, falling back to the app's EnableSplittingOnParsers config when no
+// per-chain override has been set.
+func (b *Bind) splittingEnabled() bool {
+	if b.overrideSplitting != nil {
+		return *b.overrideSplitting
+	}
+	return b.ctx.App().config.EnableSplittingOnParsers
 }
 
 // Check WithAutoHandling/WithoutAutoHandling errors and return it by usage.
@@ -239,7 +264,7 @@ func (b *Bind) Custom(name string, dest any) error {
 // Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) Header(out any) error {
 	bind := binder.GetFromThePool[*binder.HeaderBinding](&binder.HeaderBinderPool)
-	bind.EnableSplitting = b.ctx.App().config.EnableSplittingOnParsers
+	bind.EnableSplitting = b.splittingEnabled()
 
 	defer releasePooledBinder(&binder.HeaderBinderPool, bind)
 
@@ -254,7 +279,7 @@ func (b *Bind) Header(out any) error {
 // Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) RespHeader(out any) error {
 	bind := binder.GetFromThePool[*binder.RespHeaderBinding](&binder.RespHeaderBinderPool)
-	bind.EnableSplitting = b.ctx.App().config.EnableSplittingOnParsers
+	bind.EnableSplitting = b.splittingEnabled()
 
 	defer releasePooledBinder(&binder.RespHeaderBinderPool, bind)
 
@@ -270,7 +295,7 @@ func (b *Bind) RespHeader(out any) error {
 // NOTE: If your cookie is like key=val1,val2; they'll be bound as a slice if your map is map[string][]string. Else, it'll use last element of cookie.
 func (b *Bind) Cookie(out any) error {
 	bind := binder.GetFromThePool[*binder.CookieBinding](&binder.CookieBinderPool)
-	bind.EnableSplitting = b.ctx.App().config.EnableSplittingOnParsers
+	bind.EnableSplitting = b.splittingEnabled()
 
 	defer releasePooledBinder(&binder.CookieBinderPool, bind)
 
@@ -285,7 +310,7 @@ func (b *Bind) Cookie(out any) error {
 // Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 func (b *Bind) Query(out any) error {
 	bind := binder.GetFromThePool[*binder.QueryBinding](&binder.QueryBinderPool)
-	bind.EnableSplitting = b.ctx.App().config.EnableSplittingOnParsers
+	bind.EnableSplitting = b.splittingEnabled()
 
 	defer releasePooledBinder(&binder.QueryBinderPool, bind)
 
@@ -349,7 +374,7 @@ func (b *Bind) Form(out any) error {
 	// by doing it itself, so a fold here would be a second pass over the same
 	// header. Body still folds, because it must read the media type to dispatch.
 	bind := binder.GetFromThePool[*binder.FormBinding](&binder.FormBinderPool)
-	bind.EnableSplitting = b.ctx.App().config.EnableSplittingOnParsers
+	bind.EnableSplitting = b.splittingEnabled()
 	bind.MaxBodySize = b.ctx.App().config.BodyLimit
 
 	defer releasePooledBinder(&binder.FormBinderPool, bind)

--- a/bind.go
+++ b/bind.go
@@ -38,9 +38,7 @@ var bindPool = sync.Pool{
 // By default (manual mode), parsing failures are returned as *BindError; use errors.As to extract source and field details.
 // With WithAutoHandling(), parsing failures set HTTP 400 and return *Error instead.
 type Bind struct {
-	ctx Ctx
-	// overrideSplitting tri-state: nil falls back to the app's
-	// EnableSplittingOnParsers config; non-nil forces the value for this chain.
+	ctx                   Ctx
 	overrideSplitting     *bool
 	shouldSkipErrHandling bool
 	shouldSkipValidation  bool
@@ -160,20 +158,13 @@ func (b *Bind) SkipValidation(skip bool) *Bind {
 	return b
 }
 
-// WithSplitting overrides the app's EnableSplittingOnParsers config for the
-// current bind chain. When enabled, comma-separated values are split into
-// individual elements for fields whose target type is a slice.
-// Pass true to force splitting on, false to force it off; the override applies
-// until the Bind instance is released back to the pool.
+// WithSplitting overrides the app's EnableSplittingOnParsers config for the current bind chain.
 func (b *Bind) WithSplitting(enable bool) *Bind {
 	b.overrideSplitting = &enable
 
 	return b
 }
 
-// splittingEnabled reports the effective comma-splitting setting for this bind
-// chain, falling back to the app's EnableSplittingOnParsers config when no
-// per-chain override has been set.
 func (b *Bind) splittingEnabled() bool {
 	if b.overrideSplitting != nil {
 		return *b.overrideSplitting

--- a/bind_test.go
+++ b/bind_test.go
@@ -3309,3 +3309,100 @@ func Test_Bind_Form_ContentTypeNormalization(t *testing.T) {
 		require.Equal(t, StatusOK, resp.StatusCode)
 	})
 }
+
+// Test_Bind_WithSplitting covers the per-chain override of the
+// EnableSplittingOnParsers config flag. It verifies:
+//  1. With no override, the chain inherits the app config.
+//  2. WithSplitting(true) forces splitting even when the app config is off.
+//  3. WithSplitting(false) suppresses splitting even when the app config is on.
+//  4. The override is scoped to the bind chain: it does not leak across
+//     requests that reuse the same pool entry.
+func Test_Bind_WithSplitting(t *testing.T) {
+	t.Parallel()
+
+	type filter struct {
+		Colors []string `query:"colors"`
+	}
+
+	t.Run("override on, app config off", func(t *testing.T) {
+		t.Parallel()
+
+		app := New(Config{EnableSplittingOnParsers: false})
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
+
+		c.Request().URI().SetQueryString("colors=red,blue")
+
+		f := new(filter)
+		require.NoError(t, c.Bind().WithSplitting(true).Query(f))
+		require.Equal(t, []string{"red", "blue"}, f.Colors)
+	})
+
+	t.Run("override off, app config on", func(t *testing.T) {
+		t.Parallel()
+
+		app := New(Config{EnableSplittingOnParsers: true})
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
+
+		c.Request().URI().SetQueryString("colors=red,blue")
+
+		f := new(filter)
+		require.NoError(t, c.Bind().WithSplitting(false).Query(f))
+		require.Equal(t, []string{"red,blue"}, f.Colors)
+	})
+
+	t.Run("no override honors app config", func(t *testing.T) {
+		t.Parallel()
+
+		app := New(Config{EnableSplittingOnParsers: true})
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
+
+		c.Request().URI().SetQueryString("colors=red,blue")
+
+		f := new(filter)
+		require.NoError(t, c.Bind().Query(f))
+		require.Equal(t, []string{"red", "blue"}, f.Colors)
+	})
+
+	t.Run("override does not leak across reused pool entries", func(t *testing.T) {
+		t.Parallel()
+
+		app := New(Config{EnableSplittingOnParsers: false})
+
+		// First request sets a per-chain override to true.
+		c1 := app.AcquireCtx(&fasthttp.RequestCtx{})
+		c1.Request().URI().SetQueryString("colors=red,blue")
+		f1 := new(filter)
+		require.NoError(t, c1.Bind().WithSplitting(true).Query(f1))
+		require.Equal(t, []string{"red", "blue"}, f1.Colors)
+		app.ReleaseCtx(c1)
+
+		// A second request must not inherit the first request's override.
+		c2 := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c2) })
+		c2.Request().URI().SetQueryString("colors=red,blue")
+		f2 := new(filter)
+		require.NoError(t, c2.Bind().Query(f2))
+		require.Equal(t, []string{"red,blue"}, f2.Colors)
+	})
+
+	t.Run("override applies to header binding", func(t *testing.T) {
+		t.Parallel()
+
+		type hdr struct {
+			Posts []string `header:"Posts"`
+		}
+
+		app := New(Config{EnableSplittingOnParsers: false})
+		c := app.AcquireCtx(&fasthttp.RequestCtx{})
+		t.Cleanup(func() { app.ReleaseCtx(c) })
+
+		c.Request().Header.Set("Posts", "post1,post2,post3")
+
+		h := new(hdr)
+		require.NoError(t, c.Bind().WithSplitting(true).Header(h))
+		require.Equal(t, []string{"post1", "post2", "post3"}, h.Posts)
+	})
+}

--- a/bind_test.go
+++ b/bind_test.go
@@ -3310,13 +3310,7 @@ func Test_Bind_Form_ContentTypeNormalization(t *testing.T) {
 	})
 }
 
-// Test_Bind_WithSplitting covers the per-chain override of the
-// EnableSplittingOnParsers config flag. It verifies:
-//  1. With no override, the chain inherits the app config.
-//  2. WithSplitting(true) forces splitting even when the app config is off.
-//  3. WithSplitting(false) suppresses splitting even when the app config is on.
-//  4. The override is scoped to the bind chain: it does not leak across
-//     requests that reuse the same pool entry.
+// Test_Bind_WithSplitting covers the per-chain override of the EnableSplittingOnParsers config flag.
 func Test_Bind_WithSplitting(t *testing.T) {
 	t.Parallel()
 

--- a/docs/api/bind.md
+++ b/docs/api/bind.md
@@ -660,6 +660,24 @@ type Query struct {
 // Result: Hobby = ["soccer", "basketball", "football"]  ← 3 elements
 ```
 
+##### Per-Bind Override
+
+When you don't want to flip `EnableSplittingOnParsers` for the whole app, override the behavior for a single bind chain with `WithSplitting(true)` or `WithSplitting(false)`:
+
+```go
+type Query struct {
+    Hobby []string `query:"hobby"`
+}
+
+// Comma split just for this request, regardless of the app config:
+c.Bind().WithSplitting(true).Query(&q)
+
+// Or suppress splitting even if it's enabled globally:
+c.Bind().WithSplitting(false).Query(&q)
+```
+
+The override applies to all binding methods on the same chain (`Query`, `Header`, `RespHeader`, `Cookie`, `Form`) and is scoped to that bind instance — it does not affect other requests.
+
 ##### Indexed Bracket Notation (Nested Structs)
 
 Use indexed brackets to bind arrays of nested structs:

--- a/docs/api/bind.md
+++ b/docs/api/bind.md
@@ -668,6 +668,7 @@ When you don't want to flip `EnableSplittingOnParsers` for the whole app, overri
 type Query struct {
     Hobby []string `query:"hobby"`
 }
+var q Query
 
 // Comma split just for this request, regardless of the app config:
 c.Bind().WithSplitting(true).Query(&q)


### PR DESCRIPTION
## Add `Bind().WithSplitting()` for per-call override of `EnableSplittingOnParsers`

### Summary

`EnableSplittingOnParsers` is currently a single, global `fiber.Config` flag that controls whether comma-separated values are split into slice elements for `Query`, `Header`, `RespHeader`, `Cookie`, and `Form` binding. This forces an all-or-nothing choice: turning it on splits everywhere, leaving it off disables splitting everywhere.

This PR adds a chainable per-call override so a single request can opt in or out without flipping the global config:

```go
// Force splitting for this request only:
c.bind().WithSplitting(true).Query(&q)

// Suppress splitting even if the app config has it enabled:
c.bind().WithSplitting(false).Query(&q)

```
The override applies to every binding method on the same Bind chain (Query, Header, RespHeader, Cookie, Form) and is scoped to that bind instance — it does not leak across requests that reuse the same pool entry.


### Changes
`bind.go`
- Add tri-state overrideSplitting *bool field to Bind. nil falls back to the app's EnableSplittingOnParsers config; non-nil forces the value for the current chain. (*bool is required to distinguish "use config" from "explicitly false".)
- Add Bind.WithSplitting(enable bool) *Bind chainable method.
- Add internal Bind.splittingEnabled() helper that resolves the effective value.
- Replace the five direct reads of b.ctx.App().config.EnableSplittingOnParsers in Header, RespHeader, Cookie, Query, and Form with b.splittingEnabled().
- Reset overrideSplitting = nil in Bind.release() so the override does not leak across pooled Bind instances.
- Reorder Bind struct fields per betteralign (saves 8 bytes per instance).

`bind_test.go`
- Add Test_Bind_WithSplitting with 5 parallel subtests covering:
1. Override on with app config off.
2. Override off with app config on.
3. No override honors the app config.
4. Override does not leak across reused pool entries.
5. Override applies to Header binding (not just Query).

`docs/api/bind.md`
- Add a "Per-Bind Override" section under the comma-separated values docs describing the new method, the affected binding methods, and the per-instance scoping guarantee.
WhyUsers have asked for the ability to split in some routes but not others without maintaining two app configurations. The existing SkipValidation(bool) / WithAutoHandling() chainable methods establish the pattern; WithSplitting follows the same convention.

### Behavior
- Default (no WithSplitting call): identical to current code — uses fiber.Config{EnableSplittingOnParsers}.
- WithSplitting(true): splits comma-separated values for the current chain regardless of the app config.
- WithSplitting(false): suppresses splitting for the current chain regardless of the app config.
- Override is reset when the Bind instance is released back to bindPool (Bind.release()), matching the lifecycle of shouldSkipValidation and shouldSkipErrHandling.

### Verification
All programmatic checks pass:
make audit # ✅ go mod verify, go vet, govulncheck — clean
make generate    # ✅
make betteralign # ✅ (pre-existing path.go / router.go warnings on main are unrelated and not touched)
make format # ✅
make lint        # ✅ 0 issues
make test # ✅ 5515 tests, 1 skipped in 47.317s
The new test Test_Bind_WithSplitting passes alongside the full suite.

## Compatibility
Purely additive — no breaking changes. Existing callers that never invoke WithSplitting see identical behavior.