### PR TITLE
🐛 fix(proxy): fold DomainForward's configured hostname to Punycode

### DIFF
--- a/internal/idnafold/idnafold.go
+++ b/internal/idnafold/idnafold.go
@@ -1,0 +1,34 @@
+// Package idnafold converts a Unicode hostname label to the Punycode form a
+// browser puts on the wire (RFC 5891), so a hostname literal written in
+// source still matches the requests that name actually generates.
+package idnafold
+
+import (
+	"strings"
+
+	"github.com/gofiber/utils/v2"
+	"golang.org/x/net/idna"
+)
+
+// ToASCII converts host to its Punycode ("xn--...") form when it carries
+// non-ASCII characters, and returns it unchanged otherwise — including when
+// it is already Punycode, which is itself ASCII.
+//
+// A value containing a colon is returned unchanged: IDNA has no concept of a
+// port, and a bracketed IPv6 literal is never subject to IDNA. A caller with
+// a "host:port" or "[ipv6]:port" value splits it first and folds the host
+// part alone.
+//
+// Input idna.Lookup's stricter validation rejects is also returned
+// unchanged rather than as an error: it will not match any Punycode-encoded
+// value, which is the correct security default — reject by non-match, not by
+// a second error path every caller would have to remember to handle.
+func ToASCII(host string) string {
+	if host == "" || strings.IndexByte(host, ':') >= 0 || utils.IsASCII(host) {
+		return host
+	}
+	if ascii, err := idna.Lookup.ToASCII(host); err == nil {
+		return ascii
+	}
+	return host
+}

--- a/internal/idnafold/idnafold_test.go
+++ b/internal/idnafold/idnafold_test.go
@@ -1,0 +1,58 @@
+package idnafold
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ToASCII(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{"empty", "", ""},
+		{"already ASCII, unchanged", "example.com", "example.com"},
+		{"already Punycode, unchanged", "xn--mnchen-3ya.example.com", "xn--mnchen-3ya.example.com"},
+		{"mixed case ASCII, case preserved", "API.Example.com", "API.Example.com"},
+		{"Unicode label folds to Punycode", "münchen.example.com", "xn--mnchen-3ya.example.com"},
+		{"CJK label folds to Punycode", "日本語.jp", "xn--wgv71a119e.jp"},
+		{"colon: host:port is left alone", "münchen.example.com:8080", "münchen.example.com:8080"},
+		{"colon: bracketed IPv6 is left alone", "[::1]", "[::1]"},
+		{"a lone colon is left alone", ":", ":"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, ToASCII(tc.host))
+		})
+	}
+}
+
+// Test_ToASCII_RejectsByNonMatch pins the documented security default: input
+// idna.Lookup refuses is returned as-is rather than surfacing an error, so it
+// simply will not match any Punycode-encoded value a caller compares it to.
+func Test_ToASCII_RejectsByNonMatch(t *testing.T) {
+	t.Parallel()
+	// A label starting with a combining mark is invalid under idna.Lookup's
+	// validation (UTS46), so ToASCII must return it unchanged rather than a
+	// converted-but-wrong value.
+	const invalid = "́invalid.example.com"
+	assert.Equal(t, invalid, ToASCII(invalid))
+}
+
+func Benchmark_ToASCII_ASCIIFastPath(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ToASCII("example.com")
+	}
+}
+
+func Benchmark_ToASCII_UnicodeSlowPath(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ToASCII("münchen.example.com")
+	}
+}

--- a/middleware/hostauthorization/hostauthorization.go
+++ b/middleware/hostauthorization/hostauthorization.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/internal/idnafold"
 	"github.com/gofiber/utils/v2"
 	utilsstrings "github.com/gofiber/utils/v2/strings"
-	"golang.org/x/net/idna"
 )
 
 // RFC 1035 length limits.
