### PR TITLE
🐛 bug: snapshot client request ownership on response

### DIFF
--- a/client/core.go
+++ b/client/core.go
@@ -62,6 +62,10 @@ func (c *core) execFunc() (*Response, error) {
 		reqv.SetBodyStream(bodyStream, c.req.RawRequest.Header.ContentLength())
 	}
 	// Read what the goroutine needs now; only its own copy is safe to touch later.
+	// Ownership is included: once the caller times out, execute releases a
+	// client-owned request and the pool may hand it to another call while the
+	// transport is still finishing, so reading the flag from the goroutine races.
+	reqOwned := c.req.clientOwned
 	maxRedirects := c.req.maxRedirects
 	method := string(reqv.Header.Method())
 	followRedirects := maxRedirects > 0 && (method == fiber.MethodGet || method == fiber.MethodHead || method == fiber.MethodQuery)
@@ -114,7 +118,7 @@ func (c *core) execFunc() (*Response, error) {
 
 		resp = AcquireResponse()
 		resp.setClient(c.client)
-		resp.setRequest(c.req)
+		resp.setRequest(c.req, reqOwned)
 		// reqv carries the URI of the hop that produced this response, which after a
 		// redirect is not c.req's. Record it before reqv is pooled so the response
 		// hooks can attribute cookies to its real origin — and only where a jar

--- a/client/core_test.go
+++ b/client/core_test.go
@@ -169,6 +169,38 @@ func Test_Exec_Func(t *testing.T) {
 		}
 	})
 
