### PR TITLE
🐛 bug: parse malformed Set-Cookie attributes in linear time

### DIFF
--- a/client/hooks.go
+++ b/client/hooks.go
@@ -587,25 +587,32 @@ func parserResponseCookie(c *Client, resp *Response, req *Request) error {
 // attributes fasthttp cannot parse. RFC 6265 §5.2 has an unparsable attribute
 // ignored, while fasthttp abandons the cookie at the first one — losing the
 // name, the value, and every attribute it had already accepted. Each attribute
-// is offered against the ones kept so far, so those on either side of a bad one
-// survive. Only a name/value pair that will not parse fails the cookie.
+// is validated independently before the retained attributes are parsed once,
+// keeping the fallback's work linear in the header length. Only a name/value
+// pair that will not parse fails the cookie.
 func parseCookieIgnoringBadAttrs(cookie *fasthttp.Cookie, value []byte) error {
 	pair, rest, _ := bytes.Cut(value, []byte{';'})
-	kept := append([]byte(nil), pair...)
+	kept := make([]byte, len(pair), len(value))
+	copy(kept, pair)
 
-	// ParseBytes resets the cookie, so a rejected attempt leaves nothing behind.
 	trial := fasthttp.AcquireCookie()
 	defer fasthttp.ReleaseCookie(trial)
 	if err := trial.ParseBytes(kept); err != nil {
 		return err
 	}
 
+	// A fixed valid pair lets fasthttp validate each attribute without repeatedly
+	// copying and parsing the growing cookie. ParseBytes resets trial each time.
+	const probePair = "_=_;"
+	probe := make([]byte, len(probePair), len(probePair)+len(rest))
+	copy(probe, probePair)
 	for len(rest) > 0 {
 		var attr []byte
 		attr, rest, _ = bytes.Cut(rest, []byte{';'})
-		candidate := append(append(append([]byte(nil), kept...), ';'), attr...)
-		if err := trial.ParseBytes(candidate); err == nil {
-			kept = candidate
+		probe = append(probe[:len(probePair)], attr...)
+		if err := trial.ParseBytes(probe); err == nil {
+			kept = append(kept, ';')
+			kept = append(kept, attr...)
 		}
 	}
 

--- a/client/hooks_test.go
+++ b/client/hooks_test.go
@@ -1023,6 +1023,43 @@ func Test_ParseCookieIgnoringBadAttrs(t *testing.T) {
 	}
 }
 
+func Test_ParseCookieIgnoringBadAttrs_ManyAttributes(t *testing.T) {
+	t.Parallel()
+
+	value := make([]byte, 0, 16*1024)
+	value = append(value, "a=1; Expires=bogus"...)
+	for range 4_000 {
+		value = append(value, "; x"...)
+	}
+	value = append(value, "; Secure"...)
+
+	cookie := fasthttp.AcquireCookie()
+	t.Cleanup(func() { fasthttp.ReleaseCookie(cookie) })
+
+	require.NoError(t, parseCookieIgnoringBadAttrs(cookie, value))
+	require.Equal(t, "1", string(cookie.Value()))
+	require.True(t, cookie.Secure())
+}
+
+func Benchmark_ParseCookieIgnoringBadAttrs(b *testing.B) {
+	value := make([]byte, 0, 16*1024)
+	value = append(value, "a=1; Expires=bogus"...)
+	for range 4_000 {
+		value = append(value, "; x"...)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(value)))
+	b.ResetTimer()
+	for range b.N {
+		cookie := fasthttp.AcquireCookie()
+		if err := parseCookieIgnoringBadAttrs(cookie, value); err != nil {
+			b.Fatal(err)
+		}
+		fasthttp.ReleaseCookie(cookie)
+	}
+}
+
 func Test_Client_ResponseCookie_UnparsableAttribute(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Motivation

- A fallback parser for malformed `Set-Cookie` headers rebuilt and reparsed a growing cumulative cookie for each attribute, producing quadratic CPU and allocation cost on attacker-controlled headers. 
- The goal is to preserve RFC 6265 behavior (ignore an unparsable attribute but keep other attributes) while bounding work to linear time in header length.

### Description

- Rewrote `parseCookieIgnoringBadAttrs` to validate each attribute against a fixed probe cookie pair and append accepted attributes to a preallocated `kept` buffer, avoiding repeated full reparses so work is linear in header size. 
- Preallocated the initial `kept` buffer and used a constant `probePair` to let `fasthttp.ParseBytes` validate attributes without copying the entire cookie repeatedly. 
- Added `Test_ParseCookieIgnoringBadAttrs_ManyAttributes` to exercise a high-attribute-count malicious header and a `Benchmark_ParseCookieIgnoringBadAttrs` to guard regressions in CPU and allocations. 

### Testing

- `make audit` — produced a warning: `govulncheck` reported 23 vulnerabilities in the installed Go 1.26.0 standard library (toolchain upgrade recommended); other audit steps (`go mod verify`, `go vet`) succeeded. 
- `make generate`, `make betteralign`, `make format`, and `make lint` — all completed successfully (lint reported 0 issues). 
- `make test` — test suite completed successfully (5,775 tests run, 2 skipped). 
- Focused checks: `go test ./client -run 'Test_(ParseCookieIgnoringBadAttrs|Client_ResponseCookie_UnparsableAttribute)$|Test_ParseCookieIgnoringBadAttrs_ManyAttributes' -count=1 -v` and `go test ./client -bench '^Benchmark_ParseCookieIgnoringBadAttrs$' -benchmem` — both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9cb19386808333928b8ac6f909c056)