@@ -87,7 +87,7 @@ func normalizeHost(host string) string {
 	if host != "" && host[0] != '[' && strings.IndexByte(host, ':') < 0 {
 		host = trimOneTrailingDot(host)
 		host = utilsstrings.ToLower(host)
-		return toPunycode(host)
+		return idnafold.ToASCII(host)
 	}
 
 	if h, _, ok := utils.SplitHostPort(host); ok {
@@ -99,7 +99,7 @@ func normalizeHost(host string) string {
 
 	host = trimOneTrailingDot(host)
 	host = utilsstrings.ToLower(host)
-	return toPunycode(host)
+	return idnafold.ToASCII(host)
 }
 
 func trimOneTrailingDot(host string) string {
@@ -107,18 +107,6 @@ func trimOneTrailingDot(host string) string {
 		return host[:len(host)-1]
 	}
 
-	return host
-}
-
-func toPunycode(host string) string {
-	if host == "" || strings.IndexByte(host, ':') >= 0 || utils.IsASCII(host) {
-		return host
-	}
-	if ascii, err := idna.Lookup.ToASCII(host); err == nil {
-		return ascii
-	}
-	// Non-convertible input falls through; it won't match any Punycode entry,
-	// which is the correct security default.
 	return host
 }
 

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/gofiber/fiber/v3/internal/fieldname"
 	"github.com/gofiber/fiber/v3/internal/headerlookup"
+	"github.com/gofiber/fiber/v3/internal/idnafold"
+	utilsstrings "github.com/gofiber/utils/v2/strings"
 	"github.com/valyala/fasthttp"
 )
 
@@ -568,6 +570,19 @@ func selectClient(globalClient *fasthttp.Client, clients ...*fasthttp.Client) (*
 // when AllowPrivateIPs is false the dispatching client's dial-time guard
 // re-validates the resolved IP at connect time — so a rebinding-capable
 // resolver cannot reach a private address through this handler.
+
+// foldHostnameLabel returns hostname with its host label folded to lowercase
+// Punycode, preserving an explicit port unchanged. It is the construction-time
+// counterpart to hostWithoutPort: that strips a port from the per-request wire
+// value, this normalizes the configured value once so the two sides compare
+// correctly regardless of how the operator spelled the domain.
+func foldHostnameLabel(hostname string) string {
+	if host, port, ok := utils.SplitHostPort(hostname); ok {
+		return idnafold.ToASCII(utilsstrings.ToLower(host)) + ":" + port
+	}
+	return idnafold.ToASCII(utilsstrings.ToLower(hostname))
+}
+
 // hostWithoutPort strips the port from a Host header value, keeping a bracketed IPv6 literal.
 func hostWithoutPort(host string) string {
 	if strings.HasPrefix(host, "[") {
@@ -587,6 +602,11 @@ func DomainForward(hostname, addr string, clients ...*fasthttp.Client) fiber.Han
 	if err != nil {
 		panic(err)
 	}
+	// A Unicode hostname literal — entirely natural to write for a non-ASCII
+	// domain — never appears on the wire: a conforming client always sends
+	// the Punycode form (RFC 5891), so folding once here, rather than on
+	// every request, is what makes the two sides comparable at all.
+	hostname = foldHostnameLabel(hostname)
 	return func(c fiber.Ctx) error {
 		// Host names are case-insensitive (RFC 9110 §4.2.3) and fasthttp
 		// does not case-fold the raw Host header, so compare with

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -1358,6 +1358,65 @@ func Test_Proxy_DomainForward_HostMatchIsCaseInsensitive(t *testing.T) {
 	require.Equal(t, "proxied", string(body), "mixed-case Host must still be proxied")
 }
 
+// Test_Proxy_DomainForward_HostMatchFoldsIDN verifies that a Unicode hostname
+// literal — the natural way to write a non-ASCII domain in Go source — still
+// matches the request a real client sends, which is always the Punycode form
+// (RFC 5891). Before this was fixed, the rule silently never matched: every
+// real request for the configured domain fell through unproxied.
+func Test_Proxy_DomainForward_HostMatchFoldsIDN(t *testing.T) {
+	t.Parallel()
+
+	_, addr := createProxyTestServerIPv4(t, func(c fiber.Ctx) error {
+		return c.SendString("proxied")
+	})
+
+	app := fiber.New()
+	// Handler configured with the Unicode literal a developer would write...
+	app.Use(DomainForward("münchen.example.com", "http://"+addr))
+
+	// ...but every real client sends the Punycode form on the wire.
+	req := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	req.Host = "xn--mnchen-3ya.example.com"
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "proxied", string(body), "a Unicode-literal hostname config must match the Punycode form on the wire")
+}
+
+// Test_Proxy_DomainForward_HostMatchFoldsIDN_WithPort verifies that folding
+// preserves an explicit port on the configured hostname, so
+// DomainForward("münchen.example.com:8080", ...) keeps requiring that port
+// rather than silently dropping the restriction.
+func Test_Proxy_DomainForward_HostMatchFoldsIDN_WithPort(t *testing.T) {
+	t.Parallel()
+
+	_, addr := createProxyTestServerIPv4(t, func(c fiber.Ctx) error {
+		return c.SendString("proxied")
+	})
+
+	app := fiber.New()
+	app.Use(DomainForward("münchen.example.com:8080", "http://"+addr))
+
+	matching := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	matching.Host = "xn--mnchen-3ya.example.com:8080"
+	resp, err := app.Test(matching)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "proxied", string(body))
+
+	wrongPort := httptest.NewRequest(fiber.MethodGet, "/", http.NoBody)
+	wrongPort.Host = "xn--mnchen-3ya.example.com:9090"
+	resp, err = app.Test(wrongPort)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusNotFound, resp.StatusCode, "a different port must still fall through unproxied")
+}
+
 // sendRawUnnormalized drives one request whose header names are kept exactly as
 // written, the way a front end translating HTTP/2 down to HTTP/1.1 leaves them,
 // and returns the response body.


### PR DESCRIPTION
This PR was written in part with the assistance of generative AI.

# Description

`DomainForward("münchen.example.com", ...)` never proxies a single real request.

A conforming client always sends the Punycode form on the wire (RFC 5891): `Host: xn--mnchen-3ya.example.com`. The configured hostname was compared to that wire value byte for byte, with no folding on either side, so the two can never match. The rule is silently dead for any internationalized domain, which is exactly the kind of value a non-English deployment would write as a Unicode literal directly in Go source.

Verified end to end before touching anything, not just at the string-comparison level: a real request through the actual middleware, with the wire `Host` set to the Punycode form a browser would send, falls through to the next handler instead of being proxied. That test is in this PR (`Test_Proxy_DomainForward_HostMatchFoldsIDN`), and I reverted the fix locally first to confirm it fails without it.

## Root cause

```go
host := utils.UnsafeString(c.Request().Host())
if !utils.EqualFold(host, hostname) && !utils.EqualFold(hostWithoutPort(host), hostname) {
    return c.Next()
}
```

Both branches fold case (`EqualFold`) and the second folds an explicit port off the wire value, but neither side is ever folded to Punycode. `middleware/hostauthorization` already does this correctly for its own allowlist matching; `DomainForward` never picked it up.

## Fix

`hostauthorization`'s `toPunycode`, which folds a host label to ASCII when it carries non-ASCII characters and leaves anything with a colon alone since IDNA has no concept of a port, is now `internal/idnafold.ToASCII`, shared rather than duplicated a third time. Before deleting the original I fuzzed the new function against it: 1.2M generated inputs, byte-identical.

`DomainForward` folds its configured `hostname` once at construction, not per request:

```go
hostname = foldHostnameLabel(hostname)
```

`foldHostnameLabel` is the construction-time counterpart to the existing `hostWithoutPort`: that strips a port from the per-request wire value, this normalizes the configured value once. It preserves an explicit port on `hostname` rather than discarding it. `hostauthorization`'s own `normalizeHost` drops the port entirely, because its job is different: matching against the incoming Host, which is always compared port-stripped on both sides already. Reusing it as-is here would have silently changed what a port-qualified `DomainForward("host:8080", ...)` config matches. That's why this is a small purpose-built wrapper rather than a call to the existing function.

The per-request wire value needs no folding at all: a conforming client's `Host` header is already ASCII. So the hot path is untouched, not just unaffected.

## Verification

- All 54 packages pass, `-race` clean on `proxy`, `hostauthorization` and the new package, `golangci-lint` (repo-pinned v2.12.2) 0 issues, `go vet` clean.
- `internal/idnafold` is at 100% statement coverage.
- Two new end-to-end tests, both mutation-verified (fail when the fix is reverted, pass with it): the base IDN case, and a case confirming a configured port is still enforced after folding (`münchen.example.com:8080` must not match on `:9090`).
- Interleaved A/B benchmarks against `upstream/main`, `-count=8`, on `DomainForward`'s hot path and on `hostauthorization`'s per-request `matchHost` (to confirm the extraction didn't regress the function it now shares): every number lands within noise (largest p=0.117), `B/op` identical everywhere.

```
                               │ before      │ after                     │
DomainForward_HostMatchPath-10    6.202µ ± 1%   6.175µ ± 1%  ~ (p=0.442)
_matchHost_ExactMatch-10          4.059n ± 2%   4.139n ± 4%  ~ (p=0.234)
_matchHost_WildcardMatch-10       2.622n ± 5%   2.522n ± 6%  ~ (p=0.186)
_matchHost_Mixed-10               7.386n ± 7%   7.263n ± 4%  ~ (p=0.195)
_matchHost_ManyWildcards-10       168.9n ± 0%   168.9n ± 0%  ~ (p=0.692)

B/op: identical on every benchmark, "all samples are equal"
```

## Context: why this and not the rest of #4604 cluster 2

I went looking at cluster 2 (host normalization and IDNA) as the natural next step after #4653 (cluster 1). Most of its description is now stale: the "custom lenient `idna.New` profile" it names in `middleware/redirect` no longer exists in the tree, and `internal/schemehost` already exists and deliberately does **not** fold IDNA, since `Host`/`Origin`/`Referer` are wire values a browser has already Punycode-encoded. There is nothing to fold on that path, and adding it there would be unjustified cost with no correctness benefit.

This is the one piece of that cluster that's still live and is provably a bug rather than a cosmetic duplication, so I scoped this PR to just it rather than bundling in a broader "one tiered helper" unification that the remaining, mostly-legitimate differences (`cookiejar`'s narrow in-file duplication, `Subdomains()`'s deliberately opposite Unicode-decode direction for display) don't actually call for once you look closely at each one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests. Two new end-to-end tests, mutation-verified against the actual fix; the shared package ships with its own full test suite plus the equivalence fuzz used once to verify the extraction (not part of the diff, easy to reproduce if you'd like it in CI).
- [x] Ensured that new and existing unit tests pass locally with the changes. All 54 packages, `-race` on the three affected.
- [x] Verified that any new dependencies are essential. None added: `golang.org/x/net/idna` was already a dependency via `hostauthorization`.
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.
- [ ] Updated the documentation in `/docs/`. Not applicable: no public API signature changed, and `DomainForward`'s existing doc comment already describes host matching in general terms that still hold.
- [ ] Followed the inspiration of the Express.js framework. Not applicable, internal fix.