+	t.Run("timeout snapshots ownership before transport", func(t *testing.T) {
+		t.Parallel()
+		core, client, req := newCore(), New(), AcquireRequest()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		// A helper-owned request: execute releases it as soon as the caller
+		// times out, while the transport goroutine is still completing on its
+		// own clock. Nothing orders that release before the goroutine builds
+		// its response, so any read of req there is a data race.
+		req.clientOwned = true
+		req.SetURL("http://example.com/owned-timeout")
+
+		transport := newDelayedTransport(150 * time.Millisecond)
+		client.transport = transport
+
+		// Once execute returns, req is back in the pool, so the test must not
+		// touch it again either: another test may already own the same object.
+		resp, err := core.execute(ctx, client, req)
+		require.Nil(t, resp)
+		require.ErrorIs(t, err, ErrTimeoutOrCancel)
+
+		select {
+		case <-transport.finished:
+		case <-time.After(time.Second):
+			t.Fatal("transport Do did not finish")
+		}
+
+		// Let the goroutine build and hand off its response after Do returned.
+		time.Sleep(50 * time.Millisecond)
+	})
+
 	t.Run("panic in transport returns error", func(t *testing.T) {
 		t.Parallel()
 		core, client, req := newCore(), New(), AcquireRequest()
@@ -555,6 +587,61 @@ func Test_AfterHooks_ReturnsUserHookError(t *testing.T) {
 	defer ReleaseResponse(resp)
 
 	require.ErrorIs(t, core.afterHooks(resp), wantErr)
+}
+
+// delayedTransport completes successfully after a fixed delay, without any
+// synchronization with the caller, mirroring a slow upstream that answers after
+// the client has already given up.
+type delayedTransport struct {
+	finished chan struct{}
+	delay    time.Duration
+}
+
+func newDelayedTransport(delay time.Duration) *delayedTransport {
+	return &delayedTransport{delay: delay, finished: make(chan struct{})}
+}
+
+func (d *delayedTransport) Do(_ *fasthttp.Request, resp *fasthttp.Response) error {
+	time.Sleep(d.delay)
+	resp.SetStatusCode(fasthttp.StatusOK)
+	close(d.finished)
+	return nil
+}
+
+func (d *delayedTransport) DoTimeout(req *fasthttp.Request, resp *fasthttp.Response, _ time.Duration) error {
+	return d.Do(req, resp)
+}
+
+func (d *delayedTransport) DoDeadline(req *fasthttp.Request, resp *fasthttp.Response, _ time.Time) error {
+	return d.Do(req, resp)
+}
+
+func (d *delayedTransport) DoRedirects(req *fasthttp.Request, resp *fasthttp.Response, _ int) error {
+	return d.Do(req, resp)
+}
+
+func (*delayedTransport) CloseIdleConnections() {
+}
+
+func (*delayedTransport) TLSConfig() *tls.Config {
+	return nil
+}
+
+func (*delayedTransport) SetTLSConfig(_ *tls.Config) {
+}
+
+func (*delayedTransport) SetDial(_ fasthttp.DialFunc) {
+}
+
+func (*delayedTransport) Client() any {
+	return nil
+}
+
+func (*delayedTransport) StreamResponseBody() bool {
+	return false
+}
+
+func (*delayedTransport) SetStreamResponseBody(_ bool) {
 }
 
 type blockingErrTransport struct {

--- a/client/response.go
+++ b/client/response.go
@@ -36,12 +36,14 @@ func (r *Response) setClient(c *Client) {
 	r.client = c
 }
 
-// setRequest sets the request object in the response and snapshots its
-// ownership. Request objects are pooled, so their fields may belong to a new
-// logical request by the time Response.Close is called.
-func (r *Response) setRequest(req *Request) {
+// setRequest sets the request object in the response along with a snapshot of
+// its ownership. The caller reads owned before the transport goroutine starts:
+// Request objects are pooled, so req.clientOwned may already be reset, or
+// belong to a new logical request, by the time the response is built or
+// Response.Close is called.
+func (r *Response) setRequest(req *Request, owned bool) {
 	r.request = req
-	r.requestOwned = req.clientOwned
+	r.requestOwned = owned
 }
 
 // setRespondedURI records where the response was served from, copying into the

--- a/client/response.go
+++ b/client/response.go
@@ -28,6 +28,7 @@ type Response struct {
 	// for an origin it does not control. Byte slices: a URI would cost ~296 bytes.
 	respondedHost []byte
 	respondedPath []byte
+	requestOwned  bool
 }
 
 // setClient sets the client instance in the response. The client object is used by core functionalities.
@@ -35,9 +36,12 @@ func (r *Response) setClient(c *Client) {
 	r.client = c
 }
 
-// setRequest sets the request object in the response. The request is released when Response.Close is called.
+// setRequest sets the request object in the response and snapshots its
+// ownership. Request objects are pooled, so their fields may belong to a new
+// logical request by the time Response.Close is called.
 func (r *Response) setRequest(req *Request) {
 	r.request = req
+	r.requestOwned = req.clientOwned
 }
 
 // setRespondedURI records where the response was served from, copying into the
@@ -235,6 +239,7 @@ func (r *Response) Save(v any) error {
 func (r *Response) Reset() {
 	r.client = nil
 	r.request = nil
+	r.requestOwned = false
 	r.respondedHost = resetOriginBuf(r.respondedHost)
 	r.respondedPath = resetOriginBuf(r.respondedPath)
 
@@ -254,9 +259,10 @@ func (r *Response) Close() {
 	if r.request != nil {
 		tmp := r.request
 		r.request = nil
-		if tmp.clientOwned {
+		if r.requestOwned {
 			ReleaseRequest(tmp)
 		}
+		r.requestOwned = false
 	}
 	ReleaseResponse(r)
 }

--- a/client/response_test.go
+++ b/client/response_test.go
@@ -76,7 +76,7 @@ func Test_Response_CloseUsesSnapshottedRequestOwnership(t *testing.T) {
 
 	req := AcquireRequest()
 	resp := AcquireResponse()
-	resp.setRequest(req)
+	resp.setRequest(req, false)
 
 	// Simulate the caller releasing this request and a helper reusing the pooled
 	// object. The stale response must not release the helper's logical request.

--- a/client/response_test.go
+++ b/client/response_test.go
@@ -71,6 +71,22 @@ func Test_Response_Status(t *testing.T) {
 	})
 }
 
+func Test_Response_CloseUsesSnapshottedRequestOwnership(t *testing.T) {
+	t.Parallel()
+
+	req := AcquireRequest()
+	resp := AcquireResponse()
+	resp.setRequest(req)
+
+	// Simulate the caller releasing this request and a helper reusing the pooled
+	// object. The stale response must not release the helper's logical request.
+	req.clientOwned = true
+	resp.Close()
+	require.True(t, req.clientOwned)
+
+	ReleaseRequest(req)
+}
+
 func Test_Response_Status_Code(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Motivation

- Prevent a TOCTOU where a pooled `Request`'s mutable `clientOwned` flag could be changed after a `Response` retained the pointer, allowing a stale `Response` to release a different logical request on `Close`.

### Description

- Add a `requestOwned` boolean field to `Response` and snapshot `req.clientOwned` in `setRequest` so ownership is stable for the response lifetime.
- Use the response-local `requestOwned` snapshot in `Response.Close` instead of reading the (mutable) `Request.clientOwned` flag, and clear it in `Reset`.
- Add `Test_Response_CloseUsesSnapshottedRequestOwnership` to simulate pool-reuse ownership mutation and verify `Close` does not release a reused logical request.

### Testing

- Ran `go test ./client -run '^Test_Response_CloseUsesSnapshottedRequestOwnership$' -count=1` and the focused test passed.
- Ran `make generate` and code generation completed successfully.
- Ran `make betteralign` and `make format` and both completed successfully (struct alignment and formatting applied).
- Ran `make lint` which completed with no issues reported (`0 issues.`).
- Ran `make test` which completed successfully: the full suite finished with all tests passing (5775 tests, 2 skipped).
- Ran `make audit` where `go mod verify` and `go vet` passed but `govulncheck` reported vulnerabilities in the environment's pinned Go standard library (23 findings in the local Go 1.26.0 toolchain), causing `make audit` to fail due to toolchain-standard-library issues unrelated to this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9d4e656f988333aa9525ce4d919a53)