### PR TITLE
🐛 bug: prevent typed-nil view engine panics

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -9134,6 +9134,20 @@ func Test_Ctx_Render_Engine(t *testing.T) {
 	require.Equal(t, "<h1>Hello, World!</h1>", string(c.Response().Body()))
 }
 
+func Test_Ctx_Render_TypedNilEngine(t *testing.T) {
+	t.Parallel()
+
+	var engine *testTemplateEngine
+	app := New(Config{Views: engine})
+	c := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	err := c.Render("./.github/testdata/index.tmpl", Map{
+		"Title": "Hello, World!",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "<h1>Hello, World!</h1>", string(c.Response().Body()))
+}
+
 // go test -run Test_Ctx_Render_Engine_With_View_Layout
 func Test_Ctx_Render_Engine_With_View_Layout(t *testing.T) {
 	t.Parallel()

--- a/mount.go
+++ b/mount.go
@@ -286,7 +286,7 @@ func domainMountRender(owner domainOwner) (*App, string) { //nolint:gocritic // 
 	}
 
 	layout := owner.app.config.ViewsLayout
-	if owner.app.config.Views != nil {
+	if !isNilViews(owner.app.config.Views) {
 		return owner.app, layout
 	}
 
@@ -295,7 +295,7 @@ func domainMountRender(owner domainOwner) (*App, string) { //nolint:gocritic // 
 			layout = ancestor.config.ViewsLayout
 		}
 
-		if ancestor.config.Views != nil {
+		if !isNilViews(ancestor.config.Views) {
 			return ancestor, layout
 		}
 	}

--- a/res.go
+++ b/res.go
@@ -1057,7 +1057,7 @@ func (r *DefaultRes) Render(name string, bind any, layouts ...string) error {
 			}
 
 			// Render template from Views
-			if app.config.Views != nil {
+			if !isNilViews(app.config.Views) {
 				if err := func() error {
 					viewsLock := getViewsLock(app.config.Views)
 					viewsLock.RLock()


### PR DESCRIPTION
### Motivation

- A recent change started treating typed-nil view engines as absent at startup but request-time rendering still used a plain interface nil check, allowing a typed-nil `Views` to be invoked and panic during request handling.  
- That panic is reachable by an unauthenticated request when an operator accidentally supplies a typed-nil engine, risking process termination unless the app installs recover middleware.  
- The intent of this change is to make request-time rendering use the same typed-nil detection as startup so typed-nil engines are treated as absent and rendering falls back to ancestor engines or raw templates.

### Description

- Updated the request-scoped rendering check to use the existing `isNilViews` predicate so typed-nil `Views` are treated as absent in `DefaultRes.Render` (`res.go`).
- Applied the same `isNilViews` check to domain-mounted view resolution so domain mounts do not dispatch to typed-nil engines (`mount.go`).
- Added a regression test `Test_Ctx_Render_TypedNilEngine` to `ctx_test.go` proving that a typed-nil engine does not panic and raw template rendering still succeeds.
- Changes are limited to runtime nil-detection and tests; no public API behavior was changed.

### Testing

- `make audit` — `go mod verify` and `go vet` succeeded but `govulncheck` reported 23 vulnerabilities in the environment Go 1.26.0 standard library (these are environment/tooling findings, not introduced by this change).  
- `make generate`, `make betteralign`, `make format`, and `make lint` were executed and completed successfully with `make lint` reporting no issues.  
- `make test` was run and completed successfully, with the suite passing (5,809 tests, 1 skipped) and the targeted `go test` invocations for render tests including `Test_Ctx_Render_TypedNilEngine` passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9d9ae40c648333b1c68d80511afdc0)