### PR TITLE
🧹 chore: require Go 1.26

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,6 +24,8 @@ jobs:
   benchmark:
     uses: gofiber/.github/.github/workflows/benchmark.yml@main
     with:
+      # the reusable default is still 1.25.x; keep in sync with go.mod
+      go-version: 1.26.x
       # ~9 months of main pushes; the columnar data.js keeps this at a few MB
       max-items-in-chart: 555
       # ~15 min of benchmark time against ~20s of compile, so this scales close to

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
   unit:
     strategy:
       matrix:
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.26.x, 1.27.x]
         platform: [blacksmith-4vcpu-ubuntu-2404, blacksmith-4vcpu-windows-2025, blacksmith-6vcpu-macos-latest]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30
@@ -44,7 +44,7 @@ jobs:
           args: -race -count=1 -coverprofile=coverage.txt -covermode=atomic -shuffle=on
 
       - name: Upload coverage reports to Codecov
-        if: ${{ runner.os == 'Linux' && matrix.go-version == '1.25.x' }}
+        if: ${{ runner.os == 'Linux' && matrix.go-version == '1.26.x' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -128,6 +128,11 @@ linters:
       no-printf-like: true
     misspell:
       locale: US
+    modernize:
+      disable:
+        # reflect's Fields()/Methods() iterators cost a closure per loop
+        # (~40B, 3 allocs); the index form stays allocation-free
+        - stditerators
     nolintlint:
       require-explanation: true
       require-specific: true

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
 <!-- skip-docs -->
 ## ⚙️ Installation
 
-Fiber requires **Go version `1.25` or higher** to run. If you need to install or upgrade Go, visit the [official Go download page](https://go.dev/dl/). To start setting up your project, create a new directory for your project and navigate into it. Then, initialize your project with Go modules by executing the following command in your terminal:
+Fiber requires **Go version `1.26` or higher** to run. If you need to install or upgrade Go, visit the [official Go download page](https://go.dev/dl/). To start setting up your project, create a new directory for your project and navigate into it. Then, initialize your project with Go modules by executing the following command in your terminal:
 
 ```bash
 go mod init github.com/your/repo
@@ -159,7 +159,7 @@ We **listen** to our users in [issues](https://github.com/gofiber/fiber/issues),
 
 ## ⚠️ Limitations
 
-- Due to Fiber's usage of unsafe, the library may not always be compatible with the latest Go version. Fiber v3 has been tested with Go version 1.25 or higher.
+- Due to Fiber's usage of unsafe, the library may not always be compatible with the latest Go version. Fiber v3 has been tested with Go version 1.26 or higher.
 - Fiber automatically adapts common `net/http` handler shapes when you register them on the router, and you can still use the [adaptor middleware](https://docs.gofiber.io/next/middleware/adaptor/) when you need to bridge entire apps or `net/http` middleware.
 
 ### net/http compatibility

--- a/client/transport_test.go
+++ b/client/transport_test.go
@@ -47,10 +47,6 @@ type stubRedirectCall struct {
 	location *string
 }
 
-func ptrInt(v int) *int { return &v }
-
-func ptrString(v string) *string { return &v }
-
 type stubRedirectClient struct {
 	calls     []stubRedirectCall
 	callCount int
@@ -287,8 +283,8 @@ func TestDoRedirectsWithClient_DropsBodyForAnyMethod(t *testing.T) {
 				req.SetBodyString(`{"q":"secret"}`)
 
 				client := &stubRedirectClient{calls: []stubRedirectCall{
-					{status: ptrInt(status), location: ptrString("http://other.example/next")},
-					{status: ptrInt(fasthttp.StatusOK)},
+					{status: new(status), location: new("http://other.example/next")},
+					{status: new(fasthttp.StatusOK)},
 				}}
 				require.NoError(t, doRedirectsWithClient(req, resp, -1, client))
 
@@ -318,8 +314,8 @@ func TestDoRedirectsWithClient_DropsBodyForAnyMethod(t *testing.T) {
 			req.SetBodyString("body-must-survive")
 
 			client := &stubRedirectClient{calls: []stubRedirectCall{
-				{status: ptrInt(status), location: ptrString("/next")},
-				{status: ptrInt(fasthttp.StatusOK)},
+				{status: new(status), location: new("/next")},
+				{status: new(fasthttp.StatusOK)},
 			}}
 			require.NoError(t, doRedirectsWithClient(req, resp, -1, client))
 
@@ -345,8 +341,8 @@ func TestDoRedirectsWithClient_DropsBodyForAnyMethod(t *testing.T) {
 			req.SetBodyString(`{"q":"secret"}`)
 
 			client := &stubRedirectClient{calls: []stubRedirectCall{
-				{status: ptrInt(fasthttp.StatusSeeOther), location: ptrString("http://other.example/next")},
-				{status: ptrInt(fasthttp.StatusOK)},
+				{status: new(fasthttp.StatusSeeOther), location: new("http://other.example/next")},
+				{status: new(fasthttp.StatusOK)},
 			}}
 			require.NoError(t, doRedirectsWithClient(req, resp, -1, client))
 
@@ -370,7 +366,7 @@ func TestDoRedirectsWithClientBranches(t *testing.T) {
 	req.Header.SetContentType("application/json")
 	req.SetBodyString("payload")
 
-	client := &stubRedirectClient{calls: []stubRedirectCall{{status: ptrInt(fasthttp.StatusMovedPermanently), location: ptrString("/redirect")}, {status: ptrInt(fasthttp.StatusOK)}}}
+	client := &stubRedirectClient{calls: []stubRedirectCall{{status: new(fasthttp.StatusMovedPermanently), location: new("/redirect")}, {status: new(fasthttp.StatusOK)}}}
 	require.NoError(t, doRedirectsWithClient(req, resp, -1, client))
 	require.Equal(t, fasthttp.MethodGet, string(req.Header.Method()))
 	require.Equal(t, "http://example.com/redirect", req.URI().String())
@@ -382,7 +378,7 @@ func TestDoRedirectsWithClientBranches(t *testing.T) {
 	req.Header.SetContentType("application/json")
 	req.SetBodyString("payload")
 
-	seeOtherClient := &stubRedirectClient{calls: []stubRedirectCall{{status: ptrInt(fasthttp.StatusSeeOther), location: ptrString("/see-other")}, {status: ptrInt(fasthttp.StatusOK)}}}
+	seeOtherClient := &stubRedirectClient{calls: []stubRedirectCall{{status: new(fasthttp.StatusSeeOther), location: new("/see-other")}, {status: new(fasthttp.StatusOK)}}}
 	require.NoError(t, doRedirectsWithClient(req, resp, -1, seeOtherClient))
 	require.Equal(t, fasthttp.MethodGet, string(req.Header.Method()))
 	require.Equal(t, "http://example.com/see-other", req.URI().String())
@@ -398,7 +394,7 @@ func TestDoRedirectsWithClientBranches(t *testing.T) {
 	// it, as fasthttp's own DoRedirects does. Returning nil made a request that
 	// finished indistinguishable from one that stopped at a hop, and the request
 	// is left as it was sent, since the error comes before any rewrite.
-	singleCall := &stubRedirectClient{calls: []stubRedirectCall{{status: ptrInt(fasthttp.StatusFound), location: ptrString("/ignored")}}}
+	singleCall := &stubRedirectClient{calls: []stubRedirectCall{{status: new(fasthttp.StatusFound), location: new("/ignored")}}}
 	require.ErrorIs(t, doRedirectsWithClient(req, resp, 0, singleCall), fasthttp.ErrTooManyRedirects)
 	require.Equal(t, fasthttp.StatusFound, resp.StatusCode())
 	require.Equal(t, fasthttp.MethodPost, string(req.Header.Method()))
@@ -411,28 +407,28 @@ func TestDoRedirectsWithClientBranches(t *testing.T) {
 	req.Header.SetMethod(fasthttp.MethodPost)
 	req.SetRequestURI("http://example.com/start")
 
-	client = &stubRedirectClient{calls: []stubRedirectCall{{status: ptrInt(fasthttp.StatusFound)}}}
+	client = &stubRedirectClient{calls: []stubRedirectCall{{status: new(fasthttp.StatusFound)}}}
 	require.ErrorIs(t, doRedirectsWithClient(req, resp, 1, client), fasthttp.ErrMissingLocation)
 
 	resp.Reset()
 	req.Header.SetMethod(fasthttp.MethodPost)
 	req.SetRequestURI("http://example.com/start")
 
-	client = &stubRedirectClient{calls: []stubRedirectCall{{status: ptrInt(fasthttp.StatusMovedPermanently), location: ptrString("ftp://example.com")}}}
+	client = &stubRedirectClient{calls: []stubRedirectCall{{status: new(fasthttp.StatusMovedPermanently), location: new("ftp://example.com")}}}
 	require.ErrorIs(t, doRedirectsWithClient(req, resp, 1, client), fasthttp.ErrorInvalidURI)
 
 	resp.Reset()
 	req.Header.SetMethod(fasthttp.MethodPost)
 	req.SetRequestURI("http://example.com/start")
 
-	client = &stubRedirectClient{calls: []stubRedirectCall{{status: ptrInt(fasthttp.StatusFound), location: ptrString("/bad\x00path")}}}
+	client = &stubRedirectClient{calls: []stubRedirectCall{{status: new(fasthttp.StatusFound), location: new("/bad\x00path")}}}
 	require.ErrorIs(t, doRedirectsWithClient(req, resp, 1, client), fasthttp.ErrorInvalidURI)
 
 	resp.Reset()
 	req.Header.SetMethod(fasthttp.MethodPost)
 	req.SetRequestURI("http://example.com/start")
 
-	client = &stubRedirectClient{calls: []stubRedirectCall{{status: ptrInt(fasthttp.StatusMovedPermanently), location: ptrString("/loop")}, {status: ptrInt(fasthttp.StatusFound), location: ptrString("/final")}, {status: ptrInt(fasthttp.StatusOK)}}}
+	client = &stubRedirectClient{calls: []stubRedirectCall{{status: new(fasthttp.StatusMovedPermanently), location: new("/loop")}, {status: new(fasthttp.StatusFound), location: new("/final")}, {status: new(fasthttp.StatusOK)}}}
 	require.ErrorIs(t, doRedirectsWithClient(req, resp, 1, client), fasthttp.ErrTooManyRedirects)
 }
 
@@ -540,8 +536,8 @@ func TestDoRedirectsWithClient_StripsCredentialsCrossHost(t *testing.T) {
 		defer fasthttp.ReleaseResponse(resp)
 
 		client := &stubRedirectClient{calls: []stubRedirectCall{
-			{status: ptrInt(fasthttp.StatusFound), location: ptrString("http://www.example.com/next")},
-			{status: ptrInt(fasthttp.StatusOK)},
+			{status: new(fasthttp.StatusFound), location: new("http://www.example.com/next")},
+			{status: new(fasthttp.StatusOK)},
 		}}
 		require.NoError(t, doRedirectsWithClient(req, resp, 5, client))
 		require.Equal(t, "Bearer secret", string(req.Header.Peek(fasthttp.HeaderAuthorization)))
@@ -556,8 +552,8 @@ func TestDoRedirectsWithClient_StripsCredentialsCrossHost(t *testing.T) {
 		defer fasthttp.ReleaseResponse(resp)
 
 		client := &stubRedirectClient{calls: []stubRedirectCall{
-			{status: ptrInt(fasthttp.StatusFound), location: ptrString("http://example.com:80/next")},
-			{status: ptrInt(fasthttp.StatusOK)},
+			{status: new(fasthttp.StatusFound), location: new("http://example.com:80/next")},
+			{status: new(fasthttp.StatusOK)},
 		}}
 		require.NoError(t, doRedirectsWithClient(req, resp, 5, client))
 		require.Equal(t, "Bearer secret", string(req.Header.Peek(fasthttp.HeaderAuthorization)))
@@ -572,8 +568,8 @@ func TestDoRedirectsWithClient_StripsCredentialsCrossHost(t *testing.T) {
 		defer fasthttp.ReleaseResponse(resp)
 
 		client := &stubRedirectClient{calls: []stubRedirectCall{
-			{status: ptrInt(fasthttp.StatusFound), location: ptrString("http://example.com/next")},
-			{status: ptrInt(fasthttp.StatusOK)},
+			{status: new(fasthttp.StatusFound), location: new("http://example.com/next")},
+			{status: new(fasthttp.StatusOK)},
 		}}
 		require.NoError(t, doRedirectsWithClient(req, resp, 5, client))
 		require.Equal(t, "Bearer secret", string(req.Header.Peek(fasthttp.HeaderAuthorization)))
@@ -590,8 +586,8 @@ func TestDoRedirectsWithClient_StripsCredentialsCrossHost(t *testing.T) {
 		defer fasthttp.ReleaseResponse(resp)
 
 		client := &stubRedirectClient{calls: []stubRedirectCall{
-			{status: ptrInt(fasthttp.StatusFound), location: ptrString("http://attacker.example/collect")},
-			{status: ptrInt(fasthttp.StatusOK)},
+			{status: new(fasthttp.StatusFound), location: new("http://attacker.example/collect")},
+			{status: new(fasthttp.StatusOK)},
 		}}
 		require.NoError(t, doRedirectsWithClient(req, resp, 5, client))
 		require.Equal(t, "http://attacker.example/collect", req.URI().String())
@@ -628,7 +624,7 @@ func TestDoRedirectsWithClient_ValidatesTargets(t *testing.T) {
 
 			req.SetRequestURI(tc.base)
 			client := &stubRedirectClient{calls: []stubRedirectCall{
-				{status: ptrInt(fasthttp.StatusFound), location: ptrString(tc.location)},
+				{status: new(fasthttp.StatusFound), location: new(tc.location)},
 			}}
 			require.ErrorIs(t, doRedirectsWithClient(req, resp, 5, client), tc.wantErr)
 		})
@@ -738,7 +734,7 @@ func TestDoRedirectsWithClientDefaultLimit(t *testing.T) {
 
 	calls := make([]stubRedirectCall, 0, defaultRedirectLimit+1)
 	for range defaultRedirectLimit + 1 {
-		calls = append(calls, stubRedirectCall{status: ptrInt(fasthttp.StatusFound), location: ptrString("/loop")})
+		calls = append(calls, stubRedirectCall{status: new(fasthttp.StatusFound), location: new("/loop")})
 	}
 
 	client := &stubRedirectClient{calls: calls}

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -20,7 +20,7 @@ Coming from Fiber v2? See [What's New in v3](./whats_new.md) for the migration g
 
 ## Installation
 
-First, [download](https://go.dev/dl/) and install Go. Version `1.25` or higher is required.
+First, [download](https://go.dev/dl/) and install Go. Version `1.26` or higher is required.
 
 Install Fiber using the [`go get`](https://pkg.go.dev/cmd/go/#hdr-Add_dependencies_to_current_module_and_install_them) command:
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -63,7 +63,7 @@ Here's a quick overview of the changes in Fiber `v3`:
 
 ## Dropping support for old Go versions
 
-Fiber `v3` requires Go `1.25` or later. Update your toolchain to `1.25+` before upgrading so the module `go` directive and standard library features align with the new minimum version.
+Fiber `v3` requires Go `1.26` or later. Update your toolchain to `1.26+` before upgrading so the module `go` directive and standard library features align with the new minimum version.
 
 ## 🚀 App
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofiber/fiber/v3
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/gofiber/schema v1.8.5


### PR DESCRIPTION
# Description

`golang.org/x/crypto` v0.56.0 raised its own `go` directive to `1.26.0`. Go requires
the main module's directive to be at least the maximum of its dependencies, so any
module taking that release is pushed to Go 1.26 as well. That is what turns #4651 red
across the board: every job pinned to 1.25 dies with
`go: go.mod requires go >= 1.26.0 (running go 1.25.14; GOTOOLCHAIN=local)`.

Go 1.27 is stable, so 1.25 is already past upstream support (Go maintains the latest
two releases). This PR moves the minimum to 1.26 and tests against the supported pair,
1.26 and 1.27, following the previous bumps (#3682, #3481).

Unblocks #4651, which should rebase cleanly once this lands.

## Changes introduced

- `go.mod`: `go 1.26.0`
- `test.yml`: matrix `[1.26.x, 1.27.x]`, codecov upload moved to the new lower bound
- `benchmark.yml`: explicit `go-version: 1.26.x`. The reusable workflow in
  `gofiber/.github` still defaults to `1.25.x`, so without the pin the benchmark
  shards keep failing on the go directive.
- `.golangci.yml`: disable `modernize`'s `stditerators`. It only starts firing once the
  module is on 1.26, and its rewrite to `reflect.Type.Fields()` costs a closure per loop
  (~40 B, 3 allocs) where the index form is allocation-free. Measured in isolation the
  iterator is 1.45x to 2.3x slower depending on field count, so `bind.go` and
  `binder/mapping.go` keep index iteration and stay untouched by this PR.
- `client/transport_test.go`: the `ptrInt`/`ptrString` helpers give way to Go 1.26
  `new(expr)`, which `modernize`'s `newexpr` flagged at both the helpers and every
  call site.

- [x] Documentation Update: `README.md`, `docs/intro.md`, `docs/whats_new.md`
- [ ] Benchmarks: no production code changes remain, so the bind path is untouched.
- [ ] Migration Guide: users on Go 1.25 upgrade their toolchain; noted in
      `docs/whats_new.md`.

## Type of change

- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Verification

Locally on Go 1.26.0 with golangci-lint v2.12.2 (the version pinned in `lint.yml`):

- `go build ./...` and `go vet ./...` clean
- `golangci-lint config verify` and `golangci-lint run`: 0 issues
- `go test ./...`: all 50 packages pass
- `go test -race -shuffle=on . ./binder ./client` pass
- `go mod tidy -diff` clean, `actionlint` clean on both changed workflows
