### PR TITLE
📚 Doc: explain what MIMETypes does to an existing format

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -393,10 +393,11 @@ func (b *Bind) MsgPack(out any) error {
 // Body binds the request body into the struct, map[string]string and map[string][]string.
 // Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 // It supports decoding the following content types based on the Content-Type header:
-// application/json, application/xml, application/x-www-form-urlencoded, multipart/form-data
-// Custom binders are checked first, so one whose MIMETypes() holds the request's
-// content type runs instead of the built-in decoder for that type.
-// If neither matches the content type, it will return a ErrUnprocessableEntity error.
+// application/json, application/vnd.msgpack, application/xml, text/xml, application/cbor,
+// application/x-www-form-urlencoded, multipart/form-data
+// Custom binders are checked first, so the first one whose MIMETypes() holds the
+// request's content type runs instead of the built-in decoder for that type.
+// If neither matches the content type, it will return an ErrUnprocessableEntity error.
 func (b *Bind) Body(out any) error {
 	ctype := bindMediaType(&b.ctx.RequestCtx().Request.Header)
 

--- a/bind.go
+++ b/bind.go
@@ -394,8 +394,9 @@ func (b *Bind) MsgPack(out any) error {
 // Returns *BindError on parse failure (manual mode) or *Error with status 400 (auto-handling mode).
 // It supports decoding the following content types based on the Content-Type header:
 // application/json, application/xml, application/x-www-form-urlencoded, multipart/form-data
-// If none of the content types above are matched, it'll take a look custom binders by checking the MIMETypes() method of custom binder.
-// If there is no custom binder for mime type of body, it will return a ErrUnprocessableEntity error.
+// Custom binders are checked first, so one whose MIMETypes() holds the request's
+// content type runs instead of the built-in decoder for that type.
+// If neither matches the content type, it will return a ErrUnprocessableEntity error.
 func (b *Bind) Body(out any) error {
 	ctype := bindMediaType(&b.ctx.RequestCtx().Request.Header)
 

--- a/docs/api/bind.md
+++ b/docs/api/bind.md
@@ -886,8 +886,54 @@ app.Post("/custom", func(c fiber.Ctx) error {
 })
 ```
 
-Internally, custom binders are also used in the [Body](#body) method.
-The `MIMETypes` method is used to check if the custom binder should be used for the given content type.
+### MIMETypes and Body
+
+[`Body`](#body) consults the registered custom binders before its own content-type
+switch, so `MIMETypes` decides how a binder can be reached:
+
+| `MIMETypes()` returns              | `Bind().Custom(name, dest)` | `Bind().Body(dest)`               |
+| ---------------------------------- | --------------------------- | --------------------------------- |
+| a content type no built-in handles | yes                         | yes, for that content type        |
+| a content type a built-in handles  | yes                         | yes, the built-in no longer runs  |
+| `nil`                              | yes                         | no                                |
+
+Returning `nil` makes a binder opt-in: it is reachable only by name, and the
+built-in decoders keep handling `Body`.
+
+### Overriding a built-in format
+
+Claiming a content type that already has a decoder replaces it for every
+`Bind().Body()` call in the application, not only on the route you had in mind.
+A binder returning `[]string{fiber.MIMEApplicationJSON}` handles all JSON bodies
+from then on.
+
+To decode strictly on selected routes instead, return `nil` and call the binder
+by name:
+
+```go title="Example"
+type strictJSON struct{}
+
+func (strictJSON) Name() string        { return "strict" }
+func (strictJSON) MIMETypes() []string { return nil }
+
+func (strictJSON) Parse(c fiber.Ctx, out any) error {
+    d := json.NewDecoder(bytes.NewReader(c.Body()))
+    d.DisallowUnknownFields()
+    return d.Decode(out)
+}
+
+app.RegisterCustomBinder(strictJSON{})
+
+// curl -X POST http://localhost:3000/strict -H "Content-Type: application/json" -d '{"name":"John","admin":true}'
+app.Post("/strict", func(c fiber.Ctx) error {
+    var user User
+    // Rejects the unknown "admin" field; c.Bind().JSON(&user) still accepts it
+    if err := c.Bind().Custom("strict", &user); err != nil {
+        return err
+    }
+    return c.JSON(user)
+})
+```
 
 ## Options
 

--- a/docs/api/bind.md
+++ b/docs/api/bind.md
@@ -902,10 +902,11 @@ built-in decoders keep handling `Body`.
 
 ### Overriding a built-in format
 
-Claiming a content type that already has a decoder replaces it for every
-`Bind().Body()` call in the application, not only on the route you had in mind.
-A binder returning `[]string{fiber.MIMEApplicationJSON}` handles all JSON bodies
-from then on.
+Claiming a content type that already has a decoder takes precedence over the
+built-in one for every `Bind().Body()` call in the application, not only on the
+route you had in mind. `Body` uses the first registered binder whose `MIMETypes()`
+contains the request's content type, so a second binder claiming
+`fiber.MIMEApplicationJSON` never runs.
 
 To decode strictly on selected routes instead, return `nil` and call the binder
 by name:


### PR DESCRIPTION
# Description

`docs/api/bind.md` documents custom binders with a YAML example, where `MIMETypes` returning `[]string{"application/yaml"}` is obviously right because nothing else handles that type. The page never says what happens when a binder claims a type a built-in already handles, and the doc comment on `Bind.Body` had the precedence backwards.

Verified on `fe38a78e`:

- A binder returning `[]string{fiber.MIMEApplicationJSON}` handles every `Bind().Body()` call in the application. The custom binder loop runs before the content-type switch (`bind.go:403`), so the built-in JSON decoder never runs. Registering a strict binder that way is an app-wide change, not a per-call one.
- A binder returning `nil` is opt-in: `slices.Contains(nil, ctype)` is false, so `Body` keeps using the built-in decoder and the binder is reachable only through `Bind().Custom(name, dest)`.

The second form is what #2858 asks for, and it works today without new API:

```go
type strictJSON struct{}

func (strictJSON) Name() string        { return "strict" }
func (strictJSON) MIMETypes() []string { return nil }

func (strictJSON) Parse(c fiber.Ctx, out any) error {
    d := json.NewDecoder(bytes.NewReader(c.Body()))
    d.DisallowUnknownFields()
    return d.Decode(out)
}
```

On `{"name":"john","admin":true}`, `c.Bind().Custom("strict", &p)` returns `json: unknown field "admin"` and `c.Bind().Body(&p)` binds normally.

Fixes #2858

## Changes introduced

- [x] Documentation Update: two subsections under `Custom` in `docs/api/bind.md`. A table of what `MIMETypes` does to `Bind().Custom` and `Bind().Body`, and an "Overriding a built-in format" section with the opt-in example above.
- `bind.go`: the doc comment on `Body` said custom binders are consulted "if none of the content types above are matched". They are consulted first and win. Corrected.

## Type of change

- [x] Documentation update (changes to documentation)
