### PR TITLE
🐛 bug: prevent unbounded function-backed SendFile caching

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -11324,6 +11324,30 @@ func Test_Ctx_SendFile_UncomparableFS(t *testing.T) {
 	}
 }
 
+func Test_Ctx_SendFile_FunctionFSDoesNotGrowHandlerCache(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	files := fstest.MapFS{"hello.txt": &fstest.MapFile{Data: []byte("hello")}}
+	open := funcFS(files.Open)
+	app.Get("/", func(c Ctx) error {
+		return c.SendFile("hello.txt", SendFile{FS: open})
+	})
+
+	for range 10 {
+		resp, err := app.Test(httptest.NewRequest(MethodGet, "/", http.NoBody))
+		require.NoError(t, err)
+		require.Equal(t, StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, "hello", string(body))
+	}
+
+	app.sendfilesMutex.RLock()
+	defer app.sendfilesMutex.RUnlock()
+	require.Empty(t, app.sendfiles)
+}
+
 func Test_Ctx_SendFile_KeepsAcceptEncoding(t *testing.T) {
 	t.Parallel()
 

--- a/res.go
+++ b/res.go
@@ -1209,17 +1209,24 @@ func (r *DefaultRes) SendFile(file string, config ...SendFile) error {
 
 	var fsHandler fasthttp.RequestHandler
 	var cacheControlValue string
+	// Function values have no safe identity in Go: reflect.Value.Pointer only
+	// identifies their shared code, not captured closure data. Do not retain
+	// handlers for function-backed file systems, since they can never be safely
+	// matched and would otherwise grow the application cache on every request.
+	cacheHandler := cfg.FS == nil || reflect.ValueOf(cfg.FS).Kind() != reflect.Func
 
 	app := r.c.app
-	app.sendfilesMutex.RLock()
-	for _, sf := range app.sendfiles {
-		if sf.configEqual(cfg) {
-			fsHandler = sf.handler
-			cacheControlValue = sf.cacheControlValue
-			break
+	if cacheHandler {
+		app.sendfilesMutex.RLock()
+		for _, sf := range app.sendfiles {
+			if sf.configEqual(cfg) {
+				fsHandler = sf.handler
+				cacheControlValue = sf.cacheControlValue
+				break
+			}
 		}
+		app.sendfilesMutex.RUnlock()
 	}
-	app.sendfilesMutex.RUnlock()
 
 	if fsHandler == nil {
 		fasthttpFS := &fasthttp.FS{
@@ -1233,7 +1240,7 @@ func (r *DefaultRes) SendFile(file string, config ...SendFile) error {
 			CompressZstd:           cfg.Compress,
 			CompressedFileSuffixes: app.config.CompressedFileSuffixes,
 			CacheDuration:          cfg.CacheDuration,
-			SkipCache:              cfg.CacheDuration < 0,
+			SkipCache:              cfg.CacheDuration < 0 || !cacheHandler,
 			IndexNames:             []string{"index.html"},
 			PathNotFound: func(ctx *fasthttp.RequestCtx) {
 				ctx.Response.SetStatusCode(StatusNotFound)
@@ -1254,9 +1261,11 @@ func (r *DefaultRes) SendFile(file string, config ...SendFile) error {
 		fsHandler = sf.handler
 		cacheControlValue = sf.cacheControlValue
 
-		app.sendfilesMutex.Lock()
-		app.sendfiles = append(app.sendfiles, sf)
-		app.sendfilesMutex.Unlock()
+		if cacheHandler {
+			app.sendfilesMutex.Lock()
+			app.sendfiles = append(app.sendfiles, sf)
+			app.sendfilesMutex.Unlock()
+		}
 	}
 
 	// Keep original path for mutable params


### PR DESCRIPTION
### Motivation
- A previous change to `sameFS` caused function-backed `fs.FS` values to never match existing `SendFile` handlers, which made every request create and retain a new fasthttp handler and grow `app.sendfiles` unboundedly. 
- The intent is to preserve correct SendFile behavior while preventing unbounded memory and goroutine retention when users serve files from function-valued `fs.FS` implementations.

### Description
- Add a `cacheHandler` guard in `DefaultRes.SendFile` so function-backed `fs.FS` (dynamic kind `reflect.Func`) do not participate in the persistent `app.sendfiles` handler cache. 
- Disable fasthttp's per-handler file cache for these transient handlers by setting `SkipCache` when `cacheHandler` is false. 
- Only read/append `app.sendfiles` when `cacheHandler` is true, preventing the pathological append-on-every-request behavior. 
- Add `Test_Ctx_SendFile_FunctionFSDoesNotGrowHandlerCache` in `ctx_test.go` to exercise a stable function-backed FS over repeated requests and assert `app.sendfiles` remains empty.

### Testing
- Ran `go test ./... -run 'Test_(Ctx_SendFile_FunctionFSDoesNotGrowHandlerCache|SameFS)$'` and the focused tests passed. 
- Ran the repository programmatic checks: `make generate`, `make betteralign`, `make format`, `make lint`, and `make test`, and they completed successfully with `make test` reporting `DONE 5775 tests, 1 skipped in 224.046s`. 
- `make audit` exercised `govulncheck` and returned non-zero due to 23 known vulnerabilities reported in the environment's Go 1.26.0 standard library (these are external to this change and fixed in later Go patch releases), so `make audit` did not fully succeed in this environment. 
- Verified `git diff --check` produced no whitespace errors and the change was committed as `🐛 bug: bound function-backed SendFile handlers`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9c9cac9d208333baf1a6a7a36e9536)